### PR TITLE
[JSC] Clean up JSPromiseCombinatorsGlobalContext

### DIFF
--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -372,11 +372,8 @@ static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
         values->putDirectIndex(globalObject, index, resolution);
         RETURN_IF_EXCEPTION(scope, void());
 
-        uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-        RETURN_IF_EXCEPTION(scope, void());
-
-        --count;
-        globalContext->setRemainingElementsCount(vm, jsNumber(count));
+        uint64_t count = globalContext->remainingElementsCount() - 1;
+        globalContext->setRemainingElementsCount(count);
         if (!count) {
             auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
             scope.release();
@@ -418,11 +415,8 @@ static void promiseAllSettledResolveJob(JSGlobalObject* globalObject, VM& vm, JS
     values->putDirectIndex(globalObject, index, resultObject);
     RETURN_IF_EXCEPTION(scope, void());
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, void());
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
         scope.release();
@@ -451,11 +445,8 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
         errors->putDirectIndex(globalObject, index, resolution);
         RETURN_IF_EXCEPTION(scope, void());
 
-        uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-        RETURN_IF_EXCEPTION(scope, void());
-
-        --count;
-        globalContext->setRemainingElementsCount(vm, jsNumber(count));
+        uint64_t count = globalContext->remainingElementsCount() - 1;
+        globalContext->setRemainingElementsCount(count);
         if (!count) {
             auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
             auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
@@ -760,11 +751,11 @@ JSC_DEFINE_HOST_FUNCTION(asyncGeneratorCompleteAndDrain, (JSGlobalObject* global
     return JSValue::encode(jsUndefined());
 }
 
-static void promiseFinallyAwaitJob(JSGlobalObject* globalObject, VM& vm, JSValue settledValue, JSPromiseCombinatorsGlobalContext* context, JSPromise::Status status)
+static void promiseFinallyAwaitJob(JSGlobalObject* globalObject, VM& vm, JSValue settledValue, JSSlimPromiseReaction* context, JSPromise::Status status)
 {
     auto* resultPromise = uncheckedDowncast<JSPromise>(context->promise());
-    JSValue originalValue = context->values();
-    bool wasFulfilled = context->remainingElementsCount().asBoolean();
+    JSValue originalValue = context->handlerOrContext();
+    bool wasFulfilled = context->isFulfillHandler();
 
     if (status == JSPromise::Status::Rejected) {
         resultPromise->rejectPromise(vm, settledValue);
@@ -777,11 +768,11 @@ static void promiseFinallyAwaitJob(JSGlobalObject* globalObject, VM& vm, JSValue
         resultPromise->rejectPromise(vm, originalValue);
 }
 
-static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPromise* resultPromise, JSValue valueOrReason, JSPromiseCombinatorsGlobalContext* context, JSPromise::Status status)
+static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPromise* resultPromise, JSValue valueOrReason, JSSlimPromiseReaction* context, JSPromise::Status status)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue onFinally = context->values();
+    JSValue onFinally = context->handlerOrContext();
 
     JSValue result;
     JSValue error;
@@ -802,8 +793,8 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
         return;
     }
 
-    context->setValues(vm, valueOrReason);
-    context->setRemainingElementsCount(vm, jsBoolean(status == JSPromise::Status::Fulfilled));
+    context->setHandlerOrContext(vm, valueOrReason);
+    context->setPerCellBit(status == JSPromise::Status::Fulfilled);
 
     if (result.inherits<JSPromise>()) {
         auto* promise = uncheckedDowncast<JSPromise>(result);
@@ -1407,7 +1398,7 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     // PerformPromiseThen(evaluatePromise, onFulfilled, onRejected).
     // We inline the AND-join: each dep promise either rejects capabilityPromise (idempotent),
     // or decrements the join count; the last dep to fulfill resolves the deferred namespace.
-    auto* joinContext = JSPromiseCombinatorsGlobalContext::create(vm, capabilityPromise, module, jsNumber(asyncDepsEvaluationPromises.size()));
+    auto* joinContext = JSPromiseCombinatorsGlobalContext::create(vm, capabilityPromise, module, asyncDepsEvaluationPromises.size());
     for (unsigned i = 0; i < asyncDepsEvaluationPromises.size(); ++i) {
         auto* depPromise = uncheckedDowncast<JSPromise>(asyncDepsEvaluationPromises.at(i));
         depPromise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::DynamicImportDeferDependencySettled, capabilityPromise, joinContext);
@@ -1419,7 +1410,7 @@ static void dynamicImportDeferDependencySettled(JSGlobalObject* globalObject, VM
     // SafePerformPromiseAll AND-join for the deferred-phase ContinueDynamicImport.
     // arguments[0] = capabilityPromise
     // arguments[1] = resolution or error
-    // arguments[2] = JSPromiseCombinatorsGlobalContext* (m_promise = capabilityPromise, m_values = module, m_remainingElementsCount = jsNumber(count))
+    // arguments[2] = JSPromiseCombinatorsGlobalContext* (m_promise = capabilityPromise, m_values = module, m_remainingElementsCount = count)
     auto* capabilityPromise = uncheckedDowncast<JSPromise>(arguments[0]);
     auto* joinContext = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[2]);
     auto status = static_cast<JSPromise::Status>(payload);
@@ -1428,9 +1419,10 @@ static void dynamicImportDeferDependencySettled(JSGlobalObject* globalObject, VM
         capabilityPromise->reject(vm, arguments[1]);
         return;
     }
-    int32_t remaining = joinContext->remainingElementsCount().asInt32() - 1;
-    ASSERT(remaining >= 0);
-    joinContext->setRemainingElementsCount(vm, jsNumber(remaining));
+    uint64_t count = joinContext->remainingElementsCount();
+    ASSERT(count > 0);
+    uint64_t remaining = count - 1;
+    joinContext->setRemainingElementsCount(remaining);
     if (remaining)
         return;
     auto* module = uncheckedDowncast<AbstractModuleRecord>(joinContext->values());
@@ -1818,14 +1810,14 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         // Phase 1: Original promise settled
         // arguments[0] = resultPromise
         // arguments[1] = value/reason from original promise
-        // arguments[2] = context (JSPromiseCombinatorsGlobalContext: promise=resultPromise, values=onFinally)
+        // arguments[2] = context (JSSlimPromiseReaction: promise=resultPromise, handlerOrContext=onFinally)
         // payload = Fulfilled/Rejected status
         auto* resultPromise = uncheckedDowncast<JSPromise>(arguments[0]);
         scope.release();
         promiseFinallyReactionJob(resultPromise->realm(), vm,
             resultPromise,
             arguments[1],
-            uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[2]),
+            uncheckedDowncast<JSSlimPromiseReaction>(arguments[2]),
             static_cast<JSPromise::Status>(payload));
         return;
     }
@@ -1834,9 +1826,9 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         // Phase 2: onFinally's result settled
         // arguments[0] = unused (we get resultPromise from context)
         // arguments[1] = settled value from onFinally's result
-        // arguments[2] = context (JSPromiseCombinatorsGlobalContext: promise=resultPromise, values=originalValue, remainingElementsCount=wasFulfilled)
+        // arguments[2] = context (JSSlimPromiseReaction: promise=resultPromise, handlerOrContext=originalValue, perCellBit=wasFulfilled)
         // payload = status of onFinally's result
-        auto* context = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[2]);
+        auto* context = uncheckedDowncast<JSSlimPromiseReaction>(arguments[2]);
         auto* resultPromise = uncheckedDowncast<JSPromise>(context->promise());
         scope.release();
         promiseFinallyAwaitJob(resultPromise->realm(), vm,

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -34,7 +34,6 @@
 #include "JSFunctionWithFields.h"
 #include "JSMicrotask.h"
 #include "JSPromiseCombinatorsContext.h"
-#include "JSPromiseCombinatorsGlobalContext.h"
 #include "JSPromiseConstructor.h"
 #include "JSPromisePrototype.h"
 #include "JSPromiseReaction.h"
@@ -661,10 +660,9 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionResolveWithInternalMicrotask, (
     callee->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, jsNull());
 
-    auto* context = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
+    auto* contextCell = uncheckedDowncast<JSSlimPromiseReaction>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
     JSValue argument = callFrame->argument(0);
-    JSValue onFulfilled = context->promise();
-    JSPromise::resolveWithInternalMicrotask(globalObject, vm, argument, static_cast<InternalMicrotask>(onFulfilled.asInt32()), context->remainingElementsCount());
+    JSPromise::resolveWithInternalMicrotask(globalObject, vm, argument, contextCell->internalMicrotask(), contextCell->handlerOrContext());
     return JSValue::encode(jsUndefined());
 }
 
@@ -680,10 +678,9 @@ JSC_DEFINE_HOST_FUNCTION(promiseResolvingFunctionRejectWithInternalMicrotask, (J
     callee->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, jsNull());
     other->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, jsNull());
 
-    auto* context = uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
+    auto* contextCell = uncheckedDowncast<JSSlimPromiseReaction>(callee->getField(JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext));
     JSValue argument = callFrame->argument(0);
-    JSValue onFulfilled = context->promise();
-    JSPromise::rejectWithInternalMicrotask(vm, globalObject, argument, static_cast<InternalMicrotask>(onFulfilled.asInt32()), context->remainingElementsCount());
+    JSPromise::rejectWithInternalMicrotask(vm, globalObject, argument, contextCell->internalMicrotask(), contextCell->handlerOrContext());
     return JSValue::encode(jsUndefined());
 }
 
@@ -742,17 +739,15 @@ std::tuple<JSFunction*, JSFunction*> JSPromise::createFirstResolvingFunctions(VM
 
 std::tuple<JSFunction*, JSFunction*> JSPromise::createResolvingFunctionsWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, InternalMicrotask task, JSValue context)
 {
-    JSValue encodedTask = jsNumber(static_cast<int32_t>(task));
-
     auto* resolve = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionResolveWithInternalMicrotaskExecutable());
     auto* reject = JSFunctionWithFields::create(vm, globalObject, vm.promiseResolvingFunctionRejectWithInternalMicrotaskExecutable());
 
-    auto* all = JSPromiseCombinatorsGlobalContext::create(vm, encodedTask, encodedTask, context);
+    auto* contextCell = JSSlimPromiseReaction::create(vm, jsUndefined(), task, context, /* next */ nullptr);
 
-    resolve->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext, all);
+    resolve->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext, contextCell);
     resolve->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, reject);
 
-    reject->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext, all);
+    reject->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskContext, contextCell);
     reject->setField(vm, JSFunctionWithFields::Field::ResolvingWithInternalMicrotaskOther, resolve);
 
     return std::tuple { resolve, reject };

--- a/Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.cpp
@@ -32,7 +32,7 @@ namespace JSC {
 
 const ClassInfo JSPromiseCombinatorsGlobalContext::s_info = { "PromiseCombinatorsGlobalContext"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(JSPromiseCombinatorsGlobalContext) };
 
-JSPromiseCombinatorsGlobalContext* JSPromiseCombinatorsGlobalContext::create(VM& vm, JSValue promise, JSValue values, JSValue remainingElementsCount)
+JSPromiseCombinatorsGlobalContext* JSPromiseCombinatorsGlobalContext::create(VM& vm, JSValue promise, JSValue values, uint64_t remainingElementsCount)
 {
     auto* structure = vm.promiseCombinatorsGlobalContextStructure.get();
     JSPromiseCombinatorsGlobalContext* result = new (NotNull, allocateCell<JSPromiseCombinatorsGlobalContext>(vm)) JSPromiseCombinatorsGlobalContext(vm, structure, promise, values, remainingElementsCount);
@@ -53,7 +53,6 @@ void JSPromiseCombinatorsGlobalContext::visitChildrenImpl(JSCell* cell, Visitor&
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_promise);
     visitor.append(thisObject->m_values);
-    visitor.append(thisObject->m_remainingElementsCount);
 }
 
 DEFINE_VISIT_CHILDREN(JSPromiseCombinatorsGlobalContext);

--- a/Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.h
@@ -45,28 +45,28 @@ public:
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    static JSPromiseCombinatorsGlobalContext* create(VM&, JSValue promise, JSValue values, JSValue remainingElementsCount);
+    static JSPromiseCombinatorsGlobalContext* create(VM&, JSValue promise, JSValue values, uint64_t remainingElementsCount);
 
     JSValue promise() const { return m_promise.get(); }
     JSValue values() const { return m_values.get(); }
-    JSValue remainingElementsCount() const { return m_remainingElementsCount.get(); }
+    uint64_t remainingElementsCount() const { return m_remainingElementsCount; }
 
     void setPromise(VM& vm, JSValue promise) { m_promise.set(vm, this, promise); }
     void setValues(VM& vm, JSValue values) { m_values.set(vm, this, values); }
-    void setRemainingElementsCount(VM& vm, JSValue remainingElementsCount) { m_remainingElementsCount.set(vm, this, remainingElementsCount); }
+    void setRemainingElementsCount(uint64_t remainingElementsCount) { m_remainingElementsCount = remainingElementsCount; }
 
 private:
-    JSPromiseCombinatorsGlobalContext(VM& vm, Structure* structure, JSValue promise, JSValue values, JSValue remainingElementsCount)
+    JSPromiseCombinatorsGlobalContext(VM& vm, Structure* structure, JSValue promise, JSValue values, uint64_t remainingElementsCount)
         : Base(vm, structure)
         , m_promise(promise, WriteBarrierEarlyInit)
         , m_values(values, WriteBarrierEarlyInit)
-        , m_remainingElementsCount(remainingElementsCount, WriteBarrierEarlyInit)
+        , m_remainingElementsCount(remainingElementsCount)
     {
     }
 
     WriteBarrier<Unknown> m_promise;
     WriteBarrier<Unknown> m_values;
-    WriteBarrier<Unknown> m_remainingElementsCount;
+    uint64_t m_remainingElementsCount;
 };
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSPromiseCombinatorsGlobalContext);

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -385,7 +385,7 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
         return promise;
     }
 
-    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, values, jsNumber(1));
+    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, values, 1);
 
     uint64_t index = 0;
 
@@ -408,9 +408,7 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
         }
         ASSERT(nextPromise);
 
-        uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-        RETURN_IF_EXCEPTION(scope, void());
-        globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+        globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
 
         uint64_t currentIndex = index++;
 
@@ -441,14 +439,8 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
         return promise;
     }
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    if (scope.exception()) [[unlikely]] {
-        callRejectWithScopeException();
-        return promise;
-    }
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         MarkedArgumentBuffer resolveArguments;
         resolveArguments.append(values);
@@ -496,7 +488,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         return JSValue::encode(promise);
     }
 
-    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, values, jsNumber(1));
+    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, values, 1);
 
     uint64_t index = 0;
     JSFunction* onRejected = nullptr;
@@ -508,9 +500,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         RETURN_IF_EXCEPTION(scope, void());
 
         if (canSkipIntermediatePromise(globalObject, value)) {
-            uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-            RETURN_IF_EXCEPTION(scope, void());
-            globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+            globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
             scope.release();
             globalObject->queueMicrotask(vm, InternalMicrotask::PromiseAllResolveJob, static_cast<uint8_t>(JSPromise::Status::Fulfilled), globalContext, value, jsNumber(index));
             ++index;
@@ -520,9 +510,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         JSPromise* nextPromise = JSPromise::resolvedPromise(globalObject, value);
         RETURN_IF_EXCEPTION(scope, void());
 
-        uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-        RETURN_IF_EXCEPTION(scope, void());
-        globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+        globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
 
         if (nextPromise->isThenFastAndNonObservable()) [[likely]] {
             auto* constructor = promiseSpeciesConstructor(globalObject, nextPromise);
@@ -563,14 +551,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         return JSValue::encode(promise);
     }
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    if (scope.exception()) [[unlikely]] {
-        callReject();
-        return JSValue::encode(promise);
-    }
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         scope.release();
         promise->resolve(globalObject, vm, values);
@@ -605,11 +587,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllFulfillFunction, (JSGlobalObject* globalObjec
     values->putDirectIndex(globalObject, index, value);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         scope.release();
         promise->resolve(globalObject, vm, values);
@@ -642,11 +621,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSlowFulfillFunction, (JSGlobalObject* globalO
     values->putDirectIndex(globalObject, index, value);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         MarkedArgumentBuffer resolveArguments;
         resolveArguments.append(values);
@@ -713,7 +689,7 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
         return promise;
     }
 
-    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, resolve, values, jsNumber(1));
+    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, resolve, values, 1);
 
     uint64_t index = 0;
 
@@ -736,9 +712,7 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
         }
         ASSERT(nextPromise);
 
-        uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-        RETURN_IF_EXCEPTION(scope, void());
-        globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+        globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
 
         uint64_t currentIndex = index++;
 
@@ -774,14 +748,8 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
         return promise;
     }
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    if (scope.exception()) [[unlikely]] {
-        callRejectWithScopeException();
-        return promise;
-    }
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         MarkedArgumentBuffer resolveArguments;
         resolveArguments.append(values);
@@ -829,7 +797,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
         return JSValue::encode(promise);
     }
 
-    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, values, jsNumber(1));
+    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, values, 1);
 
     uint64_t index = 0;
 
@@ -840,9 +808,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
         RETURN_IF_EXCEPTION(scope, void());
 
         if (canSkipIntermediatePromise(globalObject, value)) {
-            uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-            RETURN_IF_EXCEPTION(scope, void());
-            globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+            globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
             scope.release();
             globalObject->queueMicrotask(vm, InternalMicrotask::PromiseAllSettledResolveJob, static_cast<uint8_t>(JSPromise::Status::Fulfilled), globalContext, value, jsNumber(index));
             ++index;
@@ -852,9 +818,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
         JSPromise* nextPromise = JSPromise::resolvedPromise(globalObject, value);
         RETURN_IF_EXCEPTION(scope, void());
 
-        uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-        RETURN_IF_EXCEPTION(scope, void());
-        globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+        globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
 
         if (nextPromise->isThenFastAndNonObservable()) [[likely]] {
             auto* constructor = promiseSpeciesConstructor(globalObject, nextPromise);
@@ -899,14 +863,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
         return JSValue::encode(promise);
     }
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    if (scope.exception()) [[unlikely]] {
-        callReject();
-        return JSValue::encode(promise);
-    }
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         scope.release();
         promise->resolve(globalObject, vm, values);
@@ -950,11 +908,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledFulfillFunction, (JSGlobalObject* glob
     values->putDirectIndex(globalObject, index, resultObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         scope.release();
         promise->resolve(globalObject, vm, values);
@@ -994,11 +949,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledRejectFunction, (JSGlobalObject* globa
     values->putDirectIndex(globalObject, index, resultObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         scope.release();
         promise->resolve(globalObject, vm, values);
@@ -1038,11 +990,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowFulfillFunction, (JSGlobalObject* 
     values->putDirectIndex(globalObject, index, resultObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         MarkedArgumentBuffer resolveArguments;
         resolveArguments.append(values);
@@ -1087,11 +1036,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAllSettledSlowRejectFunction, (JSGlobalObject* g
     values->putDirectIndex(globalObject, index, resultObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         MarkedArgumentBuffer resolveArguments;
         resolveArguments.append(values);
@@ -1205,7 +1151,7 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
         return promise;
     }
 
-    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, errors, jsNumber(1));
+    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, errors, 1);
 
     uint64_t index = 0;
 
@@ -1227,9 +1173,7 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
             RETURN_IF_EXCEPTION(scope, void());
         }
 
-        uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-        RETURN_IF_EXCEPTION(scope, void());
-        globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+        globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
 
         JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
 
@@ -1260,14 +1204,8 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
         return promise;
     }
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    if (scope.exception()) [[unlikely]] {
-        callRejectWithScopeException();
-        return promise;
-    }
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         callReject(aggregateError);
@@ -1312,7 +1250,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
         return JSValue::encode(promise);
     }
 
-    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, errors, jsNumber(1));
+    JSPromiseCombinatorsGlobalContext* globalContext = JSPromiseCombinatorsGlobalContext::create(vm, promise, errors, 1);
 
     uint64_t index = 0;
 
@@ -1323,9 +1261,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
         RETURN_IF_EXCEPTION(scope, void());
 
         if (canSkipIntermediatePromise(globalObject, value)) {
-            uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-            RETURN_IF_EXCEPTION(scope, void());
-            globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+            globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
             scope.release();
             globalObject->queueMicrotask(vm, InternalMicrotask::PromiseAnyResolveJob, static_cast<uint8_t>(JSPromise::Status::Fulfilled), globalContext, value, jsNumber(index));
             ++index;
@@ -1335,9 +1271,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
         JSPromise* nextPromise = JSPromise::resolvedPromise(globalObject, value);
         RETURN_IF_EXCEPTION(scope, void());
 
-        uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-        RETURN_IF_EXCEPTION(scope, void());
-        globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+        globalContext->setRemainingElementsCount(globalContext->remainingElementsCount() + 1);
 
         if (nextPromise->isThenFastAndNonObservable()) [[likely]] {
             auto* constructor = promiseSpeciesConstructor(globalObject, nextPromise);
@@ -1380,14 +1314,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
         return JSValue::encode(promise);
     }
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    if (scope.exception()) [[unlikely]] {
-        callReject();
-        return JSValue::encode(promise);
-    }
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         scope.release();
@@ -1423,11 +1351,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnyRejectFunction, (JSGlobalObject* globalObject
     errors->putDirectIndex(globalObject, index, reason);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         scope.release();
@@ -1461,11 +1386,8 @@ JSC_DEFINE_HOST_FUNCTION(promiseAnySlowRejectFunction, (JSGlobalObject* globalOb
     errors->putDirectIndex(globalObject, index, reason);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    --count;
-    globalContext->setRemainingElementsCount(vm, jsNumber(count));
+    uint64_t count = globalContext->remainingElementsCount() - 1;
+    globalContext->setRemainingElementsCount(count);
     if (!count) {
         auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
         MarkedArgumentBuffer rejectArguments;

--- a/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
@@ -31,7 +31,7 @@
 #include "JSCInlines.h"
 #include "JSFunctionWithFields.h"
 #include "JSPromise.h"
-#include "JSPromiseCombinatorsGlobalContext.h"
+#include "JSPromiseReaction.h"
 
 namespace JSC {
 
@@ -288,7 +288,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncFinally, (JSGlobalObject* globalObject,
 
         if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]] {
             JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
-            auto* context = JSPromiseCombinatorsGlobalContext::create(vm, resultPromise, onFinally, jsUndefined());
+            auto* context = JSSlimPromiseReaction::create(vm, resultPromise, onFinally, /* isFulfill */ false, /* next */ nullptr);
             promise->performPromiseThenWithInternalMicrotask(vm, InternalMicrotask::PromiseFinallyReactionJob, resultPromise, context);
             return JSValue::encode(resultPromise);
         }


### PR DESCRIPTION
#### 7b0aff184802ce5d37c1c399313d52a5baed433c
<pre>
[JSC] Clean up JSPromiseCombinatorsGlobalContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=316553">https://bugs.webkit.org/show_bug.cgi?id=316553</a>
<a href="https://rdar.apple.com/179025550">rdar://179025550</a>

Reviewed by Yijia Huang.

JSPromiseCombinatorsGlobalContext was used for normal combinator&apos;s
context, or a bit random cell holders. Let&apos;s replace this random cell
holder to JSSlimPromiseReaction instead. And then making
JSPromiseCombinatorsGlobalContext cleaner and efficient: using uint64_t
for m_remainingElementsCount and making access around it efficient.

* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::promiseAllResolveJob):
(JSC::promiseAllSettledResolveJob):
(JSC::promiseAnyResolveJob):
(JSC::promiseFinallyAwaitJob):
(JSC::promiseFinallyReactionJob):
(JSC::dynamicImportLoadSettled):
(JSC::dynamicImportDeferDependencySettled):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.cpp:
(JSC::JSPromiseCombinatorsGlobalContext::create):
(JSC::JSPromiseCombinatorsGlobalContext::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.h:
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::promiseAllSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::promiseAllSettledSlow):
(JSC::promiseAnySlow):
* Source/JavaScriptCore/runtime/JSPromisePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/314756@main">https://commits.webkit.org/314756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75e23c0a3eb3460bae9b5e8350074ebf2b0197a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176174 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/897a9478-39f4-4495-ae51-1217bda9479c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129985 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/105479cd-6208-4fd2-ad49-7ed947907a3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110502 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d15837b-bb0e-49b4-8063-9737d4019ca5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24913 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159289 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178715 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28022 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31615 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138363 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138262 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41383 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104341 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33519 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199803 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39887 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53726 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39284 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4625 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39534 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39428 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->