### PR TITLE
[GStreamer] Migrate GLVideoSink to PadProbeHandle

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -28,6 +28,7 @@
 #include "GUniquePtrGStreamer.h"
 #include "PlatformDisplay.h"
 #include <gst/gl/gl.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/glib/GThreadSafeWeakPtr.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -53,6 +54,23 @@ enum {
 GST_DEBUG_CATEGORY_STATIC(webkit_gl_video_sink_debug);
 #define GST_CAT_DEFAULT webkit_gl_video_sink_debug
 
+class GLSinkHolder final : public WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GLSinkHolder> {
+public:
+    static RefPtr<GLSinkHolder> create(WTF::GThreadSafeWeakPtr<GstElement>&& element)
+    {
+        return adoptRef(*new GLSinkHolder(WTF::move(element)));
+    }
+
+    [[nodiscard]] GRefPtr<GstElement> sink() { return m_sink.get(); }
+
+private:
+    GLSinkHolder(GThreadSafeWeakPtr<GstElement>&& element)
+        : m_sink(WTF::move(element))
+    {
+    }
+    GThreadSafeWeakPtr<GstElement> m_sink;
+};
+
 struct _WebKitGLVideoSinkPrivate {
     ~_WebKitGLVideoSinkPrivate()
     {
@@ -69,6 +87,8 @@ struct _WebKitGLVideoSinkPrivate {
     GRefPtr<GstElement> queue;
     GRefPtr<GstElement> appSink;
     WebKitVideoSinkSignalIdentifiers signalIdentifiers;
+    RefPtr<PadProbeHandle<GLSinkHolder>> sinkPadProbe;
+    RefPtr<GLSinkHolder> sinkPadProbeData;
 };
 
 #define GST_GL_CAPS_FORMAT "{ A420, RGBx, RGBA, I420, Y444, YV12, Y41B, Y42B, NV12, NV21, VUYA }"
@@ -94,70 +114,6 @@ static void initializeDMABufAvailability()
     });
 }
 #endif
-
-struct GLSinkHolder {
-    GThreadSafeWeakPtr<GstElement> sink;
-};
-WEBKIT_DEFINE_ASYNC_DATA_STRUCT(GLSinkHolder);
-
-static GstPadProbeReturn sinkPadProbeCallback(GstPad*, GstPadProbeInfo* info, gpointer userData)
-{
-    auto query = GST_PAD_PROBE_INFO_QUERY(info);
-    if (GST_QUERY_TYPE(query) != GST_QUERY_ACCEPT_CAPS)
-        return GST_PAD_PROBE_OK;
-
-    GstCaps* caps;
-    gst_query_parse_accept_caps(query, &caps);
-    if (!caps)
-        return GST_PAD_PROBE_OK;
-
-    if (gst_caps_features_contains(gst_caps_get_features(caps, 0), GST_CAPS_FEATURE_MEMORY_GL_MEMORY))
-        return GST_PAD_PROBE_OK;
-
-    auto holder = reinterpret_cast<GLSinkHolder*>(userData);
-    auto sink = holder->sink.get();
-    if (!sink) [[unlikely]]
-        return GST_PAD_PROBE_REMOVE;
-
-    auto& quirksManager = GStreamerQuirksManager::singleton();
-    auto isVideoCapsGLCompatible = quirksManager.isVideoCapsGLCompatible(GRefPtr(caps));
-    GST_DEBUG_OBJECT(sink.get(), "Accept caps query for caps %" GST_PTR_FORMAT " isVideoCapsGLCompatible=%d", caps, isVideoCapsGLCompatible);
-    if (!isVideoCapsGLCompatible)
-        return GST_PAD_PROBE_OK;
-
-    GST_DEBUG_OBJECT(sink.get(), "Inserting GL converters before appsink");
-    auto priv = WEBKIT_GL_VIDEO_SINK(sink.get())->priv;
-    auto upload = makeGStreamerElement("glupload"_s);
-    auto colorconvert = makeGStreamerElement("glcolorconvert"_s);
-    RELEASE_ASSERT(upload);
-    RELEASE_ASSERT(colorconvert);
-
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
-    gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(sinkPad.get()), nullptr);
-
-    gst_bin_add_many(GST_BIN_CAST(sink.get()), upload, colorconvert, nullptr);
-    gst_element_link_many(upload, colorconvert, priv->queue.get(), nullptr);
-    auto target = adoptGRef(gst_element_get_static_pad(upload, "sink"));
-
-    GstElement* imxVideoConvert = nullptr;
-    if (auto imxVideoConvertFactory = adoptGRef(gst_element_factory_find("imxvideoconvert_g2d"))) {
-        imxVideoConvert = gst_element_factory_create(imxVideoConvertFactory.get(), nullptr);
-        gst_bin_add(GST_BIN_CAST(sink.get()), imxVideoConvert);
-        gst_element_link(imxVideoConvert, upload);
-        target = adoptGRef(gst_element_get_static_pad(imxVideoConvert, "sink"));
-    }
-
-    gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(sinkPad.get()), target.get());
-
-    if (imxVideoConvert)
-        gst_element_sync_state_with_parent(imxVideoConvert);
-    gst_element_sync_state_with_parent(upload);
-    gst_element_sync_state_with_parent(colorconvert);
-
-    gst_query_set_accept_caps_result(query, TRUE);
-    GST_PAD_PROBE_INFO_FLOW_RETURN(info) = GST_FLOW_OK;
-    return GST_PAD_PROBE_HANDLED;
-}
 
 static void webKitGLVideoSinkConstructed(GObject* object)
 {
@@ -219,10 +175,63 @@ static void webKitGLVideoSinkConstructed(GObject* object)
             sinkPad = adoptGRef(gst_element_get_static_pad(imxVideoConvert, "sink"));
         }
     } else {
-        auto data = createGLSinkHolder();
-        data->sink.reset(GST_ELEMENT_CAST(sink));
-        gst_pad_add_probe(sinkPad.get(), GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM, sinkPadProbeCallback, data,
-            reinterpret_cast<GDestroyNotify>(destroyGLSinkHolder));
+        sink->priv->sinkPadProbeData = GLSinkHolder::create(GThreadSafeWeakPtr(GST_ELEMENT_CAST(sink)));
+        sink->priv->sinkPadProbe = PadProbeHandle<GLSinkHolder>::create(*sink->priv->sinkPadProbeData, GRefPtr(sinkPad), GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM, [](const auto& holder, const auto&, auto info) -> GstPadProbeReturn {
+            auto query = GST_PAD_PROBE_INFO_QUERY(info);
+            if (GST_QUERY_TYPE(query) != GST_QUERY_ACCEPT_CAPS)
+                return GST_PAD_PROBE_OK;
+
+            GstCaps* caps;
+            gst_query_parse_accept_caps(query, &caps);
+            if (!caps)
+                return GST_PAD_PROBE_OK;
+
+            if (gst_caps_features_contains(gst_caps_get_features(caps, 0), GST_CAPS_FEATURE_MEMORY_GL_MEMORY))
+                return GST_PAD_PROBE_OK;
+
+            auto sink = holder->sink();
+            if (!sink) [[unlikely]]
+                return GST_PAD_PROBE_REMOVE;
+
+            auto& quirksManager = GStreamerQuirksManager::singleton();
+            auto isVideoCapsGLCompatible = quirksManager.isVideoCapsGLCompatible(GRefPtr(caps));
+            GST_DEBUG_OBJECT(sink.get(), "Accept caps query for caps %" GST_PTR_FORMAT " isVideoCapsGLCompatible=%d", caps, isVideoCapsGLCompatible);
+            if (!isVideoCapsGLCompatible)
+                return GST_PAD_PROBE_OK;
+
+            GST_DEBUG_OBJECT(sink.get(), "Inserting GL converters before appsink");
+            auto priv = WEBKIT_GL_VIDEO_SINK(sink.get())->priv;
+            auto upload = makeGStreamerElement("glupload"_s);
+            auto colorconvert = makeGStreamerElement("glcolorconvert"_s);
+            RELEASE_ASSERT(upload);
+            RELEASE_ASSERT(colorconvert);
+
+            auto sinkPad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
+            gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(sinkPad.get()), nullptr);
+
+            gst_bin_add_many(GST_BIN_CAST(sink.get()), upload, colorconvert, nullptr);
+            gst_element_link_many(upload, colorconvert, priv->queue.get(), nullptr);
+            auto target = adoptGRef(gst_element_get_static_pad(upload, "sink"));
+
+            GstElement* imxVideoConvert = nullptr;
+            if (auto imxVideoConvertFactory = adoptGRef(gst_element_factory_find("imxvideoconvert_g2d"))) {
+                imxVideoConvert = gst_element_factory_create(imxVideoConvertFactory.get(), nullptr);
+                gst_bin_add(GST_BIN_CAST(sink.get()), imxVideoConvert);
+                gst_element_link(imxVideoConvert, upload);
+                target = adoptGRef(gst_element_get_static_pad(imxVideoConvert, "sink"));
+            }
+
+            gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(sinkPad.get()), target.get());
+
+            if (imxVideoConvert)
+                gst_element_sync_state_with_parent(imxVideoConvert);
+            gst_element_sync_state_with_parent(upload);
+            gst_element_sync_state_with_parent(colorconvert);
+
+            gst_query_set_accept_caps_result(query, TRUE);
+            GST_PAD_PROBE_INFO_FLOW_RETURN(info) = GST_FLOW_OK;
+            return GST_PAD_PROBE_HANDLED;
+        });
     }
 
     g_object_set(sink->priv->appSink.get(), "caps", caps.get(), nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -398,7 +398,7 @@ template<class T>
 class PadProbeHandle : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PadProbeHandle<T>, WTF::DestructionThread::Main> {
 public:
     using PadProbeCallback = Function<GstPadProbeReturn(const RefPtr<T>&, const GRefPtr<GstPad>&, GstPadProbeInfo*)>;
-    static Ref<PadProbeHandle> create(const T& owner, GRefPtr<GstPad>&& pad, GstPadProbeType probeType, PadProbeCallback&& callback)
+    static RefPtr<PadProbeHandle> create(const T& owner, GRefPtr<GstPad>&& pad, GstPadProbeType probeType, PadProbeCallback&& callback)
     {
         return adoptRef(*new PadProbeHandle<T>(owner, WTF::move(pad), probeType, WTF::move(callback)));
     }


### PR DESCRIPTION
#### 8e4cc2301a1e79b0e61eb2f9217742a8124c415d
<pre>
[GStreamer] Migrate GLVideoSink to PadProbeHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=316556">https://bugs.webkit.org/show_bug.cgi?id=316556</a>

Reviewed by Xabier Rodriguez-Calvar.

Refactoring migrating from gst_pad_add_probe to PadProbeHandle.

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkConstructed):
(sinkPadProbeCallback): Deleted.

Canonical link: <a href="https://commits.webkit.org/314895@main">https://commits.webkit.org/314895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18638782c55603935a692deee52c90d47ff30083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176324 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130122 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31504 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30205 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178865 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138509 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138399 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37323 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41532 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104552 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26658 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113117 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39433 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4756 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->