### PR TITLE
Use default member initializers for SVGTransformDistance data members

### DIFF
--- a/Source/WebCore/svg/SVGTransformDistance.cpp
+++ b/Source/WebCore/svg/SVGTransformDistance.cpp
@@ -26,14 +26,6 @@
 
 namespace WebCore {
     
-SVGTransformDistance::SVGTransformDistance()
-    : m_type(SVGTransformValue::SVG_TRANSFORM_UNKNOWN)
-    , m_angle(0)
-    , m_cx(0)
-    , m_cy(0)
-{
-}
-
 SVGTransformDistance::SVGTransformDistance(SVGTransformValue::SVGTransformType type, float angle, float cx, float cy, const AffineTransform& transform)
     : m_type(type)
     , m_angle(angle)
@@ -45,9 +37,6 @@ SVGTransformDistance::SVGTransformDistance(SVGTransformValue::SVGTransformType t
 
 SVGTransformDistance::SVGTransformDistance(const SVGTransformValue& fromSVGTransform, const SVGTransformValue& toSVGTransform)
     : m_type(fromSVGTransform.type())
-    , m_angle(0)
-    , m_cx(0)
-    , m_cy(0)
 {
     ASSERT(m_type == toSVGTransform.type());
     

--- a/Source/WebCore/svg/SVGTransformDistance.h
+++ b/Source/WebCore/svg/SVGTransformDistance.h
@@ -27,9 +27,9 @@ class AffineTransform;
     
 class SVGTransformDistance {
 public:
-    SVGTransformDistance();
+    SVGTransformDistance() = default;
     SVGTransformDistance(const SVGTransformValue& fromTransform, const SVGTransformValue& toTransform);
-    
+
     SVGTransformDistance scaledDistance(float scaleFactor) const;
     SVGTransformValue addToSVGTransform(const SVGTransformValue&) const;
 
@@ -37,11 +37,11 @@ public:
 
 private:
     SVGTransformDistance(SVGTransformValue::SVGTransformType, float angle, float cx, float cy, const AffineTransform&);
-        
-    SVGTransformValue::SVGTransformType m_type;
-    float m_angle;
-    float m_cx;
-    float m_cy;
+
+    SVGTransformValue::SVGTransformType m_type { SVGTransformValue::SVG_TRANSFORM_UNKNOWN };
+    float m_angle { 0 };
+    float m_cx { 0 };
+    float m_cy { 0 };
     AffineTransform m_transform; // for storing scale, translation or matrix transforms
 };
 


### PR DESCRIPTION
#### 8240c6a579435092c5ebdac70e81c154598e5174
<pre>
Use default member initializers for SVGTransformDistance data members
<a href="https://bugs.webkit.org/show_bug.cgi?id=316558">https://bugs.webkit.org/show_bug.cgi?id=316558</a>
<a href="https://rdar.apple.com/179026455">rdar://179026455</a>

Reviewed by Taher Ali.

SVGTransformDistance has three constructors, and the m_type/m_angle/m_cx/m_cy
scalar members had no default initializers in the header, so two of the three
constructors redundantly re-initialized them to UNKNOWN/0/0/0.

Move { SVG_TRANSFORM_UNKNOWN }, { 0 }, { 0 }, { 0 } to default member
initializers in the header so every constructor stays in sync:

- The default constructor becomes = default.
- The from/to constructor drops the redundant m_angle/m_cx/m_cy inits, keeping
  only m_type(fromSVGTransform.type()).

No change in behavior.

* Source/WebCore/svg/SVGTransformDistance.cpp:
(WebCore::SVGTransformDistance::SVGTransformDistance):
* Source/WebCore/svg/SVGTransformDistance.h:

Canonical link: <a href="https://commits.webkit.org/314781@main">https://commits.webkit.org/314781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e661c7597fa2b63939467404d27214dd446420d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176177 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ced6517-4f04-4165-95ff-28ea2e5338a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129990 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1480819d-a7f0-4d41-8cb0-4d3b2810425b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110507 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd922591-8d8c-416d-9667-c404fc4fef47) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30078 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24916 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178718 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31618 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138367 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37239 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41386 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104344 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26532 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39287 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4630 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39431 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->