### PR TITLE
Move to API for grammar checking.

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -261,6 +261,13 @@ selectors = [
     { name = "requestProofreadingReviewOfString:range:language:options:completionHandler:", class = "UITextChecker" },
 ]
 
+ [[temporary-usage]]
+ request = "rdar://165789536"
+ cleanup = "rdar://179184814"
+ selectors = [
+     { name = "requestGrammarCheckingOfString:range:waitForAllResults:completionHandler:", class = "UITextChecker" },
+ ]
+
 [[temporary-usage]]
 request = "rdar://165789536"
 cleanup = "rdar://165842824"

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1118,6 +1118,7 @@ typedef NS_ENUM(NSInteger, _UIScrollViewDecelerationTrackingBehavior) {
 @end
 
 @interface UITextChecker (Staging_165842824)
+- (void)requestGrammarCheckingOfString:(NSString *)stringToCheck range:(NSRange)range waitForAllResults:(BOOL)waitForAllResults completionHandler:(void (^)(NSArray<NSTextCheckingResult *> *results))completionHandler;
 - (void)requestProofreadingReviewOfString:(NSString *)stringToCheck range:(NSRange)range language:(NSString *)language options:(NSDictionary<NSString *, id> *)options completionHandler:(void (^)(NSArray<NSTextCheckingResult *> *results))completionHandler;
 @end
 

--- a/Source/WebKit/UIProcess/ios/TextCheckerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/TextCheckerIOS.mm
@@ -404,19 +404,28 @@ void TextChecker::requestExtendedCheckingOfString(Ref<TextCheckerCompletion>&& t
         return;
     }
 
-    if (![textChecker respondsToSelector:@selector(requestProofreadingReviewOfString:range:language:options:completionHandler:)]) {
+    bool hasGrammarCheckingAPI = [textChecker respondsToSelector:@selector(requestGrammarCheckingOfString:range:waitForAllResults:completionHandler:)];
+    bool hasProofreadingReviewSPI = [textChecker respondsToSelector:@selector(requestProofreadingReviewOfString:range:language:options:completionHandler:)];
+    if (!hasGrammarCheckingAPI && !hasProofreadingReviewSPI) {
         textCheckerCompletion->didFinishCheckingText({ });
         return;
     }
 
     RetainPtr textString = textCheckerCompletion->textCheckingRequestData().text().createNSString();
     NSRange range = NSMakeRange(0, textCheckerCompletion->textCheckingRequestData().text().length());
-    [textChecker requestProofreadingReviewOfString:textString.get() range:range language:nil options:@{ } completionHandler:makeBlockPtr([textCompletion = WTF::move(textCheckerCompletion)](NSArray<NSTextCheckingResult *> *incomingResults) mutable {
+    auto completionHandler = makeBlockPtr([textCompletion = WTF::move(textCheckerCompletion)](NSArray<NSTextCheckingResult *> *incomingResults) mutable {
         auto results = convertExtendedCheckingResults(incomingResults);
         callOnMainRunLoop([textCompletion = WTF::move(textCompletion), results = crossThreadCopy(WTF::move(results))] {
             textCompletion->didFinishCheckingText(results);
         });
-    }).get()];
+    });
+
+    if (hasGrammarCheckingAPI) {
+        [textChecker requestGrammarCheckingOfString:textString.get() range:range waitForAllResults:YES completionHandler:completionHandler.get()];
+        return;
+    }
+
+    [textChecker requestProofreadingReviewOfString:textString.get() range:range language:nil options:@{ } completionHandler:completionHandler.get()];
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 10ed2f46571b4429b35f98fa79ccbab10ad5fdb9
<pre>
Move to API for grammar checking.
<a href="https://bugs.webkit.org/show_bug.cgi?id=316562">https://bugs.webkit.org/show_bug.cgi?id=316562</a>
<a href="https://rdar.apple.com/165842824">rdar://165842824</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

Moving from temporary SPI to shipping API. Not removing
the old SPI calls and allowances yet, as this is very
new and people need time to update their systems and tools.
Will completely remove SPI in a later step.

* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/TextCheckerIOS.mm:
(WebKit::TextChecker::requestExtendedCheckingOfString):

Canonical link: <a href="https://commits.webkit.org/314976@main">https://commits.webkit.org/314976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ec52a83cc056c5ae37079245b18fcbada5d133c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176666 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a011c71a-9af2-4dff-9d07-144379a1e0b2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130410 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1504634-6e48-4e0c-b92a-3ff80d170d62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110927 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04ee4b18-3cd1-4e97-9b4b-04db2078ed9f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31805 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30504 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25399 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141792 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179206 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138812 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138697 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37370 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41866 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105026 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26959 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113616 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39767 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5060 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40018 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39912 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->