### PR TITLE
Remove unused code in WKPagePrivateMac.mm

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -891,7 +891,6 @@ symbols = [
     "SecTrustSetClientAuditToken",
     "_AXSEnhanceTextLegibilityEnabled",
     "_CFNetworkHTTPConnectionCacheSetLimit",
-    "_CFNetworkIsKnownHSTSHostWithSession",
     "_CFURLStorageSessionCopyCookieStorage",
     "_kCFURLConnectionPropertyShouldSniff",
     "kAXSEnhanceTextLegibilityChangedNotification",

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h
@@ -37,32 +37,8 @@ extern "C" {
 #ifdef __OBJC__
 
 @class WKWebView;
-@class _WKRemoteObjectRegistry;
-
-@protocol _WKObservablePageState
-
-@property (nonatomic, readonly, copy) NSString *title;
-@property (nonatomic, readonly, copy) NSURL *URL;
-@property (nonatomic, readonly, getter=isLoading) BOOL loading;
-@property (nonatomic, readonly) double estimatedProgress;
-@property (nonatomic, readonly) BOOL hasOnlySecureContent;
-@property (nonatomic, readonly) BOOL _webProcessIsResponsive;
-
-// Not KVO compliant.
-@property (nonatomic, readonly) NSURL *unreachableURL;
-@property (nonatomic, readonly) SecTrustRef serverTrust;
-
-@end
-
-WK_EXPORT id <_WKObservablePageState> WKPageCreateObservableState(WKPageRef page) NS_RETURNS_RETAINED;
-WK_EXPORT _WKRemoteObjectRegistry *WKPageGetObjectRegistry(WKPageRef page);
-
-@protocol _WKFullscreenDelegate;
-WK_EXPORT void WKPageSetFullscreenDelegate(WKPageRef page, id <_WKFullscreenDelegate>);
-WK_EXPORT id <_WKFullscreenDelegate> WKPageGetFullscreenDelegate(WKPageRef page);
 
 @class WKNavigation;
-WK_EXPORT WKNavigation *WKPageLoadURLRequestReturningNavigation(WKPageRef page, WKURLRequestRef request);
 WK_EXPORT WKNavigation *WKPageLoadFileReturningNavigation(WKPageRef page, WKURLRef fileURL, WKURLRef resourceDirectoryURL);
 
 WK_EXPORT WKWebView *WKPageGetWebView(WKPageRef page);
@@ -74,8 +50,6 @@ WK_EXPORT NSArray *WKPageGetAccessibilityWebProcessDebugInfoForAllProcesses(WKPa
 WK_EXPORT void WKPageAccessibilityClearIsolatedTree(WKPageRef page);
 
 #endif // __OBJC__
-
-WK_EXPORT bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url);
 
 #if !TARGET_OS_IPHONE
 WK_EXPORT bool WKPageIsPlayingVideoInPictureInPicture(WKPageRef page);

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -40,107 +40,6 @@
 #import "WebProcessPool.h"
 #import <wtf/MainThread.h>
 
-@interface WKObservablePageState : NSObject <_WKObservablePageState> {
-    @package
-    RefPtr<WebKit::WebPageProxy> _page;
-    RefPtr<WebKit::PageLoadStateObserver> _observer;
-}
-
-@end
-
-@implementation WKObservablePageState
-
-- (id)initWithPage:(RefPtr<WebKit::WebPageProxy>&&)page
-{
-    if (!(self = [super init]))
-        return nil;
-
-    _page = WTF::move(page);
-    Ref observer = WebKit::PageLoadStateObserver::create(self, @"URL");
-    _observer = observer.get();
-    protect(protect(*_page)->pageLoadState())->addObserver(observer.get());
-
-    return self;
-}
-
-- (void)dealloc
-{
-    protect(*_observer)->clearObject();
-
-    ensureOnMainRunLoop([page = WTF::move(_page), observer = std::exchange(_observer, nullptr)] {
-        protect(page->pageLoadState())->removeObserver(*observer);
-    });
-
-    [super dealloc];
-}
-
-- (BOOL)isLoading
-{
-    return protect(protect(*_page)->pageLoadState())->isLoading();
-}
-
-- (NSString *)title
-{
-    return protect(protect(*_page)->pageLoadState())->title().createNSString().autorelease();
-}
-
-- (NSURL *)URL
-{
-    return protect(protect(*_page)->pageLoadState())->activeURL().createNSURL().autorelease();
-}
-
-- (BOOL)hasOnlySecureContent
-{
-    return protect(protect(*_page)->pageLoadState())->hasOnlySecureContent();
-}
-
-- (BOOL)_webProcessIsResponsive
-{
-    return (*_page).legacyMainFrameProcess().isResponsive();
-}
-
-- (double)estimatedProgress
-{
-    return protect(*_page)->estimatedProgress();
-}
-
-- (NSURL *)unreachableURL
-{
-    return (*_page).pageLoadState().unreachableURL().createNSURL().autorelease();
-}
-
-- (SecTrustRef)serverTrust
-{
-    return (*_page).pageLoadState().certificateInfo().trust().get();
-}
-
-@end
-
-id <_WKObservablePageState> WKPageCreateObservableState(WKPageRef pageRef)
-{
-    SUPPRESS_RETAINPTR_CTOR_ADOPT return [[WKObservablePageState alloc] initWithPage:WebKit::toImpl(pageRef)];
-}
-
-_WKRemoteObjectRegistry *WKPageGetObjectRegistry(WKPageRef pageRef)
-{
-#if PLATFORM(MAC)
-    return protect(WebKit::toImpl(pageRef))->remoteObjectRegistry();
-#else
-    return nil;
-#endif
-}
-
-bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url)
-{
-    return protect(protect(WebKit::toImpl(page))->configuration().processPool())->isURLKnownHSTSHost(WebKit::toImpl(url)->string());
-}
-
-WKNavigation *WKPageLoadURLRequestReturningNavigation(WKPageRef pageRef, WKURLRequestRef urlRequestRef)
-{
-    auto resourceRequest = WebKit::toImpl(urlRequestRef)->resourceRequest();
-    return WebKit::wrapper(protect(WebKit::toImpl(pageRef))->loadRequest(WTF::move(resourceRequest))).autorelease();
-}
-
 WKNavigation *WKPageLoadFileReturningNavigation(WKPageRef pageRef, WKURLRef fileURL, WKURLRef resourceDirectoryURL)
 {
     return WebKit::wrapper(protect(WebKit::toImpl(pageRef))->loadFile(WebKit::toWTFString(fileURL), WebKit::toWTFString(resourceDirectoryURL))).autorelease();
@@ -162,22 +61,6 @@ bool WKPageIsPlayingVideoInEnhancedFullscreen(WKPageRef pageRef)
     return WKPageIsPlayingVideoInPictureInPicture(pageRef);
 }
 #endif
-
-void WKPageSetFullscreenDelegate(WKPageRef page, id <_WKFullscreenDelegate> delegate)
-{
-#if ENABLE(FULLSCREEN_API)
-    downcast<WebKit::FullscreenClient>(WebKit::toImpl(page)->fullscreenClient()).setDelegate(delegate);
-#endif
-}
-
-id <_WKFullscreenDelegate> WKPageGetFullscreenDelegate(WKPageRef page)
-{
-#if ENABLE(FULLSCREEN_API)
-    return downcast<WebKit::FullscreenClient>(WebKit::toImpl(page)->fullscreenClient()).delegate().autorelease();
-#else
-    return nil;
-#endif
-}
 
 NSDictionary *WKPageGetAccessibilityWebProcessDebugInfo(WKPageRef pageRef)
 {

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1111,13 +1111,6 @@ void WebProcessPool::setNotifyState(const String& name, int status, uint64_t sta
 
 #endif
 
-bool WebProcessPool::isURLKnownHSTSHost(const String& urlString) const
-{
-    RetainPtr<CFURLRef> url = URL { urlString }.createCFURL();
-
-    return _CFNetworkIsKnownHSTSHostWithSession(url.get(), nullptr);
-}
-
 // FIXME: Deprecated. Left here until a final decision is made.
 void WebProcessPool::setCookieStoragePartitioningEnabled(bool enabled)
 {

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -423,8 +423,6 @@ public:
     static void NODELETE setInvalidMessageCallback(void (*)(WKStringRef));
     static void didReceiveInvalidMessage(IPC::MessageName);
 
-    bool isURLKnownHSTSHost(const String& urlString) const;
-
     static void registerGlobalURLSchemeAsHavingCustomProtocolHandlers(const String&);
     static void unregisterGlobalURLSchemeAsHavingCustomProtocolHandlers(const String&);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/ResponsivenessTimerCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/ResponsivenessTimerCrash.mm
@@ -77,15 +77,6 @@ TEST(WebKit, ResponsivenessTimerCrash)
         webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
         
         [webView addObserver:observer.get() forKeyPath:@"_webProcessIsResponsive" options:0 context:nullptr];
-
-        auto pageRef = [webView _pageRefForTransitionToWKWebView];
-        
-        for (size_t i = 0; i < 50; ++i) {
-            RetainPtr<id> observableState = adoptNS(WKPageCreateObservableState(pageRef));
-            [observableState.get() addObserver:observer.get() forKeyPath:@"_webProcessIsResponsive" options:0 context:nullptr];
-            observableStates.add(WTF::move(observableState));
-        }
-
         [webView synchronouslyLoadHTMLString:@"<script>document.addEventListener('keydown', function(){while(1){}});</script>"];
         [webView typeCharacter:'a'];
     }


### PR DESCRIPTION
#### 047a6414f50cd86867933555cd83e6796b27d498
<pre>
Remove unused code in WKPagePrivateMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=316565">https://bugs.webkit.org/show_bug.cgi?id=316565</a>
<a href="https://rdar.apple.com/179030994">rdar://179030994</a>

Reviewed by Per Arne Vollan.

There is a lot of code that hasn&apos;t been used in many years.  Remove it.
I also remove the piece of the unit test ResponsivenessTimerCrash that tested
the code that no longer exists.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/ResponsivenessTimerCrash.mm

* Source/WebKit/Configurations/AllowedSPI-legacy.toml:
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h:
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(-[WKObservablePageState initWithPage:]): Deleted.
(-[WKObservablePageState dealloc]): Deleted.
(-[WKObservablePageState isLoading]): Deleted.
(-[WKObservablePageState title]): Deleted.
(-[WKObservablePageState URL]): Deleted.
(-[WKObservablePageState hasOnlySecureContent]): Deleted.
(-[WKObservablePageState _webProcessIsResponsive]): Deleted.
(-[WKObservablePageState estimatedProgress]): Deleted.
(-[WKObservablePageState unreachableURL]): Deleted.
(-[WKObservablePageState serverTrust]): Deleted.
(WKPageCreateObservableState): Deleted.
(WKPageGetObjectRegistry): Deleted.
(WKPageIsURLKnownHSTSHost): Deleted.
(WKPageLoadURLRequestReturningNavigation): Deleted.
(WKPageSetFullscreenDelegate): Deleted.
(WKPageGetFullscreenDelegate): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::isURLKnownHSTSHost const): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/ResponsivenessTimerCrash.mm:
(TestWebKitAPI::TEST(WebKit, ResponsivenessTimerCrash)):

Canonical link: <a href="https://commits.webkit.org/314973@main">https://commits.webkit.org/314973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60aef959d7425ed52aaded5a68408c389c9c4db3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176669 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e40e38aa-8df0-4471-a418-3ac98fae562d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32835 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150596 "Found 1 new API test failure: TestWebKitAPI.WritingTools.ShowDetailsForSuggestions (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110935 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/325f4ece-ddbe-48ed-830e-a5d7413c6cb7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30509 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25402 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179209 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138815 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138700 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41869 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105029 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26962 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113619 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39770 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5063 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->