### PR TITLE
[JSC][Temporal] Cache ICU UCalendar per CalendarID in CalendarICUBridge

### DIFF
--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -32,6 +32,8 @@
 #include <unicode/ucal.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DateMath.h>
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -57,11 +59,9 @@ static CString buildICULocale(StringView calendarId)
     return makeString("und@calendar="_s, icuKeyword).utf8();
 }
 
-// openCalendar — internal: opens ICU UCalendar for the given CalendarID, set to UTC.
+// buildCalendarTemplate — internal: opens ICU UCalendar for the given CalendarID, set to UTC.
 // NOTE: For Gregory/ISO/Japanese/Buddhist/Roc: sets Gregorian change date to -infinity for proleptic Gregorian arithmetic.
-// FIXME: Cache one UCalendar per CalendarID in a Vector<std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>, numberOfCalendarIDs>
-//        to avoid repeated ucal_open overhead on hot paths like calendarYear/calendarMonth/calendarDay.
-static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendar(CalendarID calendarId)
+static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> buildCalendarTemplate(CalendarID calendarId)
 {
     auto str = calendarIDToString(calendarId);
     auto locale = buildICULocale(str);
@@ -84,34 +84,77 @@ static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendar(CalendarI
     return cal;
 }
 
+struct CalendarCacheEntry {
+    WTF::Lock useLock;
+    std::atomic<bool> initialized { false };
+    UCalendar* cal { nullptr };
+};
+
+static CalendarCacheEntry& calendarCacheEntry(CalendarID calendarId)
+{
+    static LazyNeverDestroyed<Vector<CalendarCacheEntry>> cache;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        cache.construct(intlAvailableCalendars().size());
+    });
+    return cache.get()[calendarId];
+}
+
+static void ensureCalendar(CalendarCacheEntry& entry, CalendarID calendarId)
+{
+    if (entry.initialized.load(std::memory_order_acquire))
+        return;
+    WTF::Locker locker { entry.useLock };
+    if (!entry.initialized.load(std::memory_order_relaxed)) {
+        auto owned = buildCalendarTemplate(calendarId);
+        entry.cal = owned.release();
+        entry.initialized.store(true, std::memory_order_release);
+    }
+}
+
+template<typename F>
+static auto withCalendar(CalendarID calendarId, F&& fn) -> decltype(fn(static_cast<UCalendar*>(nullptr)))
+{
+    CalendarCacheEntry& entry = calendarCacheEntry(calendarId);
+    ensureCalendar(entry, calendarId);
+    WTF::Locker locker { entry.useLock };
+    if (entry.cal)
+        ucal_clear(entry.cal);
+    return fn(entry.cal);
+}
+
 // lunarCalendarExtendedYearFor1972 — probes UCAL_EXTENDED_YEAR for the given lunisolar calendar
 // at ISO 1972-02-15. Returns 1972 on ISO-proleptic ICU; epoch-based year on older Apple ICU.
 // Chinese uses epoch 2637 BCE -> returns 4609 on ICU ≥76; Dangi uses epoch 2333 BCE -> returns 4305.
 // Result is cached per calendar: ICU version is fixed for the process lifetime.
 int32_t lunarCalendarExtendedYearFor1972(CalendarID calendarId)
 {
-    static int32_t chineseCached = INT32_MIN;
-    static int32_t dangiCached = INT32_MIN;
-    int32_t& cached = (calendarId == dangiCalendarID()) ? dangiCached : chineseCached;
-    if (cached != INT32_MIN)
-        return cached;
-    auto cal = openCalendar(calendarId);
-    if (!cal)
-        return cached = 1972; // fallback: assume ISO-proleptic
+    static std::atomic<int32_t> chineseCached { INT32_MIN };
+    static std::atomic<int32_t> dangiCached { INT32_MIN };
+    auto& cached = (calendarId == dangiCalendarID()) ? dangiCached : chineseCached;
+    int32_t value = cached.load(std::memory_order_relaxed);
+    if (value != INT32_MIN)
+        return value;
     // Use ucal_setMillis with a precomputed ISO epoch time — NOT ucal_setDateTime which
     // sets calendar-native fields (not ISO fields) on a non-Gregorian calendar.
     // ISO 1972-02-15 00:00:00 UTC = 66,960,000,000 ms from Unix epoch (1970-01-01).
     static constexpr double iso1972Feb15EpochMs = 66960000000.0;
-    UErrorCode status = U_ZERO_ERROR;
-    ucal_setMillis(cal.get(), iso1972Feb15EpochMs, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return cached = 1972; // fallback: assume ISO-proleptic
-    int32_t extYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return cached = 1972; // fallback: assume ISO-proleptic
-    // Return the raw EXTENDED_YEAR: 1972 on ISO-proleptic ICU,
-    // epoch-based year (whatever the current ICU uses) on older Apple ICU.
-    return cached = extYear;
+    value = withCalendar(calendarId, [&](UCalendar* cal) -> int32_t {
+        if (!cal)
+            return 1972; // fallback: assume ISO-proleptic
+        UErrorCode status = U_ZERO_ERROR;
+        ucal_setMillis(cal, iso1972Feb15EpochMs, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return 1972; // fallback: assume ISO-proleptic
+        int32_t extYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return 1972; // fallback: assume ISO-proleptic
+        // Return the raw EXTENDED_YEAR: 1972 on ISO-proleptic ICU,
+        // epoch-based year (whatever the current ICU uses) on older Apple ICU.
+        return extYear;
+    });
+    cached.store(value, std::memory_order_relaxed);
+    return value;
 }
 
 // isoDateToEpochMs — internal: converts ISO PlainDate to epoch ms at noon UTC (avoids DST boundary issues)
@@ -165,35 +208,37 @@ static constexpr auto japaneseEras = WTF::toArray<JapaneseEra>({
 // Bridges ICU4C's UCAL_ERA integer to a Gregorian start year for lookup in japaneseEras[].
 static std::optional<int32_t> japaneseEraStartYear(int32_t icuEraCode)
 {
-    auto cal = openCalendar(japaneseCalendarID());
-    if (!cal)
-        return std::nullopt;
-    UErrorCode status = U_ZERO_ERROR;
-    ucal_set(cal.get(), UCAL_ERA, icuEraCode);
-    // YEAR=2: YEAR=1/January doesn't exist for eras starting mid-year (e.g. Showa on Dec 25).
-    ucal_set(cal.get(), UCAL_YEAR, 2);
-    ucal_set(cal.get(), UCAL_MONTH, UCAL_JANUARY);
-    ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
-    int32_t extYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return std::nullopt;
-    return extYear - 1; // EXTENDED_YEAR of YEAR=2/Jan 1 is eraStartYear+1.
+    return withCalendar(japaneseCalendarID(), [&](UCalendar* cal) -> std::optional<int32_t> {
+        if (!cal)
+            return std::nullopt;
+        UErrorCode status = U_ZERO_ERROR;
+        ucal_set(cal, UCAL_ERA, icuEraCode);
+        ucal_set(cal, UCAL_YEAR, 2);
+        // YEAR=2: YEAR=1/January doesn't exist for eras starting mid-year (e.g. Showa on Dec 25).
+        ucal_set(cal, UCAL_MONTH, UCAL_JANUARY);
+        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+        int32_t extYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        return extYear - 1; // EXTENDED_YEAR of YEAR=2/Jan 1 is eraStartYear+1.
+    });
 }
 
 // japaneseEraCode — inverse of japaneseEraStartYear: derives the ICU era integer from a known era start year.
 static std::optional<int32_t> japaneseEraCode(int32_t startYear)
 {
-    auto cal = openCalendar(japaneseCalendarID());
-    if (!cal)
-        return std::nullopt;
-    UErrorCode status = U_ZERO_ERROR;
-    ucal_set(cal.get(), UCAL_EXTENDED_YEAR, startYear + 1); // startYear+1/Jan 1 is always within the era.
-    ucal_set(cal.get(), UCAL_MONTH, UCAL_JANUARY);
-    ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
-    int32_t eraCode = ucal_get(cal.get(), UCAL_ERA, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return std::nullopt;
-    return eraCode;
+    return withCalendar(japaneseCalendarID(), [&](UCalendar* cal) -> std::optional<int32_t> {
+        if (!cal)
+            return std::nullopt;
+        UErrorCode status = U_ZERO_ERROR;
+        ucal_set(cal, UCAL_EXTENDED_YEAR, startYear + 1); // startYear+1/Jan 1 is always within the era.
+        ucal_set(cal, UCAL_MONTH, UCAL_JANUARY);
+        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+        int32_t eraCode = ucal_get(cal, UCAL_ERA, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return std::nullopt;
+        return eraCode;
+    });
 }
 
 // mapICUEraToTemporalEra — ICU4C has no locale-independent era identifier API (UDAT_ERA_NAMES is locale-dependent).
@@ -236,10 +281,11 @@ static std::optional<String> mapICUEraToTemporalEra(CalendarID calendarId, int32
     return std::nullopt;
 }
 
-// computeMonthCode — internal: computes monthCode string from ICU calendar state (e.g. "M05L" for Hebrew Adar I)
+// getMonthCode — internal: returns monthCode string from ICU calendar state (e.g. "M05L" for Hebrew Adar I).
+// Read-only: does not modify cal.
 // icu4x: components/calendar/src/cal/hebrew.rs (Hebrew special case)
 // icu4x: components/calendar/src/cal/chinese_based.rs (Chinese/Dangi IS_LEAP_MONTH)
-static std::optional<String> computeMonthCode(UCalendar* cal, CalendarID calendarId)
+static std::optional<String> getMonthCode(UCalendar* cal, CalendarID calendarId)
 {
     UErrorCode status = U_ZERO_ERROR;
     int32_t ucalMonth = ucal_get(cal, UCAL_MONTH, &status);
@@ -276,6 +322,8 @@ static std::optional<String> computeMonthCode(UCalendar* cal, CalendarID calenda
 
 // computeOrdinalMonth — internal: returns 1-based ordinal month position in year, counting leap months for lunisolar
 // icu4x: components/calendar/src/date.rs Date::month().ordinal
+// NOTE: mutates cal (walks months via ucal_add). Must be the last ICU cal operation in a withCalendar lambda;
+//       withCalendar calls ucal_clear before the next use so no restore is needed.
 static std::optional<uint8_t> computeOrdinalMonth(UCalendar* cal, CalendarID calendarId)
 {
     UErrorCode status = U_ZERO_ERROR;
@@ -286,10 +334,7 @@ static std::optional<uint8_t> computeOrdinalMonth(UCalendar* cal, CalendarID cal
         return static_cast<uint8_t>(month); // For lunisolar: the ordinal month includes leap months.
     // UCAL_MONTH gives the underlying month index (leap months share same index).
     // Count how many months from start of year to current position.
-    int32_t isLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status); // Save current state.
-    if (U_FAILURE(status)) [[unlikely]]
-        return std::nullopt;
-    double savedMs = ucal_getMillis(cal, &status); // Go to the first day of the calendar year.
+    int32_t isLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
     ucal_set(cal, UCAL_MONTH, 0);
@@ -298,7 +343,7 @@ static std::optional<uint8_t> computeOrdinalMonth(UCalendar* cal, CalendarID cal
 
     int32_t ordinal = 1;
     int32_t targetMonth = month - 1; // 0-indexed for comparison with UCAL_MONTH
-    int32_t targetIsLeap = isLeap; // Walk month by month.
+    int32_t targetIsLeap = isLeap;
     for (int i = 0; i < 15; i++) {
         // max 13 months + safety
         int32_t curMonth = ucal_get(cal, UCAL_MONTH, &status);
@@ -315,10 +360,6 @@ static std::optional<uint8_t> computeOrdinalMonth(UCalendar* cal, CalendarID cal
         ordinal++;
     }
 
-    // Restore calendar state.
-    ucal_setMillis(cal, savedMs, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return std::nullopt;
     return static_cast<uint8_t>(ordinal);
 }
 
@@ -376,51 +417,67 @@ static std::optional<int32_t> mapTemporalEraToICUEra(CalendarID calendarId, Stri
 // isoToCalendarFields — no single temporal_rs equivalent; aggregates Calendar::year/month/month_code/day/era into one ICU pass.
 TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
+    struct RawFields {
+        int32_t extendedYear { 0 };
+        int32_t ucalEra { 0 };
+        int32_t ucalYear { 0 };
+        int32_t day { 0 };
+        std::optional<uint8_t> ordinalMonth;
+        std::optional<String> monthCode;
+        bool hasEra { false };
+    };
 
-    UErrorCode status = U_ZERO_ERROR;
+    auto rawOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<RawFields> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+
+        UErrorCode status = U_ZERO_ERROR;
+        RawFields raw;
+        // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; handled below.
+        raw.extendedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        raw.ucalEra = ucal_get(cal, UCAL_ERA, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        raw.ucalYear = ucal_get(cal, UCAL_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        raw.day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        raw.monthCode = getMonthCode(cal, calendarId);
+        if (!raw.monthCode) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        raw.hasEra = calendarHasEras(calendarId);
+        raw.ordinalMonth = computeOrdinalMonth(cal, calendarId);
+        if (!raw.ordinalMonth) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return raw;
+    });
+
+    if (!rawOrError)
+        return makeUnexpected(rawOrError.error());
+    auto& raw = *rawOrError;
+
     CalendarFields fields;
-    // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; handled below.
-    fields.year = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    if (calendarId == rocCalendarID()) {
-        int32_t era = ucal_get(cal.get(), UCAL_ERA, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        fields.year = !era ? -(eraYear - 1) : eraYear;
-    }
-    auto ordinalMonth = computeOrdinalMonth(cal.get(), calendarId);
-    if (!ordinalMonth) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    fields.month = *ordinalMonth;
-    fields.day = static_cast<uint8_t>(ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status));
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    fields.isLeapMonth = !!ucal_get(cal.get(), UCAL_IS_LEAP_MONTH, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    auto monthCode = computeMonthCode(cal.get(), calendarId);
-    if (!monthCode) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    fields.monthCode = WTF::move(*monthCode);
+    fields.year = raw.extendedYear;
+    if (calendarId == rocCalendarID())
+        fields.year = !raw.ucalEra ? -(raw.ucalYear - 1) : raw.ucalYear;
+    fields.month = *raw.ordinalMonth;
+    fields.day = static_cast<uint8_t>(raw.day);
+    fields.monthCode = WTF::move(*raw.monthCode);
 
-    if (calendarHasEras(calendarId)) {
-        int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        fields.era = mapICUEraToTemporalEra(calendarId, icuEra);
-        // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
-        fields.eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
+    // isLeapMonth is re-derived from the month code (avoids needing UCAL_IS_LEAP_MONTH in raw)
+    fields.isLeapMonth = fields.monthCode.endsWith("L"_s);
+
+    if (raw.hasEra) {
+        // mapICUEraToTemporalEra for Japanese calls japaneseEraStartYear which uses withCalendar
+        // on the same calendarId — safe because the outer lock was released above.
+        fields.era = mapICUEraToTemporalEra(calendarId, raw.ucalEra);
+        fields.eraYear = raw.ucalYear;
         if (calendarId == japaneseCalendarID()) {
             if (isoDate.year() < 1873) {
                 fields.era = isoDate.year() > 0 ? "ce"_s : "bce"_s;
@@ -442,28 +499,27 @@ TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const 
 TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the extended year of isoDate in calendarId.
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-
-    UErrorCode status = U_ZERO_ERROR;
-    // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; compute from era+year.
-    if (calendarId == rocCalendarID()) {
-        int32_t era = ucal_get(cal.get(), UCAL_ERA, &status);
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; compute from era+year.
+        if (calendarId == rocCalendarID()) {
+            int32_t era = ucal_get(cal, UCAL_ERA, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            int32_t eraYear = ucal_get(cal, UCAL_YEAR, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            return !era ? -(eraYear - 1) : eraYear;
+        }
+        auto result = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
-        int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        return !era ? -(eraYear - 1) : eraYear;
-    }
-    auto result = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return result;
+        return result;
+    });
 }
 
 // calendarMonth — temporal_rs: Calendar::month (src/builtins/core/calendar.rs)
@@ -478,15 +534,16 @@ TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::Plai
     // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
         return isoDate.month();
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    auto ordinal = computeOrdinalMonth(cal.get(), calendarId);
-    if (!ordinal) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return *ordinal;
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        auto ordinal = computeOrdinalMonth(cal, calendarId);
+        if (!ordinal) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return *ordinal;
+    });
 }
 
 // calendarMonthCode — temporal_rs: Calendar::month_code (src/builtins/core/calendar.rs)
@@ -501,15 +558,16 @@ TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::P
     // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month code directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
         return ISO8601::monthCode(isoDate.month());
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    auto code = computeMonthCode(cal.get(), calendarId);
-    if (!code) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return WTF::move(*code);
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<String> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        auto code = getMonthCode(cal, calendarId);
+        if (!code) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return WTF::move(*code);
+    });
 }
 
 // calendarDay — temporal_rs: Calendar::day (src/builtins/core/calendar.rs)
@@ -524,16 +582,17 @@ TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainD
     // NOTE: Japanese pre-1873 "ce"/"bce" eras return ISO day directly to bypass ICU Julian conversion.
     if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
         return isoDate.day();
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    UErrorCode status = U_ZERO_ERROR;
-    int32_t day = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return static_cast<uint8_t>(day);
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<uint8_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        int32_t day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return static_cast<uint8_t>(day);
+    });
 }
 
 // calendarEra — temporal_rs: Calendar::era (src/builtins/core/calendar.rs)
@@ -549,18 +608,24 @@ TemporalResult<std::optional<String>> calendarEra(CalendarID calendarId, const I
         return std::optional<String>(std::nullopt);
     // 2. Return the era string for isoDate in calendarId (e.g. "ce", "bce", "reiwa").
     // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    UErrorCode status = U_ZERO_ERROR;
-    int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
     if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
         return std::optional<String>(isoDate.year() > 0 ? String("ce"_s) : String("bce"_s));
-    return mapICUEraToTemporalEra(calendarId, icuEra);
+    // Read UCAL_ERA inside the lock, then map to era string outside (mapICUEraToTemporalEra
+    // for Japanese calls japaneseEraStartYear which needs its own withCalendar call).
+    auto icuEraOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        int32_t icuEra = ucal_get(cal, UCAL_ERA, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return icuEra;
+    });
+    if (!icuEraOrError)
+        return makeUnexpected(icuEraOrError.error());
+    return mapICUEraToTemporalEra(calendarId, *icuEraOrError);
 }
 
 // calendarEraYear — temporal_rs: Calendar::era_year (src/builtins/core/calendar.rs)
@@ -576,26 +641,38 @@ TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, co
         return std::optional<int32_t>(std::nullopt);
     // 2. Return the era year (year within the current era) of isoDate in calendarId.
     // NOTE: Japanese "ce"/"bce" fallback: eraYear is the Gregorian year.
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    UErrorCode status = U_ZERO_ERROR;
-    int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+        return std::optional<int32_t>(isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year()));
+
+    struct RawEraYear {
+        int32_t eraYear { 0 };
+        int32_t icuEra { 0 };
+    };
+    auto rawOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<RawEraYear> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        RawEraYear raw;
+        raw.eraYear = ucal_get(cal, UCAL_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        raw.icuEra = ucal_get(cal, UCAL_ERA, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return raw;
+    });
+    if (!rawOrError)
+        return makeUnexpected(rawOrError.error());
+
+    int32_t eraYear = rawOrError->eraYear;
     if (calendarId == japaneseCalendarID()) {
-        if (isoDate.year() < 1873)
-            eraYear = isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year());
-        else {
-            int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            auto era = mapICUEraToTemporalEra(calendarId, icuEra);
-            if (era && *era == "ce"_s)
-                eraYear = isoDate.year();
-        }
+        // isoDate.year() >= 1873 here (earlier case handled above).
+        // mapICUEraToTemporalEra calls japaneseEraStartYear which uses its own withCalendar.
+        auto era = mapICUEraToTemporalEra(calendarId, rawOrError->icuEra);
+        if (era && *era == "ce"_s)
+            eraYear = isoDate.year();
     }
     return std::optional<int32_t>(eraYear);
 }
@@ -609,16 +686,17 @@ TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, co
 TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the number of days in the month containing isoDate in calendarId.
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    UErrorCode status = U_ZERO_ERROR;
-    auto result = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return result;
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        auto result = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return result;
+    });
 }
 
 // calendarDaysInYear — temporal_rs: Calendar::days_in_year (src/builtins/core/calendar.rs)
@@ -630,16 +708,17 @@ TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601
 TemporalResult<int32_t> calendarDaysInYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
 {
     // 1. Return the number of days in the year containing isoDate in calendarId.
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    UErrorCode status = U_ZERO_ERROR;
-    int32_t result = ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return result;
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        int32_t result = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return result;
+    });
 }
 
 // calendarMonthsInYear — temporal_rs: Calendar::months_in_year (src/builtins/core/calendar.rs)
@@ -652,44 +731,45 @@ TemporalResult<int32_t> calendarMonthsInYear(CalendarID calendarId, const ISO860
 {
     // 1. Return the number of months in the year containing isoDate in calendarId.
     // NOTE: Lunisolar calendars may have 12 or 13 months; requires walking all months.
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    UErrorCode status = U_ZERO_ERROR;
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<int32_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
 
-    if (calendarIsLunisolar(calendarId)) {
-        // For lunisolar calendars, count months by walking from month 1 to end of year.
-        // cal is local; mutating it has no observable effect outside this function.
-        int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        ucal_set(cal.get(), UCAL_MONTH, 0);
-        ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
-        ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
-        ucal_getMillis(cal.get(), &status); // resolve
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-        int32_t count = 1;
-        for (int i = 0; i < 14; i++) {
-            ucal_add(cal.get(), UCAL_MONTH, 1, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            int32_t curYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+        if (calendarIsLunisolar(calendarId)) {
+            // For lunisolar calendars, count months by walking from month 1 to end of year.
+            // cal is local; mutating it has no observable effect outside this function.
+            int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
-            if (curYear != savedYear)
-                break;
-            count++;
+            ucal_set(cal, UCAL_MONTH, 0);
+            ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+            ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+            ucal_getMillis(cal, &status); // resolve
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            int32_t count = 1;
+            for (int i = 0; i < 14; i++) {
+                ucal_add(cal, UCAL_MONTH, 1, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
+                if (curYear != savedYear)
+                    break;
+                count++;
+            }
+            return count;
         }
-        return count;
-    }
 
-    int32_t result = ucal_getLimit(cal.get(), UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return result;
+        int32_t result = ucal_getLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return result;
+    });
 }
 
 // calendarInLeapYear — temporal_rs: Calendar::in_leap_year (src/builtins/core/calendar.rs)
@@ -709,19 +789,20 @@ TemporalResult<bool> calendarInLeapYear(CalendarID calendarId, const ISO8601::Pl
             return makeUnexpected(months.error());
         return *months > 12;
     }
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    UErrorCode status = U_ZERO_ERROR;
-    int32_t actualMax = ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    int32_t leastMax = ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_LEAST_MAXIMUM, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    return actualMax > leastMax;
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<bool> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        int32_t actualMax = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        int32_t leastMax = ucal_getLimit(cal, UCAL_DAY_OF_YEAR, UCAL_LEAST_MAXIMUM, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return actualMax > leastMax;
+    });
 }
 
 // setCalendarToMonthCode — internal: sets ICU calendar to the first day of the month matching monthCode in the current year.
@@ -748,7 +829,7 @@ static std::optional<int> setCalendarToMonthCode(UCalendar* cal, CalendarID cale
             return std::nullopt;
 
         for (int i = 0; i < 15; i++) {
-            auto curCode = computeMonthCode(cal, calendarId);
+            auto curCode = getMonthCode(cal, calendarId);
             if (!curCode) [[unlikely]]
                 return std::nullopt;
             if (*curCode == monthCode)
@@ -784,7 +865,7 @@ static std::optional<int> setCalendarToMonthCode(UCalendar* cal, CalendarID cale
         return std::nullopt;
 
     for (int i = 0; i < 14; i++) {
-        auto curCode = computeMonthCode(cal, calendarId);
+        auto curCode = getMonthCode(cal, calendarId);
         if (!curCode) [[unlikely]]
             return std::nullopt;
         if (*curCode == monthCode)
@@ -839,47 +920,48 @@ static bool compareSurpassesOrdinally(
 // resolveMonthCodeToOrdinal — internal: resolves a monthCode to its 1-based ordinal position in the given year
 static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& monthCode, int32_t year)
 {
-    auto cal = openCalendar(calendarId);
-    if (!cal)
-        return 1;
-    UErrorCode status = U_ZERO_ERROR;
-    ucal_set(cal.get(), UCAL_EXTENDED_YEAR, year);
-    ucal_set(cal.get(), UCAL_MONTH, 0);
-    ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
-    ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
-    ucal_getMillis(cal.get(), &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return 1;
+    return withCalendar(calendarId, [&](UCalendar* cal) -> int32_t {
+        if (!cal)
+            return 1;
+        UErrorCode status = U_ZERO_ERROR;
+        ucal_set(cal, UCAL_EXTENDED_YEAR, year);
+        ucal_set(cal, UCAL_MONTH, 0);
+        ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+        ucal_getMillis(cal, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return 1;
 
-    int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return 1;
-    int32_t lastOrdinal = 1;
-    for (int i = 0; i < 14; i++) {
-        auto curCode = computeMonthCode(cal.get(), calendarId);
-        if (!curCode) [[unlikely]]
-            return lastOrdinal;
-        if (*curCode == monthCode)
-            return i + 1;
-        if (codePointCompare(*curCode, monthCode) > 0) {
-            // Hebrew M05L (Adar I) constrains FORWARD to M06 (Adar) in non-leap years.
-            // icu4x components/calendar/src/cal/hebrew.rs ordinal_from_month: M05L -> ordinal 6 with Overflow::Constrain.
-            // All other calendars constrain backward to the previous existing month.
-            if (calendarId == hebrewCalendarID() && monthCode == "M05L"_s)
+        int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return 1;
+        int32_t lastOrdinal = 1;
+        for (int i = 0; i < 14; i++) {
+            auto curCode = getMonthCode(cal, calendarId);
+            if (!curCode) [[unlikely]]
+                return lastOrdinal;
+            if (*curCode == monthCode)
                 return i + 1;
-            return lastOrdinal;
+            if (codePointCompare(*curCode, monthCode) > 0) {
+                // Hebrew M05L (Adar I) constrains FORWARD to M06 (Adar) in non-leap years.
+                // icu4x components/calendar/src/cal/hebrew.rs ordinal_from_month: M05L -> ordinal 6 with Overflow::Constrain.
+                // All other calendars constrain backward to the previous existing month.
+                if (calendarId == hebrewCalendarID() && monthCode == "M05L"_s)
+                    return i + 1;
+                return lastOrdinal;
+            }
+            lastOrdinal = i + 1;
+            ucal_add(cal, UCAL_MONTH, 1, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return lastOrdinal;
+            int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return lastOrdinal;
+            if (curYear != savedYear)
+                return lastOrdinal;
         }
-        lastOrdinal = i + 1;
-        ucal_add(cal.get(), UCAL_MONTH, 1, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return lastOrdinal;
-        int32_t curYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return lastOrdinal;
-        if (curYear != savedYear)
-            return lastOrdinal;
-    }
-    return lastOrdinal;
+        return lastOrdinal;
+    });
 }
 
 // nonISODateSurpasses — icu4x: surpasses() (components/calendar/src/calendar_arithmetic.rs) — two-phase lexicographic + ordinal check
@@ -930,83 +1012,85 @@ TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const 
     if (!fitsInt32(duration.years()) || !fitsInt32(duration.months()) || !fitsInt32(totalDays64)) [[unlikely]]
         return makeUnexpected(rangeError("duration is out of the representable range"_s));
 
-    // 4. Open ICU calendar for calendarId.
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    // 5. Set ICU calendar to isoDate.
-    if (!setCalendarToISODate(cal.get(), isoDate)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::PlainDate> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
 
-    // 6. Let origMonthCode and origDay be the source month code and day (preserved across year addition per icu4x).
-    UErrorCode status = U_ZERO_ERROR;
-    auto origMonthCodeOpt = computeMonthCode(cal.get(), calendarId);
-    if (!origMonthCodeOpt) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    String origMonthCode = WTF::move(*origMonthCodeOpt);
-    int32_t originalDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    // 7. If duration.[[Years]] ≠ 0, add years; for lunisolar, re-resolve the original month code in the new year.
-    if (duration.years()) {
-        ucal_add(cal.get(), UCAL_EXTENDED_YEAR, clampTo<int32_t>(duration.years()), &status);
+        // 4. Open ICU calendar for calendarId. (done by withCalendar above)
+        // 5. Set ICU calendar to isoDate.
+        if (!setCalendarToISODate(cal, isoDate)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+
+        // 6. Let origMonthCode and origDay be the source month code and day (preserved across year addition per icu4x).
+        UErrorCode status = U_ZERO_ERROR;
+        auto origMonthCodeOpt = getMonthCode(cal, calendarId);
+        if (!origMonthCodeOpt) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        String origMonthCode = WTF::move(*origMonthCodeOpt);
+        int32_t originalDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
         if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-        if (calendarIsLunisolar(calendarId)) {
-            auto foundState = setCalendarToMonthCode(cal.get(), calendarId, origMonthCode);
-            if (!foundState) [[unlikely]]
-                return makeUnexpected(rangeError("Failed to resolve month code after year addition"_s));
-            //    a. If overflow is ~reject~ and month code doesn't exist in new year, throw RangeError.
-            if (!foundState.value() && overflow == TemporalOverflow::Reject) [[unlikely]]
-                return makeUnexpected(rangeError("month code does not exist in the target year (overflow: reject)"_s));
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        // 7. If duration.[[Years]] ≠ 0, add years; for lunisolar, re-resolve the original month code in the new year.
+        if (duration.years()) {
+            ucal_add(cal, UCAL_EXTENDED_YEAR, clampTo<int32_t>(duration.years()), &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            if (calendarIsLunisolar(calendarId)) {
+                auto foundState = setCalendarToMonthCode(cal, calendarId, origMonthCode);
+                if (!foundState) [[unlikely]]
+                    return makeUnexpected(rangeError("Failed to resolve month code after year addition"_s));
+                //    a. If overflow is ~reject~ and month code doesn't exist in new year, throw RangeError.
+                if (!foundState.value() && overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("month code does not exist in the target year (overflow: reject)"_s));
+            }
         }
-    }
 
-    // 8. If duration.[[Months]] ≠ 0, add months.
-    if (duration.months()) {
-        ucal_add(cal.get(), UCAL_MONTH, clampTo<int32_t>(duration.months()), &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-    }
-    // 9. Clamp or reject the day to the new month's maximum.
-    // NOTE: ucal_add already clamps for constrain. For reject, check if day was reduced.
-    // Do NOT use ucal_set(DAY_OF_MONTH) after ucal_add — causes ICU state corruption on lunisolar calendars.
-    int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    if (overflow == TemporalOverflow::Reject && originalDay > maxDay) [[unlikely]]
-        return makeUnexpected(rangeError("day is out of range for the resulting month (overflow: reject)"_s));
-    int32_t curDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-
-    if (curDay != originalDay && originalDay <= maxDay) {
-        ucal_add(cal.get(), UCAL_DAY_OF_MONTH, originalDay - curDay, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-    } else if (originalDay > maxDay) {
-        int32_t adj = maxDay - curDay;
-        if (adj) {
-            ucal_add(cal.get(), UCAL_DAY_OF_MONTH, adj, &status);
+        // 8. If duration.[[Months]] ≠ 0, add months.
+        if (duration.months()) {
+            ucal_add(cal, UCAL_MONTH, clampTo<int32_t>(duration.months()), &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
         }
-    }
-
-    // 10. Add totalDays.
-    // 11. If result is outside representable range, throw RangeError.
-    int32_t totalDays = static_cast<int32_t>(totalDays64);
-    if (totalDays) {
-        ucal_add(cal.get(), UCAL_DAY_OF_MONTH, totalDays, &status);
+        // 9. Clamp or reject the day to the new month's maximum.
+        // NOTE: ucal_add already clamps for constrain. For reject, check if day was reduced.
+        // Do NOT use ucal_set(DAY_OF_MONTH) after ucal_add — causes ICU state corruption on lunisolar calendars.
+        int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
         if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-    }
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        if (overflow == TemporalOverflow::Reject && originalDay > maxDay) [[unlikely]]
+            return makeUnexpected(rangeError("day is out of range for the resulting month (overflow: reject)"_s));
+        int32_t curDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
 
-    // 12. Return result.
-    auto result = isoDateFromCalendarChecked(cal.get());
-    if (!result) [[unlikely]]
-        return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
-    return *result;
+        if (curDay != originalDay && originalDay <= maxDay) {
+            ucal_add(cal, UCAL_DAY_OF_MONTH, originalDay - curDay, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        } else if (originalDay > maxDay) {
+            int32_t adj = maxDay - curDay;
+            if (adj) {
+                ucal_add(cal, UCAL_DAY_OF_MONTH, adj, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            }
+        }
+
+        // 10. Add totalDays.
+        // 11. If result is outside representable range, throw RangeError.
+        int32_t totalDays = static_cast<int32_t>(totalDays64);
+        if (totalDays) {
+            ucal_add(cal, UCAL_DAY_OF_MONTH, totalDays, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        }
+
+        // 12. Return result.
+        auto result = isoDateFromCalendarChecked(cal);
+        if (!result) [[unlikely]]
+            return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
+        return *result;
+    });
 }
 
 // surpassesMonths — icu4x: SurpassesChecker::surpasses_months (components/calendar/src/calendar_arithmetic.rs)
@@ -1028,7 +1112,7 @@ static std::optional<bool> surpassesMonths(
     int32_t trialYear = ucal_get(trialCal, UCAL_EXTENDED_YEAR, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return std::nullopt;
-    auto trialMonthCode = computeMonthCode(trialCal, calendarId);
+    auto trialMonthCode = getMonthCode(trialCal, calendarId);
     if (!trialMonthCode) [[unlikely]]
         return std::nullopt;
     return nonISODateSurpasses(calendarId, sign, trialYear, *trialMonthCode, sourceDay, 0, targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
@@ -1064,6 +1148,9 @@ static std::optional<bool> setMonths(UCalendar* cal, int32_t sourceDay)
 //   4. Return NonISODateUntil — implementation-defined. (our steps 3–8)
 TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
 {
+    // CalendarDateUntil takes "largestUnit: a date unit" — spec guarantees Year/Month/Week/Day only.
+    ASSERT(largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month || largestUnit == TemporalUnit::Week || largestUnit == TemporalUnit::Day);
+
     // 1. If calendarId is not lunisolar, use ISO proleptic-Gregorian arithmetic (route through diffISODate).
     // NOTE: ICU's 'gregory' uses Julian before 1582, causing field mismatches; always route through ISO.
     if (!calendarIsLunisolar(calendarId))
@@ -1073,144 +1160,195 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     if (largestUnit == TemporalUnit::Day || largestUnit == TemporalUnit::Week)
         return diffISODate(one, two, largestUnit);
 
-    // 3. Open ICU calendars for both endpoints one and two.
-    auto cal1 = openCalendar(calendarId);
-    auto cal2 = openCalendar(calendarId);
-    if (!cal1 || !cal2) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-    if (!setCalendarToISODate(cal1.get(), one) || !setCalendarToISODate(cal2.get(), two)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
+    // 3. Read target (two) fields — separate withCalendar call for minimal lock scope.
+    struct TargetFields {
+        double epochMs { 0 };
+        int32_t year { 0 };
+        String monthCode;
+        int32_t day { 0 };
+        int32_t ordinalMonth { 0 };
+    };
+    auto targetOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<TargetFields> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, two)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        TargetFields t;
+        t.epochMs = ucal_getMillis(cal, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        t.year = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        auto monthCodeOpt = getMonthCode(cal, calendarId);
+        if (!monthCodeOpt) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        t.monthCode = WTF::move(*monthCodeOpt);
+        t.day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        auto ordinalMonthOpt = computeOrdinalMonth(cal, calendarId);
+        if (!ordinalMonthOpt) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        t.ordinalMonth = *ordinalMonthOpt;
+        return t;
+    });
+    if (!targetOrError)
+        return makeUnexpected(targetOrError.error());
+    auto& target = *targetOrError;
 
-    // 4. Let sign be +1 if one < two, -1 if one > two, 0 if equal. Return zero duration if sign = 0.
-    UErrorCode status = U_ZERO_ERROR;
-    double epochMs1 = ucal_getMillis(cal1.get(), &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    double epochMs2 = ucal_getMillis(cal2.get(), &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
+    // 4. Read source (one) fields — separate withCalendar call for minimal lock scope.
+    struct SourceFields {
+        double epochMs { 0 };
+        int32_t year { 0 };
+        String monthCode;
+        int32_t day { 0 };
+    };
+    auto sourceOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<SourceFields> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, one)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode status = U_ZERO_ERROR;
+        SourceFields s;
+        s.epochMs = ucal_getMillis(cal, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        s.year = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        auto monthCodeOpt = getMonthCode(cal, calendarId);
+        if (!monthCodeOpt) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        s.monthCode = WTF::move(*monthCodeOpt);
+        s.day = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuReadCalendarFailed));
+        return s;
+    });
+    if (!sourceOrError)
+        return makeUnexpected(sourceOrError.error());
+    auto& source = *sourceOrError;
+
+    // 5. Let sign be +1 if one < two, -1 if one > two, 0 if equal. Return zero duration if sign = 0.
+    //    (Source/target calendar fields already read above.)
     int32_t sign;
-    if (epochMs1 < epochMs2)
+    if (source.epochMs < target.epochMs)
         sign = 1;
-    else if (epochMs1 > epochMs2)
+    else if (source.epochMs > target.epochMs)
         sign = -1;
     else
         return ISO8601::Duration { };
-    // 5. Read source (one) and target (two) calendar fields: year, monthCode, day, ordinalMonth.
-    int32_t sourceYear = ucal_get(cal1.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    auto sourceMonthCodeOpt = computeMonthCode(cal1.get(), calendarId);
-    if (!sourceMonthCodeOpt) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    String sourceMonthCode = WTF::move(*sourceMonthCodeOpt);
-    int32_t sourceDay = ucal_get(cal1.get(), UCAL_DAY_OF_MONTH, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    int32_t targetYear = ucal_get(cal2.get(), UCAL_EXTENDED_YEAR, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    auto targetMonthCodeOpt = computeMonthCode(cal2.get(), calendarId);
-    if (!targetMonthCodeOpt) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    String targetMonthCode = WTF::move(*targetMonthCodeOpt);
-    int32_t targetDay = ucal_get(cal2.get(), UCAL_DAY_OF_MONTH, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    auto targetOrdinalMonthOpt = computeOrdinalMonth(cal2.get(), calendarId);
-    if (!targetOrdinalMonthOpt) [[unlikely]]
-        return makeUnexpected(rangeError(icuReadCalendarFailed));
-    int32_t targetOrdinalMonth = *targetOrdinalMonthOpt;
+
     // NOTE: min_years fast-forward: pre-guess year delta that doesn't surpass (icu4x optimization).
-    int32_t yearDiff = targetYear - sourceYear;
+    int32_t yearDiff = target.year - source.year;
     int32_t minYears = !yearDiff ? 0 : yearDiff - sign;
 
     int32_t years = 0, months = 0, weeks = 0;
 
-    // 6. If largestUnit is ~year~ or ~month~, then
-    if (largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month) {
+    // 6. largestUnit is ~year~ or ~month~: use a cloned working calendar for the month/year loop.
+    //    The clone is obtained inside its own withCalendar call; all subsequent mutations happen
+    //    on the clone, which is not shared — no lock needed for the clone itself.
+    ASSERT(largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month);
+    // Obtain a clone of the shared calendar to use as our working state for the iteration.
+    auto workCalOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        // Set to source (one) so the clone starts at the right position.
+        if (!setCalendarToISODate(cal, one)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        UErrorCode cloneStatus = U_ZERO_ERROR;
+        auto cloned = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_clone(cal, &cloneStatus));
+        if (!cloned || U_FAILURE(cloneStatus)) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        return cloned;
+    });
+    if (!workCalOrError)
+        return makeUnexpected(workCalOrError.error());
+    auto workCal = WTF::move(*workCalOrError);
+    UCalendar* cal = workCal.get();
 
-        //    a. If largestUnit is ~year~: count full years using nonISODateSurpasses fast-forward.
-        if (largestUnit == TemporalUnit::Year) {
-            int64_t candidateYears = minYears ? minYears : sign;
-            auto yearDoesNotSurpass = [&] {
-                return !nonISODateSurpasses(calendarId, sign, sourceYear, sourceMonthCode, sourceDay, static_cast<int32_t>(candidateYears), targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
-            };
-            while (yearDoesNotSurpass()) {
-                years = static_cast<int32_t>(candidateYears);
-                candidateYears += sign;
-            }
-            //       i. Set cal1 to (one + years) using calendarDateAdd (preserves month code).
-            if (years) {
-                ISO8601::Duration yearDur;
-                yearDur.setYears(static_cast<int64_t>(years));
-                auto advanced = calendarDateAdd(calendarId, one, yearDur, TemporalOverflow::Constrain);
-                if (!advanced) [[unlikely]]
-                    return makeUnexpected(advanced.error());
-                if (!setCalendarToISODate(cal1.get(), *advanced)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuSetCalendarFailed));
-            }
+    UErrorCode status = U_ZERO_ERROR;
+
+    //    a. If largestUnit is ~year~: count full years using nonISODateSurpasses fast-forward.
+    if (largestUnit == TemporalUnit::Year) {
+        int64_t candidateYears = minYears ? minYears : sign;
+        auto yearDoesNotSurpass = [&] {
+            return !nonISODateSurpasses(calendarId, sign, source.year, source.monthCode, source.day, static_cast<int32_t>(candidateYears), target.year, target.monthCode, target.ordinalMonth, target.day);
+        };
+        while (yearDoesNotSurpass()) {
+            years = static_cast<int32_t>(candidateYears);
+            candidateYears += sign;
         }
-
-        //    b. Count full months from cal1 using surpassesMonths (day=1 to avoid clamping).
-        {
-            // NOTE: lunisolar months per year vary; iterate one at a time (no min_months fast-forward).
-            int32_t candidateMonths = sign;
-            //    c. Set cal1 to (one + years) with day=1 for clamping-free month advancement.
-            double startMs = ucal_getMillis(cal1.get(), &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            ucal_set(cal1.get(), UCAL_DAY_OF_MONTH, 1);
-            ucal_getMillis(cal1.get(), &status); // force ICU state resolution
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-
-            for (;;) {
-                auto surpasses = surpassesMonths(cal1.get(), calendarId, sign, sourceDay, targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
-                if (!surpasses) [[unlikely]]
-                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                if (*surpasses)
-                    break;
-                months = candidateMonths;
-                candidateMonths += sign;
-            }
-
-            // Restore cal1 to (one + years), apply total months in one ucal_add (avoids undo asymmetry).
-            ucal_setMillis(cal1.get(), startMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
+        //       i. Set cal to (one + years) using calendarDateAdd (preserves month code).
+        if (years) {
+            ISO8601::Duration yearDur;
+            yearDur.setYears(static_cast<int64_t>(years));
+            auto advanced = calendarDateAdd(calendarId, one, yearDur, TemporalOverflow::Constrain);
+            if (!advanced) [[unlikely]]
+                return makeUnexpected(advanced.error());
+            // Set the working clone to the advanced date.
+            if (!setCalendarToISODate(cal, *advanced)) [[unlikely]]
                 return makeUnexpected(rangeError(icuSetCalendarFailed));
-            if (months) {
-                ucal_add(cal1.get(), UCAL_MONTH, months, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            }
-            //    c. Apply regulated day = min(sourceDay, end_of_month) via setMonths.
-            if (!setMonths(cal1.get(), sourceDay)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            //    d. If largestUnit is ~month~, clear years (months were counted from one + years=0).
-            if (largestUnit == TemporalUnit::Month)
-                years = 0;
         }
     }
 
-    // 7. Compute remaining days from the epoch ms difference between cal1 and two.
-    const double msPerDay = 86'400'000.0; // nsPerDay / nsPerMillisecond
-    if (largestUnit == TemporalUnit::Week) {
-        double endMs = ucal_getMillis(cal1.get(), &status);
+    //    b. Count full months from cal using surpassesMonths (day=1 to avoid clamping).
+    {
+        // NOTE: lunisolar months per year vary; iterate one at a time (no min_months fast-forward).
+        int32_t candidateMonths = sign;
+        //    c. Set cal to (one + years) with day=1 for clamping-free month advancement.
+        double startMs = ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
-        double dayDiff = (epochMs2 - endMs) / msPerDay;
-        //    a. If largestUnit is ~week~, extract weeks = floor(daysDiff / 7) and remaining days.
-        weeks = static_cast<int32_t>(std::trunc(dayDiff / ISO8601::daysPerWeek));
+        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+        ucal_getMillis(cal, &status); // force ICU state resolution
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+
+        // Clone for surpassesMonths iteration.
+        UErrorCode cloneStatus = U_ZERO_ERROR;
+        auto trialCalOwned = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_clone(cal, &cloneStatus));
+        if (!trialCalOwned || U_FAILURE(cloneStatus)) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+
+        for (;;) {
+            auto surpasses = surpassesMonths(trialCalOwned.get(), calendarId, sign, source.day, target.year, target.monthCode, target.ordinalMonth, target.day);
+            if (!surpasses) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            if (*surpasses)
+                break;
+            months = candidateMonths;
+            candidateMonths += sign;
+            // trialCal already advanced by surpassesMonths — no reset needed.
+            // (Resetting to cal's fixed position would cause infinite loop since cal never moves.)
+        }
+
+        // Restore cal to (one + years), apply total months in one ucal_add (avoids undo asymmetry).
+        ucal_setMillis(cal, startMs, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        if (months) {
+            ucal_add(cal, UCAL_MONTH, months, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        }
+        //    c. Apply regulated day = min(sourceDay, end_of_month) via setMonths.
+        if (!setMonths(cal, source.day)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        //    d. If largestUnit is ~month~, clear years (months were counted from one + years=0).
+        if (largestUnit == TemporalUnit::Month)
+            years = 0;
     }
 
+    // 7. Compute remaining days from the epoch ms difference between cal and two.
+    const double msPerDay = 86'400'000.0; // nsPerDay / nsPerMillisecond
     // 8. Return Duration { years, months, weeks, days }.
-    double finalMs1 = ucal_getMillis(cal1.get(), &status);
+    double finalMs1 = ucal_getMillis(cal, &status);
     if (U_FAILURE(status)) [[unlikely]]
         return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-    double daysDiff = std::trunc((epochMs2 - finalMs1) / msPerDay);
-    if (largestUnit == TemporalUnit::Week)
-        daysDiff = std::trunc(std::fmod(daysDiff, static_cast<double>(ISO8601::daysPerWeek)));
+    double daysDiff = std::trunc((target.epochMs - finalMs1) / msPerDay);
 
     return ISO8601::Duration {
         years,
@@ -1220,6 +1358,7 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         0, 0, 0, 0, Int128(0), Int128(0)
     };
 }
+
 
 // ecmaReferenceYear — No spec AO and no ICU4C equivalent.
 // Ported from icu4x: ecma_reference_year (components/calendar/src/cal/east_asian_traditional.rs, hijri.rs, hebrew.rs, coptic.rs).
@@ -1449,13 +1588,6 @@ int32_t ecmaReferenceYear(CalendarID calendarId, uint8_t monthNumber, bool isLea
 //   4. Return result.
 TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId, std::optional<int32_t> year, uint8_t month, uint8_t day, std::optional<StringView> era, std::optional<int32_t> eraYear, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
 {
-    auto cal = openCalendar(calendarId);
-    if (!cal) [[unlikely]]
-        return makeUnexpected(rangeError(icuOpenCalendarFailed));
-
-    UErrorCode status = U_ZERO_ERROR;
-    ucal_clear(cal.get());
-
     bool tookEraPath = false;
     if (era && eraYear) {
         tookEraPath = true;
@@ -1487,259 +1619,288 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
             }
             return ISO8601::PlainDate(isoYear, resolvedMonth, resolvedDay);
         }
-        auto icuEra = mapTemporalEraToICUEra(calendarId, *era);
-        if (!icuEra) [[unlikely]]
+    }
+
+    std::optional<int32_t> icuEraCode;
+    if (tookEraPath && era) {
+        icuEraCode = mapTemporalEraToICUEra(calendarId, *era);
+        if (!icuEraCode) [[unlikely]]
             return makeUnexpected(rangeError("era is not valid for this calendar"_s));
-        ucal_set(cal.get(), UCAL_ERA, *icuEra);
-        ucal_set(cal.get(), UCAL_YEAR, *eraYear);
-    } else if (calendarId == rocCalendarID()) {
-        // ROC: convert temporal year to era+eraYear for ICU.
-        int32_t y = year.value_or(0);
-        if (y <= 0) {
-            ucal_set(cal.get(), UCAL_ERA, 0); // broc
-            ucal_set(cal.get(), UCAL_YEAR, 1 - y);
-        } else {
-            ucal_set(cal.get(), UCAL_ERA, 1); // roc
-            ucal_set(cal.get(), UCAL_YEAR, y);
-        }
-    } else
-        ucal_set(cal.get(), UCAL_EXTENDED_YEAR, year.value_or(0));
+    }
 
-    if (monthCode) {
-        // Month codes > M13 are always invalid. M13 is only valid for Coptic/Ethiopian.
-        if (monthCode->monthNumber > 13) [[unlikely]]
-            return makeUnexpected(rangeError("month is out of range"_s));
-        if (monthCode->monthNumber == 13 && calendarId != copticCalendarID() && calendarId != ethiopicCalendarID() && calendarId != ethioaaCalendarID()) [[unlikely]]
-            return makeUnexpected(rangeError("month is out of range"_s));
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::PlainDate> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
 
-        if (calendarIsLunisolar(calendarId)) {
-            // Lunisolar: walk months from start of year to find target monthCode.
-            // ICU4X uses precomputed year.packed.leap_month() for O(1) lookup; ICU4C
-            // doesn't expose this data, so we walk. The walk is correct and safe.
-            ucal_set(cal.get(), UCAL_MONTH, 0);
-            ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
-            ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
-            ucal_getMillis(cal.get(), &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        UErrorCode status = U_ZERO_ERROR;
 
-            String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
-                monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
-            int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            bool found = false;
-            for (int i = 0; i < 14; i++) {
-                auto curCode = computeMonthCode(cal.get(), calendarId);
-                if (!curCode) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                if (*curCode == targetCode) {
-                    found = true;
-                    break;
-                }
-                // For constrain: if we've passed the target code, stop at previous.
-                if (codePointCompare(*curCode, targetCode) > 0) {
-                    // Leap month doesn't exist — constrain to previous month.
-                    if (overflow == TemporalOverflow::Constrain && monthCode->isLeapMonth) {
-                        if (calendarId == hebrewCalendarID()) {
-                            // M05L -> M06 (Adar), which is this current month.
-                            found = true;
-                        } else {
-                            // Chinese/Dangi: M01L->M01, revert one step.
-                            ucal_add(cal.get(), UCAL_MONTH, -1, &status);
-                            if (U_FAILURE(status)) [[unlikely]]
-                                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                            found = true;
-                        }
-                    }
-                    break;
-                }
-                ucal_add(cal.get(), UCAL_MONTH, 1, &status);
+        if (tookEraPath) {
+            // era && eraYear, not Japanese "ce"/"bce".
+            if (!icuEraCode) [[unlikely]]
+                return makeUnexpected(rangeError("era is not valid for this calendar"_s));
+            ucal_set(cal, UCAL_ERA, *icuEraCode);
+            ucal_set(cal, UCAL_YEAR, *eraYear);
+        } else if (calendarId == rocCalendarID()) {
+            // ROC: convert temporal year to era+eraYear for ICU.
+            int32_t y = year.value_or(0);
+            if (y <= 0) {
+                ucal_set(cal, UCAL_ERA, 0); // broc
+                ucal_set(cal, UCAL_YEAR, 1 - y);
+            } else {
+                ucal_set(cal, UCAL_ERA, 1); // roc
+                ucal_set(cal, UCAL_YEAR, y);
+            }
+        } else
+            ucal_set(cal, UCAL_EXTENDED_YEAR, year.value_or(0));
+
+        if (monthCode) {
+            // Month codes > M13 are always invalid. M13 is only valid for Coptic/Ethiopian.
+            if (monthCode->monthNumber > 13) [[unlikely]]
+                return makeUnexpected(rangeError("month is out of range"_s));
+            if (monthCode->monthNumber == 13 && calendarId != copticCalendarID() && calendarId != ethiopicCalendarID() && calendarId != ethioaaCalendarID()) [[unlikely]]
+                return makeUnexpected(rangeError("month is out of range"_s));
+
+            if (calendarIsLunisolar(calendarId)) {
+                // Lunisolar: walk months from start of year to find target monthCode.
+                // ICU4X uses precomputed year.packed.leap_month() for O(1) lookup; ICU4C
+                // doesn't expose this data, so we walk. The walk is correct and safe.
+                ucal_set(cal, UCAL_MONTH, 0);
+                ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+                ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+                ucal_getMillis(cal, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                int32_t curYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+
+                String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
+                    monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
+                int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
-                if (curYear != savedYear) {
-                    ucal_add(cal.get(), UCAL_MONTH, -1, &status);
+                bool found = false;
+                for (int i = 0; i < 14; i++) {
+                    auto curCode = getMonthCode(cal, calendarId);
+                    if (!curCode) [[unlikely]]
+                        return makeUnexpected(rangeError(icuReadCalendarFailed));
+                    if (*curCode == targetCode) {
+                        found = true;
+                        break;
+                    }
+                    // For constrain: if we've passed the target code, stop at previous.
+                    if (codePointCompare(*curCode, targetCode) > 0) {
+                        // Leap month doesn't exist — constrain to previous month.
+                        if (overflow == TemporalOverflow::Constrain && monthCode->isLeapMonth) {
+                            if (calendarId == hebrewCalendarID()) {
+                                // M05L -> M06 (Adar), which is this current month.
+                                found = true;
+                            } else {
+                                // Chinese/Dangi: M01L->M01, revert one step.
+                                ucal_add(cal, UCAL_MONTH, -1, &status);
+                                if (U_FAILURE(status)) [[unlikely]]
+                                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                                found = true;
+                            }
+                        }
+                        break;
+                    }
+                    ucal_add(cal, UCAL_MONTH, 1, &status);
                     if (U_FAILURE(status)) [[unlikely]]
                         return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                    int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+                    if (U_FAILURE(status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuReadCalendarFailed));
+                    if (curYear != savedYear) {
+                        ucal_add(cal, UCAL_MONTH, -1, &status);
+                        if (U_FAILURE(status)) [[unlikely]]
+                            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                        break;
+                    }
+                }
+                if (!found && overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s)); // Clamp day via ucal_add.
+                int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
+                uint8_t clampedDay = day;
+                if (day > maxDay) {
+                    if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+                    clampedDay = static_cast<uint8_t>(maxDay);
+                }
+                if (clampedDay > 1)
+                    ucal_add(cal, UCAL_DAY_OF_MONTH, clampedDay - 1, &status);
+            } else if (calendarId == hebrewCalendarID()) [[unlikely]] {
+                // Hebrew non-lunisolar path — shouldn't reach here since Hebrew IS lunisolar.
+                ASSERT_NOT_REACHED();
+                return makeUnexpected(rangeError("unexpected hebrew non-lunisolar path"_s));
+            } else {
+                // Non-lunisolar with monthCode (Gregorian-based calendars).
+                // Set month with day=1 first to avoid ICU normalizing out-of-range day.
+                ucal_set(cal, UCAL_MONTH, monthCode->monthNumber - 1);
+                if (monthCode->isLeapMonth)
+                    ucal_set(cal, UCAL_IS_LEAP_MONTH, 1);
+                ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+                ucal_getMillis(cal, &status); // force resolution of year+month
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+
+                // Now check maxDay for the resolved month.
+                int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
+                if (day > maxDay) {
+                    if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+                    ucal_set(cal, UCAL_DAY_OF_MONTH, maxDay);
+                } else if (day > 1)
+                    ucal_set(cal, UCAL_DAY_OF_MONTH, day);
+            }
+        } else if (calendarIsLunisolar(calendarId)) {
+            // For lunisolar calendars, 'month' is the ordinal month (1-indexed).
+            // Count monthsInYear using a separate calendar to avoid state corruption.
+            ucal_set(cal, UCAL_MONTH, 0);
+            ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+            ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+            ucal_getMillis(cal, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s)); // Use a separate calendar to count months in year.
+            // Clone: need an independent copy to advance months while cal stays at its current date.
+            UErrorCode cloneStatus = U_ZERO_ERROR;
+            auto countCal = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_clone(cal, &cloneStatus));
+            if (U_FAILURE(cloneStatus)) [[unlikely]]
+                return makeUnexpected(rangeError("Failed to open counting calendar"_s));
+            double calMs = ucal_getMillis(cal, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            ucal_setMillis(countCal.get(), calMs, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuSetCalendarFailed));
+            int32_t savedYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            int32_t monthsInYear = 1;
+            for (int i = 0; i < 14; i++) {
+                ucal_add(countCal.get(), UCAL_MONTH, 1, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                int32_t curYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuReadCalendarFailed));
+                if (curYear != savedYear)
                     break;
+                monthsInYear++;
+            }
+
+            // Clamp or reject month against monthsInYear.
+            uint8_t resolvedMonth = month;
+            if (month > monthsInYear) {
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("month is out of range for this calendar year"_s));
+                resolvedMonth = static_cast<uint8_t>(monthsInYear);
+            }
+
+            // Advance the original calendar to the target month.
+            if (resolvedMonth > 1) {
+                ucal_add(cal, UCAL_MONTH, resolvedMonth - 1, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError("Failed to resolve lunisolar month"_s));
+            }
+
+            // Clamp day to daysInMonth if constrain.
+            int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            uint8_t resolvedDay = day;
+            if (day > maxDay) {
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+                resolvedDay = static_cast<uint8_t>(maxDay);
+            }
+            // Use ucal_add (not ucal_set) to advance within the month — avoids
+            // ICU's lazy-field resolution resetting the month position.
+            if (resolvedDay > 1) {
+                ucal_add(cal, UCAL_DAY_OF_MONTH, resolvedDay - 1, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+            }
+        } else {
+            // Non-lunisolar: clamp month to calendar max.
+            int32_t maxMonth = ucal_getLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            uint8_t resolvedMonth = month;
+            if (month > maxMonth) {
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("month is out of range for this calendar"_s));
+                resolvedMonth = static_cast<uint8_t>(maxMonth);
+            }
+            ucal_set(cal, UCAL_MONTH, resolvedMonth - 1); // Resolve to get actual max day for this month.
+            ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+            int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuReadCalendarFailed));
+            uint8_t resolvedDay = day;
+            if (day > maxDay) {
+                if (overflow == TemporalOverflow::Reject) [[unlikely]]
+                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+                resolvedDay = static_cast<uint8_t>(maxDay);
+            }
+            ucal_set(cal, UCAL_DAY_OF_MONTH, resolvedDay);
+        }
+
+        if (overflow == TemporalOverflow::Reject) {
+            int32_t resolvedDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError("Failed to resolve calendar date"_s));
+            if (monthCode) {
+                if (calendarIsLunisolar(calendarId)) {
+                    // For lunisolar calendars, ICU slot numbers != monthCode numbers (e.g. Hebrew
+                    // M05L at slot 5 gives UCAL_MONTH+1=6, and ICU4C never sets IS_LEAP_MONTH).
+                    // Use getMonthCode to verify the actual month — the walk already positioned
+                    // the calendar at the target month, so we only need to verify the day.
+                    if (resolvedDay != static_cast<int32_t>(day)) [[unlikely]]
+                        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+                } else {
+                    int32_t resolvedMonth = ucal_get(cal, UCAL_MONTH, &status) + 1;
+                    if (U_FAILURE(status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuReadCalendarFailed));
+                    int32_t resolvedLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status);
+                    if (U_FAILURE(status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuReadCalendarFailed));
+                    bool leapMismatch = monthCode->isLeapMonth && !resolvedLeap;
+                    if (resolvedDay != static_cast<int32_t>(day) || resolvedMonth != static_cast<int32_t>(monthCode->monthNumber) || leapMismatch) [[unlikely]]
+                        return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
                 }
             }
-            if (!found && overflow == TemporalOverflow::Reject) [[unlikely]]
-                return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s)); // Clamp day via ucal_add.
-            int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            uint8_t clampedDay = day;
-            if (day > maxDay) {
-                if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-                clampedDay = static_cast<uint8_t>(maxDay);
-            }
-            if (clampedDay > 1)
-                ucal_add(cal.get(), UCAL_DAY_OF_MONTH, clampedDay - 1, &status);
-        } else if (calendarId == hebrewCalendarID()) [[unlikely]] {
-            // Hebrew non-lunisolar path — shouldn't reach here since Hebrew IS lunisolar.
-            ASSERT_NOT_REACHED();
-            return makeUnexpected(rangeError("unexpected hebrew non-lunisolar path"_s));
-        } else {
-            // Non-lunisolar with monthCode (Gregorian-based calendars).
-            // Set month with day=1 first to avoid ICU normalizing out-of-range day.
-            ucal_set(cal.get(), UCAL_MONTH, monthCode->monthNumber - 1);
-            if (monthCode->isLeapMonth)
-                ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 1);
-            ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
-            ucal_getMillis(cal.get(), &status); // force resolution of year+month
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-
-            // Now check maxDay for the resolved month.
-            int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            if (day > maxDay) {
-                if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-                ucal_set(cal.get(), UCAL_DAY_OF_MONTH, maxDay);
-            } else if (day > 1)
-                ucal_set(cal.get(), UCAL_DAY_OF_MONTH, day);
-        }
-    } else if (calendarIsLunisolar(calendarId)) {
-        // For lunisolar calendars, 'month' is the ordinal month (1-indexed).
-        // Count monthsInYear using a separate calendar to avoid state corruption.
-        ucal_set(cal.get(), UCAL_MONTH, 0);
-        ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
-        ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
-        ucal_getMillis(cal.get(), &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s)); // Use a separate calendar to count months in year.
-        auto countCal = openCalendar(calendarId);
-        if (!countCal) [[unlikely]]
-            return makeUnexpected(rangeError("Failed to open counting calendar"_s));
-        double calMs = ucal_getMillis(cal.get(), &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        ucal_setMillis(countCal.get(), calMs, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        int32_t savedYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        int32_t monthsInYear = 1;
-        for (int i = 0; i < 14; i++) {
-            ucal_add(countCal.get(), UCAL_MONTH, 1, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-            int32_t curYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuReadCalendarFailed));
-            if (curYear != savedYear)
-                break;
-            monthsInYear++;
         }
 
-        // Clamp or reject month against monthsInYear.
-        uint8_t resolvedMonth = month;
-        if (month > monthsInYear) {
-            if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                return makeUnexpected(rangeError("month is out of range for this calendar year"_s));
-            resolvedMonth = static_cast<uint8_t>(monthsInYear);
+        // For constrain with a leap monthCode that doesn't exist: ICU silently drops the leap
+        // flag and lands on the non-leap version of the month, which is the correct constrain
+        // behavior. No explicit fallback is needed.
+
+        auto resolved = isoDateFromCalendarChecked(cal);
+        if (!resolved) [[unlikely]]
+            return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
+
+        // NonISOResolveFields: when era+eraYear and year are all non-unset, they must identify
+        // the same year. year == nullopt means the caller did not have a user-provided year.
+        if (tookEraPath && year) {
+            // Re-use cal (we hold the lock): set it to resolved and read back calendar year.
+            if (!setCalendarToISODate(cal, *resolved)) [[unlikely]]
+                return makeUnexpected(rangeError(icuSetCalendarFailed));
+            UErrorCode yearStatus = U_ZERO_ERROR;
+            int32_t resolvedYear;
+            if (calendarId == rocCalendarID()) {
+                int32_t era = ucal_get(cal, UCAL_ERA, &yearStatus);
+                int32_t ey = ucal_get(cal, UCAL_YEAR, &yearStatus);
+                resolvedYear = !era ? -(ey - 1) : ey;
+            } else
+                resolvedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &yearStatus);
+            if (!U_FAILURE(yearStatus) && resolvedYear != *year) [[unlikely]]
+                return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
         }
 
-        // Advance the original calendar to the target month.
-        if (resolvedMonth > 1) {
-            ucal_add(cal.get(), UCAL_MONTH, resolvedMonth - 1, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError("Failed to resolve lunisolar month"_s));
-        }
-
-        // Clamp day to daysInMonth if constrain.
-        int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        uint8_t resolvedDay = day;
-        if (day > maxDay) {
-            if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-            resolvedDay = static_cast<uint8_t>(maxDay);
-        }
-        // Use ucal_add (not ucal_set) to advance within the month — avoids
-        // ICU's lazy-field resolution resetting the month position.
-        if (resolvedDay > 1) {
-            ucal_add(cal.get(), UCAL_DAY_OF_MONTH, resolvedDay - 1, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-        }
-    } else {
-        // Non-lunisolar: clamp month to calendar max.
-        int32_t maxMonth = ucal_getLimit(cal.get(), UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        uint8_t resolvedMonth = month;
-        if (month > maxMonth) {
-            if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                return makeUnexpected(rangeError("month is out of range for this calendar"_s));
-            resolvedMonth = static_cast<uint8_t>(maxMonth);
-        }
-        ucal_set(cal.get(), UCAL_MONTH, resolvedMonth - 1); // Resolve to get actual max day for this month.
-        ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
-        int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuReadCalendarFailed));
-        uint8_t resolvedDay = day;
-        if (day > maxDay) {
-            if (overflow == TemporalOverflow::Reject) [[unlikely]]
-                return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-            resolvedDay = static_cast<uint8_t>(maxDay);
-        }
-        ucal_set(cal.get(), UCAL_DAY_OF_MONTH, resolvedDay);
-    }
-
-    if (overflow == TemporalOverflow::Reject) {
-        int32_t resolvedDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError("Failed to resolve calendar date"_s));
-        if (monthCode) {
-            if (calendarIsLunisolar(calendarId)) {
-                // For lunisolar calendars, ICU slot numbers != monthCode numbers (e.g. Hebrew
-                // M05L at slot 5 gives UCAL_MONTH+1=6, and ICU4C never sets IS_LEAP_MONTH).
-                // Use computeMonthCode to verify the actual month — the walk already positioned
-                // the calendar at the target month, so we only need to verify the day.
-                if (resolvedDay != static_cast<int32_t>(day)) [[unlikely]]
-                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-            } else {
-                int32_t resolvedMonth = ucal_get(cal.get(), UCAL_MONTH, &status) + 1;
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                int32_t resolvedLeap = ucal_get(cal.get(), UCAL_IS_LEAP_MONTH, &status);
-                if (U_FAILURE(status)) [[unlikely]]
-                    return makeUnexpected(rangeError(icuReadCalendarFailed));
-                bool leapMismatch = monthCode->isLeapMonth && !resolvedLeap;
-                if (resolvedDay != static_cast<int32_t>(day) || resolvedMonth != static_cast<int32_t>(monthCode->monthNumber) || leapMismatch) [[unlikely]]
-                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
-            }
-        }
-    }
-
-    // For constrain with a leap monthCode that doesn't exist: ICU silently drops the leap
-    // flag and lands on the non-leap version of the month, which is the correct constrain
-    // behavior. No explicit fallback is needed.
-
-    auto resolved = isoDateFromCalendarChecked(cal.get());
-    if (!resolved) [[unlikely]]
-        return makeUnexpected(rangeError("Resolved calendar date is outside representable range"_s));
-
-    // NonISOResolveFields: when era+eraYear and year are all non-unset, they must identify
-    // the same year. year == nullopt means the caller did not have a user-provided year.
-    if (tookEraPath && year) {
-        auto resolvedTemporalYear = calendarYear(calendarId, *resolved);
-        if (resolvedTemporalYear && *resolvedTemporalYear != *year) [[unlikely]]
-            return makeUnexpected(rangeError("year is inconsistent with era and eraYear"_s));
-    }
-
-    return *resolved;
+        return *resolved;
+    });
 }
 
 } // namespace TemporalCore


### PR DESCRIPTION
#### 7636f61497084c5b86ae9a6e2d6157bca4f3f7ee
<pre>
[JSC][Temporal] Cache ICU UCalendar per CalendarID in CalendarICUBridge
<a href="https://bugs.webkit.org/show_bug.cgi?id=316569">https://bugs.webkit.org/show_bug.cgi?id=316569</a>
<a href="https://rdar.apple.com/179036919">rdar://179036919</a>

Reviewed by Yusuke Suzuki.

Previously every CalendarICUBridge call (calendarYear, calendarMonth,
calendarDay, etc.) called ucal_open/ucal_close, allocating and freeing
an ICU calendar object on each invocation.

This patch caches one UCalendar template per CalendarID in a static
per-process Vector. Access is controlled by a per-entry WTF::Lock and
a double-checked atomic initialized flag (acquire/release ordering).

The withCalendar(calendarId, lambda) helper acquires the entry lock,
runs the lambda with the cached UCalendar*, and releases immediately,
keeping lock scope minimal. For operations that need an independent
calendar state (calendarDateUntil month loop, calendarDateFromFields
countCal), the template is cloned via ucal_clone inside the lock.

Canonical link: <a href="https://commits.webkit.org/314904@main">https://commits.webkit.org/314904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7e9a69131a91ee1889c7a6b3880a58c948142ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176545 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130299 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50653ada-8eaa-48ea-8065-9e74ad17781e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110816 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30391 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25280 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159778 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179085 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138695 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138582 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41749 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104854 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25499 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26853 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200169 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113334 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53800 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39650 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4952 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39901 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39795 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->