### PR TITLE
Use default member initializers for SVGSMILElement data members

### DIFF
--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -73,9 +73,6 @@ static const AtomString& indefiniteAtom()
     return indefiniteValue;
 }
 
-// This is used for duration type time values that can't be negative.
-static const double invalidCachedTime = -1.;
-    
 class ConditionEventListener final : public EventListener {
 public:
     static Ref<ConditionEventListener> create(SVGSMILElement* animation, SVGSMILElement::Condition* condition)
@@ -139,22 +136,6 @@ SVGSMILElement::Condition::Condition(Type type, BeginOrEnd beginOrEnd, const Str
 SVGSMILElement::SVGSMILElement(const QualifiedName& tagName, Document& doc, UniqueRef<SVGPropertyRegistry>&& propertyRegistry)
     : SVGElement(tagName, doc, WTF::move(propertyRegistry))
     , m_attributeName(anyQName())
-    , m_conditionsConnected(false)
-    , m_hasEndEventConditions(false)
-    , m_isWaitingForFirstInterval(true)
-    , m_intervalBegin(SMILTime::unresolved())
-    , m_intervalEnd(SMILTime::unresolved())
-    , m_previousIntervalBegin(SMILTime::unresolved())
-    , m_activeState(Inactive)
-    , m_lastPercent(0)
-    , m_lastRepeat(0)
-    , m_nextProgressTime(0)
-    , m_documentOrderIndex(0)
-    , m_cachedDur(invalidCachedTime)
-    , m_cachedRepeatDur(invalidCachedTime)
-    , m_cachedRepeatCount(invalidCachedTime)
-    , m_cachedMin(invalidCachedTime)
-    , m_cachedMax(invalidCachedTime)
 {
 }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -188,10 +188,10 @@ private:
     WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_targetElement;
 
     Vector<Condition> m_conditions;
-    bool m_conditionsConnected;
-    bool m_hasEndEventConditions;     
+    bool m_conditionsConnected { false };
+    bool m_hasEndEventConditions { false };
 
-    bool m_isWaitingForFirstInterval;
+    bool m_isWaitingForFirstInterval { true };
 
     WeakHashSet<SVGSMILElement, WeakPtrImplWithEventTargetData> m_timeDependents;
 
@@ -200,25 +200,28 @@ private:
     Vector<SMILTimeWithOrigin> m_endTimes;
 
     // This is the upcoming or current interval
-    SMILTime m_intervalBegin;
-    SMILTime m_intervalEnd;
+    SMILTime m_intervalBegin { SMILTime::unresolved() };
+    SMILTime m_intervalEnd { SMILTime::unresolved() };
 
-    SMILTime m_previousIntervalBegin;
+    SMILTime m_previousIntervalBegin { SMILTime::unresolved() };
 
-    ActiveState m_activeState;
-    float m_lastPercent;
-    unsigned m_lastRepeat;
+    ActiveState m_activeState { Inactive };
+    float m_lastPercent { 0 };
+    unsigned m_lastRepeat { 0 };
 
-    SMILTime m_nextProgressTime;
+    SMILTime m_nextProgressTime { 0 };
 
     RefPtr<SMILTimeContainer> m_timeContainer;
-    unsigned m_documentOrderIndex;
+    unsigned m_documentOrderIndex { 0 };
 
-    mutable SMILTime m_cachedDur;
-    mutable SMILTime m_cachedRepeatDur;
-    mutable SMILTime m_cachedRepeatCount;
-    mutable SMILTime m_cachedMin;
-    mutable SMILTime m_cachedMax;
+    // This is used for duration type time values that can't be negative.
+    static constexpr double invalidCachedTime = -1;
+
+    mutable SMILTime m_cachedDur { invalidCachedTime };
+    mutable SMILTime m_cachedRepeatDur { invalidCachedTime };
+    mutable SMILTime m_cachedRepeatCount { invalidCachedTime };
+    mutable SMILTime m_cachedMin { invalidCachedTime };
+    mutable SMILTime m_cachedMax { invalidCachedTime };
 
     // FIXME: Remove once TimeEvent carries the repeat iteration count directly (webkit.org/b/313717).
     Deque<unsigned> m_pendingRepeatIterations;


### PR DESCRIPTION
#### 7901fa53097755901ce0f45505aa65ab2ae62721
<pre>
Use default member initializers for SVGSMILElement data members
<a href="https://bugs.webkit.org/show_bug.cgi?id=316580">https://bugs.webkit.org/show_bug.cgi?id=316580</a>
<a href="https://rdar.apple.com/179040357">rdar://179040357</a>

Reviewed by Dan Glastonbury.

Move SVGSMILElement&apos;s data members to default member initializers in the
header instead of its 18-entry constructor init list. The header was already
half-migrated (only m_lastDispatchedRepeatIteration used the modern style),
so the two styles had drifted apart.

The cached-time members now initialize from invalidCachedTime instead of a
bare -1 literal. To make that constant visible at the header initializer
sites, it moves from a file-scope definition in the .cpp into a
static constexpr double on SVGSMILElement; the reset/comparison sites in the
.cpp resolve to it unchanged. The init list now collapses to the base
SVGElement call plus m_attributeName(anyQName()). No change in behavior.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::SVGSMILElement):
* Source/WebCore/svg/animation/SVGSMILElement.h:

Canonical link: <a href="https://commits.webkit.org/314791@main">https://commits.webkit.org/314791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e75602fbd43dd5282660935907625c7591d8143a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176267 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba06323b-7b84-42ff-a325-23787baef3ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130067 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec1ae936-1dd8-4c93-91ac-5582c8da1aa2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110584 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e9fd819-15d4-451a-aac3-41aeaa78194c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25005 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178808 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31707 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138453 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40787 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138344 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37246 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41475 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104458 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33592 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113058 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39376 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4701 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39626 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39521 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->