### PR TITLE
Use default member initializers for Table Layout data members

### DIFF
--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2002 Lars Knoll (knoll@kde.org)
  *           (C) 2002 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2014-2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -38,8 +38,6 @@ namespace WebCore {
 
 AutoTableLayout::AutoTableLayout(RenderTable* table)
     : TableLayout(table)
-    , m_hasPercent(false)
-    , m_effectiveLogicalWidthDirty(true)
 {
 }
 

--- a/Source/WebCore/rendering/AutoTableLayout.h
+++ b/Source/WebCore/rendering/AutoTableLayout.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2002 Lars Knoll (knoll@kde.org)
  *           (C) 2002 Dirk Mueller (mueller@kde.org)
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -63,8 +64,8 @@ private:
 
     Vector<Layout> m_layoutStruct;
     Vector<RenderTableCell*> m_spanCells;
-    bool m_hasPercent : 1;
-    mutable bool m_effectiveLogicalWidthDirty : 1;
+    bool m_hasPercent : 1 { false };
+    mutable bool m_effectiveLogicalWidthDirty : 1 { true };
     LayoutUnit m_scaledWidthFromPercentColumns;
 };
 

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -79,14 +79,6 @@ static_assert(sizeof(CollapsedBorderValue) <= 24, "CollapsedBorderValue should s
 
 RenderTableCell::RenderTableCell(Element& element, Style::ComputedStyle&& style)
     : RenderBlockFlow(Type::TableCell, element, WTF::move(style))
-    , m_column(unsetColumnIndex)
-    , m_cellWidthChanged(false)
-    , m_hasColSpan(false)
-    , m_hasRowSpan(false)
-    , m_hasEmptyCollapsedBeforeBorder(false)
-    , m_hasEmptyCollapsedAfterBorder(false)
-    , m_hasEmptyCollapsedStartBorder(false)
-    , m_hasEmptyCollapsedEndBorder(false)
 {
     // We only update the flags when notified of DOM changes in colSpanOrRowSpanChanged()
     // so we need to set their initial values here in case something asks for colSpan()/rowSpan() before then.
@@ -96,14 +88,6 @@ RenderTableCell::RenderTableCell(Element& element, Style::ComputedStyle&& style)
 
 RenderTableCell::RenderTableCell(Document& document, Style::ComputedStyle&& style)
     : RenderBlockFlow(Type::TableCell, document, WTF::move(style))
-    , m_column(unsetColumnIndex)
-    , m_cellWidthChanged(false)
-    , m_hasColSpan(false)
-    , m_hasRowSpan(false)
-    , m_hasEmptyCollapsedBeforeBorder(false)
-    , m_hasEmptyCollapsedAfterBorder(false)
-    , m_hasEmptyCollapsedStartBorder(false)
-    , m_hasEmptyCollapsedEndBorder(false)
 {
     ASSERT(isRenderTableCell());
 }

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -209,15 +209,14 @@ private:
 
     bool hasLineIfEmpty() const final;
 
-    // Note MSVC will only pack members if they have identical types, hence we use unsigned instead of bool here.
-    unsigned m_column : 25;
-    unsigned m_cellWidthChanged : 1;
-    unsigned m_hasColSpan: 1;
-    unsigned m_hasRowSpan: 1;
-    mutable unsigned m_hasEmptyCollapsedBeforeBorder: 1;
-    mutable unsigned m_hasEmptyCollapsedAfterBorder: 1;
-    mutable unsigned m_hasEmptyCollapsedStartBorder: 1;
-    mutable unsigned m_hasEmptyCollapsedEndBorder: 1;
+    unsigned m_column : 25 { unsetColumnIndex };
+    bool m_cellWidthChanged : 1 { false };
+    bool m_hasColSpan : 1 { false };
+    bool m_hasRowSpan : 1 { false };
+    mutable bool m_hasEmptyCollapsedBeforeBorder : 1 { false };
+    mutable bool m_hasEmptyCollapsedAfterBorder : 1 { false };
+    mutable bool m_hasEmptyCollapsedStartBorder : 1 { false };
+    mutable bool m_hasEmptyCollapsedEndBorder : 1 { false };
     bool m_isComputingPreferredSize { false };
     LayoutUnit m_intrinsicPaddingBefore { 0 };
     LayoutUnit m_intrinsicPaddingAfter { 0 };

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
@@ -53,7 +53,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTableRow);
 
 RenderTableRow::RenderTableRow(Element& element, Style::ComputedStyle&& style)
     : RenderBlock(Type::TableRow, element, WTF::move(style), { })
-    , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
     ASSERT(isRenderTableRow());
@@ -61,7 +60,6 @@ RenderTableRow::RenderTableRow(Element& element, Style::ComputedStyle&& style)
 
 RenderTableRow::RenderTableRow(Document& document, Style::ComputedStyle&& style)
     : RenderBlock(Type::TableRow, document, WTF::move(style), { })
-    , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
     ASSERT(isRenderTableRow());

--- a/Source/WebCore/rendering/RenderTableRow.h
+++ b/Source/WebCore/rendering/RenderTableRow.h
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2016 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -94,7 +94,7 @@ private:
     void nextSibling() const = delete;
     void previousSibling() const = delete;
 
-    unsigned m_rowIndex : 31;
+    unsigned m_rowIndex : 31 { unsetRowIndex };
 };
 
 inline void RenderTableRow::setRowIndex(unsigned rowIndex)


### PR DESCRIPTION
#### 1e2d07153e5938d1e318a46472ad025252756010
<pre>
Use default member initializers for Table Layout data members
<a href="https://bugs.webkit.org/show_bug.cgi?id=316589">https://bugs.webkit.org/show_bug.cgi?id=316589</a>
<a href="https://rdar.apple.com/179044738">rdar://179044738</a>

Reviewed by Alan Baradlay.

Follow-up to 314742@main, applying the same cleanup to the rest of the
table renderers. RenderTableCell and RenderTableRow each have two
constructors (Element&amp; and Document&amp;) that duplicated their member-init
lists; move those members to default member initializers in the header so
the constructors collapse to the base call. AutoTableLayout&apos;s single
constructor is likewise emptied.

The unsetColumnIndex/unsetRowIndex sentinels and the non-default
m_effectiveLogicalWidthDirty { true } are preserved. RenderTableCell&apos;s
seven 1-bit flags are also switched from unsigned to bool now that the
MSVC-only mixed-type packing workaround is no longer needed (since no port
uses MSVC compiler - drive-by fix).

No change in behavior.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::AutoTableLayout):
* Source/WebCore/rendering/AutoTableLayout.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::RenderTableCell):
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::RenderTableRow):
(WebCore::m_rowIndex): Deleted.
* Source/WebCore/rendering/RenderTableRow.h:

Canonical link: <a href="https://commits.webkit.org/314784@main">https://commits.webkit.org/314784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/411f9a6c36a7108d47b35e0766031f8a6a567473

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176226 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21c6e777-00e6-4131-b427-43d2a38809c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130035 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79f05d86-f89d-465f-be5e-70de0d8a8153) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110552 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57aa72ba-28e4-4d94-b24d-b2cce14883bc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30121 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24964 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178767 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31666 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138420 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40746 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34274 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138313 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37240 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41434 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104403 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33561 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39938 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113017 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39335 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4673 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->