### PR TITLE
[Scroll Anchoring] Scroll anchoring can stop working if anchoring is triggered inside a scroll event handler

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-anchoring-after-scroll-event-suppression-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-anchoring-after-scroll-event-suppression-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Scroll anchoring still functions after an adjustment is suppressed inside a scroll event handler
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-anchoring-after-scroll-event-suppression.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-anchoring-after-scroll-event-suppression.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Scroll anchoring still functions after an adjustment suppressed during a scroll event</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-anchoring/#scroll-adjustment">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  body { margin: 0; }
+  #adjuster { height: 100px; }
+  #anchor { height: 100px; }
+  #filler { height: 3000px; }
+  #dirtier { height: 50px; }
+</style>
+<div id="adjuster"></div>
+<div id="anchor"></div>
+<div id="filler"></div>
+<div id="dirtier"></div>
+<script>
+const scroller = document.scrollingElement;
+
+function forceLayout() { return scroller.scrollTop; }
+
+promise_test(async t => {
+  // Trigger anchoring.
+  scroller.scrollTop = 1010;
+  await new Promise(requestAnimationFrame);
+
+  // Trigger adjustment inside a scroll event handler.
+  await new Promise(resolve => {
+    window.addEventListener("scroll", function onScroll() {
+      document.getElementById("dirtier").style.height = "60px"; // dirty layout (below the viewport)
+      forceLayout();
+      resolve();
+    }, { once: true });
+    scroller.scrollTop = 1020;
+  });
+
+  await new Promise(requestAnimationFrame);
+
+  // Verify that anchoring is active.
+  const before = scroller.scrollTop;
+  document.getElementById("adjuster").style.height = "300px";
+  const after = forceLayout();
+
+  assert_equals(after - before, 200, "scroll anchoring should have adjusted the scroll position");
+  document.getElementById("filler").style.height = "0px";
+}, "Scroll anchoring still functions after an adjustment is suppressed inside a scroll event handler");
+</script>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -613,6 +613,13 @@ void ScrollAnchoringController::updateBeforeLayout()
 // https://drafts.csswg.org/css-scroll-anchoring/#scroll-adjustment
 void ScrollAnchoringController::adjustScrollPositionForAnchoring()
 {
+    // We have already been removed from the frame view's pending-update set by the time we get here
+    // (adjustScrollAnchoringPositionForScrollableAreas() drains it before calling us), so always
+    // consume the queued flag to keep the two in sync regardless of which early-return we take below.
+    // Otherwise m_isQueuedForScrollPositionUpdate gets stuck true and updateBeforeLayout() stops
+    // re-selecting an anchor.
+    auto queued = std::exchange(m_isQueuedForScrollPositionUpdate, false);
+
     LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " adjustScrollPositionForAnchoring() - anchor " << m_anchorObject << " offset " << m_lastAnchorOffset << " suppressedByStyleChange  " << m_anchoringSuppressedByStyleChange << " in scroll event " << !!m_inScrollEventCount << " in suppression scope " << !!m_suppressionCount);
 
     // FIXME: Test for running animated scrolls?
@@ -622,7 +629,6 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
         return;
     }
 
-    auto queued = std::exchange(m_isQueuedForScrollPositionUpdate, false);
     if (!m_anchorObject || !queued)
         return;
 


### PR DESCRIPTION
#### de0c5a12918d1da024c9f90975a074a08536bdcc
<pre>
[Scroll Anchoring] Scroll anchoring can stop working if anchoring is triggered inside a scroll event handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=316592">https://bugs.webkit.org/show_bug.cgi?id=316592</a>
<a href="https://rdar.apple.com/179047840">rdar://179047840</a>

Reviewed by NOBODY (OOPS!).

Scroll anchoring could stop working if anchoring was triggered inside a scroll event handler,
because `m_isQueuedForScrollPositionUpdate` would get stuck as true. This is because
`adjustScrollPositionForAnchoring()` would early return based on `m_inScrollEventCount`
before the `std::exchange(m_isQueuedForScrollPositionUpdate, false)`, yet the caller
removes the controller from `m_scrollableAreasWithScrollAnchoringControllersNeedingUpdate`
so `m_isQueuedForScrollPositionUpdate` and the registration get out of sync. From then on
the controller always considers itself registered when it&apos;s not.

Fix by taking the value of `m_isQueuedForScrollPositionUpdate` before any returns in
`adjustScrollPositionForAnchoring()`.

Test: imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-anchoring-after-scroll-event-suppression.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-anchoring-after-scroll-event-suppression-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-anchoring-after-scroll-event-suppression.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de0c5a12918d1da024c9f90975a074a08536bdcc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124903 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40730 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130069 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-change.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-to-abspos-change.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91586 "1 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110586 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3fa1c78-f312-400e-87f1-7132d329606a) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31452 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-change.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-to-abspos-change.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30154 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25009 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178812 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31711 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29653 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-change.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-to-abspos-change.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138455 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-change.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-to-abspos-change.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40791 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34307 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-change.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-to-abspos-change.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138346 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104463 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33594 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26605 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-change.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-to-abspos-change.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113062 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39380 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4703 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39630 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39525 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->