### PR TITLE
[libpas] Wrap test_pas with xctest harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 autoinstall.cache.d
 project.xcworkspace
 xcuserdata
+*.xcresult
 DerivedData
 .mailmap
 results
@@ -93,4 +94,6 @@ CLAUDE.md
 
 # Ignore tracing files
 *.atrc
+*.profraw
+*.pas_stats.jsonl
 

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 				0F8A80EE25F6A70A00790B4A /* PBXTargetDependency */,
 				0F8A80F025F6A70A00790B4A /* PBXTargetDependency */,
 				0F8A80EC25F6A70A00790B4A /* PBXTargetDependency */,
+				BE5700E51A2B3C4D5E6F7092 /* PBXTargetDependency */,
 			);
 			name = all;
 			productName = all;
@@ -87,6 +88,9 @@
 		0F329A3023F1D63600A133C4 /* pas_ensure_heap_forced_into_reserved_memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F329A2A23F1D63600A133C4 /* pas_ensure_heap_forced_into_reserved_memory.c */; };
 		0F373E522659EA5E0034BA96 /* pas_system_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F373E512659EA5E0034BA96 /* pas_system_heap.h */; };
 		0F443B3E23416AC300BE50D1 /* Verifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F443B3523416A4000BE50D1 /* Verifier.cpp */; };
+		BE5700E51A2B3C4D5E6F7089 /* LibpasTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = BE5700E51A2B3C4D5E6F7087 /* LibpasTests.mm */; };
+		BE5700E51A2B3C4D5E6F708C /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE5700E51A2B3C4D5E6F708A /* XCTest.framework */; };
+		BE5700E51A2B3C4D5E6F708D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE5700E51A2B3C4D5E6F708B /* Foundation.framework */; };
 		0F443B4023416BEA00BE50D1 /* libpas.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FDEA5D92295FC8C0085E340 /* libpas.dylib */; };
 		0F443B4423416DD500BE50D1 /* libpas_verifier.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F443B3A23416A7C00BE50D1 /* libpas_verifier.dylib */; };
 		0F443B482341761500BE50D1 /* mbmalloc_iso_common_primitive.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FF08F5522A86E2E00386575 /* mbmalloc_iso_common_primitive.c */; settings = {COMPILER_FLAGS = "-DPAS_VERIFIED"; }; };
@@ -723,6 +727,20 @@
 			remoteGlobalIDString = 0FDEA5D82295FC8C0085E340;
 			remoteInfo = pas;
 		};
+		BE5700E51A2B3C4D5E6F7090 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A6CA64F21012895003EFDBF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0FC681DA210FAC4B003C6A13;
+			remoteInfo = test_pas;
+		};
+		BE5700E51A2B3C4D5E6F7091 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A6CA64F21012895003EFDBF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BE5700E51A2B3C4D5E6F7081;
+			remoteInfo = "libpas-xctests";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1324,6 +1342,10 @@
 		F3EFAAB92E90316400A1EDE0 /* pas_mar_registry.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pas_mar_registry.c; sourceTree = "<group>"; };
 		F3EFAABA2E90316400A1EDE0 /* pas_mar_report_crash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_mar_report_crash.h; sourceTree = "<group>"; };
 		F3EFAABB2E90316400A1EDE0 /* pas_mar_report_crash.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pas_mar_report_crash.c; sourceTree = "<group>"; };
+		BE5700E51A2B3C4D5E6F7087 /* LibpasTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LibpasTests.mm; sourceTree = "<group>"; };
+		BE5700E51A2B3C4D5E6F7088 /* libpas-xctests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "libpas-xctests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE5700E51A2B3C4D5E6F708A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		BE5700E51A2B3C4D5E6F708B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1392,6 +1414,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BE5700E51A2B3C4D5E6F7086 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BE5700E51A2B3C4D5E6F708D /* Foundation.framework in Frameworks */,
+				BE5700E51A2B3C4D5E6F708C /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -1415,6 +1446,7 @@
 		0FC681E3210FAC87003C6A13 /* test */ = {
 			isa = PBXGroup;
 			children = (
+				BE5700E51A2B3C4D5E6F708E /* xctest */,
 				0FDEA45D228B651B0085E340 /* BitfieldVectorTests.cpp */,
 				2CE2AE34275A953E00D02BBC /* BitfitTests.cpp */,
 				0F53181022C954ED003F7B6A /* BitvectorTests.cpp */,
@@ -2018,6 +2050,7 @@
 				0F443B4E2341761500BE50D1 /* libmbmalloc_iso_common_primitive_verified.dylib */,
 				0FDEA5D92295FC8C0085E340 /* libpas.dylib */,
 				0F443B3A23416A7C00BE50D1 /* libpas_verifier.dylib */,
+				BE5700E51A2B3C4D5E6F7088 /* libpas-xctests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2037,8 +2070,18 @@
 		3A6CA66621012BAB003EFDBF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BE5700E51A2B3C4D5E6F708B /* Foundation.framework */,
+				BE5700E51A2B3C4D5E6F708A /* XCTest.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		BE5700E51A2B3C4D5E6F708E /* xctest */ = {
+			isa = PBXGroup;
+			children = (
+				BE5700E51A2B3C4D5E6F7087 /* LibpasTests.mm */,
+			);
+			path = xctest;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2558,6 +2601,23 @@
 			productReference = 0FC681DB210FAC4B003C6A13 /* test_pas */;
 			productType = "com.apple.product-type.tool";
 		};
+		BE5700E51A2B3C4D5E6F7081 /* libpas-xctests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BE5700E51A2B3C4D5E6F7082 /* Build configuration list for PBXNativeTarget "libpas-xctests" */;
+			buildPhases = (
+				BE5700E51A2B3C4D5E6F7085 /* Sources */,
+				BE5700E51A2B3C4D5E6F7086 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BE5700E51A2B3C4D5E6F708F /* PBXTargetDependency */,
+			);
+			name = "libpas-xctests";
+			productName = "libpas-xctests";
+			productReference = BE5700E51A2B3C4D5E6F7088 /* libpas-xctests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		0FDEA5D82295FC8C0085E340 /* pas */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0FDEA5DA2295FC8E0085E340 /* Build configuration list for PBXNativeTarget "pas" */;
@@ -2641,6 +2701,7 @@
 				0F8A808E25F6A44F00790B4A /* mbmalloc_hotbit */,
 				0F8A80BE25F6A48600790B4A /* mbmalloc */,
 				0F8A80DD25F6A6E700790B4A /* all */,
+				BE5700E51A2B3C4D5E6F7081 /* libpas-xctests */,
 			);
 		};
 /* End PBXProject section */
@@ -2898,6 +2959,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BE5700E51A2B3C4D5E6F7085 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BE5700E51A2B3C4D5E6F7089 /* LibpasTests.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -2985,6 +3054,16 @@
 			isa = PBXTargetDependency;
 			target = 0FDEA5D82295FC8C0085E340 /* pas */;
 			targetProxy = 0FF3D2D9247C91D000EBD22C /* PBXContainerItemProxy */;
+		};
+		BE5700E51A2B3C4D5E6F708F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0FC681DA210FAC4B003C6A13 /* test_pas */;
+			targetProxy = BE5700E51A2B3C4D5E6F7090 /* PBXContainerItemProxy */;
+		};
+		BE5700E51A2B3C4D5E6F7092 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BE5700E51A2B3C4D5E6F7081 /* libpas-xctests */;
+			targetProxy = BE5700E51A2B3C4D5E6F7091 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -3511,6 +3590,45 @@
 			};
 			name = Release;
 		};
+		BE5700E51A2B3C4D5E6F7083 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++23";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.webkit.libpas-xctests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx.internal;
+				SUPPORTED_PLATFORMS = macosx;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		BE5700E51A2B3C4D5E6F7084 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++23";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.webkit.libpas-xctests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx.internal;
+				SUPPORTED_PLATFORMS = macosx;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3582,6 +3700,15 @@
 			buildConfigurations = (
 				0FC681E0210FAC4B003C6A13 /* Debug */,
 				0FC681E1210FAC4B003C6A13 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BE5700E51A2B3C4D5E6F7082 /* Build configuration list for PBXNativeTarget "libpas-xctests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BE5700E51A2B3C4D5E6F7083 /* Debug */,
+				BE5700E51A2B3C4D5E6F7084 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Source/bmalloc/libpas/libpas.xcodeproj/xcshareddata/xcschemes/libpas-xctests.xcscheme
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/xcshareddata/xcschemes/libpas-xctests.xcscheme
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BE5700E51A2B3C4D5E6F7081"
+               BuildableName = "libpas-xctests.xctest"
+               BlueprintName = "libpas-xctests"
+               ReferencedContainer = "container:libpas.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:libpas.xcodeproj/xcshareddata/xcschemes/libpas-xctests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Source/bmalloc/libpas/libpas.xcodeproj/xcshareddata/xcschemes/libpas-xctests.xctestplan
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/xcshareddata/xcschemes/libpas-xctests.xctestplan
@@ -1,0 +1,26 @@
+{
+  "configurations" : [
+    {
+      "id" : "00000000-0000-0000-0000-000000000001",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "defaultTestExecutionTimeAllowance" : 1800,
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:libpas.xcodeproj",
+        "identifier" : "BE5700E51A2B3C4D5E6F7081",
+        "name" : "libpas-xctests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Source/bmalloc/libpas/src/test/LotsOfHeapsAndThreads.cpp
+++ b/Source/bmalloc/libpas/src/test/LotsOfHeapsAndThreads.cpp
@@ -69,10 +69,10 @@ void addLotsOfHeapsAndThreadsTests()
 {
 #if PAS_ENABLE_BMALLOC
     (void)testLotsOfHeapsAndThreads;
-//    ForceTLAs forceTLAs;
-//    
-//    ADD_TEST(testLotsOfHeapsAndThreads(10000, 100, 10));
-//    ADD_TEST(testLotsOfHeapsAndThreads(25000, 100, 10));
-//    ADD_TEST(testLotsOfHeapsAndThreads(30000, 100, 10)); // This is about as high as we can reliably go right now!
+    ForceTLAs forceTLAs;
+
+    ADD_TEST(testLotsOfHeapsAndThreads(10000, 100, 10));
+    ADD_TEST(testLotsOfHeapsAndThreads(25000, 100, 10));
+    ADD_TEST(testLotsOfHeapsAndThreads(30000, 100, 10)); // This is about as high as we can reliably go right now!
 #endif // PAS_ENABLE_BMALLOC
 }

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -195,6 +195,12 @@ InstallVerifier::InstallVerifier()
 {
 }
 
+NoVerifier::NoVerifier()
+    : TestScope(
+        "no-verifier",
+        [] () { })
+{ }
+
 EpochIsCounter::EpochIsCounter()
     : TestScope(
         "epoch-is-counter",
@@ -611,8 +617,8 @@ ParsedArguments parseArguments(int argc, char** argv)
             }
             i++;
             int value = atoi(argv[i]);
-            if (value <= 0) {
-                cerr << "Error: --child-processes must be a positive integer, got: " << argv[i] << endl;
+            if (value < 0) {
+                cerr << "Error: --child-processes must be a non-negative integer, got: " << argv[i] << endl;
                 exit(1);
             }
             args.childProcesses = value;
@@ -636,6 +642,9 @@ ParsedArguments parseArguments(int argc, char** argv)
 
 unsigned computeTestConcurrency(std::optional<int> childProcesses)
 {
+    if (childProcesses.has_value() && !(*childProcesses))
+        return 1;
+
     const char* envConcurrency = getenv("PasTestConcurrency");
     if (envConcurrency) {
         int concurrency = atoi(envConcurrency);
@@ -747,7 +756,7 @@ size_t waitForAnyProcess(vector<RunningTest>& runningTests)
             cout << "    FAIL: unexpected exit with code " << WEXITSTATUS(waitStatus) << endl;
         }
     } else if (WIFSIGNALED(waitStatus)) {
-        cout << "    CRASH: with signal " << WTERMSIG(waitStatus) << endl;
+        cout << "    FAIL: CRASH with signal " << WTERMSIG(waitStatus) << endl;
     } else
         cout << "    FAIL: child process terminated with unknown status code " << waitStatus << endl;
 
@@ -836,6 +845,11 @@ int main(int argc, char** argv)
 #if SEGHEAP
     pas_segregated_page_config_do_validate = true;
 #endif
+
+    // This list should be kept in sync with the
+    // LIBPAS_SUITE() list in src/test/xctest/LibpasTests.mm;
+    // missing entries in that list will not be run in xctest-based configs,
+    // e.g. CI.
 
     // Run the Thingy tests first because they catch the most bugs.
     ADD_SUITE(ThingyAndUtilityHeapAllocation);

--- a/Source/bmalloc/libpas/src/test/TestHarness.h
+++ b/Source/bmalloc/libpas/src/test/TestHarness.h
@@ -271,6 +271,12 @@ public:
     InstallVerifier();
 };
 
+/* This exists to make it easier to filter for non-verifier tests */
+class NoVerifier : public TestScope {
+public:
+    NoVerifier();
+};
+
 class EpochIsCounter : public TestScope {
 public:
     EpochIsCounter();

--- a/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ThingyAndUtilityHeapAllocationTests.cpp
@@ -3257,15 +3257,18 @@ void addThingyAndUtilityHeapAllocationTests()
     // pas API outside of ADD_TEST().
     CHECK(!pas_bootstrap_free_heap.num_mapped_bytes);
 
-    ForceTLAs forceTLAs;
-    EpochIsCounter epochIsCounter;
-
     {
         InstallVerifier installVerifier;
+        ForceTLAs forceTLAs;
+        EpochIsCounter epochIsCounter;
         addAllTests();
     }
-
-    addAllTests();
+    {
+        NoVerifier noVerifier;
+        ForceTLAs forceTLAs;
+        EpochIsCounter epochIsCounter;
+        addAllTests();
+    }
 #endif // PAS_ENABLE_THINGY
 }
 

--- a/Source/bmalloc/libpas/src/test/xctest/LibpasTests.mm
+++ b/Source/bmalloc/libpas/src/test/xctest/LibpasTests.mm
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <TargetConditionals.h>
+#import <XCTest/XCTest.h>
+
+// This bundle drives test_pas as a subprocess via NSTask, which is macOS-only
+// (iOS sandboxing forbids spawning arbitrary executables). On iOS the file
+// compiles to an empty translation unit, so the bundle still builds cleanly
+// but registers zero test classes. Running libpas tests on iOS is a separate
+// effort — historically handled by build.sh's tar-and-ssh path in
+// test-impl.sh, not by xctest.
+#if TARGET_OS_OSX
+
+// Each LIBPAS_SUITE() below produces a distinct XCTestCase subclass. xctest
+// parallelizes work at the test-class level — when xcodebuild is invoked with
+// -parallel-testing-worker-count N, each runner takes a disjoint subset of the
+// classes. With one class per suite, all 33 suites can fan out across runners.
+//
+// The suite filter passed to test_pas is a substring match against
+// Test::fullName() in TestHarness.cpp, which has the form
+// "(idx):path:line/SUITE/scope/.../testname". Bracketing the suite name with
+// '/'s isolates exactly that suite's tests.
+//
+// The LIBPAS_SUITE() list at the bottom MUST stay in sync with the ADD_SUITE()
+// block in src/test/TestHarness.cpp. Mismatches surface as missing test
+// classes, not silent regressions.
+
+@interface LibpasSuite : XCTestCase
+@end
+
+@implementation LibpasSuite
+
++ (BOOL)isParallelizable
+{
+    return YES;
+}
+
+- (NSString *)libpas_suiteName
+{
+    // Subclasses override.
+    return nil;
+}
+
+- (int)libpas_childProcesses
+{
+    // Default: serialize within test_pas (xctest fans out across suites).
+    // Subclasses can override to give a single suite its own internal
+    // parallelism — useful for chaos-style suites that benefit from running
+    // many short scenarios concurrently inside one test_pas invocation.
+    return 0;
+}
+
+- (NSURL *)libpas_testPasURL
+{
+    NSURL *bundleDir = [[NSBundle bundleForClass:[self class]].bundleURL URLByDeletingLastPathComponent];
+    return [bundleDir URLByAppendingPathComponent:@"test_pas"];
+}
+
+- (void)test_run
+{
+    NSString *suite = [self libpas_suiteName];
+    if (!suite) {
+        // Skip the abstract base class when xctest enumerates it.
+        return;
+    }
+
+    NSURL *binary = [self libpas_testPasURL];
+    XCTAssertTrue([NSFileManager.defaultManager isExecutableFileAtPath:binary.path],
+                  @"test_pas not found or not executable at %@", binary.path);
+
+    // Use the test class name, not the suite filter, for the temp file path:
+    // LIBPAS_SUITE_FILTER lets the filter contain '/' (sub-scope drill), and
+    // that breaks stringByAppendingPathComponent: into a nonexistent directory.
+    NSString *className = NSStringFromClass([self class]);
+    NSString *tmpPath = [NSTemporaryDirectory() stringByAppendingPathComponent:
+                         [NSString stringWithFormat:@"%@-%@.log", className, NSUUID.UUID.UUIDString]];
+    [NSFileManager.defaultManager createFileAtPath:tmpPath contents:nil attributes:nil];
+    NSFileHandle *log = [NSFileHandle fileHandleForWritingAtPath:tmpPath];
+    XCTAssertNotNil(log, @"failed to open temp log %@", tmpPath);
+
+    NSTask *task = [[NSTask alloc] init];
+    task.executableURL = binary;
+    NSString *childProcessesArg = [NSString stringWithFormat:@"%d", [self libpas_childProcesses]];
+    task.arguments = @[ @"--child-processes", childProcessesArg,
+                        [NSString stringWithFormat:@"/%@/", suite] ];
+    NSMutableDictionary<NSString *, NSString *> *env = [NSProcessInfo.processInfo.environment mutableCopy];
+    env[@"DYLD_LIBRARY_PATH"] = [binary URLByDeletingLastPathComponent].path;
+    task.environment = env;
+    task.standardOutput = log;
+    task.standardError = log;
+
+    NSError *launchError = nil;
+    if (![task launchAndReturnError:&launchError]) {
+        [log closeFile];
+        [NSFileManager.defaultManager removeItemAtPath:tmpPath error:nil];
+        XCTFail(@"failed to launch test_pas for /%@/: %@", suite, launchError);
+        return;
+    }
+    [task waitUntilExit];
+    [log closeFile];
+
+    int status = task.terminationStatus;
+    NSTaskTerminationReason reason = task.terminationReason;
+
+    if (status != 0 || reason != NSTaskTerminationReasonExit) {
+        NSData *captured = [NSData dataWithContentsOfFile:tmpPath] ?: [NSData data];
+
+        // xctest has this annoying behavior where it seems to trim anything after
+        // the first 64KiB of a log; some of our tests will fill that up even when
+        // they succeed, much less when they start logging errors.
+        // So we need to fetch the full log and attach it as a sidecar in the .xcresult,
+        // in the case that the XCTFail message gets trimmed.
+        XCTAttachment *attachment = [XCTAttachment attachmentWithData:captured
+                                                uniformTypeIdentifier:@"public.plain-text"];
+        attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+        attachment.name = [NSString stringWithFormat:@"test_pas-%@.log", className];
+        [self addAttachment:attachment];
+
+        const NSUInteger cap = 64 * 1024;
+        NSData *tail = (captured.length > cap)
+                           ? [captured subdataWithRange:NSMakeRange(captured.length - cap, cap)]
+                           : captured;
+        NSString *tailStr = [[NSString alloc] initWithData:tail encoding:NSUTF8StringEncoding] ?: @"<non-utf8 output>";
+        NSString *reasonStr = (reason == NSTaskTerminationReasonUncaughtSignal) ? @"signal" : @"exit";
+        XCTFail(@"test_pas /%@/ failed (%@ %d)\n----- last %lu of %lu bytes (full log attached) -----\n%@",
+                suite, reasonStr, status, (unsigned long)tail.length, (unsigned long)captured.length, tailStr);
+    }
+
+    [NSFileManager.defaultManager removeItemAtPath:tmpPath error:nil];
+}
+
+@end
+
+// SIMPLE_LIBPAS_SUITE is for the common case where the test_pas filter is just
+// the ADD_SUITE name and is a valid ObjC identifier — no in-test_pas
+// parallelism. LIBPAS_SUITE is the full form: pass an identifier-safe class
+// suffix, the filter string (which may contain '/' to drill into a sub-scope),
+// and N for --child-processes. Pass 0 for the default no-internal-parallelism
+// behavior; pass >0 to give a long suite its own internal parallelism.
+// LIBPAS_SUITE_FLAKY tolerates failures by wrapping test_run in an
+// XCTExpectFailureWithOptions call configured with non-strict options, so
+// either failure or success is reported as a passing test.
+#define SIMPLE_LIBPAS_SUITE(NAME) LIBPAS_SUITE(NAME, #NAME, 0)
+#define LIBPAS_SUITE(IDENT, FILTER, N)                                \
+    @interface Libpas_##IDENT : LibpasSuite @end                      \
+    @implementation Libpas_##IDENT                                    \
+    - (NSString *)libpas_suiteName { return @FILTER; }                \
+    - (int)libpas_childProcesses { return N; }                        \
+    @end
+#define LIBPAS_SUITE_FLAKY(IDENT, FILTER, N, REASON)                  \
+    @interface Libpas_##IDENT : LibpasSuite @end                      \
+    @implementation Libpas_##IDENT                                    \
+    - (NSString *)libpas_suiteName { return @FILTER; }                \
+    - (int)libpas_childProcesses { return N; }                        \
+    - (void)test_run                                                  \
+    {                                                                 \
+        XCTExpectFailureWithOptions(@REASON,                          \
+            [XCTExpectedFailureOptions nonStrictOptions]);            \
+        [super test_run];                                             \
+    }                                                                 \
+    @end
+
+// We split up a few of the longest suites to improve parallelism and make it easier
+// to track down failures.
+LIBPAS_SUITE(ThingyAndUtilityHeapAllocation_WithVerifier, "ThingyAndUtilityHeapAllocation/install-verifier", 0)
+LIBPAS_SUITE(ThingyAndUtilityHeapAllocation_SansVerifier, "ThingyAndUtilityHeapAllocation/no-verifier", 0)
+SIMPLE_LIBPAS_SUITE(BitfieldVector)
+SIMPLE_LIBPAS_SUITE(Bitfit)
+SIMPLE_LIBPAS_SUITE(Bitvector)
+SIMPLE_LIBPAS_SUITE(Bmalloc)
+SIMPLE_LIBPAS_SUITE(CartesianTree)
+SIMPLE_LIBPAS_SUITE(Coalign)
+SIMPLE_LIBPAS_SUITE(Enumeration)
+SIMPLE_LIBPAS_SUITE(ExpendableMemory)
+SIMPLE_LIBPAS_SUITE(ExtendedGCD)
+SIMPLE_LIBPAS_SUITE(Hashtable)
+SIMPLE_LIBPAS_SUITE(HeapRefAllocatorIndex)
+SIMPLE_LIBPAS_SUITE(IsoDynamicPrimitiveHeap)
+LIBPAS_SUITE_FLAKY(IsoHeapChaos_EnablePageBalancing, "IsoHeapChaos/enable-page-balancing", 4, "rdar://179251452 — rarely crashes")
+LIBPAS_SUITE_FLAKY(IsoHeapChaos_DisablePageBalancing, "IsoHeapChaos/disable-page-balancing", 4, "rdar://179251452 — rarely crashes")
+SIMPLE_LIBPAS_SUITE(IsoHeapPageSharing)
+SIMPLE_LIBPAS_SUITE(IsoHeapReservedMemory)
+SIMPLE_LIBPAS_SUITE(JITHeap)
+SIMPLE_LIBPAS_SUITE(LargeFreeHeap)
+SIMPLE_LIBPAS_SUITE(LargeSharingPool)
+SIMPLE_LIBPAS_SUITE(LockFreeReadPtrPtrHashtable)
+SIMPLE_LIBPAS_SUITE(LotsOfHeapsAndThreads)
+SIMPLE_LIBPAS_SUITE(MAR)
+SIMPLE_LIBPAS_SUITE(Memalign)
+SIMPLE_LIBPAS_SUITE(MinHeap)
+SIMPLE_LIBPAS_SUITE(PGM)
+SIMPLE_LIBPAS_SUITE(Race)
+SIMPLE_LIBPAS_SUITE(RedBlackTree)
+SIMPLE_LIBPAS_SUITE(ReallocFastPath)
+SIMPLE_LIBPAS_SUITE(ScavengerExternalWork)
+LIBPAS_SUITE_FLAKY(TLCDecommit, "TLCDecommit", 0, "rdar://86924027 — broken pending some accounting fixes from the kernel")
+SIMPLE_LIBPAS_SUITE(TSD)
+SIMPLE_LIBPAS_SUITE(Utils)
+SIMPLE_LIBPAS_SUITE(ViewCache)
+
+
+#undef SIMPLE_LIBPAS_SUITE
+#undef LIBPAS_SUITE
+#undef LIBPAS_SUITE_FLAKY
+
+#endif // TARGET_OS_OSX


### PR DESCRIPTION
#### e7665a906ab0d885bf4c9890c9da4caebf7a4b27
<pre>
[libpas] Wrap test_pas with xctest harness
<a href="https://bugs.webkit.org/show_bug.cgi?id=316595">https://bugs.webkit.org/show_bug.cgi?id=316595</a>
<a href="https://rdar.apple.com/179050730">rdar://179050730</a>

Reviewed by Keith Miller.

This patch intentionally leaves the core test infrastructure in place;
we prefer to not have to route everything through xctest, which is
poorly-shaped for libpas&apos; needs. Rather, it adds a wrapper scheme
which has a single xctest suite per libpas test suite, and which
builds the necessary harness components (xctestrun file and the
wrapping xctestproducts directory) for automated systems to hook into
it. This does introduce some fragility insofar as the two lists need to
be kept in sync, but that&apos;s also benificial in that it allows us to
fine-tune which tests are run in CI vs. at desk.

Canonical link: <a href="https://commits.webkit.org/314947@main">https://commits.webkit.org/314947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adfe8218f6b391314d8f92a963f1bd64f5969685

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167654 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176711 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41164 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/110961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25444 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28341 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179251 "") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30059 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/179251 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41223 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/179251 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37349 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41911 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105079 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33990 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200331 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40415 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53822 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39812 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5113 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40063 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->