### PR TITLE
[JSC] ParenthesesSubpatternFixedCount should support captures

### DIFF
--- a/JSTests/microbenchmarks/regexp-empty-body-parens.js
+++ b/JSTests/microbenchmarks/regexp-empty-body-parens.js
@@ -1,0 +1,58 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+// This benchmarks quantified parentheses whose body can match an empty
+// string, e.g. /(){3}/, /(?:){5}/, /(a?){3}/. The Yarr JIT compiles these
+// patterns and then bails to the interpreter at runtime via the
+// empty-match-detection branch in ParenthesesSubpattern[FixedCount]End.
+// This microbenchmark guards against regressions in either the JIT
+// compilation path or the interpreter fallback for the empty-body case.
+
+(function() {
+    var result = 0;
+    var n = 200000;
+
+    var str1 = "abc";
+    var str2 = "";
+    var str3 = "aaa";
+    var str4 = "aaab";
+    var str5 = "xx";
+
+    // Pure empty body — JIT bails to interpreter on the first iteration.
+    var re1 = /(){3}/;             // capturing empty
+    var re2 = /(?:){3}/;           // non-capturing empty
+    var re3 = /((?:)){3}/;         // capturing of empty alternative
+
+    // Optional / alternation that matches empty for some inputs.
+    var re4 = /(a?){3}/;           // optional content
+    var re5 = /(|x){3}/;           // empty alternation
+    var re6 = /(x|){3}/;           // empty alternation
+
+    // Empty inner inside a non-empty outer.
+    var re7 = /(a()){3}/;          // outer non-empty, inner empty
+
+    // Empty paren followed by capturing content.
+    var re8 = /(){2}(a)b/;
+
+    for (var i = 0; i < n; ++i) {
+        if (re1.exec(str1))
+            ++result;
+        if (re2.exec(str1))
+            ++result;
+        if (re3.exec(str1))
+            ++result;
+        if (re4.exec(str2))
+            ++result;
+        if (re4.exec(str3))
+            ++result;
+        if (re5.exec(str2))
+            ++result;
+        if (re6.exec(str5))
+            ++result;
+        if (re7.exec(str4))
+            ++result;
+        if (re8.exec("ab"))
+            ++result;
+    }
+
+    if (result != n * 9)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/microbenchmarks/regexp-fixed-count-capturing-parens.js
+++ b/JSTests/microbenchmarks/regexp-fixed-count-capturing-parens.js
@@ -1,0 +1,44 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+// This benchmarks capturing parentheses with fixed-count quantifiers whose
+// body has a single alternative and contains nothing backtrackable, e.g.
+// /([0-9a-fA-F]){12}/ or /([0-9a-fA-F]{4}\.){2}/. These now route to the
+// ParenthesesSubpatternFixedCount fast path that no longer allocates a
+// ParenContext per iteration.
+
+(function() {
+    var result = 0;
+    var n = 500000;
+
+    // Test strings that will match
+    var str1 = "0123456789ab";        // for ([0-9a-fA-F]){12}
+    var str2 = "abcd.efff.0011";      // for ([0-9a-fA-F]{4}\.){2}([0-9a-fA-F]{4})
+    var str3 = "aaa";                 // for ([a-z]){3}
+    var str4 = "abcabc";              // for ([a-z]{3}){2}
+
+    // Test strings that will fail (exercise the abort/backtrack path).
+    var fail1 = "0123456789ax";
+    var fail2 = "abcd.efgh.0011";
+
+    var re1 = /([0-9a-fA-F]){12}/;
+    var re2 = /([0-9a-fA-F]{4}\.){2}([0-9a-fA-F]{4})/;
+    var re3 = /([a-z]){3}/;
+    var re4 = /([a-z]{3}){2}/;
+
+    for (var i = 0; i < n; ++i) {
+        if (re1.exec(str1))
+            ++result;
+        if (re2.exec(str2))
+            ++result;
+        if (re3.exec(str3))
+            ++result;
+        if (re4.exec(str4))
+            ++result;
+        if (re1.exec(fail1) === null)
+            ++result;
+        if (re2.exec(fail2) === null)
+            ++result;
+    }
+
+    if (result != n * 6)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/stress/yarr-quantified-empty-parentheses.js
+++ b/JSTests/stress/yarr-quantified-empty-parentheses.js
@@ -1,0 +1,75 @@
+// Coverage for quantified parentheses whose body can match an empty string —
+// e.g. /(){3}/, /(?:){5}/, /((?:)){2}/, /(a?){3}/. The Yarr JIT punts these
+// runs to the interpreter via the empty-match-detection branch in
+// ParenthesesSubpattern[FixedCount]End; this test exercises both the JIT
+// (which aborts and bails) and the interpreter to confirm they agree on
+// the captured value, the match index, and overall match success.
+// Expected values were verified against the Yarr interpreter and V8.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: got ${actual}, expected ${expected}`);
+}
+
+function match(re, str) {
+    let m = re.exec(str);
+    return m === null ? "null" : JSON.stringify(Array.from(m).map(x => x === undefined ? null : x)) + "@" + m.index;
+}
+
+function test(reSource, flags, str, expected) {
+    let re = new RegExp(reSource, flags);
+    for (let i = 0; i < 200; ++i)
+        shouldBe(match(re, str), expected);
+}
+
+// --- Capturing FixedCount empty body ---
+test("(){3}", "", "", '["",""]@0');
+test("(){3}", "", "abc", '["",""]@0');
+test("^(){3}$", "", "", '["",""]@0');
+test("^(){3}$", "", "a", "null");
+test("a(){3}", "", "a", '["a",""]@0');
+test("a(){3}", "", "abc", '["a",""]@0');
+test("a(){3}b", "", "ab", '["ab",""]@0');
+test("(){1}", "", "x", '["",""]@0');
+test("(){10}", "", "x", '["",""]@0');
+
+// --- Non-capturing FixedCount empty body ---
+test("(?:){3}", "", "abc", '[""]@0');
+test("^(?:){3}$", "", "", '[""]@0');
+test("a(?:){3}b", "", "ab", '["ab"]@0');
+
+// --- Capturing empty alternative inside ---
+test("((?:)){3}", "", "abc", '["",""]@0');
+test("((?:)){2}x", "", "x", '["x",""]@0');
+
+// --- Mixed: outer non-empty, inner can be empty ---
+test("(a()){3}", "", "aaa", '["aaa","a",""]@0');
+test("(a()){3}b", "", "aaab", '["aaab","a",""]@0');
+test("((a)()){2}", "", "aa", '["aa","a","a",""]@0');
+
+// --- Optional content (a? matches empty when a is absent) ---
+test("(a?){3}", "", "", '["",""]@0');
+test("(a?){3}", "", "a", '["a",""]@0');
+test("(a?){3}", "", "aaa", '["aaa","a"]@0');
+test("(a?){3}", "", "aaaa", '["aaa","a"]@0');
+test("^(a?){3}$", "", "", '["",""]@0');
+test("^(a?){3}$", "", "aaa", '["aaa","a"]@0');
+test("^(a?){3}$", "", "aaaa", "null");
+
+// --- Empty alternation ---
+test("(|x){3}", "", "", '["",""]@0');
+test("(|x){3}", "", "xxx", '["",""]@0');
+test("(x|){3}", "", "xx", '["xx",""]@0');
+
+// --- Quantified empty paren followed by capturing content ---
+test("(){2}(a)", "", "a", '["a","","a"]@0');
+test("(){2}(a)b", "", "ab", '["ab","","a"]@0');
+
+// --- Greedy empty (?: ... )* — JIT also bails for the empty case ---
+test("(?:)*", "", "abc", '[""]@0');
+test("()*", "", "abc", '["",null]@0');
+test("()+", "", "abc", '["",""]@0');
+
+// --- Backreference to an empty-body capture group ---
+test("(){3}\\1", "", "abc", '["",""]@0');
+test("()\\1", "", "abc", '["",""]@0');

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1635,6 +1635,53 @@ class YarrGenerator final : public YarrJITInfo {
 #endif
     }
 
+    void emitClearCapturesForTerm(PatternTerm* term)
+    {
+        if (!shouldRecordSubpatterns() || !term->containsAnyCaptures())
+            return;
+        for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; ++subpattern)
+            clearSubpattern(subpattern);
+    }
+
+    void emitClearAllCaptures()
+    {
+        if (!shouldRecordSubpatterns())
+            return;
+        for (unsigned subpatternId = 0; subpatternId < m_pattern.m_numSubpatterns + 1; ++subpatternId)
+            clearSubpattern(subpatternId);
+        for (unsigned i = 1; i <= m_pattern.m_numDuplicateNamedCaptureGroups; ++i)
+            m_jit.store32(MacroAssembler::TrustedImm32(0), duplicateNamedGroupAddress(i));
+    }
+
+    void emitCaptureStart(PatternTerm* term, Checked<unsigned> checkedOffset, MacroAssembler::RegisterID indexTemporary, unsigned extraOffset = 0)
+    {
+        // FIXME: could avoid offsetting this value in JIT code, apply offsets only afterwards, at the point the results array is being accessed.
+        ASSERT(term->capture() && shouldRecordSubpatterns());
+        unsigned inputOffset = checkedOffset - term->inputPosition + extraOffset;
+        if (inputOffset) {
+            m_jit.sub32(m_regs.index, MacroAssembler::Imm32(inputOffset), indexTemporary);
+            setSubpatternStart(indexTemporary, term->parentheses.subpatternId);
+        } else
+            setSubpatternStart(m_regs.index, term->parentheses.subpatternId);
+    }
+
+    void emitCaptureEnd(PatternTerm* term, Checked<unsigned> checkedOffset, MacroAssembler::RegisterID indexTemporary)
+    {
+        // FIXME: could avoid offsetting this value in JIT code, apply offsets only afterwards, at the point the results array is being accessed.
+        ASSERT(term->capture() && shouldRecordSubpatterns());
+        auto subpatternId = term->parentheses.subpatternId;
+        unsigned inputOffset = checkedOffset - term->inputPosition;
+        if (inputOffset) {
+            m_jit.sub32(m_regs.index, MacroAssembler::Imm32(inputOffset), indexTemporary);
+            setSubpatternEnd(indexTemporary, subpatternId);
+        } else
+            setSubpatternEnd(m_regs.index, subpatternId);
+        if (m_pattern.m_numDuplicateNamedCaptureGroups) {
+            if (auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId])
+                storeDuplicateNamedGroupSubpatternId(duplicateNamedGroupId, subpatternId);
+        }
+    }
+
     void storeDuplicateNamedGroupSubpatternId(unsigned duplicateNamedGroupId, unsigned subpatternId)
     {
         m_jit.store32(MacroAssembler::TrustedImm32(subpatternId), duplicateNamedGroupAddress(duplicateNamedGroupId));
@@ -4089,7 +4136,6 @@ class YarrGenerator final : public YarrJITInfo {
                 termMatchTargets.append(MatchTargets());
 
                 unsigned parenthesesFrameLocation = term->frameLocation;
-                const MacroAssembler::RegisterID indexTemporary = m_regs.regT0;
                 ASSERT(term->quantityMaxCount == 1);
 
                 // Upon entry to a Greedy quantified set of parenthese store the index.
@@ -4115,27 +4161,15 @@ class YarrGenerator final : public YarrJITInfo {
                     storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoParenthesesOnce::beginIndex());
                 }
 
-                // If the parenthese are capturing, store the starting index value to the
-                // captures array, offsetting as necessary.
-                //
-                // FIXME: could avoid offsetting this value in JIT code, apply
-                // offsets only afterwards, at the point the results array is
-                // being accessed.
+                // If the parenthese are capturing, store the starting index value to the captures array.
                 if (term->capture() && shouldRecordSubpatterns()) {
-                    unsigned inputOffset = op.m_checkedOffset - term->inputPosition;
-                    if (term->quantityType == QuantifierType::FixedCount)
-                        inputOffset += term->parentheses.disjunction->m_minimumSize;
-                    if (inputOffset) {
-                        m_jit.sub32(m_regs.index, MacroAssembler::Imm32(inputOffset), indexTemporary);
-                        setSubpatternStart(indexTemporary, term->parentheses.subpatternId);
-                    } else
-                        setSubpatternStart(m_regs.index, term->parentheses.subpatternId);
+                    unsigned extraOffset = term->quantityType == QuantifierType::FixedCount ? term->parentheses.disjunction->m_minimumSize : 0;
+                    emitCaptureStart(term, op.m_checkedOffset, m_regs.regT0, extraOffset);
                 }
                 break;
             }
             case YarrOpCode::ParenthesesSubpatternOnceEnd: {
                 PatternTerm* term = op.m_term;
-                const MacroAssembler::RegisterID indexTemporary = m_regs.regT0;
                 ASSERT(term->quantityMaxCount == 1);
 
                 termMatchTargets.takeLast();
@@ -4146,25 +4180,9 @@ class YarrGenerator final : public YarrJITInfo {
                 if (term->quantityType != QuantifierType::FixedCount && !term->parentheses.disjunction->m_minimumSize)
                     m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(term->frameLocation * sizeof(void*))));
 
-                // If the parenthese are capturing, store the ending index value to the
-                // captures array, offsetting as necessary.
-                //
-                // FIXME: could avoid offsetting this value in JIT code, apply
-                // offsets only afterwards, at the point the results array is
-                // being accessed.
-                if (term->capture() && shouldRecordSubpatterns()) {
-                    auto subpatternId = term->parentheses.subpatternId;
-                    unsigned inputOffset = op.m_checkedOffset - term->inputPosition;
-                    if (inputOffset) {
-                        m_jit.sub32(m_regs.index, MacroAssembler::Imm32(inputOffset), indexTemporary);
-                        setSubpatternEnd(indexTemporary, subpatternId);
-                    } else
-                        setSubpatternEnd(m_regs.index, subpatternId);
-                    if (m_pattern.m_numDuplicateNamedCaptureGroups) {
-                        if (auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId])
-                            storeDuplicateNamedGroupSubpatternId(duplicateNamedGroupId, subpatternId);
-                    }
-                }
+                // If the parenthese are capturing, store the ending index value to the captures array.
+                if (term->capture() && shouldRecordSubpatterns())
+                    emitCaptureEnd(term, op.m_checkedOffset, m_regs.regT0);
 
                 // If the parentheses are quantified Greedy then add a label to jump back
                 // to if we get a failed match from after the parentheses. For NonGreedy
@@ -4221,11 +4239,19 @@ class YarrGenerator final : public YarrJITInfo {
 
             // YarrOpCode::ParenthesesSubpatternFixedCountBegin/End
             //
-            // These nodes support non-capturing parentheses with FixedCount quantifier.
-            // Example: (?:abc){3,3} or (?:x){5,5}
+            // Used to wrap FixedCount parentheses (capturing or non-capturing) whose
+            // content has a single alternative and contains nothing backtrackable
+            // (no backreferences, no variable quantifiers, no multi-alt). Examples:
+            //   (?:abc){3,3}, (?:x){5,5}, ([0-9a-fA-F]){12}, ([0-9]{4}\.){2}
+            //
             // The semantics are: match exactly N times. Any failure = total failure.
-            // Note: We reuse BackTrackInfoParentheses offsets for frame layout compatibility
-            // with the interpreter fallback path.
+            // For capturing parens, the body cannot observe intermediate capture
+            // values (the safety check above rejects any inner backref), so we only
+            // need to set the capture to the last iteration's positions; per-iteration
+            // bookkeeping in a ParenContext is not required.
+            //
+            // Note: We reuse BackTrackInfoParentheses offsets for frame layout
+            // compatibility with the interpreter fallback path.
             case YarrOpCode::ParenthesesSubpatternFixedCountBegin: {
                 termMatchTargets.append(MatchTargets());
 
@@ -4243,13 +4269,20 @@ class YarrGenerator final : public YarrJITInfo {
                 // Set the reentry label for looping.
                 defineReentryLabel(op);
 
-                // Clear nested captures at the start of each iteration.
-                // This is required by ECMAScript spec - capture groups are reset to undefined
-                // at the beginning of each iteration of a quantified group.
-                if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
-                    for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
+                // Clear nested captures at the start of each iteration. ECMAScript
+                // requires capture groups to be reset to undefined at the start of
+                // each iteration of a quantified group. For a capturing outer, we
+                // skip its own id here because BEGIN's setSubpatternStart and END's
+                // setSubpatternEnd unconditionally overwrite both halves.
+                unsigned firstClear = term->parentheses.subpatternId + (term->capture() ? 1 : 0);
+                if (shouldRecordSubpatterns() && firstClear <= term->parentheses.lastSubpatternId) {
+                    for (unsigned subpattern = firstClear; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
                         clearSubpattern(subpattern);
                 }
+
+                // For capturing parens, record this iteration's starting index.
+                if (term->capture() && shouldRecordSubpatterns())
+                    emitCaptureStart(term, op.m_checkedOffset, m_regs.regT0);
 
                 // Store the current index for empty match detection.
                 storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
@@ -4266,6 +4299,12 @@ class YarrGenerator final : public YarrJITInfo {
                 // FIXME: <https://bugs.webkit.org/show_bug.cgi?id=200786>
                 if (!term->parentheses.disjunction->m_minimumSize)
                     m_abortExecution.append(m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(parenthesesFrameLocation * sizeof(void*))));
+
+                // For capturing parens, record this iteration's ending index. After
+                // the loop exits with success the surviving values are exactly the
+                // last iteration's positions, which is what ECMA requires.
+                if (term->capture() && shouldRecordSubpatterns())
+                    emitCaptureEnd(term, op.m_checkedOffset, m_regs.regT0);
 
                 // Increment the match count.
                 const MacroAssembler::RegisterID countTemporary = m_regs.regT0;
@@ -4348,21 +4387,9 @@ class YarrGenerator final : public YarrJITInfo {
                 storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
                 storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
 
-                // If the parenthese are capturing, store the starting index value to the
-                // captures array, offsetting as necessary.
-                //
-                // FIXME: could avoid offsetting this value in JIT code, apply
-                // offsets only afterwards, at the point the results array is
-                // being accessed.
-                if (term->capture() && shouldRecordSubpatterns()) {
-                    const MacroAssembler::RegisterID indexTemporary = m_regs.regT0;
-                    unsigned inputOffset = op.m_checkedOffset - term->inputPosition;
-                    if (inputOffset) {
-                        m_jit.sub32(m_regs.index, MacroAssembler::Imm32(inputOffset), indexTemporary);
-                        setSubpatternStart(indexTemporary, term->parentheses.subpatternId);
-                    } else
-                        setSubpatternStart(m_regs.index, term->parentheses.subpatternId);
-                }
+                // If the parenthese are capturing, store the starting index value to the captures array.
+                if (term->capture() && shouldRecordSubpatterns())
+                    emitCaptureStart(term, op.m_checkedOffset, m_regs.regT0);
 #else // !YARR_JIT_ALL_PARENS_EXPRESSIONS
                 RELEASE_ASSERT_NOT_REACHED();
 #endif
@@ -4388,27 +4415,9 @@ class YarrGenerator final : public YarrJITInfo {
                 const MacroAssembler::RegisterID countTemporary = m_regs.regT1;
                 loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
 
-                // If the parenthese are capturing, store the ending index value to the
-                // captures array, offsetting as necessary.
-                //
-                // FIXME: could avoid offsetting this value in JIT code, apply
-                // offsets only afterwards, at the point the results array is
-                // being accessed.
-                if (term->capture() && shouldRecordSubpatterns()) {
-                    const MacroAssembler::RegisterID indexTemporary = m_regs.regT0;
-
-                    auto subpatternId = term->parentheses.subpatternId;
-                    unsigned inputOffset = op.m_checkedOffset - term->inputPosition;
-                    if (inputOffset) {
-                        m_jit.sub32(m_regs.index, MacroAssembler::Imm32(inputOffset), indexTemporary);
-                        setSubpatternEnd(indexTemporary, subpatternId);
-                    } else
-                        setSubpatternEnd(m_regs.index, subpatternId);
-                    if (m_pattern.m_numDuplicateNamedCaptureGroups) {
-                        if (auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId])
-                            storeDuplicateNamedGroupSubpatternId(duplicateNamedGroupId, subpatternId);
-                    }
-                }
+                // If the parenthese are capturing, store the ending index value to the captures array.
+                if (term->capture() && shouldRecordSubpatterns())
+                    emitCaptureEnd(term, op.m_checkedOffset, m_regs.regT0);
 
                 switch (term->quantityType) {
                 case QuantifierType::FixedCount:
@@ -4469,11 +4478,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // If inverted, a successful match of the assertion must be treated
                 // as a failure, clear any nested captures and jump to backtracking.
                 if (term->invert()) {
-                    if (shouldRecordSubpatterns()
-                        && term->containsAnyCaptures()) {
-                        for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
-                            clearSubpattern(subpattern);
-                    }
+                    emitClearCapturesForTerm(term);
                     op.m_jumps.append(m_jit.jump());
                     defineReentryLabel(op);
                 }
@@ -5007,15 +5012,15 @@ class YarrGenerator final : public YarrJITInfo {
 
             // YarrOpCode::ParenthesesSubpatternFixedCountBegin/End
             //
-            // For non-capturing FixedCount parentheses, any failure means the entire
-            // pattern fails. There's no partial backtracking - we either match
-            // exactly N times or we fail completely.
+            // For FixedCount parentheses (capturing or non-capturing) on the fast
+            // path, any failure means the entire pattern fails. There's no partial
+            // backtracking - we either match exactly N times or we fail completely.
             case YarrOpCode::ParenthesesSubpatternFixedCountBegin: {
                 // Any backtrack to Begin means we failed to match the required count.
                 // Link any pending backtrack state from the content inside, restore
                 // the index to the position when we entered the group (since one or
-                // more iterations may have advanced it), clear any nested captures,
-                // then propagate the failure upward.
+                // more iterations may have advanced it), clear this paren's capture
+                // and any nested captures, then propagate the failure upward.
                 PatternTerm* term = op.m_term;
                 unsigned parenthesesFrameLocation = term->frameLocation;
 
@@ -5023,10 +5028,7 @@ class YarrGenerator final : public YarrJITInfo {
 
                 loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex(), m_regs.index);
 
-                if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
-                    for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
-                        clearSubpattern(subpattern);
-                }
+                emitClearCapturesForTerm(term);
 
                 m_backtrackingState.fallthrough();
                 break;
@@ -5039,9 +5041,11 @@ class YarrGenerator final : public YarrJITInfo {
 
             // YarrOpCode::ParenthesesSubpatternBegin/End
             //
-            // These handle capturing subpatterns, and non-capturing subpatterns that need
-            // ParenContext for inter-iteration backtracking (FixedCount with backtrackable
-            // content, multi-alt FixedCount, or Greedy/NonGreedy quantifiers).
+            // Capturing or non-capturing subpatterns that need a ParenContext for
+            // inter-iteration backtracking: FixedCount with backtrackable content,
+            // multi-alt FixedCount, or Greedy/NonGreedy quantifiers. (Capturing
+            // FixedCount with non-backtrackable single-alt body is routed instead
+            // to ParenthesesSubpatternFixedCountBegin/End above.)
             //
             // In all quantifiers, we always save the state at BEGIN (save-at-BEGIN model).
             // Each iteration's pre-iteration state is snapshotted into a ParenContext that
@@ -5108,10 +5112,7 @@ class YarrGenerator final : public YarrJITInfo {
                     // This is because NonGreedy already tried with count = 0, failing and reaching here.
                     // So there is no way to proceed further, just propagate a failure.
                     noPreviousIteration.link(&m_jit);
-                    if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
-                        for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
-                            clearSubpattern(subpattern);
-                    }
+                    emitClearCapturesForTerm(term);
                     storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
                     m_backtrackingState.fallthrough();
                     break;
@@ -5143,10 +5144,7 @@ class YarrGenerator final : public YarrJITInfo {
                         // We need to clear the state, and go back to the further former backtracking.
                         noPreviousIteration.link(&m_jit);
                         op.m_jumps.link(&m_jit);
-                        if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
-                            for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
-                                clearSubpattern(subpattern);
-                        }
+                        emitClearCapturesForTerm(term);
                     } else {
                         // Try fewer iterations.
                         m_jit.jump(endOp.m_reentry);
@@ -5254,10 +5252,7 @@ class YarrGenerator final : public YarrJITInfo {
                     // subpattern. We already have adjusted the input position
                     // back to that before the assertion, which is correct.
                     if (term->invert()) {
-                        if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
-                            for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
-                                clearSubpattern(subpattern);
-                        }
+                        emitClearCapturesForTerm(term);
                         m_jit.jump(endOp.m_reentry);
                     }
 
@@ -5278,8 +5273,7 @@ class YarrGenerator final : public YarrJITInfo {
                 PatternTerm* term = op.m_term;
                 if (!term->invert() && shouldRecordSubpatterns() && term->containsAnyCaptures()) {
                     m_backtrackingState.link(*this, op);
-                    for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
-                        clearSubpattern(subpattern);
+                    emitClearCapturesForTerm(term);
                     m_backtrackingState.fallthrough();
                 }
                 m_backtrackingState.takeBacktracksToJumpList(op.m_jumps, &m_jit);
@@ -5357,24 +5351,20 @@ class YarrGenerator final : public YarrJITInfo {
         } else {
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
             if (term->quantityType == QuantifierType::FixedCount) {
-                // Handle FixedCount parentheses.
-                // For non-capturing FixedCount without backtrackable content AND single alternative,
-                // we can use the simpler opcodes that don't need ParenContext.
-                // For capturing FixedCount, FixedCount with backtrackable content, or multi-alt FixedCount,
-                // we use ParenContext to save/restore state between iterations.
                 bool hasMultipleAlternatives = term->parentheses.disjunction->m_alternatives.size() != 1;
                 bool hasBacktrackableContent = term->quantityMaxCount > 1 && disjunctionContainsBacktrackableContent(term->parentheses.disjunction);
 
-                // Multi-alt FixedCount needs ParenContext for inter-iteration backtracking
-                // (trying different alternatives in previous iterations)
-                if (!term->capture() && !hasBacktrackableContent && !hasMultipleAlternatives) {
-                    // Non-capturing FixedCount without backtrackable content AND single alternative:
-                    // use the simpler, more efficient opcodes that don't need ParenContext.
+                if (!hasBacktrackableContent && !hasMultipleAlternatives) {
+                    // Single-alt FixedCount whose body has nothing backtrackable —
+                    // capture support is also legal here because no inner term can
+                    // observe an intermediate capture value (see ParenthesesSubpattern-
+                    // FixedCountBegin's header for the full argument).
                     parenthesesBeginOpCode = YarrOpCode::ParenthesesSubpatternFixedCountBegin;
                     parenthesesEndOpCode = YarrOpCode::ParenthesesSubpatternFixedCountEnd;
                 } else {
-                    // Capturing FixedCount, FixedCount with backtrackable content, or multi-alt FixedCount:
-                    // need ParenContext to save/restore state between iterations.
+                    // Multi-alt FixedCount (needs to remember which alternative each
+                    // iteration took) or backtrackable inner content (needs to roll
+                    // state back across iterations) — use the ParenContext path.
                     m_containsNestedSubpatterns = true;
                     m_usesT2 = true;
                     parenthesesBeginOpCode = YarrOpCode::ParenthesesSubpatternBegin;
@@ -6906,12 +6896,7 @@ public:
 
         // Initialize subpatterns' starts. And initialize matchStart if `!m_pattern.m_body->m_hasFixedSize`.
         // If shouldRecordSubpatterns(), then matchStart is subpatterns[0]'s start.
-        if (shouldRecordSubpatterns()) {
-            for (unsigned subpatternId = 0; subpatternId < m_pattern.m_numSubpatterns + 1; ++subpatternId)
-                clearSubpattern(subpatternId);
-            for (unsigned i = 1; i <= m_pattern.m_numDuplicateNamedCaptureGroups; ++i)
-                m_jit.store32(MacroAssembler::TrustedImm32(0), duplicateNamedGroupAddress(i));
-        }
+        emitClearAllCaptures();
         if (!m_pattern.m_body->m_hasFixedSize)
             setMatchStart(m_regs.index);
 
@@ -7054,12 +7039,7 @@ public:
             m_jit.getEffectiveAddress(MacroAssembler::BaseIndex(m_regs.input, m_regs.length, MacroAssembler::TimesTwo), m_regs.endOfStringAddress);
 #endif
 
-        if (shouldRecordSubpatterns()) {
-            for (unsigned subpatternId = 0; subpatternId < m_pattern.m_numSubpatterns + 1; ++subpatternId)
-                clearSubpattern(subpatternId);
-            for (unsigned i = 1; i <= m_pattern.m_numDuplicateNamedCaptureGroups; ++i)
-                m_jit.store32(MacroAssembler::TrustedImm32(0), duplicateNamedGroupAddress(i));
-        }
+        emitClearAllCaptures();
         if (!m_pattern.m_body->m_hasFixedSize)
             setMatchStart(m_regs.index);
 
@@ -7277,13 +7257,21 @@ public:
             return 0;
 
         case YarrOpCode::ParenthesesSubpatternFixedCountBegin:
-            out.printf("ParenthesesSubpatternFixedCountBegin checked-offset:(%u) non-capturing ", op.m_checkedOffset.value());
+            out.printf("ParenthesesSubpatternFixedCountBegin checked-offset:(%u) ", op.m_checkedOffset.value());
+            if (term->capture())
+                out.printf("capturing pattern #%u", term->parentheses.subpatternId);
+            else
+                out.print("non-capturing");
             term->dumpQuantifier(out);
             out.print("\n");
             return 0;
 
         case YarrOpCode::ParenthesesSubpatternFixedCountEnd:
-            out.printf("ParenthesesSubpatternFixedCountEnd checked-offset:(%u) non-capturing ", op.m_checkedOffset.value());
+            out.printf("ParenthesesSubpatternFixedCountEnd checked-offset:(%u) ", op.m_checkedOffset.value());
+            if (term->capture())
+                out.printf("capturing pattern #%u", term->parentheses.subpatternId);
+            else
+                out.print("non-capturing");
             term->dumpQuantifier(out);
             out.print("\n");
             return 0;


### PR DESCRIPTION
#### 3f58e2018a6b5a953372488d2440129d59d3765e
<pre>
[JSC] ParenthesesSubpatternFixedCount should support captures
<a href="https://bugs.webkit.org/show_bug.cgi?id=316599">https://bugs.webkit.org/show_bug.cgi?id=316599</a>
<a href="https://rdar.apple.com/179054696">rdar://179054696</a>

Reviewed by Yijia Huang.

This patch expands the coverage of ParenthesesSubpatternFixedCount to
patterns having a capture.
Let&apos;s say /([a-z]){4}/, [a-z] is not having content backtracking so the
entire pattern ([a-z]){4} does not have backtracking: there is no way to
reduce the consumption / increase the consumption of characters to try
the different matchings. However because they have captures, we are
currently not applying ParenthesesSubpatternFixedCount optimization.

It is trivial to handle captures in ParenthesesSubpatternFixedCount
because we can just keep the last capture as a result since this
is FixedCount, so passing all iterations or nothing.

                                                         ToT                     Patched

    regexp-empty-body-parens                       80.3693+-0.2860     ^     78.8855+-0.3478        ^ definitely 1.0188x faster
    regexp-fixed-count-capturing-parens           195.9219+-0.6061     ^     80.0022+-1.1346        ^ definitely 2.4490x faster

Test: JSTests/stress/yarr-quantified-empty-parentheses.js

* JSTests/microbenchmarks/regexp-empty-body-parens.js: Added.
(re1):
(re2):
(re3):
(re4):
(re5):
(re6):
(re7.a):
(re8):
* JSTests/microbenchmarks/regexp-fixed-count-capturing-parens.js: Added.
(re1):
(re2):
(re3):
(re4):
* JSTests/stress/yarr-quantified-empty-parentheses.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/314853@main">https://commits.webkit.org/314853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/275e7e707d0f9c8a1990f6b648c8d2c756c03829

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176443 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95da9c80-7aa6-4d21-9cfa-cc94fdc2ddcd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130217 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9cc4d81-b555-4470-ab0d-de3acf352f09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110734 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4454dd7-440f-4cbf-8820-ca7f5d584ee9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30308 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25182 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159576 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178986 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28309 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31883 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138612 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138500 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41651 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104726 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33754 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26764 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200071 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40155 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113236 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53778 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39552 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4862 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39802 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->