### PR TITLE
[AppKit Gestures] Fatal error: Attempted to read an unowned reference but the object was already destroyed

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -32,7 +32,7 @@ private import CxxStdlib
 @objc
 @implementation
 extension WKTextSelectionController {
-    private unowned let view: WKWebView
+    private weak var view: WKWebView?
 
     @nonobjc
     private var currentRangeSelectionGranularity: NSTextSelection.Granularity? = nil
@@ -43,7 +43,7 @@ extension WKTextSelectionController {
     }
 
     func addTextSelectionManager() {
-        guard let page = view._protectedPage().get() else {
+        guard let view, let page = view._protectedPage().get() else {
             return
         }
 
@@ -51,7 +51,7 @@ extension WKTextSelectionController {
             return
         }
 
-        Logger.viewGestures.log("Creating a text selection manager for view \(self.view)")
+        Logger.viewGestures.log("Creating a text selection manager for view \(view)")
 
         let manager = NSTextSelectionManager()
         manager._webkitDelegate = self
@@ -63,7 +63,7 @@ extension WKTextSelectionController {
     }
 
     func selectionDidChange() {
-        guard let page = view._protectedPage().get() else {
+        guard let view, let page = view._protectedPage().get() else {
             return
         }
 
@@ -77,7 +77,7 @@ extension WKTextSelectionController {
 @implementation
 extension WKTextSelectionController {
     var insertionCursorRect: NSRect {
-        guard let page = view._protectedPage().get() else {
+        guard let view, let page = view._protectedPage().get() else {
             return .zero
         }
 
@@ -89,7 +89,7 @@ extension WKTextSelectionController {
     }
 
     var selectionIsInsertionPoint: Bool {
-        guard let page = view._protectedPage().get() else {
+        guard let view, let page = view._protectedPage().get() else {
             return false
         }
 
@@ -101,7 +101,7 @@ extension WKTextSelectionController {
     func isTextSelected(at point: NSPoint) -> Bool {
         // The `point` location is relative to the view.
 
-        guard let page = view._protectedPage().get() else {
+        guard let view, let page = view._protectedPage().get() else {
             return false
         }
 
@@ -135,7 +135,7 @@ extension WKTextSelectionController {
     func moveInsertionCursor(to point: NSPoint, placeAtWordBoundary: Bool) async -> Bool {
         // A return value of `true` indicates the selection has changed.
 
-        guard let page = view._protectedPage().get() else {
+        guard let view, let page = view._protectedPage().get() else {
             return false
         }
 
@@ -181,7 +181,7 @@ extension WKTextSelectionController {
     func showContextMenu(at point: NSPoint) {
         // The `point` location is relative to the window.
 
-        guard let page = view._protectedPage().get(), let impl = view._impl() else {
+        guard let view, let page = view._protectedPage().get(), let impl = view._impl() else {
             return
         }
 
@@ -203,7 +203,7 @@ extension WKTextSelectionController {
 
     @objc(dragSelectionWithGesture:completionHandler:)
     func dragSelection(withGesture gesture: NSGestureRecognizer, completionHandler: @escaping @Sendable (NSDraggingSession) -> Void) {
-        guard let page = view._protectedPage().get(), let impl = view._impl() else {
+        guard let view, let page = view._protectedPage().get(), let impl = view._impl() else {
             return
         }
 
@@ -246,7 +246,7 @@ extension WKTextSelectionController {
 
     @objc
     private func textSelectionDragGestureUpdated(_ gesture: NSGestureRecognizer) {
-        guard let impl = view._impl() else {
+        guard let view, let impl = view._impl() else {
             gesture.removeTarget(self, action: #selector(textSelectionDragGestureUpdated(_:)))
             return
         }
@@ -296,7 +296,7 @@ extension WKTextSelectionController {
 
     @objc(beginRangeSelectionAtPoint:withGranularity:)
     func beginRangeSelection(at point: NSPoint, with granularity: NSTextSelection.Granularity) {
-        guard let page = view._protectedPage().get(), let impl = view._impl() else {
+        guard let view, let page = view._protectedPage().get(), let impl = view._impl() else {
             return
         }
 
@@ -319,7 +319,7 @@ extension WKTextSelectionController {
 
     @objc(continueRangeSelectionAtPoint:)
     func continueRangeSelection(at point: NSPoint) {
-        guard let page = view._protectedPage().get() else {
+        guard let view, let page = view._protectedPage().get() else {
             return
         }
 
@@ -342,7 +342,7 @@ extension WKTextSelectionController {
 
     @objc(endRangeSelectionAtPoint:)
     func endRangeSelection(at point: NSPoint) {
-        guard let page = view._protectedPage().get(), let impl = view._impl() else {
+        guard let view, let page = view._protectedPage().get(), let impl = view._impl() else {
             return
         }
 


### PR DESCRIPTION
#### 7afdf9c1d82a42129366867daad470bd7142aaff
<pre>
[AppKit Gestures] Fatal error: Attempted to read an unowned reference but the object was already destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=316605">https://bugs.webkit.org/show_bug.cgi?id=316605</a>
<a href="https://rdar.apple.com/177229107">rdar://177229107</a>

Reviewed by Abrar Rahman Protyasha.

Use weak instead of unowned.

No tests since this isn&apos;t readily reproducible.

* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.view):
(WKTextSelectionController.addTextSelectionManager):
(WKTextSelectionController.selectionDidChange):
(WKTextSelectionController.insertionCursorRect):
(WKTextSelectionController.selectionIsInsertionPoint):
(WKTextSelectionController.isTextSelected(at:)):
(WKTextSelectionController.moveInsertionCursor(to:placeAtWordBoundary:)):
(WKTextSelectionController.showContextMenu(at:)):
(WKTextSelectionController.dragSelection(withGesture:completionHandler:)):
(WKTextSelectionController.textSelectionDragGestureUpdated(_:)):
(WKTextSelectionController.beginRangeSelection(at:with:)):
(WKTextSelectionController.continueRangeSelection(at:)):
(WKTextSelectionController.endRangeSelection(at:)):

Canonical link: <a href="https://commits.webkit.org/314844@main">https://commits.webkit.org/314844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e4bde9bb0594bdf9fc76e383dcfbb7cb79cbcd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40705 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34297 "Hash 2e4bde9b for PR 66723 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176259 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18022316-c4ee-410b-919e-7b9d9c52484c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b2f61c3-7bbe-40f0-b246-725d9ead19a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32461 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/34297 "Hash 2e4bde9b for PR 66723 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110578 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8914e544-9cc4-49aa-ad65-8ac7ded551b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31443 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30144 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24997 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141426 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/34297 "Hash 2e4bde9b for PR 66723 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178800 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31699 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/34297 "Hash 2e4bde9b for PR 66723 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138445 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138338 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/37238 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41467 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/34297 "Hash 2e4bde9b for PR 66723 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104445 "Hash 2e4bde9b for PR 66723 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33586 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/34297 "Hash 2e4bde9b for PR 66723 does not build (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39971 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113050 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39368 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/34297 "Hash 2e4bde9b for PR 66723 does not build (failure)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39618 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39513 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->