### PR TITLE
[GFC] Add scaffolding to classify intrinsic-width sizing path

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -49,6 +49,7 @@ GridFormattingContext::GridFormattingContext(const ElementBox& gridBox, LayoutSt
     : m_gridBox(gridBox)
     , m_globalLayoutState(layoutState)
     , m_integrationUtils(layoutState)
+    , m_intrinsicWidthSizingPath(classifyIntrinsicWidthSizingPath())
 {
 }
 
@@ -259,14 +260,31 @@ void GridFormattingContext::setGridItemGeometries(const GridItemRects& gridItemR
     }
 }
 
+IntrinsicWidthSizingPath GridFormattingContext::classifyIntrinsicWidthSizingPath() const
+{
+    auto containerWritingMode = writingMode();
+
+    auto anyGridItemInlineContributionMayRequireFullSizingAlgorithm = [&] {
+        for (CheckedRef gridItem : childrenOfType<ElementBox>(m_gridBox)) {
+            if (gridItem->isOutOfFlowPositioned())
+                continue;
+            if (GridLayoutUtils::inlineContributionMayRequireFullSizingAlgorithmForIntrinsicWidth(gridItem, containerWritingMode))
+                return true;
+        }
+        return false;
+    };
+
+    return anyGridItemInlineContributionMayRequireFullSizingAlgorithm()
+        ? IntrinsicWidthSizingPath::NeedsFullSizing
+        : IntrinsicWidthSizingPath::ColumnsOnly;
+}
+
 // https://drafts.csswg.org/css-grid-1/#intrinsic-sizes
 // The max-content size (min-content size) of a grid container is the sum of
 // the grid container's track sizes (including gutters) in the appropriate axis,
 // when the grid is sized under a max-content constraint (min-content constraint).
 GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWidths()
 {
-    auto unplacedGridItems = constructUnplacedGridItems();
-
     CheckedRef gridStyle = root().style();
     GridAutoFlowOptions autoFlowOptions {
         .strategy = gridStyle->gridAutoFlow().isDense() ? PackingStrategy::Dense : PackingStrategy::Sparse,
@@ -283,32 +301,29 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
         autoFlowOptions
     };
 
-    // Clone items for second pass since layout() consumes them
-    auto unplacedGridItemsForMaxContent = unplacedGridItems;
-
     auto usedJustifyContent = gridStyle->justifyContent().resolve();
     auto usedAlignContent = gridStyle->alignContent().resolve();
 
     auto usedColumnGap = usedGapValue(gridStyle->columnGap(), gridStyle);
     auto usedRowGap = usedGapValue(gridStyle->rowGap(), gridStyle);
 
-    // Compute min-content width by running the full grid sizing algorithm with MinContent scenario
-    GridLayoutConstraints minContentConstraints {
-        .inlineAxis = AxisConstraint::minContent(),
-        .blockAxis = AxisConstraint::minContent()
-    };
-    GridLayoutState minContentLayoutState { minContentConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedColumnGap, usedRowGap };
-    auto [minContentTrackSizes, minContentGridItemRects] = GridLayout { *this }.layout(unplacedGridItems, minContentLayoutState);
-    UNUSED_VARIABLE(minContentGridItemRects);
+    auto unplacedGridItems = constructUnplacedGridItems();
 
-    // Compute max-content width by running the full grid sizing algorithm with MaxContent scenario
-    GridLayoutConstraints maxContentConstraints {
-        .inlineAxis = AxisConstraint::maxContent(),
-        .blockAxis = AxisConstraint::maxContent()
+    auto columnSizesForConstraint = [&](AxisConstraint intrinsicConstraint) -> TrackSizes {
+        GridLayoutConstraints layoutConstraints {
+            .inlineAxis = intrinsicConstraint,
+            .blockAxis = intrinsicConstraint
+        };
+        GridLayoutState layoutState { layoutConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedColumnGap, usedRowGap };
+
+        // Clone items per scenario since the placement and sizing algorithm consumes them.
+        auto unplacedGridItemsForScenario = unplacedGridItems;
+
+        return GridLayout { *this }.layout(unplacedGridItemsForScenario, layoutState).usedTrackSizes.columnSizes;
     };
-    GridLayoutState maxContentLayoutState { maxContentConstraints, gridDefinition, usedJustifyContent, usedAlignContent, usedColumnGap, usedRowGap };
-    auto [maxContentTrackSizes, maxContentGridItemRects] = GridLayout { *this }.layout(unplacedGridItemsForMaxContent, maxContentLayoutState);
-    UNUSED_VARIABLE(maxContentGridItemRects);
+
+    TrackSizes minContentColumnSizes = columnSizesForConstraint(AxisConstraint::minContent());
+    TrackSizes maxContentColumnSizes = columnSizesForConstraint(AxisConstraint::maxContent());
 
     // Sum track sizes and add gaps
     auto computeIntrinsicWidth = [&](const TrackSizes& trackSizes) -> LayoutUnit {
@@ -320,8 +335,8 @@ GridFormattingContext::IntrinsicWidths GridFormattingContext::computeIntrinsicWi
     };
 
     return IntrinsicWidths {
-        .minimum = computeIntrinsicWidth(minContentTrackSizes.columnSizes),
-        .maximum = computeIntrinsicWidth(maxContentTrackSizes.columnSizes)
+        .minimum = computeIntrinsicWidth(minContentColumnSizes),
+        .maximum = computeIntrinsicWidth(maxContentColumnSizes)
     };
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -39,7 +39,6 @@ namespace Layout {
 
 class ElementBox;
 class PlacedGridItem;
-
 class UnplacedGridItem;
 
 struct GridAreaLines;
@@ -71,6 +70,14 @@ struct GridDefinition {
     GridAutoFlowOptions autoFlowOptions;
 };
 
+// Static classification of how much grid-sizing work is required to compute
+// the grid's intrinsic widths. Set once per GridFormattingContext before
+// either the min-content or max-content scenario runs.
+enum class IntrinsicWidthSizingPath : uint8_t {
+    ColumnsOnly, // No item's inline contribution depends on the item's own block size.
+    NeedsFullSizing, // At least one item's inline contribution depends on the item's own block size.
+};
+
 class GridFormattingContext {
     WTF_MAKE_TZONE_ALLOCATED(GridFormattingContext);
 public:
@@ -85,6 +92,7 @@ public:
     };
 
     IntrinsicWidths computeIntrinsicWidths();
+    IntrinsicWidthSizingPath intrinsicWidthSizingPath() const { return m_intrinsicWidthSizingPath; }
 
     PlacedGridItems constructPlacedGridItems(const GridAreas&) const;
 
@@ -117,6 +125,8 @@ public:
 private:
     UnplacedGridItems constructUnplacedGridItems() const;
 
+    IntrinsicWidthSizingPath classifyIntrinsicWidthSizingPath() const;
+
     const LayoutState& layoutState() const LIFETIME_BOUND { return m_globalLayoutState; }
     BoxGeometry& geometryForGridItem(const ElementBox&) LIFETIME_BOUND;
     void setGridItemGeometries(const GridItemRects&);
@@ -126,6 +136,7 @@ private:
     const CheckedRef<const ElementBox> m_gridBox;
     const CheckedRef<LayoutState> m_globalLayoutState;
     const IntegrationUtils m_integrationUtils;
+    const IntrinsicWidthSizingPath m_intrinsicWidthSizingPath;
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -36,6 +36,7 @@
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "TrackSizingAlgorithm.h"
 #include "TrackSizingFunctions.h"
+#include "WritingMode.h"
 #include <wtf/Range.h>
 
 namespace WebCore {
@@ -117,6 +118,38 @@ static bool isStretchedForAutomaticSize(const PlacedGridItem& placedGridItem, co
         return !preferredAspectRatio(placedGridItem.layoutBox()) && !placedGridItem.isReplacedElement();
 
     return alignmentPosition == ItemPosition::Stretch;
+}
+
+bool inlineContributionMayRequireFullSizingAlgorithmForIntrinsicWidth(const ElementBox& gridItem, WritingMode containerWritingMode)
+{
+    CheckedRef itemStyle = gridItem.style();
+
+    // The inline contribution of an orthogonal grid item is the grid item's block contribution. We should run the full sizing algorithm.
+    if (itemStyle->writingMode().isOrthogonal(containerWritingMode))
+        return true;
+
+    // Grid items with an aspect ratio may transfers block size into inline size, so we should run the full sizing algorithm.
+    // FIXME: This is only the case when inline size is indefinite, so we can tighten this constraint.
+    if (preferredAspectRatio(gridItem))
+        return true;
+
+    // A wrapped column flex container (flex-flow: column wrap) lays out its flex lines along the cross (inline) axis,
+    // so the number of lines - and thus its inline contribution - grows as the available block size shrinks.
+    if (itemStyle->display().isFlexibleBox() && itemStyle->isColumnFlexDirection() && itemStyle->flexWrap() != FlexWrap::NoWrap)
+        return true;
+
+    // A multi-column container fills its columns based on the available block size, so its column count - and thus
+    // its inline contribution - depends on the block size.
+    if (itemStyle->specifiesColumns())
+        return true;
+
+    // If the computed size of an item depends on the size of its containing block, we should run the full sizing algorithm.
+    if (sizeDependsOnContainingBlockSize(itemStyle->logicalHeight())
+        || sizeDependsOnContainingBlockSize(itemStyle->logicalMinHeight())
+        || sizeDependsOnContainingBlockSize(itemStyle->logicalMaxHeight()))
+        return true;
+
+    return false;
 }
 
 static bool NODELETE spansAutoMinTrackSizingFunction(WTF::Range<size_t> spannedTrackIndexes, const TrackSizingFunctionsList& trackSizingFunctions)
@@ -540,11 +573,6 @@ bool preferredSizeBehavesAsAuto(const Style::PreferredSize& preferredSize)
     // FIXME: Handle cases where preferred size is not auto but behaves as auto,
     // such as percentage height resolving against indefinite size.
     return preferredSize.isAuto();
-}
-
-bool preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize& preferredSize)
-{
-    return preferredSize.isStretch() || preferredSize.isPercentOrCalculated();
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -31,6 +31,8 @@
 
 namespace WebCore {
 
+class WritingMode;
+
 namespace Style {
 struct PreferredSize;
 }
@@ -41,6 +43,7 @@ class ElementBox;
 class GridFormattingContext;
 class IntegrationUtils;
 class PlacedGridItem;
+struct GridItemSizingFunctions;
 
 namespace GridLayoutUtils {
 
@@ -67,9 +70,14 @@ LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inl
 LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);
 
 bool preferredSizeBehavesAsAuto(const Style::PreferredSize&);
-bool NODELETE preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize&);
+template<typename SizeType>
+bool sizeDependsOnContainingBlockSize(const SizeType& size)
+{
+    return size.isStretch() || size.isPercentOrCalculated();
+}
 
 std::optional<double> preferredAspectRatio(const ElementBox&);
+bool inlineContributionMayRequireFullSizingAlgorithmForIntrinsicWidth(const ElementBox&, WritingMode containerWritingMode);
 
 } // namespace GridLayoutUtils
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -208,7 +208,7 @@ static Vector<LayoutUnit> minimumContributions(const TrackSizingItemList& trackS
         // containing block in the relevant axis, its minimum contribution is the outer size
         // that would result from assuming the item’s used minimum size as its preferred size.
         auto& preferredSize = trackSizingItem.computedSizes.preferredSize;
-        if (GridLayoutUtils::preferredSizeBehavesAsAuto(preferredSize) || GridLayoutUtils::preferredSizeDependsOnContainingBlockSize(preferredSize))
+        if (GridLayoutUtils::preferredSizeBehavesAsAuto(preferredSize) || GridLayoutUtils::sizeDependsOnContainingBlockSize(preferredSize))
             return gridItemSizingFunctions.usedMinimumSize(trackSizingItem.gridItem, trackSizingFunctions, trackSizingItem.borderAndPadding, { }, trackSizingItem.oppositeAxisConstraint);
         // else the item’s minimum contribution is its min-content contribution.
         return gridItemSizingFunctions.minContentContribution(trackSizingItem.gridItem, trackSizingItem.oppositeAxisConstraint);


### PR DESCRIPTION
#### dbf4f545d85696c4067e1c566e17c60fd44505fa
<pre>
[GFC] Add scaffolding to classify intrinsic-width sizing path
<a href="https://bugs.webkit.org/show_bug.cgi?id=316591">https://bugs.webkit.org/show_bug.cgi?id=316591</a>
&lt;<a href="https://rdar.apple.com/179042344">rdar://179042344</a>&gt;

Reviewed by Sammy Gill.

This PR adds scaffolding in GridFormattingContext for an intrinsic-width
fast-path classifier. GridFormattingContext now tracks IntrinsicWidthSizingPath
(ColumnsOnly | NeedsFullSizing) to improve intrinsic sizing performance.

This PR adds the first triggers for detecting block size dependent grid items.

Orthogonal grid items&apos; inline axis contribution is determined by its block size,
meaning that we need to run the full layout path to determine the intrinsic width
of a grid with orthogonal grid items.

Grid items with preferred aspect ratio and grid items that depend on their containing
block size may also require the full layout path for intrinsic width calcualations.

No behavior change in this PR.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::GridFormattingContext):
(WebCore::Layout::GridFormattingContext::classifyIntrinsicWidthSizingPath const):
(WebCore::Layout::GridFormattingContext::computeIntrinsicWidths):
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
(WebCore::Layout::GridFormattingContext::intrinsicWidthSizingPath const):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::inlineContributionMayRequireFullSizingAlgorithmForIntrinsicWidth):
(WebCore::Layout::GridLayoutUtils::preferredSizeDependsOnContainingBlockSize): Deleted.
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h:
(WebCore::Layout::GridLayoutUtils::sizeDependsOnContainingBlockSize):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::minimumContributions):

Canonical link: <a href="https://commits.webkit.org/317063@main">https://commits.webkit.org/317063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc5721f0b9035232ea0cb42808b060a04b6b4a9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131762 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0100104-b870-4936-962e-f0d55a57e569) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135236 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95349 "3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115714 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6199a36-cc96-4a7f-a8ce-2dcfd211a0da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37311 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35671 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31952 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185894 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144159 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47494 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143991 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48173 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113490 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38902 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120057 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46679 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10472 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46082 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46313 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->