### PR TITLE
[JSC] Deferred module namespace's `"then"` leaks into `Object.keys`

### DIFF
--- a/JSTests/modules/import-defer-then-not-enumerable.js
+++ b/JSTests/modules/import-defer-then-not-enumerable.js
@@ -1,0 +1,23 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js";
+
+import defer * as ns from "./import-defer/dep.js";
+
+// On a deferred namespace, [[GetOwnProperty]]("then") returns undefined (IsSymbolLikeNamespaceKey),
+// so enumerable-only listings must exclude "then" while [[OwnPropertyKeys]] still includes it.
+shouldBe(JSON.stringify(Object.keys(ns)), `["value"]`);
+shouldBe(JSON.stringify(Object.getOwnPropertyNames(ns)), `["then","value"]`);
+shouldBe(JSON.stringify(Reflect.ownKeys(ns).filter((key) => typeof key === "string")), `["then","value"]`);
+shouldBe(Object.getOwnPropertyDescriptor(ns, "then"), undefined);
+shouldBe(JSON.stringify(Object.entries(ns)), `[["value",1]]`);
+shouldBe(JSON.stringify(Object.values(ns)), `[1]`);
+shouldBe(JSON.stringify({ ...ns }), `{"value":1}`);
+
+const forIn = [];
+for (const key in ns)
+    forIn.push(key);
+shouldBe(JSON.stringify(forIn), `["value"]`);
+
+// Evaluation has been triggered above; the namespace stays deferred, so "then" remains hidden.
+shouldBe(ns.then, undefined);
+shouldBe(JSON.stringify(Object.keys(ns)), `["value"]`);

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -280,8 +280,10 @@ void JSModuleNamespaceObject::getOwnPropertyNames(JSObject* cell, JSGlobalObject
         if (mode == DontEnumPropertiesMode::Exclude) {
             // Perform [[GetOwnProperty]] to throw ReferenceError if binding is uninitialized.
             PropertySlot slot(cell, PropertySlot::InternalMethodType::GetOwnProperty);
-            thisObject->getOwnPropertySlotCommon(globalObject, name.get(), slot);
+            bool hasProperty = thisObject->getOwnPropertySlotCommon(globalObject, name.get(), slot);
             RETURN_IF_EXCEPTION(scope, void());
+            if (!hasProperty)
+                continue;
         }
         propertyNames.add(name);
     }


### PR DESCRIPTION
#### e46667fac7213242c664feaa8017bc9e964450e4
<pre>
[JSC] Deferred module namespace&apos;s `&quot;then&quot;` leaks into `Object.keys`
<a href="https://bugs.webkit.org/show_bug.cgi?id=316610">https://bugs.webkit.org/show_bug.cgi?id=316610</a>

Reviewed by Yusuke Suzuki.

Per the import defer proposal, IsSymbolLikeNamespaceKey(P, O) treats &quot;then&quot;
as symbol-like on a deferred namespace, so [[GetOwnProperty]](&quot;then&quot;) returns
OrdinaryGetOwnProperty(O, &quot;then&quot;) = undefined. EnumerableOwnProperties filters
each key through [[GetOwnProperty]] and skips keys whose descriptor is
undefined, so Object.keys / Object.values / Object.entries / spread / for-in
must not list &quot;then&quot;. [[OwnPropertyKeys]] returns [[Exports]] unfiltered, so
Reflect.ownKeys and Object.getOwnPropertyNames still include it.

JSModuleNamespaceObject::getOwnPropertyNames in DontEnumPropertiesMode::Exclude
already performed [[GetOwnProperty]] on each export name (for the ReferenceError
side effect on uninitialized bindings) but ignored its result and added every
key unconditionally, so &quot;then&quot; leaked into Object.keys:

    // dep.js: export let foo = 1; export function then(cb) { cb(); }
    import defer * as ns from &quot;./dep.js&quot;;
    Object.keys(ns);  // [&quot;foo&quot;, &quot;then&quot;], must be [&quot;foo&quot;]

Use the result of the [[GetOwnProperty]] lookup and skip keys with no
descriptor, the same way ProxyObject::performGetOwnEnumerablePropertyNames
implements this filter. The only key that can lack a descriptor is the
symbol-like &quot;then&quot; of a deferred namespace, so non-deferred namespaces are
unaffected.

Test: JSTests/modules/import-defer-then-not-enumerable.js

* JSTests/modules/import-defer-then-not-enumerable.js: Added.
(shouldBe.JSON.stringify):
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp:
(JSC::JSModuleNamespaceObject::getOwnPropertyNames):

Canonical link: <a href="https://commits.webkit.org/314977@main">https://commits.webkit.org/314977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9496d073225510ef381abf82fea5260dbb49cc92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124906 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130074 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91584 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110591 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31455 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30156 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25012 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159388 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141438 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27953 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178815 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28144 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31714 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29674 "Found 1 new test failure: fast/webgpu/nocrash/fuzz-298315.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138459 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37366 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41482 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104469 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33597 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26626 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199902 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39986 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113065 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53750 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39383 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4724 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->