### PR TITLE
Background Fetch and Cache Storage share a single resolved-path member

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -125,6 +125,7 @@ private:
     String m_resolvedCacheStoragePath;
     UnifiedOriginStorageLevel m_level;
     RefPtr<BackgroundFetchStoreManager> m_backgroundFetchManager;
+    String m_resolvedBackgroundFetchStoragePath;
     std::unique_ptr<ServiceWorkerStorageManager> m_serviceWorkerStorageManager;
 };
 
@@ -589,10 +590,10 @@ String OriginStorageManager::StorageBucket::resolvedCacheStoragePath()
 
 String OriginStorageManager::StorageBucket::resolvedBackgroundFetchStoragePath()
 {
-    if (m_resolvedCacheStoragePath.isNull())
-        m_resolvedCacheStoragePath = typeStoragePath(StorageType::BackgroundFetchStorage);
+    if (m_resolvedBackgroundFetchStoragePath.isNull())
+        m_resolvedBackgroundFetchStoragePath = typeStoragePath(StorageType::BackgroundFetchStorage);
 
-    return m_resolvedCacheStoragePath;
+    return m_resolvedBackgroundFetchStoragePath;
 }
 
 String OriginStorageManager::StorageBucket::resolvedPath(WebsiteDataType webisteDataType)


### PR DESCRIPTION
#### 77ee6ae99343f8819e9b1f12fffa4beac050f2bb
<pre>
Background Fetch and Cache Storage share a single resolved-path member
<a href="https://bugs.webkit.org/show_bug.cgi?id=316612">https://bugs.webkit.org/show_bug.cgi?id=316612</a>

Reviewed by Youenn Fablet.

OriginStorageManager::StorageBucket::resolvedBackgroundFetchStoragePath() reads
from and writes to m_resolvedCacheStoragePath instead of its own member. The
two storage types resolve to different on-disk subdirectories
(&quot;CacheStorage&quot; vs &quot;BackgroundFetchStorage&quot;) via typeStoragePath(), but both
accessors cache through one field, so whichever method runs first wins:

  - If Background Fetch is touched first, the field is populated with the
    BackgroundFetchStorage path, and the subsequent resolvedCacheStoragePath()
    short-circuits at its `!m_resolvedCacheStoragePath.isNull()` check and
    returns the Background Fetch path. CacheStorageManager is then constructed
    pointing at the wrong directory, and the Standard-level migration that
    moves m_customCacheStoragePath into the new location is silently skipped.

  - If Cache Storage is touched first, resolvedBackgroundFetchStoragePath()
    finds the field non-null and returns the CacheStorage path, so
    BackgroundFetchStoreManager writes its records into the Cache Storage
    directory.

Either way, one of the two features ends up reading and writing files in the
other feature&apos;s on-disk directory.

Fix by giving Background Fetch its own m_resolvedBackgroundFetchStoragePath
member, mirroring the pattern used for IDB and LocalStorage.

* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::resolvedBackgroundFetchStoragePath):

Canonical link: <a href="https://commits.webkit.org/314854@main">https://commits.webkit.org/314854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0de276bfaf5ef63f1264090a180a5ff65792d776

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176277 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130076 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110593 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c18aeb40-3a28-45fa-9382-e4b2e4ee9846) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31459 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30159 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25015 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141442 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178818 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31717 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138462 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138353 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37289 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41485 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104476 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33602 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26632 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39989 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113068 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39386 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4730 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->