### PR TITLE
[JSC] `GatherAvailableAncestors` and `AsyncModuleExecutionRejected` can overflow the stack on deep async module graphs

### DIFF
--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -507,39 +507,47 @@ static void gatherAvailableAncestors(CyclicModuleRecord* module, Vector<CyclicMo
     // "m.[[PendingAsyncDependencies]] != 0" so the loop is O(N) instead of O(N^2).
     // Within a single gather call, the two are equivalent under the spec's invariants;
     // see commit message for the proof. The ASSERT below verifies this at runtime.
+    //
+    // The spec specifies this as a recursion, but we use a worklist loop to avoid
+    // stack overflow crashes.
 
-    // 1. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
-    for (const WriteBarrier<AbstractModuleRecord>& barrier : module->asyncParentModules()) {
-        auto* m = uncheckedDowncast<CyclicModuleRecord>(barrier.get());
-        // 1.a. If execList does not contain m and m.[[CycleRoot]].[[EvaluationError]] is empty, then
-        // (Probable spec bug (https://github.com/tc39/ecma262/issues/3766). We need an additional check here that m.[[CycleRoot]] isn't empty.)
-        ASSERT_IMPLIES(!m->cycleRoot(), m->evaluationError());
-        CyclicModuleRecord* root = m->cycleRoot();
-        if (!root || root->evaluationError() != nullptr)
-            continue;
-        auto pending = m->pendingAsyncDependencies();
-        // Verify the invariant in debug: execList ∋ m  iff  pending == 0 (under cycleRoot OK).
-        ASSERT(pending);
-        ASSERT(execList.contains(m) == !*pending);
-        if (!*pending)
-            continue;
-        // 1.a.i. Assert: m.[[Status]] is EVALUATING-ASYNC.
-        ASSERT(m->status() == CyclicModuleRecord::Status::EvaluatingAsync);
-        // 1.a.ii. Assert: m.[[EvaluationError]] is EMPTY.
-        ASSERT(m->evaluationError() == nullptr);
-        // 1.a.iii. Assert: m.[[AsyncEvaluationOrder]] is an integer.
-        ASSERT(m->asyncEvaluationOrder().hasOrder());
-        // 1.a.iv. Assert: m.[[PendingAsyncDependencies]] > 0. (Implied by *pending != 0 above.)
-        // 1.a.v. Set m.[[PendingAsyncDependencies]] to m.[[PendingAsyncDependencies]] - 1.
-        int newDependencies = *pending - 1;
-        m->setPendingAsyncDependencies(newDependencies);
-        // 1.a.vi. If m.[[PendingAsyncDependencies]] = 0, then
-        if (!newDependencies) {
-            // 1.a.vi.1. Append m to execList.
-            execList.append(m);
-            // 1.a.vi.2. If m.[[HasTLA]] is false, perform GatherAvailableAncestors(m, execList).
-            if (!m->hasTLA())
-                gatherAvailableAncestors(m, execList);
+    Vector<CyclicModuleRecord*, 8> worklist;
+    worklist.append(module);
+    while (!worklist.isEmpty()) {
+        CyclicModuleRecord* record = worklist.takeLast();
+        // 1. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
+        for (const WriteBarrier<AbstractModuleRecord>& barrier : record->asyncParentModules()) {
+            auto* m = uncheckedDowncast<CyclicModuleRecord>(barrier.get());
+            // 1.a. If execList does not contain m and m.[[CycleRoot]].[[EvaluationError]] is empty, then
+            // (Probable spec bug (https://github.com/tc39/ecma262/issues/3766). We need an additional check here that m.[[CycleRoot]] isn't empty.)
+            ASSERT_IMPLIES(!m->cycleRoot(), m->evaluationError());
+            CyclicModuleRecord* root = m->cycleRoot();
+            if (!root || root->evaluationError() != nullptr)
+                continue;
+            auto pending = m->pendingAsyncDependencies();
+            // Verify the invariant in debug: execList ∋ m  iff  pending == 0 (under cycleRoot OK).
+            ASSERT(pending);
+            ASSERT(execList.contains(m) == !*pending);
+            if (!*pending)
+                continue;
+            // 1.a.i. Assert: m.[[Status]] is EVALUATING-ASYNC.
+            ASSERT(m->status() == CyclicModuleRecord::Status::EvaluatingAsync);
+            // 1.a.ii. Assert: m.[[EvaluationError]] is EMPTY.
+            ASSERT(m->evaluationError() == nullptr);
+            // 1.a.iii. Assert: m.[[AsyncEvaluationOrder]] is an integer.
+            ASSERT(m->asyncEvaluationOrder().hasOrder());
+            // 1.a.iv. Assert: m.[[PendingAsyncDependencies]] > 0. (Implied by *pending != 0 above.)
+            // 1.a.v. Set m.[[PendingAsyncDependencies]] to m.[[PendingAsyncDependencies]] - 1.
+            int newDependencies = *pending - 1;
+            m->setPendingAsyncDependencies(newDependencies);
+            // 1.a.vi. If m.[[PendingAsyncDependencies]] = 0, then
+            if (!newDependencies) {
+                // 1.a.vi.1. Append m to execList.
+                execList.append(m);
+                // 1.a.vi.2. If m.[[HasTLA]] is false, perform GatherAvailableAncestors(m, execList).
+                if (!m->hasTLA())
+                    worklist.append(m);
+            }
         }
     }
     // 2. Return UNUSED.
@@ -552,37 +560,43 @@ void CyclicModuleRecord::asyncExecutionRejected(JSGlobalObject* globalObject, JS
 
     VM& vm = globalObject->vm();
 
-    // 1. If module.[[Status]] is EVALUATED, then
-    if (status() == CyclicModuleRecord::Status::Evaluated) {
-        // 1.a. Assert: module.[[EvaluationError]] is not EMPTY.
-        ASSERT(evaluationError() != nullptr);
-        // 1.b. Return UNUSED.
-        return;
-    }
-    // 2. Assert: module.[[Status]] is EVALUATING-ASYNC.
-    ASSERT(status() == CyclicModuleRecord::Status::EvaluatingAsync);
-    // 3. Assert: module.[[AsyncEvaluationOrder]] is an integer.
-    ASSERT(asyncEvaluationOrder().hasOrder());
-    // 4. Assert: module.[[EvaluationError]] is EMPTY.
-    ASSERT(evaluationError() == nullptr);
-    // 5. Set module.[[EvaluationError]] to ThrowCompletion(error).
-    setEvaluationError(vm, error);
-    // 6. Set module.[[Status]] to EVALUATED.
-    setStatus(CyclicModuleRecord::Status::Evaluated);
-    // 7. Set module.[[AsyncEvaluationOrder]] to DONE.
-    setAsyncEvaluationOrder(AbstractModuleRecord::AsyncEvaluationOrder::done());
-    // 8. NOTE: module.[[AsyncEvaluationOrder]] is set to DONE for symmetry with AsyncModuleExecutionFulfilled. In InnerModuleEvaluation, the value of a module's [[AsyncEvaluationOrder]] internal slot is unused when its [[EvaluationError]] internal slot is not EMPTY.
-    // 9. If module.[[TopLevelCapability]] is not EMPTY, then
-    if (auto* topLevel = topLevelCapability()) {
-        // 9.a. Assert: module.[[CycleRoot]] and module are the same Module Record.
-        ASSERT(cycleRoot() == this);
-        // 9.b. Perform ! Call(module.[[TopLevelCapability]].[[Reject]], undefined, « error »).
-        topLevel->reject(vm, error);
-    }
-    // 10. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
-    for (const WriteBarrier<AbstractModuleRecord>& m : asyncParentModules()) {
-        // 10.a. Perform AsyncModuleExecutionRejected(m, error).
-        uncheckedDowncast<CyclicModuleRecord>(m.get())->asyncExecutionRejected(globalObject, error);
+    // The spec specifies this as a recursion, but we use a worklist loop to avoid
+    // stack overflow crashes.
+    Vector<CyclicModuleRecord*, 8> stack;
+    stack.append(this);
+    while (!stack.isEmpty()) {
+        CyclicModuleRecord* module = stack.takeLast();
+        // 1. If module.[[Status]] is EVALUATED, then
+        if (module->status() == CyclicModuleRecord::Status::Evaluated) {
+            // 1.a. Assert: module.[[EvaluationError]] is not EMPTY.
+            ASSERT(module->evaluationError() != nullptr);
+            // 1.b. Return UNUSED.
+            continue;
+        }
+        // 2. Assert: module.[[Status]] is EVALUATING-ASYNC.
+        ASSERT(module->status() == CyclicModuleRecord::Status::EvaluatingAsync);
+        // 3. Assert: module.[[AsyncEvaluationOrder]] is an integer.
+        ASSERT(module->asyncEvaluationOrder().hasOrder());
+        // 4. Assert: module.[[EvaluationError]] is EMPTY.
+        ASSERT(module->evaluationError() == nullptr);
+        // 5. Set module.[[EvaluationError]] to ThrowCompletion(error).
+        module->setEvaluationError(vm, error);
+        // 6. Set module.[[Status]] to EVALUATED.
+        module->setStatus(CyclicModuleRecord::Status::Evaluated);
+        // 7. Set module.[[AsyncEvaluationOrder]] to DONE.
+        module->setAsyncEvaluationOrder(AbstractModuleRecord::AsyncEvaluationOrder::done());
+        // 8. NOTE: module.[[AsyncEvaluationOrder]] is set to DONE for symmetry with AsyncModuleExecutionFulfilled. In InnerModuleEvaluation, the value of a module's [[AsyncEvaluationOrder]] internal slot is unused when its [[EvaluationError]] internal slot is not EMPTY.
+        // 9. If module.[[TopLevelCapability]] is not EMPTY, then
+        if (auto* topLevel = module->topLevelCapability()) {
+            // 9.a. Assert: module.[[CycleRoot]] and module are the same Module Record.
+            ASSERT(module->cycleRoot() == module);
+            // 9.b. Perform ! Call(module.[[TopLevelCapability]].[[Reject]], undefined, « error »).
+            topLevel->reject(vm, error);
+        }
+        // 10. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
+        //     10.a. Perform AsyncModuleExecutionRejected(m, error).
+        for (const WriteBarrier<AbstractModuleRecord>& m : module->asyncParentModules() | std::views::reverse)
+            stack.append(uncheckedDowncast<CyclicModuleRecord>(m.get()));
     }
     // 11. Return UNUSED.
 }


### PR DESCRIPTION
#### 5c64352cd6cc1f867750171e0c4bd598b61fffff
<pre>
[JSC] `GatherAvailableAncestors` and `AsyncModuleExecutionRejected` can overflow the stack on deep async module graphs
<a href="https://bugs.webkit.org/show_bug.cgi?id=316615">https://bugs.webkit.org/show_bug.cgi?id=316615</a>

Reviewed by Yusuke Suzuki.

GatherAvailableAncestors[1] and AsyncModuleExecutionRejected[2] walk
[[AsyncParentModules]] with unguarded native recursion, so when the
top-level-await leaf of a long module chain settles, a deep enough
chain crashes with a hard stack overflow.

These operations are infallible and run from microtasks, so they cannot
throw a RangeError like InnerModuleEvaluation does. Instead, flatten
both recursions into explicit worklists. AsyncModuleExecutionRejected
pushes parents in reverse to preserve the spec&apos;s depth-first order,
which is observable through the rejection order of
[[TopLevelCapability]] promises.

[1]: <a href="https://tc39.es/ecma262/#sec-gather-available-ancestors">https://tc39.es/ecma262/#sec-gather-available-ancestors</a>
[2]: <a href="https://tc39.es/ecma262/#sec-async-module-execution-rejected">https://tc39.es/ecma262/#sec-async-module-execution-rejected</a>

* Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp:
(JSC::gatherAvailableAncestors):
(JSC::CyclicModuleRecord::asyncExecutionRejected):

Canonical link: <a href="https://commits.webkit.org/314989@main">https://commits.webkit.org/314989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2f44376500668f4fd8684f3873aef0dcc68f1ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176798 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130512 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150726 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/111029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25531 "Built successfully") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179340 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30139 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37379 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41998 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105182 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34069 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200418 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40502 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113753 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53847 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39899 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5195 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40150 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->