### PR TITLE
RealityKit engineers suggest we always use transparent backgrounds

### DIFF
--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1343,10 +1343,8 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
     else if (is<RenderModel>(renderer())) {
         auto modelBackgroundColor = rendererBackgroundColor();
 #if ENABLE(GPU_PROCESS_MODEL)
-        // Model expects opaque colors but if dynamic-range-limit: standard is used, we don't make the IOSurface
-        // of the model opaque, rather we make it transparent and composite it with the user's chosen background
-        // color. Otherwise during tonemapping to standard dynamic range the background becomes too dark.
-        // Set the graphics layer's background color as a fallback for the transparent IOSurface case.
+        // Model expects opaque colors but we don't make the IOSurface of the model opaque, rather we make
+        // it transparent and composite it with the user's chosen background color.
         modelBackgroundColor = modelBackgroundColor.isValid() ? modelBackgroundColor.opaqueColor() : Color::black;
         m_graphicsLayer->setBackgroundColor(modelBackgroundColor);
 #endif

--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
@@ -90,11 +90,6 @@ void MeshImpl::setFOV(float fovY)
     m_backing->setFOV(fovY);
 }
 
-void MeshImpl::setBackgroundColor(const WebModel::Float3& color)
-{
-    m_backing->setBackgroundColor(color);
-}
-
 void MeshImpl::play(bool play)
 {
     m_backing->play(play);

--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
@@ -76,7 +76,6 @@ private:
     std::optional<WebModel::Float4x4> entityTransform() const final;
 #endif
     void setFOV(float) final;
-    void setBackgroundColor(const WebModel::Float3&) final;
     void play(bool) final;
     void setEnvironmentMap(WebModel::UpdateTextureDescriptor&&) final;
     void updateContentsHeadroom(float) final;

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -46,7 +46,6 @@ final class Renderer {
     private static let cameraDistance: Float = 0.5
     private var effectiveCameraDistance: Float = Renderer.cameraDistance
     private var fovY: Float = 60 * .pi / 180
-    private var clearColor: MTLClearColor = .init(red: 1, green: 1, blue: 1, alpha: 1)
     var tonemapEnabled: Bool = false
     var rasterSampleCount: Int = 1
     let memoryOwner: task_id_token_t
@@ -212,11 +211,7 @@ final class Renderer {
         renderer.cameras[0].position = cameraPosition
         renderer.cameras[0].rotation = cameraRotation
         renderer.cameras[0].projection = projection
-        if tonemapEnabled {
-            renderer.output.clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
-        } else {
-            renderer.output.clearColor = clearColor
-        }
+        renderer.output.clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
         renderer.output.color = .init(texture: texture)
         try renderer.setMeshInstances(meshInstances, at: 0)
 
@@ -272,10 +267,6 @@ final class Renderer {
 
     func setFOV(_ fovYRadians: Float) {
         fovY = fovYRadians
-    }
-
-    func setBackgroundColor(_ color: simd_float3) {
-        clearColor = MTLClearColor(red: Double(color.x), green: Double(color.y), blue: Double(color.z), alpha: 1.0)
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -504,7 +504,6 @@ NS_SWIFT_SENDABLE
 - (BOOL)processRemovals:(NSArray<WKBridgeTypedResourceId *> *)meshRemovals materialRemovals:(NSArray<WKBridgeTypedResourceId *> *)materialRemovals  textureRemovals:(NSArray<WKBridgeTypedResourceId *> *)textureRemovals;
 - (void)setTransform:(simd_float4x4)transform;
 - (void)setFOV:(float)fovY;
-- (void)setBackgroundColor:(simd_float3)color;
 - (void)setPlaying:(BOOL)play;
 - (void)setEnvironmentMap:(WKBridgeUpdateTexture *)imageAsset;
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -118,11 +118,6 @@ void RemoteMesh::setFOV(float fovY)
     m_backing->setFOV(fovY);
 }
 
-void RemoteMesh::setBackgroundColor(const WebModel::Float3& color)
-{
-    m_backing->setBackgroundColor(color);
-}
-
 void RemoteMesh::play(bool playing)
 {
     m_backing->play(playing);

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
@@ -96,7 +96,6 @@ private:
     void updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&&, CompletionHandler<void(bool)>&&);
     void updateTransform(const WebModel::Float4x4& transform);
     void setFOV(float fovY);
-    void setBackgroundColor(const WebModel::Float3&);
     void play(bool);
     void setEnvironmentMap(WebModel::UpdateTextureDescriptor&&);
     void updateContentsHeadroom(float);

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
@@ -38,7 +38,6 @@ messages -> RemoteMesh Stream {
     void UpdateMaterial(struct Vector<WebModel::UpdateMaterialDescriptor> descriptor) -> (bool success)
     void UpdateTransform(struct WebModel::Float4x4 transform)
     void SetFOV(float fovY)
-    void SetBackgroundColor(struct WebModel::Float3 color)
     void Play(bool playing)
     void SetEnvironmentMap(struct WebModel::UpdateTextureDescriptor imageAsset) NotStreamEncodable
     void UpdateContentsHeadroom(float headroom)

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -1079,10 +1079,6 @@ extension WKBridgeReceiver {
         appRenderer.setFOV(fovY)
     }
 
-    func setBackgroundColor(_ color: simd_float3) {
-        appRenderer.setBackgroundColor(color)
-    }
-
     func setPlaying(_ play: Bool) {
     }
 
@@ -2864,9 +2860,6 @@ extension WKBridgeReceiver {
     }
 
     func setFOV(_ fovY: Float) {
-    }
-
-    func setBackgroundColor(_ color: simd_float3) {
     }
 
     func setPlaying(_ play: Bool) {

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
@@ -70,7 +70,6 @@ public:
     void NODELETE updateMaterial(Vector<WebModel::UpdateMaterialDescriptor>&&);
     void NODELETE setTransform(const simd_float4x4&);
     void NODELETE setFOV(float);
-    void NODELETE setBackgroundColor(const simd_float3&);
     void NODELETE setEnvironmentMap(WebModel::UpdateTextureDescriptor&&);
     void NODELETE play(bool);
     void NODELETE updateRenderBuffers(const WebModel::ResizeMeshDescriptor&);

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -1045,15 +1045,6 @@ void WebMesh::setFOV(float fovY)
 #endif
 }
 
-void WebMesh::setBackgroundColor(const simd_float3& color)
-{
-#if ENABLE(GPU_PROCESS_MODEL)
-    [m_receiver setBackgroundColor:color];
-#else
-    UNUSED_PARAM(color);
-#endif
-}
-
 void WebMesh::setEnvironmentMap(WebModel::UpdateTextureDescriptor&& imageAsset)
 {
 #if ENABLE(GPU_PROCESS_MODEL)

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -305,16 +305,6 @@ void RemoteMeshProxy::setFOV(float fovY)
 #endif
 }
 
-void RemoteMeshProxy::setBackgroundColor(const WebModel::Float3& color)
-{
-#if ENABLE(GPU_PROCESS_MODEL)
-    auto sendResult = send(Messages::RemoteMesh::SetBackgroundColor(color));
-    UNUSED_PARAM(sendResult);
-#else
-    UNUSED_PARAM(color);
-#endif
-}
-
 bool RemoteMeshProxy::supportsTransform(const WebCore::TransformationMatrix& transformationMatrix)
 {
 #if ENABLE(GPU_PROCESS_MODEL)

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -114,7 +114,6 @@ private:
 #endif
     void setScale(float) final;
     void setFOV(float);
-    void setBackgroundColor(const WebModel::Float3&) final;
     void setViewportSize(float, float) final;
     void setStageMode(WebCore::StageModeOperation) final;
     void processRemovals(Vector<WebModel::TypedResourceId>&& meshRemovals, Vector<WebModel::TypedResourceId>&& materialRemovals, Vector<WebModel::TypedResourceId>&& textureRemovals, CompletionHandler<void(bool)>&&) final;

--- a/Source/WebKit/WebProcess/Model/Mesh.h
+++ b/Source/WebKit/WebProcess/Model/Mesh.h
@@ -82,7 +82,6 @@ public:
     virtual void setEntityTransform(const WebModel::Float4x4&) = 0;
     virtual void setScale(float) { }
     virtual void setFOV(float) { }
-    virtual void setBackgroundColor(const WebModel::Float3&) { }
     virtual void setViewportSize(float, float) { }
     virtual void setStageMode(WebCore::StageModeOperation) { }
     virtual void setRotation(float, float = 0.f, float = 0.f) { }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -160,7 +160,6 @@ private:
     uint32_t m_displayTextureIndex { 0 };
     bool m_hasRenderedFrame { false };
     WebCore::StageModeOperation m_stageMode { WebCore::StageModeOperation::None };
-    std::optional<WebCore::Color> m_backgroundColor;
     WebCore::IntSize m_currentPixelSize;
     bool m_didFinishLoading { false };
     enum class PauseState {

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -69,21 +69,19 @@ namespace WebKit {
 
 class ModelDisplayBufferDisplayDelegate final : public WebCore::GraphicsLayerContentsDisplayDelegate {
 public:
-    static Ref<ModelDisplayBufferDisplayDelegate> create(WebModelPlayer& modelPlayer, bool isOpaque = false, float contentsScale = 1)
+    static Ref<ModelDisplayBufferDisplayDelegate> create(WebModelPlayer& modelPlayer, float contentsScale = 1)
     {
-        return adoptRef(*new ModelDisplayBufferDisplayDelegate(modelPlayer, isOpaque, contentsScale));
+        return adoptRef(*new ModelDisplayBufferDisplayDelegate(modelPlayer, contentsScale));
     }
     // GraphicsLayerContentsDisplayDelegate overrides.
     void prepareToDelegateDisplay(WebCore::PlatformCALayer& layer) final
     {
-        layer.setOpaque(m_isOpaque);
+        layer.setOpaque(false);
         layer.setContentsScale(m_contentsScale);
         layer.setContentsFormat(m_contentsFormat);
     }
     void display(WebCore::PlatformCALayer& layer) final
     {
-        if (layer.isOpaque() != m_isOpaque)
-            layer.setOpaque(m_isOpaque);
         if (m_displayBuffer) {
             layer.setContentsFormat(m_contentsFormat);
             layer.setDelegatedContents({ MachSendRight { m_displayBuffer }, { }, std::nullopt });
@@ -112,23 +110,16 @@ public:
     void setContentsFormat(WebCore::ContentsFormat contentsFormat)
     {
         m_contentsFormat = contentsFormat;
-        setOpaque(m_contentsFormat == WebCore::ContentsFormat::RGBA16F);
-    }
-    void setOpaque(bool opaque)
-    {
-        m_isOpaque = opaque;
     }
 private:
-    ModelDisplayBufferDisplayDelegate(WebModelPlayer& modelPlayer, bool isOpaque, float contentsScale)
+    ModelDisplayBufferDisplayDelegate(WebModelPlayer& modelPlayer, float contentsScale)
         : m_modelPlayer(modelPlayer)
         , m_contentsScale(contentsScale)
-        , m_isOpaque(isOpaque)
     {
     }
     ThreadSafeWeakPtr<WebModelPlayer> m_modelPlayer;
     WTF::MachSendRight m_displayBuffer;
     const float m_contentsScale;
-    bool m_isOpaque;
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     WebCore::ContentsFormat m_contentsFormat { WebCore::ContentsFormat::RGBA16F };
 #else
@@ -499,16 +490,6 @@ void WebModelPlayer::configureGraphicsLayer(WebCore::GraphicsLayer& graphicsLaye
 {
     m_graphicsLayer = graphicsLayer;
     graphicsLayer.setContentsDisplayDelegate(contentsDisplayDelegate(), WebCore::GraphicsLayer::ContentsLayerPurpose::Canvas);
-    if (RefPtr currentModel = m_currentModel) {
-        auto backgroundColor = configuration.backgroundColor;
-        if (backgroundColor.isValid() && m_backgroundColor != backgroundColor) {
-            m_backgroundColor = backgroundColor;
-            auto opaqueColor = backgroundColor.opaqueColor();
-            auto [r, g, b, _a] = opaqueColor.toResolvedColorComponentsInColorSpace(WebCore::ColorSpace::LinearSRGB);
-            currentModel->setBackgroundColor(simd_make_float3(r, g, b));
-            startUpdateLoopIfNeeded();
-        }
-    }
 }
 
 const MachSendRight* WebModelPlayer::displayBuffer() const
@@ -865,7 +846,6 @@ void WebModelPlayer::visibilityStateDidChange()
         m_modelLoader = nil;
         m_displayBuffers.clear();
         m_environmentMap = std::nullopt;
-        m_backgroundColor = std::nullopt;
         m_isUpdateLoopRunning = false;
         m_isUpdateScheduled = false;
         m_isUpdating = false;


### PR DESCRIPTION
#### b3e6f0abd119aee7b4b2579434f9dfefa518b523
<pre>
RealityKit engineers suggest we always use transparent backgrounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=316623">https://bugs.webkit.org/show_bug.cgi?id=316623</a>
radar://179066059

Reviewed by Ruthvik Konda.

RealityKit engineers suggest we always use transparent backgrounds

* LayoutTests/fast/webgpu/regression/repro_317110-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_317110.html: Added.
* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp:
(WebKit::MeshImpl::setBackgroundColor): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(ImplicitFragmentInPlace.setFOV(_:)):
(ImplicitFragmentInPlace.setBackgroundColor(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::setBackgroundColor): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(setBackgroundColor(_:)): Deleted.
(WKBridgeReceiver.setBackgroundColor(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::WebMesh::setBackgroundColor): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::setBackgroundColor): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
* Source/WebKit/WebProcess/Model/Mesh.h:
(WebKit::Mesh::setFOV):
(WebKit::Mesh::setBackgroundColor): Deleted.
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::configureGraphicsLayer):
(WebKit::WebModelPlayer::visibilityStateDidChange):

Canonical link: <a href="https://commits.webkit.org/315635@main">https://commits.webkit.org/315635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dc6c6cde60314759a41d1f05329d9db1bc54221

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127330 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c68b6209-657c-48a7-aa07-c8b8a1c856ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171484 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132167 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59ff4af0-307c-493a-bc00-4beb0f569d61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172577 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112670 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/614ae296-f1a4-4e9a-acff-195b4aeac977) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27674 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181576 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140616 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43196 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140452 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37793 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43885 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108115 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35719 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42395 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42043 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->