### PR TITLE
WebSWClientConnection::notifyRecordResponseBodyChunk uses a HashMap iterator across an arbitrary callback

### DIFF
--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -428,14 +428,14 @@ void WebSWClientConnection::retrieveRecordResponseBody(BackgroundFetchRecordIden
 
 void WebSWClientConnection::notifyRecordResponseBodyChunk(RetrieveRecordResponseBodyCallbackIdentifier identifier, IPC::SharedBufferReference&& data)
 {
-    auto iterator = m_retrieveRecordResponseBodyCallbacks.find(identifier);
-    if (iterator == m_retrieveRecordResponseBodyCallbacks.end())
+    auto callback = m_retrieveRecordResponseBodyCallbacks.take(identifier);
+    if (!callback)
         return;
     auto buffer = data.unsafeBuffer();
     bool isDone = !buffer;
-    iterator->value(WTF::move(buffer));
-    if (isDone)
-        m_retrieveRecordResponseBodyCallbacks.remove(iterator);
+    callback(WTF::move(buffer));
+    if (!isDone)
+        m_retrieveRecordResponseBodyCallbacks.add(identifier, WTF::move(callback));
 }
 
 void WebSWClientConnection::notifyRecordResponseBodyEnd(RetrieveRecordResponseBodyCallbackIdentifier identifier, WebCore::ResourceError&& error)


### PR DESCRIPTION
#### 20af97e95c1f159d961225ec2322e467695c7bcf
<pre>
WebSWClientConnection::notifyRecordResponseBodyChunk uses a HashMap iterator across an arbitrary callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=316625">https://bugs.webkit.org/show_bug.cgi?id=316625</a>

Reviewed by Youenn Fablet.

WebSWClientConnection::notifyRecordResponseBodyChunk found an entry in
m_retrieveRecordResponseBodyCallbacks, invoked the stored Function&lt;&gt; via
the iterator, and only afterwards called m_retrieveRecordResponseBodyCallbacks
.remove(iterator). The Function is the body-loader callback registered by
BackgroundFetchResponseBodyLoader, which feeds data into a FetchResponse
body / ReadableStream. If anything reachable from that callback synchronously
re-enters retrieveRecordResponseBody (which calls
m_retrieveRecordResponseBodyCallbacks.add(...)) the HashMap may rehash,
invalidating both the in-flight reference returned by iterator-&gt;value and
the iterator subsequently passed to remove() — a classic
iterator-after-callback use-after-free.

The sibling handler notifyRecordResponseBodyEnd already uses the safe
take()-then-invoke pattern. Apply the same pattern here: take the callback
out of the map before invoking it, then re-add it for the streaming
(non-terminal) case so subsequent chunks can still reach it.

* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::notifyRecordResponseBodyChunk):

Canonical link: <a href="https://commits.webkit.org/314860@main">https://commits.webkit.org/314860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/480da318bd57c5d4e570f78b02a7d97f3ef2f8f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176295 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130093 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110610 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30177 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25033 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141458 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178836 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31735 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138481 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138371 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37292 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41503 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104496 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33618 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26627 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113086 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39404 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4725 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39654 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->