### PR TITLE
WebSWContextManagerConnection inspector handlers call main-thread-only API from a background WorkQueue

### DIFF
--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
@@ -58,11 +58,13 @@ ServiceWorkerInspectorProxy::~ServiceWorkerInspectorProxy()
 
 void ServiceWorkerInspectorProxy::serviceWorkerTerminated()
 {
+    ASSERT(isMainThread());
     m_channel = nullptr;
 }
 
 void ServiceWorkerInspectorProxy::connectToWorker(FrontendChannel& channel, bool isAutomaticConnection, bool immediatelyPause)
 {
+    ASSERT(isMainThread());
     m_channel = &channel;
 
     RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get();
@@ -74,6 +76,7 @@ void ServiceWorkerInspectorProxy::connectToWorker(FrontendChannel& channel, bool
 
 void ServiceWorkerInspectorProxy::disconnectFromWorker(FrontendChannel& channel)
 {
+    ASSERT(isMainThread());
     ASSERT_UNUSED(channel, &channel == m_channel);
     m_channel = nullptr;
 
@@ -90,6 +93,7 @@ void ServiceWorkerInspectorProxy::disconnectFromWorker(FrontendChannel& channel)
 
 void ServiceWorkerInspectorProxy::sendMessageToWorker(String&& message)
 {
+    ASSERT(isMainThread());
     m_serviceWorkerThreadProxy.get()->thread().runLoop().postDebuggerTask([message = WTF::move(message).isolatedCopy()] (ScriptExecutionContext& context) {
         downcast<WorkerGlobalScope>(context).inspectorController().dispatchMessageFromFrontend(message);
     });
@@ -97,6 +101,7 @@ void ServiceWorkerInspectorProxy::sendMessageToWorker(String&& message)
 
 void ServiceWorkerInspectorProxy::sendMessageFromWorkerToFrontend(String&& message)
 {
+    ASSERT(isMainThread());
     if (!m_channel)
         return;
 

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -642,23 +642,39 @@ void WebSWContextManagerConnection::removeNavigationFetch(WebCore::SWServerConne
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
 void WebSWContextManagerConnection::connectToInspector(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, bool isAutomaticConnection, bool immediatelyPause)
 {
-    Ref channel = ServiceWorkerDebuggableFrontendChannel::create(serviceWorkerIdentifier);
-    m_channels.add(serviceWorkerIdentifier, channel);
-    if (RefPtr serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
-        serviceWorkerThreadProxy->inspectorProxy().connectToWorker(channel, isAutomaticConnection, immediatelyPause);
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([protectedThis = Ref { *this }, serviceWorkerIdentifier, isAutomaticConnection, immediatelyPause] {
+        assertIsMainRunLoop();
+        Ref channel = ServiceWorkerDebuggableFrontendChannel::create(serviceWorkerIdentifier);
+        protectedThis->m_channels.add(serviceWorkerIdentifier, channel);
+        if (RefPtr serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
+            serviceWorkerThreadProxy->inspectorProxy().connectToWorker(channel.get(), isAutomaticConnection, immediatelyPause);
+    });
 }
 
 void WebSWContextManagerConnection::disconnectFromInspector(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
-    RefPtr channel = m_channels.take(serviceWorkerIdentifier);
-    if (RefPtr serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
-        serviceWorkerThreadProxy->inspectorProxy().disconnectFromWorker(*channel);
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([protectedThis = Ref { *this }, serviceWorkerIdentifier] {
+        assertIsMainRunLoop();
+        RefPtr channel = protectedThis->m_channels.take(serviceWorkerIdentifier);
+        if (!channel)
+            return;
+        if (RefPtr serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
+            serviceWorkerThreadProxy->inspectorProxy().disconnectFromWorker(*channel);
+    });
 }
 
 void WebSWContextManagerConnection::dispatchMessageFromInspector(WebCore::ServiceWorkerIdentifier identifier, String&& message)
 {
-    if (RefPtr serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier))
-        serviceWorkerThreadProxy->inspectorProxy().sendMessageToWorker(WTF::move(message));
+    assertIsCurrent(m_queue.get());
+
+    callOnMainRunLoop([identifier, message = WTF::move(message).isolatedCopy()]() mutable {
+        if (RefPtr serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier))
+            serviceWorkerThreadProxy->inspectorProxy().sendMessageToWorker(WTF::move(message));
+    });
 }
 
 #if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -164,7 +164,7 @@ private:
     HashMap<FetchKey, Ref<WebServiceWorkerFetchTaskClient>> m_ongoingNavigationFetchTasks WTF_GUARDED_BY_CAPABILITY(m_queue.get());
     bool isWebSWContextManagerConnection() const final { return true; }
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
-    HashMap<WebCore::ServiceWorkerIdentifier, Ref<ServiceWorkerDebuggableFrontendChannel>> m_channels;
+    HashMap<WebCore::ServiceWorkerIdentifier, Ref<ServiceWorkerDebuggableFrontendChannel>> m_channels WTF_GUARDED_BY_CAPABILITY(mainRunLoop);
 #endif
 };
 


### PR DESCRIPTION
#### 321ad9fa98b491aa3ef1cf319e22a5242259cc5e
<pre>
WebSWContextManagerConnection inspector handlers call main-thread-only API from a background WorkQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=316629">https://bugs.webkit.org/show_bug.cgi?id=316629</a>

Reviewed by BJ Burg, Qianlang Chen, and Youenn Fablet.

WebSWContextManagerConnection is an IPC::WorkQueueMessageReceiver, so every
message declared in WebSWContextManagerConnection.messages.in is dispatched
on m_queue rather than the main run loop. Every other handler in the file
correctly pairs assertIsCurrent(m_queue.get()) with a callOnMainRunLoop hop
when it needs to touch main-thread state. The three inspector handlers
(connectToInspector, disconnectFromInspector, dispatchMessageFromInspector)
forgot to do this and called SWContextManager::serviceWorkerThreadProxy()
— which ASSERT(isMainThread()) — directly from the queue, then dereferenced
the returned proxy to call into ServiceWorkerInspectorProxy, whose state
(m_channel raw pointer, SWContextManager::m_connection access in
setAsInspected) is unsynchronized main-thread state. In debug this fires
the assertion; in release it races the main thread, including a torn-pointer
race against ServiceWorkerInspectorProxy::sendMessageFromWorkerToFrontend
which reads m_channel from the main run loop.

Hop the main-thread-bound calls via callOnMainRunLoop to match the rest of
the file. The m_channels map is only touched from these three handlers, and
the channels it owns are used exclusively on the main run loop by
ServiceWorkerInspectorProxy. WebSWContextManagerConnection is itself
destroyed on the main run loop (DestructionThread::MainRunLoop), so any
channel still in m_channels at destruction time is torn down there. Rather
than confine the map to m_queue and destroy leftover channels on a different
thread than the one that normally removes them, confine the map to the main
run loop: create the channel, add it to / take it from m_channels, and call
into ServiceWorkerInspectorProxy all inside the callOnMainRunLoop hop, and
annotate m_channels with WTF_GUARDED_BY_CAPABILITY(mainRunLoop) so the
compiler enforces that single-thread invariant going forward. This makes
create/add/remove/destroy of every channel happen consistently on the main
run loop. isolatedCopy the inspector message string for the cross-thread
move in dispatchMessageFromInspector. Keep a null-channel guard in
disconnectFromInspector so that an unbalanced disconnect (channel never
inserted, or a duplicate disconnect) no longer dereferences a null RefPtr.

Also add ASSERT(isMainThread()) to the non-trivial ServiceWorkerInspectorProxy
methods so any future regression is caught at the source rather than
manifesting as a race.

* Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp:
(WebCore::ServiceWorkerInspectorProxy::serviceWorkerTerminated):
(WebCore::ServiceWorkerInspectorProxy::connectToWorker):
(WebCore::ServiceWorkerInspectorProxy::disconnectFromWorker):
(WebCore::ServiceWorkerInspectorProxy::sendMessageToWorker):
(WebCore::ServiceWorkerInspectorProxy::sendMessageFromWorkerToFrontend):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::connectToInspector):
(WebKit::WebSWContextManagerConnection::disconnectFromInspector):
(WebKit::WebSWContextManagerConnection::dispatchMessageFromInspector):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:

Canonical link: <a href="https://commits.webkit.org/314878@main">https://commits.webkit.org/314878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5b39a9571130109dc74b2f28ade351f6173bd49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176523 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130285 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110802 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25262 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179067 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31963 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138681 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138568 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37311 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41731 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104831 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33827 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26837 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113316 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39632 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4936 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39777 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->