### PR TITLE
WebSWClientConnection leaks pending callbacks when the network process connection is lost

### DIFF
--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -244,9 +244,9 @@ void WebSWClientConnection::getRegistrations(SecurityOriginData&& topOrigin, con
         return;
     }
 
-    runOrDelayTaskForImport([weakThis = WeakPtr { *this }, callback = WTF::move(callback), topOrigin = WTF::move(topOrigin), clientURL]() mutable {
+    runOrDelayTaskForImport([weakThis = WeakPtr { *this }, completionHandler = CompletionHandlerWithFinalizer<void(Vector<ServiceWorkerRegistrationData>&&)>(WTF::move(callback), [](auto& callback) { callback({ }); }), topOrigin = WTF::move(topOrigin), clientURL]() mutable {
         if (RefPtr protectedThis = weakThis.get())
-            protectedThis->sendWithAsyncReply(Messages::WebSWServerConnection::GetRegistrations { topOrigin, clientURL }, WTF::move(callback));
+            protectedThis->sendWithAsyncReply(Messages::WebSWServerConnection::GetRegistrations { topOrigin, clientURL }, WTF::move(completionHandler));
     });
 }
 
@@ -259,6 +259,14 @@ void WebSWClientConnection::connectionToServerLost()
 void WebSWClientConnection::clear()
 {
     clearPendingJobs();
+
+    auto retrieveRecordResponseBodyCallbacks = std::exchange(m_retrieveRecordResponseBodyCallbacks, { });
+    for (auto& callback : retrieveRecordResponseBodyCallbacks.values())
+        callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "Connection to network process lost"_s }));
+
+    // Destroying these tasks fires their captured CompletionHandlerWithFinalizer
+    // objects, which resolves the corresponding JS-visible promises with default values.
+    m_tasksPendingOriginImport.clear();
 }
 
 void WebSWClientConnection::terminateWorkerForTesting(ServiceWorkerIdentifier identifier, CompletionHandler<void()>&& callback)


### PR DESCRIPTION
#### e319714bc5284c981fcd26470d5537f4b39e1658
<pre>
WebSWClientConnection leaks pending callbacks when the network process connection is lost
<a href="https://bugs.webkit.org/show_bug.cgi?id=316631">https://bugs.webkit.org/show_bug.cgi?id=316631</a>

Reviewed by Youenn Fablet.

WebSWClientConnection::clear() — invoked from connectionToServerLost()
on network-process death and from the destructor — only called the base
class clearPendingJobs() and never drained the two per-instance queues
holding pending callbacks:

1. m_retrieveRecordResponseBodyCallbacks (HashMap of streaming
   BackgroundFetch record-body callbacks). retrieveRecordResponseBody()
   sends a fire-and-forget IPC and the callbacks fire only from the
   notifyRecordResponseBodyChunk / notifyRecordResponseBodyEnd replies.
   With the network process gone, the replies never arrive and each
   in-flight body retrieval was silently dropped, leaving the
   FetchResponse body / ReadableStream consumer on the JS side pending
   forever. WorkerSWClientConnection::contextStopped() already handles
   the equivalent case correctly (WorkerSWClientConnection.cpp:120-122).

2. m_tasksPendingOriginImport (Deque of tasks awaiting
   setSWOriginTableIsImported()). With the connection closed,
   setSWOriginTableIsImported() will never run, so the queue was only
   emptied via the eventual destruction of the WebSWClientConnection.
   getRegistrations() captured a plain CompletionHandler in the queued
   task — destroying it unfired hit the
   ASSERT_WITH_MESSAGE(!m_function, &quot;Completion handler should always
   be called&quot;) in debug and left the JS getRegistrations() promise hung
   in release.

Fix clear() to drain both queues. Body callbacks are invoked with an
errorDomainWebKitInternal ResourceError. The pending-import tasks are
cleared by destruction; matchRegistration() already wrapped its callback
in a CompletionHandlerWithFinalizer that supplies std::nullopt on
destruction, so the destructor chain fires the JS-visible callback.
Apply the same wrapping to getRegistrations() (finalizer supplies an
empty Vector) so its destruction is also safe and observable.
std::exchange the body-callback map onto the stack before iterating to
avoid reentrant-mutation hazards.

* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::getRegistrations):
Wrap the GetRegistrationsCallback in CompletionHandlerWithFinalizer with
an empty-Vector finalizer, mirroring matchRegistration().
(WebKit::WebSWClientConnection::clear):
Drain m_retrieveRecordResponseBodyCallbacks with a &quot;Connection to
network process lost&quot; ResourceError, and clear m_tasksPendingOriginImport
so each queued task&apos;s CompletionHandlerWithFinalizer destructor resolves
the corresponding JS promise with a default value.

Canonical link: <a href="https://commits.webkit.org/314859@main">https://commits.webkit.org/314859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc85cf5ea82bdc6702186e108e046e2509c3cca6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176303 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130101 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110618 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30186 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25041 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141468 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178844 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31743 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138488 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138378 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37293 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41511 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104510 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33626 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26637 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40015 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113094 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39412 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4735 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39662 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->