### PR TITLE
SharedWorker's navigator.userAgent ignores per-navigation _customUserAgent

### DIFF
--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -130,7 +130,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
     if (WebProcess::singleton().isLockdownModeEnabled())
         WebPage::adjustSettingsForLockdownMode(page->settings(), m_preferencesStore ? &m_preferencesStore.value() : nullptr);
 
-    if (!initializationData.userAgent.isEmpty())
+    if (initializationData.userAgent.isEmpty())
         initializationData.userAgent = m_userAgent;
 
     if (!initializationData.clientIdentifier)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm
@@ -275,4 +275,61 @@ TEST(CustomUserAgent, WebpagePreferencesCustomUserAgentAsSiteSpecificQuirksAppli
     EXPECT_WK_STREQ("User-Agent: QuirkUA", receivedUserAgentOnTarget.utf8().data());
 }
 
+// SharedWorker is hosted in a separate WebProcess. The page-side custom UA must
+// propagate through the network process and into that host process so the
+// worker observes it via navigator.userAgent. Regression test for
+// WebSharedWorkerContextManagerConnection's inverted user-agent fallback.
+//
+// Use WKWebpagePreferences._customUserAgent rather than WKWebView.customUserAgent
+// because the page-level customUserAgent is also pushed to remote-worker host
+// processes via WebProcessPool::updateRemoteWorkerUserAgent, which keeps the
+// host's m_userAgent in sync with the page UA and would mask the bug. The
+// per-navigation UA stops at the page's DocumentLoader, so the host's
+// m_userAgent stays as the standard UA and the buggy assignment becomes
+// observable.
+TEST(CustomUserAgent, SharedWorkerNavigatorUserAgent)
+{
+    constexpr auto mainPage = R"PAGE(
+<script>
+const worker = new SharedWorker("sw.js");
+worker.port.onmessage = e => window.webkit.messageHandlers.testHandler.postMessage(e.data);
+worker.port.start();
+</script>
+)PAGE"_s;
+
+    constexpr auto sharedWorkerScript = R"WORKER(
+onconnect = e => {
+    const port = e.ports[0];
+    port.postMessage(navigator.userAgent);
+    port.start();
+};
+)WORKER"_s;
+
+    HTTPServer server({
+        { "/"_s, { mainPage } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerScript } },
+    });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *navigationAction, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        preferences._customUserAgent = @"SharedWorkerCustomUA/1.0";
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    __block RetainPtr<NSString> reportedUserAgent;
+    __block bool gotMessage = false;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        reportedUserAgent = message;
+        gotMessage = true;
+    }];
+
+    [webView loadRequest:server.request()];
+    TestWebKitAPI::Util::run(&gotMessage);
+
+    EXPECT_WK_STREQ("SharedWorkerCustomUA/1.0", reportedUserAgent.get());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### fbd2160cf1ac822dbc75d1ba82c3d72ee5a814b6
<pre>
SharedWorker&apos;s navigator.userAgent ignores per-navigation _customUserAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=316637">https://bugs.webkit.org/show_bug.cgi?id=316637</a>

Reviewed by Youenn Fablet.

WebSharedWorkerContextManagerConnection::launchSharedWorker() applied an
inverted user-agent fallback:
```
      if (!initializationData.userAgent.isEmpty())
          initializationData.userAgent = m_userAgent;
```

The intent (matching the parallel logic in WebSWContextManagerConnection&apos;s
installServiceWorker, which uses `if (effectiveUserAgent.isNull())`) is to
fall back to the host&apos;s m_userAgent only when the value supplied by the
network process is empty. The condition was negated, so a non-empty
page-supplied UA was overwritten by the host&apos;s default, while an empty UA
was left empty.

The page-level WKWebView.customUserAgent path masks the bug because
WebProcessPool::updateRemoteWorkerUserAgent pushes that UA to every remote-
worker host via Messages::WebSharedWorkerContextManagerConnection::SetUserAgent,
keeping the host&apos;s m_userAgent in sync with the page UA so the buggy
assignment becomes a no-op. The bug is observable through any UA path that
does NOT round-trip through WebPageProxy::setUserAgent — most notably
WKWebpagePreferences._customUserAgent (per-navigation), which is stored on
the page&apos;s DocumentLoader and flows into WorkerScriptLoader::
userAgentForSharedWorker() but never updates the host process. In that
configuration the SharedWorker&apos;s navigator.userAgent reported the host&apos;s
standard UA instead of the per-navigation override.

Invert the condition so initializationData.userAgent is preserved when
non-empty and only filled in from m_userAgent when empty.

* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
Fall back to m_userAgent only when initializationData.userAgent is empty.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm:
(TEST(CustomUserAgent, SharedWorkerNavigatorUserAgent)):
Add a regression test that uses WKWebpagePreferences._customUserAgent so
the page UA diverges from the host&apos;s m_userAgent, and asserts that a
SharedWorker created from that page observes the per-navigation UA via
navigator.userAgent.

Canonical link: <a href="https://commits.webkit.org/314858@main">https://commits.webkit.org/314858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02f5752bb94275846292cf12dd4d992dc341af7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176308 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130106 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110623 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31489 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30190 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25046 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178849 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138493 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138383 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37295 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41516 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104519 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33631 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26642 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39417 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4740 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39667 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39562 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->