### PR TITLE
[css-anchor-position-1] position-try-fallbacks tactic keywords should be resolved against the containing block's writing mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical-expected.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+
+<style>
+.container {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+  border: solid 3px;
+}
+
+.vrl {
+  writing-mode: vertical-rl;
+}
+
+.anchor {
+  position: absolute;
+  anchor-name: --a;
+  width: 25px;
+  height: 25px;
+  background: dodgerblue;
+}
+
+.anchored {
+  position: absolute;
+  position-anchor: --a;
+  width: 15px;
+  height: 15px;
+  background: green;
+}
+</style>
+
+<!-- Row 1: position-area + horizontal-tb container -->
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<br>
+
+<!-- Row 2: position-area + vertical-rl container -->
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<br>
+
+<!-- Row 3: anchor() + horizontal-tb container -->
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<br>
+
+<!-- Row 4: anchor() + vertical-rl container -->
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical-ref.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+
+<style>
+.container {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+  border: solid 3px;
+}
+
+.vrl {
+  writing-mode: vertical-rl;
+}
+
+.anchor {
+  position: absolute;
+  anchor-name: --a;
+  width: 25px;
+  height: 25px;
+  background: dodgerblue;
+}
+
+.anchored {
+  position: absolute;
+  position-anchor: --a;
+  width: 15px;
+  height: 15px;
+  background: green;
+}
+</style>
+
+<!-- Row 1: position-area + horizontal-tb container -->
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<br>
+
+<!-- Row 2: position-area + vertical-rl container -->
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<br>
+
+<!-- Row 3: anchor() + horizontal-tb container -->
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom right"></div>
+</div>
+
+<br>
+
+<!-- Row 4: anchor() + vertical-rl container -->
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="position-area: bottom left"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12869#issuecomment-3406959070">
+
+<style>
+.container {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+  border: solid 3px;
+}
+
+.vrl {
+  writing-mode: vertical-rl;
+}
+
+.anchor {
+  position: absolute;
+  anchor-name: --a;
+  width: 25px;
+  height: 25px;
+  background: dodgerblue;
+}
+
+.anchored {
+  position: absolute;
+  position-anchor: --a;
+  width: 15px;
+  height: 15px;
+  background: green;
+}
+</style>
+
+<!-- Row 1: position-area + horizontal-tb container -->
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           position-area: top right;
+           position-try-fallbacks: flip-block;
+           writing-mode: vertical-rl;"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           position-area: top right;
+           position-try-fallbacks: flip-block;
+           writing-mode: horizontal-tb;"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           position-area: bottom left;
+           position-try-fallbacks: flip-inline;
+           writing-mode: vertical-rl;"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           position-area: bottom left;
+           position-try-fallbacks: flip-inline;
+           writing-mode: horizontal-tb;"></div>
+</div>
+
+<!-- FIXME should test flip-start too or not?? -->
+
+<br>
+
+<!-- Row 2: position-area + vertical-rl container -->
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           position-area: bottom right;
+           position-try-fallbacks: flip-block;
+           writing-mode: vertical-rl;"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           position-area: bottom right;
+           position-try-fallbacks: flip-block;
+           writing-mode: horizontal-tb;"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           position-area: top left;
+           position-try-fallbacks: flip-inline;
+           writing-mode: vertical-rl;"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           position-area: top left;
+           position-try-fallbacks: flip-inline;
+           writing-mode: horizontal-tb;"></div>
+</div>
+
+<br>
+
+<!-- Row 3: anchor() + horizontal-tb container -->
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           bottom: anchor(top); left: anchor(right);
+           position-try-fallbacks: flip-block;
+           writing-mode: vertical-rl;"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           bottom: anchor(top); left: anchor(right);
+           position-try-fallbacks: flip-block;
+           writing-mode: horizontal-tb;"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           top: anchor(bottom); right: anchor(left);
+           position-try-fallbacks: flip-inline;
+           writing-mode: vertical-rl;"></div>
+</div>
+
+<div class="container">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           top: anchor(bottom); right: anchor(left);
+           position-try-fallbacks: flip-inline;
+           writing-mode: horizontal-tb;"></div>
+</div>
+
+<br>
+
+<!-- Row 4: anchor() + vertical-rl container -->
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           top: anchor(bottom); left: anchor(right);
+           position-try-fallbacks: flip-block;
+           writing-mode: vertical-rl;"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           top: anchor(bottom); left: anchor(right);
+           position-try-fallbacks: flip-block;
+           writing-mode: horizontal-tb;"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           bottom: anchor(top); right: anchor(left);
+           position-try-fallbacks: flip-inline;
+           writing-mode: vertical-rl;"></div>
+</div>
+
+<div class="container vrl">
+  <div class="anchor"></div>
+  <div class="anchored" style="
+           bottom: anchor(top); right: anchor(left);
+           position-try-fallbacks: flip-inline;
+           writing-mode: horizontal-tb;"></div>
+</div>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -50,6 +50,7 @@
 #include "StyleDocumentScope.h"
 #include "StyleableInlines.h"
 #include "WritingMode.h"
+#include "rendering/style/RenderStyleConstants.h"
 #include <ranges>
 
 namespace WebCore {
@@ -623,9 +624,10 @@ static CSSPropertyID NODELETE getOppositeInset(CSSPropertyID propertyID)
     }
 }
 
-static std::pair<CSSPropertyID, bool> applyTryTacticsToInset(CSSPropertyID propertyID, WritingMode writingMode, const BuilderPositionTryFallback& fallback)
+static std::pair<CSSPropertyID, bool> applyTryTacticsToInset(CSSPropertyID propertyID, const BuilderPositionTryFallback& fallback)
 {
     bool isFlipped = false;
+    auto writingMode = fallback.containingBlockWritingMode;
     for (auto tactic : fallback.tactics) {
         switch (tactic) {
         case PositionTryFallback::Tactic::FlipInline:
@@ -694,12 +696,11 @@ static std::pair<CSSPropertyID, bool> applyTryTacticsToInset(CSSPropertyID prope
 // See: https://drafts.csswg.org/css-anchor-position-1/#anchor-pos
 static LayoutUnit computeInsetValue(CSSPropertyID insetPropertyID, CheckedRef<const RenderBoxModelObject> anchorBox, CheckedRef<const RenderBox> anchorPositionedRenderer, AnchorPositionEvaluator::Side anchorSide, const std::optional<BuilderPositionTryFallback>& positionTryFallback)
 {
-    auto writingMode = anchorPositionedRenderer->writingMode();
     bool isFlipped = false;
     if (positionTryFallback)
-        std::tie(insetPropertyID, isFlipped) = applyTryTacticsToInset(insetPropertyID, writingMode, *positionTryFallback);
+        std::tie(insetPropertyID, isFlipped) = applyTryTacticsToInset(insetPropertyID, *positionTryFallback);
 
-    auto selfLogicalAxis = mapInsetPropertyToLogicalAxis(insetPropertyID, writingMode);
+    auto selfLogicalAxis = mapInsetPropertyToLogicalAxis(insetPropertyID, anchorPositionedRenderer->writingMode());
     PositionedLayoutConstraints constraints(anchorPositionedRenderer, selfLogicalAxis);
 
     auto anchorPercentage = [&]() -> double {
@@ -929,7 +930,7 @@ static AnchorSizeDimension NODELETE defaultDimensionForPropertyID(CSSPropertyID 
 }
 
 // Convert anchor size dimension to the physical dimension (width or height).
-static BoxAxis NODELETE anchorSizeDimensionToPhysicalDimension(AnchorSizeDimension dimension, const Style::ComputedStyle& style, const Style::ComputedStyle& containerStyle)
+static BoxAxis NODELETE anchorSizeDimensionToPhysicalDimension(AnchorSizeDimension dimension, WritingMode selfWritingMode, WritingMode containingBlockWritingMode)
 {
     switch (dimension) {
     case AnchorSizeDimension::Width:
@@ -937,13 +938,13 @@ static BoxAxis NODELETE anchorSizeDimensionToPhysicalDimension(AnchorSizeDimensi
     case AnchorSizeDimension::Height:
         return BoxAxis::Vertical;
     case AnchorSizeDimension::Block:
-        return mapAxisLogicalToPhysical(containerStyle.writingMode(), LogicalBoxAxis::Block);
+        return mapAxisLogicalToPhysical(containingBlockWritingMode, LogicalBoxAxis::Block);
     case AnchorSizeDimension::Inline:
-        return mapAxisLogicalToPhysical(containerStyle.writingMode(), LogicalBoxAxis::Inline);
+        return mapAxisLogicalToPhysical(containingBlockWritingMode, LogicalBoxAxis::Inline);
     case AnchorSizeDimension::SelfBlock:
-        return mapAxisLogicalToPhysical(style.writingMode(), LogicalBoxAxis::Block);
+        return mapAxisLogicalToPhysical(selfWritingMode, LogicalBoxAxis::Block);
     case AnchorSizeDimension::SelfInline:
-        return mapAxisLogicalToPhysical(style.writingMode(), LogicalBoxAxis::Inline);
+        return mapAxisLogicalToPhysical(selfWritingMode, LogicalBoxAxis::Inline);
     }
 
     ASSERT_NOT_REACHED();
@@ -991,7 +992,7 @@ std::optional<double> AnchorPositionEvaluator::evaluateSize(BuilderState& builde
     ASSERT(anchorPositionedContainerRenderer);
 
     auto resolvedDimension = dimension.value_or(defaultDimensionForPropertyID(propertyID));
-    auto physicalDimension = anchorSizeDimensionToPhysicalDimension(resolvedDimension, anchorPositionedRenderer->style(), anchorPositionedContainerRenderer->style());
+    auto physicalDimension = anchorSizeDimensionToPhysicalDimension(resolvedDimension, anchorPositionedRenderer->style().writingMode(), anchorPositionedContainerRenderer->style().writingMode());
 
     if (builderState.positionTryFallback()) {
         // "For sizing properties, change the specified axis in anchor-size() functions to maintain the same relative relationship to the new direction that they had to the old."
@@ -1524,9 +1525,11 @@ static CSSPropertyID flipStart(CSSPropertyID propertyID, WritingMode writingMode
     return CSSProperty::resolveDirectionAwareProperty(flippedLogical(), writingMode);
 }
 
-CSSPropertyID AnchorPositionEvaluator::resolvePositionTryFallbackProperty(CSSPropertyID propertyID, WritingMode writingMode, const BuilderPositionTryFallback& fallback)
+CSSPropertyID AnchorPositionEvaluator::resolvePositionTryFallbackProperty(CSSPropertyID propertyID, const BuilderPositionTryFallback& fallback)
 {
     ASSERT(!CSSProperty::isDirectionAwareProperty(propertyID));
+    
+    auto writingMode = fallback.containingBlockWritingMode;
 
     for (auto tactic : fallback.tactics) {
         switch (tactic) {
@@ -1550,7 +1553,7 @@ CSSPropertyID AnchorPositionEvaluator::resolvePositionTryFallbackProperty(CSSPro
     return propertyID;
 }
 
-CSSValueID AnchorPositionEvaluator::resolvePositionTryFallbackValueForSelfPosition(CSSPropertyID propertyID, CSSValueID position, WritingMode writingMode, const BuilderPositionTryFallback& fallback)
+CSSValueID AnchorPositionEvaluator::resolvePositionTryFallbackValueForSelfPosition(CSSPropertyID propertyID, CSSValueID position, const BuilderPositionTryFallback& fallback)
 {
     // Implements the bullet starting "For the self-alignment properties" from step 4 of https://drafts.csswg.org/css-anchor-position-1/#swap-due-to-a-try-tactic.
 
@@ -1596,6 +1599,8 @@ CSSValueID AnchorPositionEvaluator::resolvePositionTryFallbackValueForSelfPositi
             return position;
         }
     };
+    
+    auto writingMode = fallback.containingBlockWritingMode;
 
     for (auto tactic : fallback.tactics) {
         switch (tactic) {

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -214,8 +214,8 @@ public:
     static bool NODELETE isStyleTimeAnchorPositioned(const Style::ComputedStyle&);
     static bool NODELETE isLayoutTimeAnchorPositioned(const Style::ComputedStyle&);
 
-    static CSSPropertyID resolvePositionTryFallbackProperty(CSSPropertyID, WritingMode, const BuilderPositionTryFallback&);
-    static CSSValueID resolvePositionTryFallbackValueForSelfPosition(CSSPropertyID, CSSValueID, WritingMode, const BuilderPositionTryFallback&);
+    static CSSPropertyID resolvePositionTryFallbackProperty(CSSPropertyID, const BuilderPositionTryFallback&);
+    static CSSValueID resolvePositionTryFallbackValueForSelfPosition(CSSPropertyID, CSSValueID, const BuilderPositionTryFallback&);
 
     static bool overflowsInsetModifiedContainingBlock(const RenderBox& anchoredBox);
     static bool isDefaultAnchorInvisibleOrClippedByInterveningBoxes(const RenderBox& anchoredBox);

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -343,7 +343,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     auto valueToApply = resolveSubstitutionFunctions(id, value);
 
     if (m_state->positionTryFallback())
-        id = AnchorPositionEvaluator::resolvePositionTryFallbackProperty(id, style.writingMode(), *m_state->positionTryFallback());
+        id = AnchorPositionEvaluator::resolvePositionTryFallbackProperty(id, *m_state->positionTryFallback());
 
     auto valueID = WebCore::valueID(valueToApply.get());
     auto valueType = [&] {

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -84,6 +84,10 @@ enum class ApplyValueType : uint8_t { Value, Initial, Inherit };
 struct BuilderPositionTryFallback {
     RefPtr<const StyleProperties> properties;
     Vector<PositionTryFallbackTactic> tactics;
+
+    // Writing mode of the containing block of the element whose position is being generated.
+    // If any flip tactics are present, this is used to determine the axis to flip.
+    WritingMode containingBlockWritingMode;
 };
 
 struct RegisteredSubstitutionAttribute {

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -77,6 +77,7 @@
 #include "ViewTransition.h"
 #include "WebAnimationTypes.h"
 #include "WebAnimationUtilities.h"
+#include "platform/BoxSides.h"
 #include <ranges>
 
 #if PLATFORM(COCOA)
@@ -1544,6 +1545,16 @@ std::unique_ptr<Update> TreeResolver::resolve()
         }
     }
 
+    for (auto& weakStyleable : m_positionTryElementsWaitingForLayout) {
+        auto styleable = weakStyleable.styleable();
+        if (!styleable)
+            continue;
+
+        styleable->element.invalidateForResumingAnchorPositionedElementResolution();
+        m_needsInterleavedLayout = true;
+    }
+    m_positionTryElementsWaitingForLayout.clear();
+
     if (!m_changedAnchorNames.isEmpty() || m_allAnchorNamesInvalid) {
         // If there are changes to the anchor names then loop through the existing anchors and see if any of them references those names.
         for (auto [weakAnchorPositioned, anchors] : m_document->styleScope().anchorPositionedToAnchorMap()) {
@@ -1644,6 +1655,11 @@ void TreeResolver::generatePositionOptionsIfNeeded(const ResolvedStyle& resolved
     if (m_positionOptions.contains(styleable))
         return;
 
+    if (!styleable.renderer()) {
+        m_positionTryElementsWaitingForLayout.add(styleable);
+        return;
+    }
+
     auto generatePositionOptions = [&] {
         ResolvedStyle clonedResolvedStyle {
             .style = Style::ComputedStyle::clonePtr(*resolvedStyle.style),
@@ -1667,6 +1683,7 @@ void TreeResolver::generatePositionOptionsIfNeeded(const ResolvedStyle& resolved
         return options;
     };
 
+    // Have to resolve the fallbacks first to catch additional anchor references.
     auto options = generatePositionOptions();
 
     // If the fallbacks contain anchor references we need to resolve the anchors first and regenerate the options.
@@ -1706,6 +1723,8 @@ std::unique_ptr<Style::ComputedStyle> TreeResolver::generatePositionOption(const
     auto builderFallback = BuilderPositionTryFallback {
         .properties = resolveFallbackProperties(),
         .tactics = fallback.ruleAndTactics.tactics->value,
+        // TreeResolver::generatePositionOptionsIfNeeded guarantees the styleable will already have a renderer.
+        .containingBlockWritingMode = styleable.renderer()->container()->style().writingMode()
     };
 
     return resolveAgainInDifferentContext(resolvedStyle, styleable, *resolutionContext.parentStyle, PropertyCascade::normalPropertyTypes(), WTF::move(builderFallback), resolutionContext);

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -249,6 +249,13 @@ private:
         std::unique_ptr<Style::ComputedStyle> currentOption() const;
     };
     HashMap<WeakStyleable, PositionOptions> m_positionOptions;
+    
+    // If an element uses position-try-fallbacks and and the specified fallbacks include tactics,
+    // the tactics uses the writing mode of the element's containing block to determine which
+    // axis to flip according to the tactic. But the render tree (to determine the containing block)
+    // is only available after one round style/layout. This holds the list of elements waiting
+    // until at least one layout has been performed before they can generate and try position options.
+    HashSet<WeakStyleable> m_positionTryElementsWaitingForLayout;
 
     HashSet<AtomString> m_changedAnchorNames;
     bool m_allAnchorNamesInvalid { false };

--- a/Source/WebCore/style/values/align/StyleAlignSelf.cpp
+++ b/Source/WebCore/style/values/align/StyleAlignSelf.cpp
@@ -92,7 +92,7 @@ auto CSSValueConversion<AlignSelf>::operator()(BuilderState& state, const CSSVal
     auto applyPositionTryFallbackTactics = [](auto& state, auto position) -> CSSValueID {
         // Flip the position according to position-try fallback, if specified.
         if (auto positionTryFallback = state.positionTryFallback())
-            position = AnchorPositionEvaluator::resolvePositionTryFallbackValueForSelfPosition(state.cssPropertyID(), position, state.style().writingMode(), *positionTryFallback);
+            position = AnchorPositionEvaluator::resolvePositionTryFallbackValueForSelfPosition(state.cssPropertyID(), position, *positionTryFallback);
         return position;
     };
 

--- a/Source/WebCore/style/values/align/StyleJustifySelf.cpp
+++ b/Source/WebCore/style/values/align/StyleJustifySelf.cpp
@@ -96,7 +96,7 @@ auto CSSValueConversion<JustifySelf>::operator()(BuilderState& state, const CSSV
     auto applyPositionTryFallbackTactics = [](auto& state, auto position) -> CSSValueID {
         // Flip the position according to position-try fallback, if specified.
         if (auto positionTryFallback = state.positionTryFallback())
-            position = AnchorPositionEvaluator::resolvePositionTryFallbackValueForSelfPosition(state.cssPropertyID(), position, state.style().writingMode(), *positionTryFallback);
+            position = AnchorPositionEvaluator::resolvePositionTryFallbackValueForSelfPosition(state.cssPropertyID(), position, *positionTryFallback);
         return position;
     };
 

--- a/Source/WebCore/style/values/anchor-position/StylePositionArea.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionArea.cpp
@@ -503,7 +503,7 @@ auto CSSValueConversion<PositionArea>::operator()(BuilderState& state, const CSS
 
     // Flip according to `position-try-fallbacks`, if specified.
     if (const auto& positionTryFallback = state.positionTryFallback()) {
-        auto writingMode = state.style().writingMode();
+        auto writingMode = positionTryFallback->containingBlockWritingMode;
         for (auto tactic : positionTryFallback->tactics) {
             switch (tactic) {
             case PositionTryFallbackTactic::FlipBlock:


### PR DESCRIPTION
#### 073092b688347d6bba801bbfb496d8f6872709bb
<pre>
[css-anchor-position-1] position-try-fallbacks tactic keywords should be resolved against the containing block&apos;s writing mode
<a href="https://rdar.apple.com/173569408">rdar://173569408</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310959">https://bugs.webkit.org/show_bug.cgi?id=310959</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Test: imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-fallback-logical.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::applyTryTacticsToInset):
(WebCore::Style::computeInsetValue):
(WebCore::Style::anchorSizeDimensionToPhysicalDimension):
(WebCore::Style::AnchorPositionEvaluator::evaluateSize):
(WebCore::Style::AnchorPositionEvaluator::resolvePositionTryFallbackProperty):
(WebCore::Style::AnchorPositionEvaluator::resolvePositionTryFallbackValueForSelfPosition):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
(WebCore::Style::TreeResolver::generatePositionOption):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/values/align/StyleAlignSelf.cpp:
(WebCore::Style::CSSValueConversion&lt;AlignSelf&gt;::operator):
* Source/WebCore/style/values/align/StyleJustifySelf.cpp:
(WebCore::Style::CSSValueConversion&lt;JustifySelf&gt;::operator):
* Source/WebCore/style/values/anchor-position/StylePositionArea.cpp:
(WebCore::Style::CSSValueConversion&lt;PositionArea&gt;::operator):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/073092b688347d6bba801bbfb496d8f6872709bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167261 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124942 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4b29ca2-6008-478e-94c8-efb8ac559ee9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41189 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40769 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130109 "Found 30 new test failures: fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html fast/forms/select/base/option-checkmark-content-change-crash.html fast/forms/select/base/option-focus-visible-outline-offset.html fast/forms/select/base/option-internal-inset-outline-offset.html fast/forms/select/base/select-pagedown-pageup-vertical.html fast/forms/select/base/select-pagedown-pageup.html fast/forms/select/base/select-tab-closes-picker.html imported/w3c/web-platform-tests/css/css-anchor-position/chrome-379758203-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/chrome-40286059-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/position-try-initial-transition.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91595 "1 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170220 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32510 "Found 10 new test failures: accessibility/base-select-option-border-radius-path.html accessibility/base-select-option-press-closes-popover.html accessibility/ios-simulator/base-select-popover-is-sibling.html fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html fast/forms/ios/select-base-appearance-picker.html fast/forms/select/base/option-checkmark-content-change-crash.html fast/forms/select/base/option-focus-visible-outline-offset.html fast/forms/select/base/option-internal-inset-outline-offset.html fast/forms/select/base/select-pagedown-pageup.html fast/forms/select/base/select-tab-closes-picker.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110626 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2149afb-f351-4114-a373-2d13c5e09d06) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31492 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/chrome-379758203-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/chrome-40286059-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/position-try-initial-transition.html imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-alignment.html imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-wm.html imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-checkmark.html imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-picker-icon.html imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-picker.html imported/w3c/web-platform-tests/css/selectors/user-action-pseudo-top-layer.html imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-height-in-flex.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30193 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25048 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178851 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31750 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29691 "Found 60 new test failures: accessibility/base-select-basic.html accessibility/base-select-complex-options.html accessibility/base-select-focus-on-open.html accessibility/base-select-notifications.html accessibility/base-select-option-border-radius-path.html accessibility/base-select-option-press-closes-popover.html accessibility/base-select-search-predicate.html compositing/shared-backing/overflow-scroll/scrolled-contents-unconstrained-clip.html fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html fast/forms/select/base/option-checkmark-content-change-crash.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138496 "Found 30 new test failures: fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html fast/forms/select/base/option-checkmark-content-change-crash.html fast/forms/select/base/option-focus-visible-outline-offset.html fast/forms/select/base/option-internal-inset-outline-offset.html fast/forms/select/base/select-pagedown-pageup-vertical.html fast/forms/select/base/select-pagedown-pageup.html fast/forms/select/base/select-tab-closes-picker.html imported/w3c/web-platform-tests/css/css-anchor-position/chrome-379758203-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/chrome-40286059-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/position-try-initial-transition.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40830 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34346 "Found 60 new test failures: accessibility/base-select-basic.html accessibility/base-select-complex-options.html accessibility/base-select-focus-on-open.html accessibility/base-select-notifications.html accessibility/base-select-option-border-radius-path.html accessibility/base-select-option-press-closes-popover.html accessibility/base-select-search-predicate.html accessibility/mac/input-replacevalue-userinfo.html fast/css/css-anchor-position/position-try-popover-transition-display-none-crash.html fast/forms/select/base/option-checkmark-content-change-crash.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138386 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104521 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33634 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26643 "Found 60 new test failures: accessibility/base-select-basic.html accessibility/base-select-complex-options.html accessibility/base-select-focus-on-open.html accessibility/base-select-notifications.html accessibility/base-select-option-border-radius-path.html accessibility/base-select-option-press-closes-popover.html accessibility/base-select-search-predicate.html compositing/overflow/no-double-painted-outline.html compositing/style-change/perspective-origin-change.html compositing/style-change/transform-style-change.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113103 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39419 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4741 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39564 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->