### PR TITLE
Extract AutoTableLayout::isColumnCollapsed helper

### DIFF
--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -43,12 +43,18 @@ AutoTableLayout::AutoTableLayout(RenderTable* table)
 
 AutoTableLayout::~AutoTableLayout() = default;
 
+bool AutoTableLayout::isColumnCollapsed(unsigned effCol) const
+{
+    CheckedPtr colElement = m_table->colElement(effCol);
+    return colElement && colElement->style().visibility() == Visibility::Collapse;
+}
+
 void AutoTableLayout::recalcColumn(unsigned effCol)
 {
     Layout& columnLayout = m_layoutStruct[effCol];
 
     // Check if this column is collapsed.
-    if (CheckedPtr colElement = m_table->colElement(effCol); colElement && colElement->style().visibility() == Visibility::Collapse) {
+    if (isColumnCollapsed(effCol)) {
         columnLayout.effectiveLogicalWidth = CSS::Keyword::Auto { };
         columnLayout.effectiveMinLogicalWidth = 0;
         columnLayout.effectiveMaxLogicalWidth = 0;
@@ -634,7 +640,7 @@ void AutoTableLayout::layout()
     // fill up every cell with its minWidth
     for (size_t i = 0; i < nEffCols; ++i) {
         // Check if this column is collapsed
-        if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse) {
+        if (isColumnCollapsed(i)) {
             m_layoutStruct[i].computedLogicalWidth = 0;
             continue;
         }
@@ -667,7 +673,7 @@ void AutoTableLayout::layout()
     // allocate width to percent cols
     if (available > 0 && havePercent) {
         for (size_t i = 0; i < nEffCols; ++i) {
-            if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+            if (isColumnCollapsed(i))
                 continue;
 
             auto& logicalWidth = m_layoutStruct[i].effectiveLogicalWidth;
@@ -682,7 +688,7 @@ void AutoTableLayout::layout()
             float excess = tableLogicalWidth * (totalPercent - 100) / 100;
             for (unsigned i = nEffCols; i; ) {
                 --i;
-                if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+                if (isColumnCollapsed(i))
                     continue;
 
                 if (m_layoutStruct[i].effectiveLogicalWidth.isPercentOrCalculated()) {
@@ -701,7 +707,7 @@ void AutoTableLayout::layout()
     // then allocate width to fixed cols
     if (available > 0) {
         for (size_t i = 0; i < nEffCols; ++i) {
-            if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+            if (isColumnCollapsed(i))
                 continue;
 
             auto& logicalWidth = m_layoutStruct[i].effectiveLogicalWidth;
@@ -723,7 +729,7 @@ void AutoTableLayout::layout()
             equalWidthForZeroLengthColumns = available / numberOfNonEmptyAuto;
         }
         for (size_t i = 0; i < nEffCols; ++i) {
-            if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+            if (isColumnCollapsed(i))
                 continue;
 
             auto& column = m_layoutStruct[i];
@@ -743,7 +749,7 @@ void AutoTableLayout::layout()
     // spread over fixed columns
     if (available > 0 && numFixed) {
         for (size_t i = 0; i < nEffCols; ++i) {
-            if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+            if (isColumnCollapsed(i))
                 continue;
 
             auto& logicalWidth = m_layoutStruct[i].effectiveLogicalWidth;
@@ -759,7 +765,7 @@ void AutoTableLayout::layout()
     // spread over percent columns
     if (available > 0 && m_hasPercent && totalPercent < 100) {
         for (size_t i = 0; i < nEffCols; ++i) {
-            if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+            if (isColumnCollapsed(i))
                 continue;
 
             auto& logicalWidth = m_layoutStruct[i].effectiveLogicalWidth;
@@ -780,7 +786,7 @@ void AutoTableLayout::layout()
         // Count collapsed columns to subtract from total
         unsigned numCollapsed = 0;
         for (size_t i = 0; i < nEffCols; ++i) {
-            if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+            if (isColumnCollapsed(i))
                 numCollapsed++;
         }
         total -= numCollapsed;
@@ -788,7 +794,7 @@ void AutoTableLayout::layout()
         // still have some width to spread
         for (unsigned i = nEffCols; i && total > 0; ) {
             --i;
-            if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+            if (isColumnCollapsed(i))
                 continue;
 
             // variable columns with empty cells only don't get any width
@@ -805,7 +811,7 @@ void AutoTableLayout::layout()
         // All columns in this table are empty with 'width: auto'.
         auto equalWidthForColumns = available / numAutoEmptyCellsOnly;
         for (size_t i = 0; i < nEffCols; ++i) {
-            if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse)
+            if (isColumnCollapsed(i))
                 continue;
 
             auto& column = m_layoutStruct[i];
@@ -829,7 +835,7 @@ void AutoTableLayout::layout()
     for (size_t i = 0; i < nEffCols; ++i) {
         m_table->setColumnPosition(i, pos);
 
-        if (CheckedPtr colElement = m_table->colElement(i); colElement && colElement->style().visibility() == Visibility::Collapse) {
+        if (isColumnCollapsed(i)) {
             // Don't add width or spacing for collapsed columns.
             continue;
         }

--- a/Source/WebCore/rendering/AutoTableLayout.h
+++ b/Source/WebCore/rendering/AutoTableLayout.h
@@ -50,6 +50,8 @@ private:
 
     void insertSpanCell(RenderTableCell*);
 
+    bool isColumnCollapsed(unsigned effCol) const;
+
     struct Layout {
         Style::PreferredSize logicalWidth { CSS::Keyword::Auto { } };
         Style::PreferredSize effectiveLogicalWidth { CSS::Keyword::Auto { } };


### PR DESCRIPTION
#### b8b7e862b86cf6d61017f0bf6455a9cc5083b648
<pre>
Extract AutoTableLayout::isColumnCollapsed helper
<a href="https://bugs.webkit.org/show_bug.cgi?id=316638">https://bugs.webkit.org/show_bug.cgi?id=316638</a>
<a href="https://rdar.apple.com/179074841">rdar://179074841</a>

Reviewed by Dan Glastonbury.

The &quot;is this column collapsed?&quot; check (colElement() non-null and
visibility:collapse) was duplicated 12 times across recalcColumn() and
layout(). Factor it into a single isColumnCollapsed() helper. No change in
behavior.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::isColumnCollapsed const):
(WebCore::AutoTableLayout::recalcColumn):
(WebCore::AutoTableLayout::layout):
* Source/WebCore/rendering/AutoTableLayout.h:

Canonical link: <a href="https://commits.webkit.org/314808@main">https://commits.webkit.org/314808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0df1d8b3c47e8577d7556a0736aaa18f78c90ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176311 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130108 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110625 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30192 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25049 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178852 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138495 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37260 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41519 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104522 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26644 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113104 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39420 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4742 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39565 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->