### PR TITLE
getEnclosureList() crashes when a descendant is inside a display:contents <g> element

### DIFF
--- a/LayoutTests/svg/hittest/getEnclosureList-display-contents-crash-expected.txt
+++ b/LayoutTests/svg/hittest/getEnclosureList-display-contents-crash-expected.txt
@@ -1,0 +1,3 @@
+Test passes if it does not crash.
+
+

--- a/LayoutTests/svg/hittest/getEnclosureList-display-contents-crash.html
+++ b/LayoutTests/svg/hittest/getEnclosureList-display-contents-crash.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<p>Test passes if it does not crash.</p>
+<svg id="svg" xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+    <g display="contents">
+        <rect id="r" x="10" y="10" width="50" height="50"/>
+    </g>
+</svg>
+<script>
+// getEnclosureList on a descendant of a display:contents <g> crashed because
+// getElementCTM dereferenced a null renderer while walking the ancestor chain.
+const svg = document.getElementById("svg");
+const svgRect = svg.createSVGRect();
+svgRect.x = 0;
+svgRect.y = 0;
+svgRect.width = 200;
+svgRect.height = 200;
+svg.getEnclosureList(svgRect, null);
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -176,8 +176,11 @@ static void getElementCTM(SVGElement* element, AffineTransform& transform)
     RefPtr<Node> current = element;
 
     while (RefPtr currentElement = dynamicDowncast<SVGElement>(current.get())) {
-        localTransform = currentElement->renderer()->localToParentTransform();
-        transform = localTransform.multiply(transform);
+        // Elements with display:contents have no renderer (children are hoisted); skip them in the CTM walk.
+        if (CheckedPtr renderer = currentElement->renderer()) {
+            localTransform = renderer->localToParentTransform();
+            transform = localTransform.multiply(transform);
+        }
         // For getCTM() computation, stop at the nearest viewport element
         if (currentElement == stopAtElement.get())
             break;


### PR DESCRIPTION
#### d7b4706e4bc8200f7d4d8123140ace459cadfed8
<pre>
getEnclosureList() crashes when a descendant is inside a display:contents &lt;g&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=316639">https://bugs.webkit.org/show_bug.cgi?id=316639</a>
<a href="https://rdar.apple.com/179003966">rdar://179003966</a>

Reviewed by Simon Fraser.

Calling getEnclosureList() on an SVG containing a display:contents &lt;g&gt; crashes in getElementCTM() due to a null renderer when walking the ancestor chain.

* LayoutTests/svg/hittest/getEnclosureList-display-contents-crash-expected.txt: Added.
* LayoutTests/svg/hittest/getEnclosureList-display-contents-crash.html: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::getElementCTM):

Canonical link: <a href="https://commits.webkit.org/314906@main">https://commits.webkit.org/314906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e030d2283158951ad50eb7496f359f5fa37a6ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176558 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110827 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30403 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25293 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179098 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138703 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138590 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37331 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104876 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26864 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40266 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113347 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39663 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4963 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39914 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39808 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->