### PR TITLE
[JSC] Set class field function names at parse time instead of via `SetFunctionName`

### DIFF
--- a/JSTests/microbenchmarks/class-fields-anonymous-arrow-function-fields.js
+++ b/JSTests/microbenchmarks/class-fields-anonymous-arrow-function-fields.js
@@ -1,0 +1,28 @@
+// Stresses SetFunctionName for anonymous arrow function class fields.
+class ArrowFunctionFields {
+    render = (...args) => args;
+    setLayout = (l) => l;
+    getLayout = () => 0;
+    setRenderer = (r) => r;
+    header = (n, v) => v;
+    status = (s) => s;
+    set = (k, v) => v;
+    get = (k) => k;
+    newResponse = (...a) => a;
+    body = (d) => d;
+    text = (t) => t;
+    json = (o) => o;
+    html = (h) => h;
+    redirect = (l) => l;
+    notFound = () => null;
+}
+
+function bench(testClass) {
+    var instance;
+    for (var i = 0; i < 1e5; i++)
+        instance = new testClass();
+    return instance;
+}
+noInline(bench);
+
+bench(ArrowFunctionFields);

--- a/JSTests/stress/class-fields-anonymous-function-name-edge-cases.js
+++ b/JSTests/stress/class-fields-anonymous-function-name-edge-cases.js
@@ -1,0 +1,158 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+// The inferred class name is visible while static members evaluate, matching
+// NamedEvaluation order: SetFunctionName happens before static fields run.
+{
+    class O { h = class { static x = this.name; }; }
+    shouldBe(new O().h.x, 'h');
+    shouldBe(new O().h.name, 'h');
+}
+
+// A static "name" field overrides the inferred name, but static fields that
+// run before it still observe the inferred name.
+{
+    class O { n = class { static x = this.name; static name = 42; }; }
+    let n = new O().n;
+    shouldBe(n.x, 'n');
+    shouldBe(n.name, 42);
+}
+
+// Many class-valued fields in one class: each constructor must get its own
+// field name (stresses the lifetime of identifiers captured by the parser).
+{
+    class O {
+        alpha = class {};
+        beta = class {};
+        gamma = class {};
+        delta = class {};
+        epsilon = class {};
+    }
+    let o = new O();
+    shouldBe(o.alpha.name, 'alpha');
+    shouldBe(o.beta.name, 'beta');
+    shouldBe(o.gamma.name, 'gamma');
+    shouldBe(o.delta.name, 'delta');
+    shouldBe(o.epsilon.name, 'epsilon');
+}
+
+// "__proto__" as a field name is a regular field, and the function gets it as
+// a name.
+{
+    class O { "__proto__" = () => {}; }
+    let desc = Object.getOwnPropertyDescriptor(new O(), '__proto__');
+    shouldBe(desc.value.name, '__proto__');
+}
+
+// Parenthesized anonymous functions are still anonymous function definitions;
+// comma, ternary, and eval results are not.
+{
+    class O {
+        p = (() => {});
+        c = (0, () => {});
+        t = true ? () => {} : 0;
+        e = eval('() => {}');
+    }
+    let o = new O();
+    shouldBe(o.p.name, 'p');
+    shouldBe(o.c.name, '');
+    shouldBe(o.t.name, '');
+    shouldBe(o.e.name, '');
+}
+
+// All anonymous function flavors are inferred.
+{
+    class O {
+        a = async () => {};
+        g = function* () {};
+        ag = async function* () {};
+        af = async function () {};
+    }
+    let o = new O();
+    shouldBe(o.a.name, 'a');
+    shouldBe(o.g.name, 'g');
+    shouldBe(o.ag.name, 'ag');
+    shouldBe(o.af.name, 'af');
+}
+
+// Nested classes with their own function-valued fields.
+{
+    class O {
+        inner = class {
+            leaf = () => 1;
+            deep = class {};
+        };
+    }
+    let innerInstance = new (new O().inner)();
+    shouldBe(new O().inner.name, 'inner');
+    shouldBe(innerInstance.leaf.name, 'leaf');
+    shouldBe(innerInstance.deep.name, 'deep');
+}
+
+// Static and computed fields mix in the same class; computed names keep the
+// runtime SetFunctionName path.
+{
+    function make(key) {
+        class D {
+            fixed = () => 1;
+            [key] = () => 2;
+            other = class {};
+        }
+        return new D();
+    }
+    let d1 = make('k1');
+    let d2 = make('k2');
+    shouldBe(d1.fixed.name, 'fixed');
+    shouldBe(d1.k1.name, 'k1');
+    shouldBe(d1.other.name, 'other');
+    shouldBe(d2.k2.name, 'k2');
+}
+
+// Names stay correct as the field initializer tiers up.
+{
+    class O { f = () => 1; k = class {}; }
+    for (let i = 0; i < 1e5; ++i) {
+        let o = new O();
+        if (o.f.name !== 'f' || o.k.name !== 'k')
+            throw new Error('bad name at iteration ' + i);
+    }
+}
+
+// Repeatedly evaluating the class definition itself.
+{
+    function makeClass() {
+        return class { f = () => 1; k = class {}; };
+    }
+    for (let i = 0; i < 1e3; ++i) {
+        let K = makeClass();
+        let o = new K();
+        shouldBe(o.f.name, 'f');
+        shouldBe(o.k.name, 'k');
+    }
+}
+
+// toString still returns the original source text.
+{
+    class O { f = () => 1; }
+    shouldBe(new O().f.toString(), '() => 1');
+}
+
+// A Proxy observing the field definition sees the already-named function.
+{
+    let observedName;
+    class Base {
+        constructor() {
+            return new Proxy({}, {
+                defineProperty(target, key, desc) {
+                    observedName = desc.value.name;
+                    return Reflect.defineProperty(target, key, desc);
+                }
+            });
+        }
+    }
+    class O extends Base { f = () => 1; }
+    new O();
+    shouldBe(observedName, 'f');
+}

--- a/JSTests/stress/class-fields-anonymous-function-name-inference.js
+++ b/JSTests/stress/class-fields-anonymous-function-name-inference.js
@@ -1,0 +1,130 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+// Anonymous functions and classes in non-computed class field initializers
+// get their names inferred statically (no SetFunctionName at runtime).
+class C {
+    f = () => 1;
+    g = function () { return 2; };
+    h = class {};
+    #p = () => 3;
+    static s = () => 4;
+    "str x" = () => 5;
+    0 = () => 6;
+    n = class { static name() { return 7; } };
+    getP() { return this.#p; }
+}
+
+for (var i = 0; i < 1e4; ++i) {
+    var c = new C();
+    shouldBe(c.f.name, 'f');
+    shouldBe(c.g.name, 'g');
+    shouldBe(c.h.name, 'h');
+    shouldBe(c.getP().name, '#p');
+    shouldBe(c['str x'].name, 'str x');
+    shouldBe(c[0].name, '0');
+}
+shouldBe(C.s.name, 's');
+
+// A static "name" method shadows the inferred class name.
+shouldBe(typeof new C().n.name, 'function');
+shouldBe(new C().n.name(), 7);
+
+// Property descriptor must match runtime SetFunctionName semantics.
+{
+    let c = new C();
+    let desc = Object.getOwnPropertyDescriptor(c.f, 'name');
+    shouldBe(desc.value, 'f');
+    shouldBe(desc.writable, false);
+    shouldBe(desc.enumerable, false);
+    shouldBe(desc.configurable, true);
+}
+
+// Own property names and their order.
+{
+    let c = new C();
+    shouldBe(Object.getOwnPropertyNames(c.f).join(','), 'length,name');
+    shouldBe(Object.keys(c.f).length, 0);
+    shouldBe(c.f.hasOwnProperty('name'), true);
+}
+
+// delete fn.name falls through to Function.prototype.name.
+{
+    let c = new C();
+    shouldBe(delete c.f.name, true);
+    shouldBe(c.f.name, '');
+    shouldBe(c.f.hasOwnProperty('name'), false);
+}
+
+// Writing is not allowed (ReadOnly), but defineProperty works (configurable).
+{
+    let c = new C();
+    let threw = false;
+    try {
+        (function () { 'use strict'; c.f.name = 'changed'; })();
+    } catch (e) {
+        threw = e instanceof TypeError;
+    }
+    shouldBe(threw, true);
+    shouldBe(c.f.name, 'f');
+    Object.defineProperty(c.f, 'name', { value: 'redefined' });
+    shouldBe(c.f.name, 'redefined');
+}
+
+// Instances are independent: reifying one must not affect another.
+{
+    let a = new C();
+    shouldBe(a.f.name, 'f');
+    let b = new C();
+    Object.defineProperty(a.f, 'name', { value: 'mutated' });
+    shouldBe(b.f.name, 'f');
+    shouldBe(a.f.name, 'mutated');
+}
+
+// length is still derived from the function itself, not the field.
+{
+    let c = new C();
+    shouldBe(c.g.length, 0);
+    shouldBe(c.f.length, 0);
+}
+
+// bind reads the inferred name.
+{
+    let c = new C();
+    shouldBe(c.f.bind(null).name, 'bound f');
+}
+
+// Error.stack shows the inferred name.
+{
+    class S { e = () => new Error(); }
+    let stack = new S().e().stack;
+    shouldBe(stack.split('\n')[0].split('@')[0], 'e');
+}
+
+// Computed field names still go through runtime SetFunctionName.
+{
+    function make(key) {
+        class D { [key] = () => 1; }
+        return new D();
+    }
+    shouldBe(make('alpha').alpha.name, 'alpha');
+    shouldBe(make('beta').beta.name, 'beta');
+    let sym = Symbol('x');
+    shouldBe(make(sym)[sym].name, '[x]');
+}
+
+// Named function expressions in field initializers keep their own name.
+{
+    class E { m = function inner() {}; }
+    shouldBe(new E().m.name, 'inner');
+}
+
+// Fields whose initializer is not a function are unaffected.
+{
+    class F { v = 42; w = 'hi'; }
+    let f = new F();
+    shouldBe(f.v, 42);
+    shouldBe(f.w, 'hi');
+}

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -419,6 +419,12 @@ public:
 
     DefineFieldNode* createDefineField(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* initializer, DefineFieldNode::Type type)
     {
+        if (initializer && type != DefineFieldNode::Type::ComputedName) {
+            if (initializer->isBaseFuncExprNode())
+                static_cast<BaseFuncExprNode*>(initializer)->metadata()->setEcmaName(ident);
+            else if (initializer->isClassExprNode())
+                static_cast<ClassExprNode*>(initializer)->setEcmaName(ident);
+        }
         return new (m_parserArena) DefineFieldNode(location, ident, initializer, type);
     }
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -3440,7 +3440,7 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
     // Clear errors from parsing anything before the initializer expressions.
     m_lexer->clearErrorCodeAndBuffers();
 
-    for (auto definition : classElementDefinitions) {
+    for (const auto& definition : classElementDefinitions) {
         auto position = definition.position;
         bool hasLineTerminatorBeforeToken = false;
 


### PR DESCRIPTION
#### b6a9b84dae1faa215e4deb5a9f5932aee10d12e5
<pre>
[JSC] Set class field function names at parse time instead of via `SetFunctionName`
<a href="https://bugs.webkit.org/show_bug.cgi?id=316646">https://bugs.webkit.org/show_bug.cgi?id=316646</a>

Reviewed by Yusuke Suzuki.

Anonymous functions and classes in class field initializers get their names
via op_set_function_name, which eagerly reifies the &quot;name&quot; property on every
closure created each time an instance is constructed (FunctionRareData +
JSString + butterfly per function-valued field). Object literal properties and
assignments already avoid this by inferring the name at parse time, but class
fields miss that inference because their initializers are re-parsed separately
via parseClassFieldInitializerSourceElements.

Apply the same ecmaName inference in ASTBuilder::createDefineField for
non-computed field names, so no op_set_function_name is emitted and &quot;name&quot; is
reified lazily like any named function. Also iterate class element definitions
by reference, since ClassExprNode::setEcmaName captures a pointer to the
identifier. The inferred name now also becomes visible to static member
initializers per spec.

                                        baseline                 parseronly
class-fields-anonymous-arrow-function-fields
                                    43.1214+-0.3197     ^      4.6281+-0.1775    ^ definitely 9.3172x faster

Tests: JSTests/microbenchmarks/class-fields-anonymous-arrow-function-fields.js
       JSTests/stress/class-fields-anonymous-function-name-edge-cases.js
       JSTests/stress/class-fields-anonymous-function-name-inference.js

* JSTests/microbenchmarks/class-fields-anonymous-arrow-function-fields.js: Added.
(bench):
* JSTests/stress/class-fields-anonymous-function-name-edge-cases.js: Added.
(shouldBe):
(shouldBe.O):
(prototype.shouldBe.O.prototype.string_appeared_here):
(prototype.shouldBe.O):
(prototype.shouldBe):
(prototype.shouldBe.O.prototype.p):
(prototype.shouldBe.O.prototype.t.true):
(prototype.shouldBe.O.prototype.a):
(prototype.shouldBe.O.async g):
(prototype.shouldBe.O.ag):
(prototype.shouldBe.O.async af):
(O.inner):
(O):
(prototype.shouldBe.make.D):
(prototype.throw.new.Error.makeClass.return.f):
(prototype.throw.new.Error.makeClass):
(prototype.throw.new.Error):
(prototype.shouldBe.Base):
* JSTests/stress/class-fields-anonymous-function-name-inference.js: Added.
(shouldBe):
(C.g):
(C.n):
(C.prototype.getP):
(prototype.shouldBe):
(prototype.shouldBe.S):
(prototype.shouldBe.make.D):
(prototype.shouldBe.make):
(prototype.shouldBe.E.m):
(prototype.shouldBe.E):
(prototype.shouldBe.F):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createDefineField):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseClassFieldInitializerSourceElements):

Canonical link: <a href="https://commits.webkit.org/314873@main">https://commits.webkit.org/314873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfd41028f385180c2e4f7dd83eada1d40fb2791c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176327 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130124 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110641 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31507 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30208 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25066 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159442 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178869 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28176 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31767 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138511 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138401 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37307 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41535 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104563 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26661 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199955 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113120 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53757 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39436 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4759 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->