### PR TITLE
Navigation Timing: cross-origin redirect opt-in should be based on destination origin.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-tao-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-tao-expected.txt
@@ -1,9 +1,11 @@
 
 
-FAIL Exposed when a cross-origin redirect opts in to the destination origin assert_equals: redirectCount expected 1 but got 0
-FAIL Exposed when a cross-origin redirect opts in with a wildcard assert_equals: redirectCount expected 1 but got 0
-FAIL Exposed when every redirect in the chain opts in to the destination origin assert_equals: redirectCount expected 2 but got 0
+PASS Exposed when a cross-origin redirect opts in to the destination origin
+PASS Exposed when a cross-origin redirect opts in with a wildcard
+PASS Exposed when every redirect in the chain opts in to the destination origin
 PASS Hidden when the redirect opts in to a non-destination origin
 PASS Hidden when only part of the chain opts in to the destination origin
 PASS Hidden for a no-referrer navigation even when the redirect opts in
+PASS Exposed when the redirect opts in to a cross-origin destination origin
+PASS Hidden when the redirect opts in to the main frame origin but not the destination origin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-tao.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-tao.html
@@ -46,5 +46,19 @@ promise_test(async () => {
       {referrerPolicy: "no-referrer"});
   assert_redirect_timing_hidden(entry);
 }, "Hidden for a no-referrer navigation even when the redirect opts in");
+
+// The following two navigations land on a cross-origin destination (distinct
+// from the main frame origin), so they distinguish "opt in to the destination"
+// from "opt in to the main frame origin".
+
+promise_test(async () => {
+  const entry = await cross_origin_destination_navigation_entry(CROSS_ORIGIN_DESTINATION);
+  assert_redirect_timing_exposed(entry, 1);
+}, "Exposed when the redirect opts in to a cross-origin destination origin");
+
+promise_test(async () => {
+  const entry = await cross_origin_destination_navigation_entry(dest);
+  assert_redirect_timing_hidden(entry);
+}, "Hidden when the redirect opts in to the main frame origin but not the destination origin");
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/resources/redirect-tao-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/resources/redirect-tao-helper.js
@@ -53,6 +53,43 @@ function navigation_entry_after_redirects(hops, {referrerPolicy} = {}) {
   });
 }
 
+// The cross-origin origin a chain can land on, used to verify the navigation TAO
+// check keys off the navigation's destination origin rather than the main
+// frame's. Served from the "www" subdomain, cross-origin to the test page.
+const CROSS_ORIGIN_DESTINATION =
+    new URL(make_absolute_url({subdomain: "www", path: "/"})).origin;
+
+// A landing page served from the cross-origin destination that reports its own
+// navigation timing back to the (cross-origin) parent via postMessage.
+const CROSS_ORIGIN_FINAL_URL = make_absolute_url({
+  subdomain: "www",
+  path: "/navigation-timing/resources/report-navigation-redirect-timing.html",
+});
+
+// Navigates an iframe through a single cross-origin redirect that lands on the
+// cross-origin destination, and resolves with the destination document's
+// reported navigation timing. `tao` is the Timing-Allow-Origin value the redirect
+// sends (or null for none).
+function cross_origin_destination_navigation_entry(tao) {
+  return new Promise(resolve => {
+    const frame = document.createElement("iframe");
+    frame.style.cssText = "width: 250px; height: 250px;";
+    const onMessage = event => {
+      if (event.source !== frame.contentWindow)
+        return;
+      window.removeEventListener("message", onMessage);
+      resolve(event.data);
+    };
+    window.addEventListener("message", onMessage);
+    const tao_query = tao === null ? "" : "tao=" + encodeURIComponent(tao) + "&";
+    frame.src = make_absolute_url({
+      path: "/navigation-timing/resources/redirect-tao.py",
+      query: tao_query + "location=" + encodeURIComponent(CROSS_ORIGIN_FINAL_URL),
+    });
+    document.body.appendChild(frame);
+  });
+}
+
 // Asserts that redirect timing is exposed, with `expectedCount` redirects.
 function assert_redirect_timing_exposed(entry, expectedCount) {
   assert_equals(entry.type, "navigate", "navigation type");

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/resources/report-navigation-redirect-timing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/resources/report-navigation-redirect-timing.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reports its navigation redirect timing to the parent</title>
+<script>
+// Landing page for a redirected cross-origin iframe navigation. It reads its own
+// PerformanceNavigationTiming entry and posts the redirect-timing fields to the
+// parent, which is cross-origin and so cannot read them directly.
+addEventListener("load", () => {
+  const entry = performance.getEntriesByType("navigation")[0];
+  parent.postMessage({
+    type: entry.type,
+    redirectCount: entry.redirectCount,
+    redirectStart: entry.redirectStart,
+    redirectEnd: entry.redirectEnd,
+  }, "*");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/response-start-after-coop-bcg-switch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/response-start-after-coop-bcg-switch.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Navigation responseStart is not clamped to zero after a cross-origin COOP browsing context group switch assert_greater_than: responseStart should not be clamped to zero after the COOP browsing context group switch expected a number greater than 0 but got 0
+FAIL Navigation responseStart is not clamped to zero after a cross-origin COOP browsing context group switch assert_equals: The cross-origin navigation should not expose the redirect count expected 0 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/unload-event-same-origin-check-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-timing/unload-event-same-origin-check-expected.txt
@@ -5,7 +5,7 @@ This test validates that the values of window.performance.getEntriesByType("navi
 
 
 PASS Redirect chain with a partial TAO opt-in
-FAIL Redirect chain with full TAO opt-in assert_equals: Expected redirectCount to be 1 expected 1 but got 0
+PASS Redirect chain with full TAO opt-in
 PASS Same-cross-same redirect chain with no TAO opt-in
 PASS cross-cross-same Redirect chain with no TAO opt-in
 PASS Previous document cross origin
@@ -14,6 +14,6 @@ PASS No previous document
 PASS Same origin previous document with same origin redirect
 PASS No previous document with same origin redirect
 PASS No previous document with cross origin redirect
-FAIL No previous document with cross origin redirect with partial TAO assert_equals: Expected redirectCount to be 1 expected 1 but got 0
+PASS No previous document with cross origin redirect with partial TAO
 PASS No previous document with cross origin redirect with TAO
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -430,6 +430,13 @@ bool DocumentLoader::isLoading() const
     return isLoadingMainResource() || !m_subresourceLoaders.isEmpty() || !m_plugInStreamLoaders.isEmpty();
 }
 
+static void hideRedirectTimingForNoReferrerNavigation(const DocumentLoader& loader, NetworkLoadMetrics& metrics)
+{
+    // https://html.spec.whatwg.org/C#initialise-the-document-object step 15.3 resets redirectCount in case of "no-referrer".
+    if (loader.triggeringAction().requester() && loader.request().httpReferrer().isEmpty())
+        metrics.redirectCount = 0;
+}
+
 void DocumentLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& fetchMetrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     ASSERT(isMainThread());
@@ -447,6 +454,8 @@ void DocumentLoader::notifyFinished(CachedResource& resource, const NetworkLoadM
     }
     if (!metrics)
         metrics = Box<NetworkLoadMetrics>::create(fetchMetrics);
+
+    hideRedirectTimingForNoReferrerNavigation(*this, *metrics);
 
     if (RefPtr document = this->document()) {
         if (RefPtr window = document->window())
@@ -1389,6 +1398,7 @@ void DocumentLoader::commitData(const SharedBuffer& data)
                     || source == ResourceResponse::Source::MemoryCacheAfterValidation;
                 if (RefPtr frameLoader = this->frameLoader())
                     finalMetrics.fromPrefetch = frameLoader->documentPrefetcher().wasPrefetched(url());
+                hideRedirectTimingForNoReferrerNavigation(*this, finalMetrics);
                 protect(window->performance())->addNavigationTiming(*this, document, protect(*m_mainResource), timing(), finalMetrics);
             }
         }

--- a/Source/WebCore/page/PerformanceNavigationTiming.cpp
+++ b/Source/WebCore/page/PerformanceNavigationTiming.cpp
@@ -121,11 +121,17 @@ PerformanceNavigationTiming::NavigationType PerformanceNavigationTiming::type() 
     return m_navigationType;
 }
 
+bool PerformanceNavigationTiming::shouldExposeRedirectTiming() const
+{
+    // https://html.spec.whatwg.org/C#initialise-the-document-object step 15 zeroes redirectCount when a
+    // cross-origin redirect chain does not opt in, so hide the redirect gap only then; a navigation with
+    // no such redirect (e.g. served by a service worker) must still expose its real fetch start.
+    auto& metrics = m_resourceTiming.networkLoadMetrics();
+    return metrics.redirectCount || !metrics.hasCrossOriginRedirect;
+}
+
 unsigned short PerformanceNavigationTiming::redirectCount() const
 {
-    if (m_resourceTiming.networkLoadMetrics().hasCrossOriginRedirect)
-        return 0;
-
     return m_resourceTiming.networkLoadMetrics().redirectCount;
 }
 

--- a/Source/WebCore/page/PerformanceNavigationTiming.h
+++ b/Source/WebCore/page/PerformanceNavigationTiming.h
@@ -77,6 +77,7 @@ private:
 
     double millisecondsSinceOrigin(MonotonicTime) const;
     bool NODELETE sameOriginCheckFails() const;
+    bool NODELETE shouldExposeRedirectTiming() const final;
 
     DocumentEventTiming m_documentEventTiming;
     DocumentLoadTiming m_documentLoadTiming;

--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -56,9 +56,11 @@ static double networkLoadTimeToDOMHighResTimeStamp(MonotonicTime timeOrigin, Mon
     return result.milliseconds();
 }
 
-static double fetchStart(MonotonicTime timeOrigin, const ResourceTiming& resourceTiming)
+static double fetchStart(MonotonicTime timeOrigin, const ResourceTiming& resourceTiming, bool exposeRedirectTiming)
 {
-    if (auto fetchStart = resourceTiming.networkLoadMetrics().fetchStart; fetchStart && !resourceTiming.networkLoadMetrics().failsTAOCheck)
+    // The real fetch start reveals how long the redirects took, so only use it when redirect timing
+    // is exposed; otherwise fall back to the start time, which collapses that gap.
+    if (auto fetchStart = resourceTiming.networkLoadMetrics().fetchStart; fetchStart && exposeRedirectTiming)
         return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, fetchStart);
 
     // fetchStart is a required property.
@@ -71,7 +73,7 @@ static double entryStartTime(MonotonicTime timeOrigin, const ResourceTiming& res
 {
     if (resourceTiming.networkLoadMetrics().failsTAOCheck
         || !resourceTiming.networkLoadMetrics().redirectCount)
-        return fetchStart(timeOrigin, resourceTiming);
+        return fetchStart(timeOrigin, resourceTiming, !resourceTiming.networkLoadMetrics().failsTAOCheck);
 
     if (resourceTiming.networkLoadMetrics().redirectStart)
         return networkLoadTimeToDOMHighResTimeStamp(timeOrigin, resourceTiming.networkLoadMetrics().redirectStart);
@@ -118,9 +120,14 @@ double PerformanceResourceTiming::workerStart() const
     return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().workerStart);
 }
 
+bool PerformanceResourceTiming::shouldExposeRedirectTiming() const
+{
+    return !m_resourceTiming.networkLoadMetrics().failsTAOCheck;
+}
+
 double PerformanceResourceTiming::redirectStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (!shouldExposeRedirectTiming())
         return 0.0;
 
     if (m_resourceTiming.isLoadedFromServiceWorker())
@@ -134,7 +141,7 @@ double PerformanceResourceTiming::redirectStart() const
 
 double PerformanceResourceTiming::redirectEnd() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (!shouldExposeRedirectTiming())
         return 0.0;
 
     if (m_resourceTiming.isLoadedFromServiceWorker())
@@ -143,6 +150,7 @@ double PerformanceResourceTiming::redirectEnd() const
     if (!m_resourceTiming.networkLoadMetrics().redirectCount)
         return 0.0;
 
+    // redirectEnd is when the last redirect finished, i.e. when the final request's fetch started.
     // These two times are so close to each other that we don't record two timestamps.
     // See https://www.w3.org/TR/resource-timing-2/#attribute-descriptions
     return fetchStart();
@@ -150,7 +158,7 @@ double PerformanceResourceTiming::redirectEnd() const
 
 double PerformanceResourceTiming::fetchStart() const
 {
-    return WebCore::fetchStart(m_timeOrigin, m_resourceTiming);
+    return WebCore::fetchStart(m_timeOrigin, m_resourceTiming, shouldExposeRedirectTiming());
 }
 
 double PerformanceResourceTiming::domainLookupStart() const

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -84,6 +84,9 @@ protected:
 
     bool isLoadedFromServiceWorker() const { return m_resourceTiming.isLoadedFromServiceWorker(); }
 
+    // Navigation timing exposes redirect timing under a different condition than the TAO check.
+    virtual bool NODELETE shouldExposeRedirectTiming() const;
+
     MonotonicTime m_timeOrigin;
     ResourceTiming m_resourceTiming;
     Vector<Ref<PerformanceServerTiming>> m_serverTiming;

--- a/Source/WebCore/platform/network/TimingAllowOrigin.cpp
+++ b/Source/WebCore/platform/network/TimingAllowOrigin.cpp
@@ -50,4 +50,15 @@ bool passesTimingAllowOriginCheck(const ResourceResponse& response, const Securi
     return false;
 }
 
+bool passesNavigationTAOCheck(const Vector<Vector<String>>& navigationTimingAllowValuesList, const SecurityOrigin& destinationOrigin)
+{
+    // https://fetch.spec.whatwg.org/#navigation-tao-check
+    auto destinationOriginString = destinationOrigin.toString();
+    for (auto& taoValues : navigationTimingAllowValuesList) {
+        if (!taoValues.contains("*"_s) && !taoValues.contains(destinationOriginString))
+            return false;
+    }
+    return true;
+}
+
 }

--- a/Source/WebCore/platform/network/TimingAllowOrigin.h
+++ b/Source/WebCore/platform/network/TimingAllowOrigin.h
@@ -25,11 +25,17 @@
 
 #pragma once
 
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
 namespace WebCore {
 
 class ResourceResponse;
 class SecurityOrigin;
 
 WEBCORE_EXPORT bool passesTimingAllowOriginCheck(const ResourceResponse&, const SecurityOrigin& initiatorSecurityOrigin);
+
+// https://fetch.spec.whatwg.org/#navigation-tao-check
+WEBCORE_EXPORT bool passesNavigationTAOCheck(const Vector<Vector<String>>& navigationTimingAllowValuesList, const SecurityOrigin& destinationOrigin);
 
 }

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -44,6 +44,7 @@
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/RegistrableDomain.h>
+#include <WebCore/TimingAllowOrigin.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -166,6 +167,9 @@ void NetworkLoadChecker::checkRedirection(ResourceRequest&& request, ResourceReq
         return;
     }
 
+    if (m_options.mode == FetchOptions::Mode::Navigate)
+        appendToNavigationTimingAllowValuesList(redirectResponse);
+
     m_previousURL = WTF::move(m_url);
     m_url = redirectRequest.url();
 
@@ -238,6 +242,10 @@ ResourceError NetworkLoadChecker::validateResponse(const ResourceRequest& reques
                 response.setDeprecatedNetworkLoadMetrics(WTF::move(metrics));
             }
         }
+
+        // https://fetch.spec.whatwg.org/#navigation-tao-check
+        if (m_options.mode == FetchOptions::Mode::Navigate && !response.isRedirection())
+            m_navigationTAOCheckPassed = WebCore::passesNavigationTAOCheck(m_navigationTimingAllowValuesList, SecurityOrigin::create(m_url).get());
     });
 
     if (m_redirectCount)
@@ -306,6 +314,19 @@ bool NetworkLoadChecker::checkTAO(const ResourceResponse& response)
 
     m_timingAllowFailedFlag = response.tainting() != ResourceResponse::Tainting::Basic;
     return !m_timingAllowFailedFlag;
+}
+
+// https://fetch.spec.whatwg.org/#append-to-a-requests-navigation-timing-allow-values-list
+void NetworkLoadChecker::appendToNavigationTimingAllowValuesList(const ResourceResponse& response)
+{
+    Vector<String> taoValues;
+    const auto& timingAllowOriginString = response.httpHeaderField(HTTPHeaderName::TimingAllowOrigin);
+    for (auto valueWithSpace : StringView(timingAllowOriginString).split(',')) {
+        auto value = valueWithSpace.trim(isASCIIWhitespaceWithoutFF<char16_t>);
+        if (!value.isEmpty())
+            taoValues.append(value.toString());
+    }
+    m_navigationTimingAllowValuesList.append(WTF::move(taoValues));
 }
 
 auto NetworkLoadChecker::accessControlErrorForValidationHandler(String&& message) -> RequestOrRedirectionTripletOrError

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -34,7 +34,9 @@
 #include <pal/SessionID.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 class ContentSecurityPolicy;
@@ -121,6 +123,7 @@ public:
     const WebCore::FetchOptions& options() const LIFETIME_BOUND { return m_options; }
 
     bool timingAllowFailedFlag() const { return m_timingAllowFailedFlag; }
+    bool navigationTAOCheckPassed() const { return m_navigationTAOCheckPassed; }
 
 private:
     NetworkLoadChecker(NetworkProcess&, NetworkResourceLoader*, NetworkSchemeRegistry*, WebCore::FetchOptions&&, PAL::SessionID, std::optional<WebPageProxyIdentifier>, WebCore::HTTPHeaderMap&&, URL&&, DocumentURL&&,  RefPtr<WebCore::SecurityOrigin>&&, RefPtr<WebCore::SecurityOrigin>&& topOrigin, RefPtr<WebCore::SecurityOrigin>&& parentOrigin, WebCore::PreflightPolicy, String&& referrer, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, bool shouldCaptureExtraNetworkLoadMetrics, LoadType requestLoadType);
@@ -159,6 +162,8 @@ private:
     RefPtr<WebCore::SecurityOrigin> parentOrigin() const { return m_parentOrigin; }
 
     bool checkTAO(const WebCore::ResourceResponse&);
+
+    void appendToNavigationTimingAllowValuesList(const WebCore::ResourceResponse&);
 
     WebCore::FetchOptions m_options;
     WebCore::StoredCredentialsPolicy m_storedCredentialsPolicy;
@@ -201,6 +206,12 @@ private:
     WeakPtr<NetworkResourceLoader> m_networkResourceLoader;
 
     bool m_timingAllowFailedFlag { false };
+
+    // Remembers each redirect's opt-in so the whole chain can be judged once the destination is known.
+    Vector<Vector<String>> m_navigationTimingAllowValuesList;
+
+    // https://fetch.spec.whatwg.org/#navigation-tao-check
+    bool m_navigationTAOCheckPassed { false };
 };
 
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1196,8 +1196,17 @@ void NetworkResourceLoader::didReceiveBuffer(const WebCore::FragmentedSharedBuff
     sendBuffer(buffer);
 }
 
-void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMetrics)
+void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& originalNetworkLoadMetrics)
 {
+    // https://fetch.spec.whatwg.org/#navigation-tao-check
+    std::optional<NetworkLoadMetrics> navigationMetrics;
+    if (parameters().options.mode == FetchOptions::Mode::Navigate && originalNetworkLoadMetrics.hasCrossOriginRedirect
+        && !(m_networkLoadChecker && m_networkLoadChecker->navigationTAOCheckPassed())) {
+        navigationMetrics = originalNetworkLoadMetrics;
+        navigationMetrics->redirectCount = 0;
+    }
+    const NetworkLoadMetrics& networkLoadMetrics = navigationMetrics ? *navigationMetrics : originalNetworkLoadMetrics;
+
     ASSERT(!m_networkLoadChecker || networkLoadMetrics.failsTAOCheck == m_networkLoadChecker->timingAllowFailedFlag());
 
     LOADER_RELEASE_LOG("didFinishLoading: (numBytesReceived=%zd, hasCacheEntryForValidation=%d)", m_numBytesReceived, !!m_cacheEntryForValidation);


### PR DESCRIPTION
#### 0df60f4248ef6652c95599d295cc4b0367f85911
<pre>
Navigation Timing: cross-origin redirect opt-in should be based on destination origin.
<a href="https://bugs.webkit.org/show_bug.cgi?id=316647">https://bugs.webkit.org/show_bug.cgi?id=316647</a>

Reviewed by Alex Christensen.

This PR aligns the WebKit implementation with <a href="https://github.com/whatwg/fetch/pull/1931">https://github.com/whatwg/fetch/pull/1931</a> and <a href="https://github.com/whatwg/html/pull/12513">https://github.com/whatwg/html/pull/12513</a>,
and ensures that TAO opt-ins for navigation timing take the destination origin into account.

New iframe tests, plus test progressions.

* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-tao-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/redirect-tao.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/resources/redirect-tao-helper.js:
* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/resources/report-navigation-redirect-timing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/response-start-after-coop-bcg-switch.https-expected.txt: Expectation change.
* LayoutTests/imported/w3c/web-platform-tests/navigation-timing/unload-event-same-origin-check-expected.txt: Progression.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::hideRedirectTimingForNoReferrerNavigation): Resets redirect count if noreferrer.
(WebCore::DocumentLoader::notifyFinished): Calls hideRedirectTimingForNoReferrerNavigation.
(WebCore::DocumentLoader::commitData): Calls hideRedirectTimingForNoReferrerNavigation.
* Source/WebCore/page/PerformanceNavigationTiming.cpp:
(WebCore::PerformanceNavigationTiming::shouldExposeRedirectTiming const): Only exposes redirect timing if redirectCount is not zero.
(WebCore::PerformanceNavigationTiming::redirectCount const): TAO check.
* Source/WebCore/page/PerformanceNavigationTiming.h:
* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::fetchStart): Pass exposeRedirectTiming.
(WebCore::entryStartTime): Use shouldExposeRedirectTiming().
(WebCore::PerformanceResourceTiming::shouldExposeRedirectTiming const): A virtual fun that enables NavigationTiming to override the default RT behavior.
(WebCore::PerformanceResourceTiming::redirectStart const): Use shouldExposeRedirectTiming().
(WebCore::PerformanceResourceTiming::redirectEnd const): Use shouldExposeRedirectTiming().
(WebCore::PerformanceResourceTiming::fetchStart const): Use shouldExposeRedirectTiming().
* Source/WebCore/page/PerformanceResourceTiming.h:
* Source/WebCore/platform/network/TimingAllowOrigin.cpp:
(WebCore::passesNavigationTAOCheck):
* Source/WebCore/platform/network/TimingAllowOrigin.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::checkRedirection): Append TAO values.
(WebKit::NetworkLoadChecker::validateResponse): Set TAO values on the response.
(WebKit::NetworkLoadChecker::appendToNavigationTimingAllowValuesList): Accumulate TAO values.
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
(WebKit::NetworkLoadChecker::navigationTAOCheckPassed const): Getter.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishLoading):

Canonical link: <a href="https://commits.webkit.org/317061@main">https://commits.webkit.org/317061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6559937ae6e831e18575c0a1a6202131a902a74d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135267 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95371 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37337 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35704 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185936 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144168 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144026 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38889 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48215 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113553 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38935 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120099 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46721 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10511 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->