### PR TITLE
REGRESSION (302334@main): WebGL canvas filled with opaque color, hiding content beneath it (breaks Construct 3)

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2183,6 +2183,7 @@ webkit.org/b/221311 [ Debug ] imported/w3c/web-platform-tests/html/canvas/offscr
 
 # This failure is related with (incomplete?) webgl support for OffscreenCanvas.
 webgl/1.0.x/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html [ Timeout ]
+webgl/webgl-modify-after-drawimage.html [ Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of OffscreenCanvas-related bugs

--- a/LayoutTests/webgl/webgl-modify-after-drawimage-expected.txt
+++ b/LayoutTests/webgl/webgl-modify-after-drawimage-expected.txt
@@ -1,0 +1,17 @@
+Verifies that drawing a WebGL canvas to a 2D canvas captures the WebGL contents at draw time, even when the WebGL drawing buffer is mutated afterwards.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 5 PASS, 0 FAIL
+
+HTMLCanvasElement WebGL drawn into 2D canvas via drawImage:
+PASS getError was expected value: NO_ERROR :
+PASS No failures HTMLCanvasElement
+OffscreenCanvas WebGL transferred to ImageBitmap, then drawn into 2D canvas:
+PASS getError was expected value: NO_ERROR :
+PASS No failures OffscreenCanvas
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/webgl-modify-after-drawimage.html
+++ b/LayoutTests/webgl/webgl-modify-after-drawimage.html
@@ -1,0 +1,78 @@
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Canvas to Context2D Canvas Flicker Test</title>
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files//js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files//js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Verifies that drawing a WebGL canvas to a 2D canvas captures the WebGL contents at draw time, even when the WebGL drawing buffer is mutated afterwards.");
+
+var wtu = WebGLTestUtils;
+var canvas2d = document.createElement("canvas");
+canvas2d.width = 3000;
+canvas2d.height = 3000;
+var ctx2d = canvas2d.getContext("2d");
+var hadFailures = false;
+var iterations = 20;
+var expected = [0, 255, 0, 255];
+
+function checkColumnIsGreen(label, i) {
+    var column = ctx2d.getImageData(0, 0, 1, canvas2d.height);
+    for (var y = 0; y < canvas2d.height; y++) {
+        var pixel = column.data.subarray(y * 4, y * 4 + 4);
+        if (!expected.every((v, i) => pixel[i] === v)) {
+            testFailed(`${label} iteration ${i}: row ${y} at x=0 was [${Array.from(pixel).join(', ')}], expected [${expected.join(', ')}]`);
+            hadFailures = true;
+            return;
+        }
+    }
+}
+
+debug("HTMLCanvasElement WebGL drawn into 2D canvas via drawImage:");
+var canvasWebGL = document.createElement("canvas");
+canvasWebGL.width = canvas2d.width;
+canvasWebGL.height = canvas2d.height;
+var gl = canvasWebGL.getContext("webgl2", {antialias: false});
+for (let i = 0; i < iterations; i++) {
+    gl.clearColor(0, 1, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    ctx2d.clearRect(0, 0, canvas2d.width, canvas2d.height);
+    ctx2d.drawImage(canvasWebGL, 0, 0);
+    gl.clearColor(1, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.flush(); // Flush the above clear. It shouldn't appear in the 2d context.
+    checkColumnIsGreen("drawImage", i);
+}
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+if (!hadFailures)
+    testPassed("No failures HTMLCanvasElement");
+
+hadFailures = false;
+debug("OffscreenCanvas WebGL transferred to ImageBitmap, then drawn into 2D canvas:");
+var offscreenWebGL = new OffscreenCanvas(canvas2d.width, canvas2d.height);
+gl = offscreenWebGL.getContext("webgl", {antialias: false});
+for (let i = 0; i < iterations; i++) {
+    gl.clearColor(0, 1, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    let bitmap = offscreenWebGL.transferToImageBitmap();
+    gl.clearColor(1, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.flush(); // Flush the above clear. It shouldn't appear in the transferred ImageBitmap.
+    ctx2d.clearRect(0, 0, canvas2d.width, canvas2d.height);
+    ctx2d.drawImage(bitmap, 0, 0);
+    checkColumnIsGreen("transferToImageBitmap", i);
+}
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+if (!hadFailures)
+    testPassed("No failures OffscreenCanvas");
+debug("");
+finishTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
@@ -51,11 +51,19 @@ RefPtr<NativeImage> IOSurfaceDrawingBuffer::copyNativeImage() const
 void IOSurfaceDrawingBuffer::forceCopy()
 {
     m_needCopy = false;
+    // Prior to upcoming external modification, "invalidate" the surface to make CGIOSurfaceContext
+    // copy the contents out.
     // See https://webkit.org/b/157966 and https://webkit.org/b/228682 for more context.
     if (PAL::canLoad_CoreGraphics_CGIOSurfaceContextInvalidateSurface())
         PAL::softLink_CoreGraphics_CGIOSurfaceContextInvalidateSurface(m_copyOnWriteContext.get());
     else
         CGContextFillRect(m_copyOnWriteContext.get(), CGRect { });
+    // Ensuring ordering with the copy and upcoming external modifications: Since the upcoming modification is external to the CGIOSurfaceContext, we
+    // must flush to guarantee that the copy has been performed before we make the modification.
+    // Ensuring ordering with committed but not scheduled reads: There might be pending read references on the IOSurface from consumer
+    // CGIOSurfaceContexts via the CGImage. I.e. the read operations have committed but not yet scheduled. Flush on
+    // the producer context will schedule these too. In other words: flushes are global.
+    CGContextFlush(m_copyOnWriteContext.get());
 }
 
 }


### PR DESCRIPTION
#### eb193e1e75323ffe39ab16f5b883a1daf793d2b9
<pre>
REGRESSION (302334@main): WebGL canvas filled with opaque color, hiding content beneath it (breaks Construct 3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=312987">https://bugs.webkit.org/show_bug.cgi?id=312987</a>
<a href="https://rdar.apple.com/175352260">rdar://175352260</a>

Reviewed by Dan Glastonbury and Simon Fraser.

Commit 302334@main would implement logic where WebGL display or drawing
buffer would be captured to NativeImage.

For Cocoa, it would do this in non-copy fashion: GraphicsContextGLCocoa
would create CGIOSurfaceContexts for each backing store IOSurface, and
create a wrapping CGImage out of that. When WebGL would be modified, it
would use CGIOSurfaceContextInvalidateSurface on the CGIOSurfaceContext
to notify that the data should be migrated away from the IOSurface to
the CGImage prior to any further WebGL modification to then backing
store IOSurface.

This is valid for CGImages that:
- have not been sourced from.
- have been sourced from at CG level but the draw waits in
  CGIOSurfaceContext queue.
- have been sourced from and the CGIOSurfaceContext has been flushed,
  i.e. the underlying draw is scheduled.

This is not a valid approach when the IOSurface reference has been
encoded to the command buffer of the underlying draw, but the command
buffer is not yet scheduled. I.e draw operation sourcing the IOSurface
has committed but not scheduled.

Fix by flushing CGIOSurfaceContextInvalidateSurface operation.
This ensures that:
 - the data is migrated before modifications happen
 - the already committed but not scheduled reads are scheduled

Tests: webgl/webgl-modify-after-drawimage.html

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/webgl/webgl-modify-after-drawimage-expected.txt: Added.
* LayoutTests/webgl/webgl-modify-after-drawimage.html: Added.
* Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp:
(WebCore::IOSurfaceDrawingBuffer::forceCopy):

Canonical link: <a href="https://commits.webkit.org/315018@main">https://commits.webkit.org/315018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7da8522bd27461bddf8a67227d2f42c0c5bea837

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176895 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125518 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130581 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111098 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25627 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179437 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32484 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139000 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37401 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105331 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34156 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40598 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113850 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39995 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5287 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40246 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->