### PR TITLE
Fix style issues in WebProcess sandbox

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -34,11 +34,10 @@
 
 (define webcontent_gpu_sandbox_extensions_blocking?
 #if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140400 && defined(RC_XBS) && RC_XBS == 1
-    TRUE
+    TRUE)
 #else
-    FALSE
+    FALSE)
 #endif
-)
 
 #if USE(SANDBOX_VERSION_3)
 (allow dynamic-code-generation)
@@ -264,8 +263,7 @@
         "vm.footprint_suspend")
     (sysctl-name-prefix "net.routetable")
     (sysctl-name-prefix "hw.optional.") ;; <rdar://problem/71462790>
-    (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>
-)
+    (sysctl-name-prefix "hw.perflevel")) ;; <rdar://problem/76783596>
 
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))
@@ -553,8 +551,7 @@
     (iokit-property "PanicOnGPUHang")
     (iokit-property "TelemetryDisable")
     (iokit-property "IOGVAH264EncodeCapabilities") ;; <rdar://problem/49498040>
-    (iokit-property "IOAVDHEVCDecodeCapabilities") ;; <rdar://problem/71100188>
-)
+    (iokit-property "IOAVDHEVCDecodeCapabilities")) ;; <rdar://problem/71100188>
 
 ;; <rdar://97677559>
 (deny iokit-get-properties
@@ -629,8 +626,7 @@
 #if !ENABLE(CFPREFS_DIRECT_MODE)
 (allow mach-lookup
     (global-name "com.apple.cfprefsd.agent")
-    (global-name "com.apple.cfprefsd.daemon")
-)
+    (global-name "com.apple.cfprefsd.daemon"))
 #endif
 
 (deny mach-lookup (with no-report)
@@ -767,8 +763,7 @@
 ;; Allow the OpenGL Profiler to attach.
 (with-filter (system-attribute apple-internal)
     (allow mach-register
-        (global-name-regex #"^_oglprof_attach_<[0-9]+>$"))
-)
+        (global-name-regex #"^_oglprof_attach_<[0-9]+>$")))
 
 #if USE(SANDBOX_PARAMS)
 (if (positive? (string-length (param "DARWIN_USER_CACHE_DIR")))
@@ -792,8 +787,7 @@
 
 #if !ENABLE(SET_WEBCONTENT_PROCESS_INFORMATION_IN_NETWORK_PROCESS)
 (allow mach-lookup
-    (global-name "com.apple.coreservices.launchservicesd")
-)
+    (global-name "com.apple.coreservices.launchservicesd"))
 #endif
 
 (deny mach-lookup (with no-report)
@@ -878,8 +872,7 @@
         (subpath "/private/var/db/mds/system")) ;; FIXME: This should be removed when <rdar://problem/9538414> is fixed.
     (allow mach-lookup
        (global-name "com.apple.system.opendirectoryd.libinfo")
-       (global-name "com.apple.system.opendirectoryd.membership"))
-)
+       (global-name "com.apple.system.opendirectoryd.membership")))
 
 #if ENABLE(REMOVE_XPC_AND_MACH_SANDBOX_EXTENSIONS_IN_WEBCONTENT)
 (deny mach-lookup (with telemetry-backtrace)
@@ -898,8 +891,7 @@
 ;; CoreFoundation. We don't import com.apple.corefoundation.sb, because it allows unnecessary access to pasteboard.
 #if !HAVE(CSCHECKFIXDISABLE)
 (allow mach-lookup
-    (global-name "com.apple.CoreServices.coreservicesd")
-)
+    (global-name "com.apple.CoreServices.coreservicesd"))
 #endif
 
 (deny mach-lookup (with no-report)
@@ -916,9 +908,7 @@
 ;; ObjC map_images needs to send logging data to syslog. <rdar://problem/39778918>
 (with-filter (system-attribute apple-internal)
     (allow network-outbound
-       (literal "/private/var/run/syslog")
-    )
-)
+       (literal "/private/var/run/syslog")))
 
 ;; CFNetwork
 (allow file-read-data (path "/private/var/db/nsurlstoraged/dafsaData.bin"))
@@ -947,8 +937,7 @@
     (with no-report))
 (with-filter (uid 0)
     (allow mach-lookup
-        (global-name "com.apple.system.logger"))
-)
+        (global-name "com.apple.system.logger")))
 
 (deny file-write-create (vnode-type SYMLINK))
 
@@ -1033,8 +1022,7 @@
     (with no-report))
 
 (deny mach-lookup (with no-report)
-    (xpc-service-name "com.apple.audio.toolbox.reporting.service")
-)
+    (xpc-service-name "com.apple.audio.toolbox.reporting.service"))
 
 (deny mach-lookup (with no-report)
     (global-name "com.apple.audio.SystemSoundServer-OSX")
@@ -1105,8 +1093,7 @@
             F_RDADVISE ;; CoreNLP::ReadOnlyFile <- +[DDScannerService scanString:range:configuration:] <- WebCore::DictionaryLookup::rangeAtHitTestResult(WebCore::HitTestResult const&)
             F_SETCONFINED
             F_SETFD ;; libwebrtc.dylib (no backtrace)
-            F_SETPROTECTIONCLASS))
-)
+            F_SETPROTECTIONCLASS)))
 
 (when (defined? 'process-codesigning*)
     ;; csops/csops_audittoken
@@ -1118,18 +1105,15 @@
     (allow process-codesigning-entitlements-blob-get) ;; WK reading entitlments via SecTaskCopyValueForEntitlement and _getSelfParsedEntitlements (accessibility)
     (allow process-codesigning-status-get) ;; _xpc_get_entitlements
     (allow process-codesigning-status-set (target self))
-    (deny process-info-codesignature (with no-report)) ;; SecTaskCopyValueForEntitlement - granting this grants all the process-codesign-* checks
-)
+    (deny process-info-codesignature (with no-report))) ;; SecTaskCopyValueForEntitlement - granting this grants all the process-codesign-* checks
 
 (when (defined? 'socket-option-get)
     ;; getsockopt
-    (deny socket-option-get)
-)
+    (deny socket-option-get))
 
 (when (defined? 'socket-option-set)
     ;; setsockopt
-    (deny socket-option-set)
-)
+    (deny socket-option-set))
 
 (disable-syscall-inference)
 
@@ -1677,12 +1661,11 @@
         "com.apple.webinspectord.availability_check"))
 
 (deny file-read* (with no-report)
-    (home-literal "/Library/Preferences/com.apple.CFNetwork.plist")
 #if PLATFORM(MAC)
     (home-literal "/Library/Preferences/com.apple.networkd.plist")
     (literal "/Library/Preferences/com.apple.networkd.plist")
 #endif
-)
+    (home-literal "/Library/Preferences/com.apple.CFNetwork.plist"))
 
 #if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
 (with-filter (webcontent-process-launched)


### PR DESCRIPTION
#### ebf02100bf1796da0af3f578919244db34437d95
<pre>
Fix style issues in WebProcess sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=316657">https://bugs.webkit.org/show_bug.cgi?id=316657</a>
<a href="https://rdar.apple.com/179108438">rdar://179108438</a>

Reviewed by Sihui Liu.

Parenthesis should not appear on a separate line. There is no behavior change from this fix.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/314836@main">https://commits.webkit.org/314836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cb682cc5e280d4c21273920b98de6e52021ee39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176344 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0fbb78e7-a3ed-489a-94eb-f89563292f99) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130136 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60e2c5f6-9493-4a0f-a58c-5e7803332828) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110653 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bcee0cc-75b6-4850-b9e3-813556b8faca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30223 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25083 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141506 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178886 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138525 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138415 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41552 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104599 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26676 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113137 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39453 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4774 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39703 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->