### PR TITLE
[MSE][Cocoa] MediaSampleAVFObjC methods other than divide() failed on CMSampleBuffers without a sample-size array

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-adts-aac-remove-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-adts-aac-remove-expected.txt
@@ -1,0 +1,18 @@
+
+RUN(video.disableRemotePlayback = true)
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer('audio/aac'))
+RUN(sourceBuffer.appendBuffer(buffer))
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '0') OK
+EXPECTED (fullEnd > 1.0 == 'true') OK
+RUN(sourceBuffer.remove(0, 1.0))
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) >= 1.0 == 'true') OK
+EXPECTED (sourceBuffer.buffered.start(0) < 1.1 == 'true') OK
+EXPECTED (Math.abs(sourceBuffer.buffered.end(0) - fullEnd) < 0.05 == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-adts-aac-remove.html
+++ b/LayoutTests/media/media-source/media-managedmse-adts-aac-remove.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true MediaContainmentEnabled=true ] -->
+<html>
+<head>
+    <title>ManagedMediaSource ADTS-framed AAC partial-sample remove()</title>
+    <script src="../video-test.js"></script>
+    <script src="../utilities.js"></script>
+    <script>
+    // Regression coverage for webkit.org/b/316467.
+    // AVStreamDataParser emits ADTS-framed AAC as multi-packet CMSampleBuffers
+    // (~0.49s each) that report kCMSampleBufferError_BufferHasNoSampleSizes.
+    // SourceBuffer.remove(start, end) needs MediaSampleAVFObjC::divide(time) to
+    // split those at packet boundaries; without that, removing a sub-range
+    // that lands inside a multi-packet sample erases the whole sample and
+    // leaves a gap larger than the requested range.
+    var source;
+    var sourceBuffer;
+    var buffer;
+    var fullEnd;
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            if (!ManagedMediaSource.isTypeSupported('audio/aac')) {
+                consoleWrite('audio/aac not supported by ManagedMediaSource on this platform; skipping.');
+                endTest();
+                return;
+            }
+
+            run('video.disableRemotePlayback = true');
+            source = new ManagedMediaSource();
+            run('video.src = URL.createObjectURL(source)');
+            await waitFor(source, 'sourceopen');
+            waitFor(video, 'error').then(failTest);
+
+            run('sourceBuffer = source.addSourceBuffer(\'audio/aac\')');
+
+            const response = await fetch('./content/test-adts.aac');
+            buffer = await response.arrayBuffer();
+            run('sourceBuffer.appendBuffer(buffer)');
+            await waitFor(sourceBuffer, 'updateend');
+
+            testExpected('sourceBuffer.buffered.length', '1');
+            testExpected('sourceBuffer.buffered.start(0)', '0');
+            fullEnd = sourceBuffer.buffered.end(0);
+            testExpected('fullEnd > 1.0', true);
+
+            // Remove [0, 1.0). AVStreamDataParser emits ADTS as multi-packet
+            // CMSampleBuffers (each ~0.49s long) that report
+            // kCMSampleBufferError_BufferHasNoSampleSizes. Without divide(time)
+            // handling that shape the multi-packet sample straddling 1.0s
+            // could not be split, so the entire sample (ending around 1.47s)
+            // was erased and buffered.start(0) jumped to ~1.47. With the fix
+            // the sample is split at ~1.0, so buffered.start(0) lands close
+            // to the requested boundary.
+            run('sourceBuffer.remove(0, 1.0)');
+            await waitFor(sourceBuffer, 'updateend');
+
+            testExpected('sourceBuffer.buffered.length', '1');
+            testExpected('sourceBuffer.buffered.start(0) >= 1.0', true);
+            testExpected('sourceBuffer.buffered.start(0) < 1.1', true);
+            testExpected('Math.abs(sourceBuffer.buffered.end(0) - fullEnd) < 0.05', true);
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <video controls disableremoteplayback></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3742,6 +3742,7 @@ media/media-allowed-codecs.html [ Skip ]
 media/media-allowed-containers.html [ Skip ]
 media/media-source/media-source-allowed-codecs.html [ Skip ]
 webkit.org/b/316466 media/media-source/media-managedmse-adts-aac.html [ Failure ]
+webkit.org/b/316466 media/media-source/media-managedmse-adts-aac-remove.html [ Failure ]
 
 webkit.org/b/214166 imported/w3c/web-platform-tests/media-source/idlharness.window.html [ Skip ]
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -228,13 +228,7 @@ void MediaSampleAVFObjC::setTimestamps(const WTF::MediaTime &presentationTimesta
 
 bool MediaSampleAVFObjC::isDivisable() const
 {
-    if (PAL::CMSampleBufferGetNumSamples(m_sample.get()) == 1)
-        return false;
-
-    if (PAL::CMSampleBufferGetSampleSizeArray(m_sample.get(), 0, nullptr, nullptr) == kCMSampleBufferError_BufferHasNoSampleSizes)
-        return false;
-
-    return true;
+    return PAL::CMSampleBufferGetNumSamples(m_sample.get()) > 1;
 }
 
 Vector<Ref<MediaSampleAVFObjC>> MediaSampleAVFObjC::divide()
@@ -244,73 +238,13 @@ Vector<Ref<MediaSampleAVFObjC>> MediaSampleAVFObjC::divide()
     if (numSamples == 1)
         return Vector<Ref<MediaSampleAVFObjC>>::from(Ref { *this });
 
-    // CMSampleBufferCallBlockForEachSample relies on a populated sample-size array.
-    // Some legal CMSampleBuffer shapes carry per-packet sizes elsewhere (e.g. ADTS
-    // framing in the data stream, or compressed audio that uses the audio stream
-    // packet description array — both report kCMSampleBufferError_BufferHasNoSampleSizes
-    // from CMSampleBufferGetSampleSizeArray). For those, walk the packet description
-    // array directly and build per-packet sub-buffers that reference the original
-    // block buffer (zero-copy).
-    if (PAL::CMSampleBufferGetSampleSizeArray(m_sample.get(), 0, nullptr, nullptr) == kCMSampleBufferError_BufferHasNoSampleSizes) {
-        auto packetDescs = getPacketDescriptions(m_sample.get());
-        if (packetDescs.size() != static_cast<size_t>(numSamples))
-            return { };
-
-        CMItemCount timingsNeeded = 0;
-        if (PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), 0, nullptr, &timingsNeeded) != noErr || !timingsNeeded)
-            return { };
-        Vector<CMSampleTimingInfo> timings(timingsNeeded);
-        if (PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), timingsNeeded, timings.mutableSpan().data(), nullptr) != noErr)
-            return { };
-
-        const bool uniformTiming = timings.size() == 1;
-        const CMSampleTimingInfo& baseTiming = timings[0];
-        CMTime runningPTS = baseTiming.presentationTimeStamp;
-        CMTime runningDTS = baseTiming.decodeTimeStamp;
-
-        RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(m_sample.get());
-        RetainPtr sourceBlockBuffer = PAL::CMSampleBufferGetDataBuffer(m_sample.get());
-        if (!formatDescription || !sourceBlockBuffer)
-            return { };
-
-        Vector<Ref<MediaSampleAVFObjC>> samples;
-        samples.reserveInitialCapacity(static_cast<size_t>(numSamples));
-        for (CMItemCount i = 0; i < numSamples; ++i) {
-            const auto& desc = packetDescs[i];
-            if (desc.mStartOffset < 0)
-                return { };
-
-            CMBlockBufferRef rawSubBlock = nullptr;
-            if (PAL::CMBlockBufferCreateEmpty(kCFAllocatorDefault, 1, 0, &rawSubBlock) != kCMBlockBufferNoErr || !rawSubBlock)
-                return { };
-            RetainPtr subBlock = adoptCF(rawSubBlock);
-            if (PAL::CMBlockBufferAppendBufferReference(subBlock.get(), sourceBlockBuffer.get(), static_cast<size_t>(desc.mStartOffset), desc.mDataByteSize, 0) != kCMBlockBufferNoErr)
-                return { };
-
-            CMSampleTimingInfo timing = uniformTiming
-                ? CMSampleTimingInfo { baseTiming.duration, runningPTS, runningDTS }
-                : timings[i];
-            if (uniformTiming && CMTIME_IS_VALID(baseTiming.duration)) {
-                if (CMTIME_IS_VALID(runningPTS))
-                    runningPTS = PAL::CMTimeAdd(runningPTS, baseTiming.duration);
-                if (CMTIME_IS_VALID(runningDTS))
-                    runningDTS = PAL::CMTimeAdd(runningDTS, baseTiming.duration);
-            }
-            size_t sampleSize = desc.mDataByteSize;
-            CMSampleBufferRef rawSample = nullptr;
-            if (PAL::CMSampleBufferCreateReady(kCFAllocatorDefault, subBlock.get(), formatDescription.get(), 1, 1, &timing, 1, &sampleSize, &rawSample) != noErr || !rawSample)
-                return { };
-            samples.append(MediaSampleAVFObjC::create(adoptCF(rawSample).get(), m_id));
-        }
-        return samples;
-    }
-
     Vector<Ref<MediaSampleAVFObjC>> samples;
     samples.reserveInitialCapacity(numSamples);
-    PAL::CMSampleBufferCallBlockForEachSample(m_sample.get(), [&samples, id = m_id] (CMSampleBufferRef sampleBuffer, CMItemCount) -> OSStatus {
+    if (forEachSample(m_sample.get(), [&samples, id = m_id] (CMSampleBufferRef sampleBuffer, CMItemCount) -> OSStatus {
         samples.append(MediaSampleAVFObjC::create(sampleBuffer, id));
         return noErr;
-    });
+    }) != noErr)
+        return { };
     return samples;
 }
 
@@ -321,7 +255,7 @@ std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> MediaSampleAVFObjC::divide(c
 
     CFIndex samplesBeforePresentationTime = 0;
 
-    PAL::CMSampleBufferCallBlockForEachSample(m_sample.get(), [&] (CMSampleBufferRef sampleBuffer, CMItemCount) -> OSStatus {
+    if (forEachSample(m_sample.get(), [&] (CMSampleBufferRef sampleBuffer, CMItemCount) -> OSStatus {
         auto timeStamp = PAL::CMSampleBufferGetOutputPresentationTimeStamp(sampleBuffer);
         if (CMTIME_IS_INVALID(timeStamp))
             timeStamp = PAL::CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
@@ -337,7 +271,8 @@ std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> MediaSampleAVFObjC::divide(c
             return 1;
         ++samplesBeforePresentationTime;
         return noErr;
-    });
+    }) == kCMSampleBufferError_CannotSubdivide)
+        return { nullptr, nullptr };
 
     if (!samplesBeforePresentationTime)
         return { nullptr, this };
@@ -346,17 +281,13 @@ std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> MediaSampleAVFObjC::divide(c
     if (samplesBeforePresentationTime >= sampleCount)
         return { this, nullptr };
 
-    CMSampleBufferRef rawSampleBefore = nullptr;
-    CFRange rangeBefore = CFRangeMake(0, samplesBeforePresentationTime);
-    if (PAL::CMSampleBufferCopySampleBufferForRange(kCFAllocatorDefault, m_sample.get(), rangeBefore, &rawSampleBefore) != noErr)
+    RetainPtr sampleBefore = copySampleBufferForRange(m_sample.get(), CFRangeMake(0, samplesBeforePresentationTime));
+    if (!sampleBefore)
         return { nullptr, nullptr };
-    RetainPtr<CMSampleBufferRef> sampleBefore = adoptCF(rawSampleBefore);
 
-    CMSampleBufferRef rawSampleAfter = nullptr;
-    CFRange rangeAfter = CFRangeMake(samplesBeforePresentationTime, sampleCount - samplesBeforePresentationTime);
-    if (PAL::CMSampleBufferCopySampleBufferForRange(kCFAllocatorDefault, m_sample.get(), rangeAfter, &rawSampleAfter) != noErr)
+    RetainPtr sampleAfter = copySampleBufferForRange(m_sample.get(), CFRangeMake(samplesBeforePresentationTime, sampleCount - samplesBeforePresentationTime));
+    if (!sampleAfter)
         return { nullptr, nullptr };
-    RetainPtr<CMSampleBufferRef> sampleAfter = adoptCF(rawSampleAfter);
 
     return { MediaSampleAVFObjC::create(sampleBefore.get(), m_id), MediaSampleAVFObjC::create(sampleAfter.get(), m_id) };
 }
@@ -365,13 +296,8 @@ Ref<MediaSample> MediaSampleAVFObjC::createCopyWithAdjustedStartTime(const Media
 {
     MediaTime clampedOffset = std::max(MediaTime::zeroTime(), std::min(offset, duration()));
 
-    CMItemCount itemCount = 0;
-    if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), 0, nullptr, &itemCount))
-        return const_cast<MediaSampleAVFObjC&>(*this);
-
-    Vector<CMSampleTimingInfo> timingInfoArray;
-    timingInfoArray.grow(itemCount);
-    if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), itemCount, timingInfoArray.mutableSpan().data(), nullptr))
+    auto timingInfoArray = getSampleTimingInfoArray(m_sample.get());
+    if (timingInfoArray.isEmpty())
         return const_cast<MediaSampleAVFObjC&>(*this);
 
     CMTime cmOffset = PAL::toCMTime(clampedOffset);
@@ -390,7 +316,7 @@ Ref<MediaSample> MediaSampleAVFObjC::createCopyWithAdjustedStartTime(const Media
     }
 
     CMSampleBufferRef newSampleBuffer = nullptr;
-    if (noErr != PAL::CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, m_sample.get(), itemCount, timingInfoArray.span().data(), &newSampleBuffer) || !newSampleBuffer)
+    if (noErr != PAL::CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, m_sample.get(), timingInfoArray.size(), timingInfoArray.span().data(), &newSampleBuffer) || !newSampleBuffer)
         return const_cast<MediaSampleAVFObjC&>(*this);
 
     return MediaSampleAVFObjC::create(adoptCF(newSampleBuffer).get(), m_id);
@@ -479,11 +405,11 @@ Vector<Ref<MediaSampleAVFObjC>> MediaSampleAVFObjC::divideIntoHomogeneousSamples
 
     SampleVector samples;
     samples.reserveInitialCapacity(ranges.size());
-    for (auto& range : ranges) {
-        CMSampleBufferRef rawSample = nullptr;
-        if (PAL::CMSampleBufferCopySampleBufferForRange(kCFAllocatorDefault, m_sample.get(), range, &rawSample) != noErr || !rawSample)
+    for (const auto& range : ranges) {
+        RetainPtr subSample = copySampleBufferForRange(m_sample.get(), range);
+        if (!subSample)
             return { };
-        samples.append(MediaSampleAVFObjC::create(adoptCF(rawSample).get(), m_id));
+        samples.append(MediaSampleAVFObjC::create(subSample.get(), m_id));
     }
     return samples;
 }

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -29,6 +29,7 @@
 #if PLATFORM(COCOA)
 
 #include <CoreAudio/CoreAudioTypes.h>
+#include <CoreMedia/CMSampleBuffer.h>
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/TrackInfo.h>
 #include <memory>
@@ -106,7 +107,31 @@ private:
 
 Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef);
 
+// Read the sample timing info array out of a CMSampleBufferRef. Returns an
+// empty Vector on failure or if the buffer carries no timing entries.
+Vector<CMSampleTimingInfo> getSampleTimingInfoArray(CMSampleBufferRef);
+
 RetainPtr<CMSampleBufferRef> sampleBufferFromVideoData(std::span<const uint8_t>, CMVideoFormatDescriptionRef);
+
+// Iterate over each sub-sample contained in a CMSampleBufferRef.
+// Transparently handles the kCMSampleBufferError_BufferHasNoSampleSizes shape
+// (e.g. compressed audio that carries per-packet sizes in the audio stream
+// packet description array, such as ADTS framing) by walking the packet
+// description array and synthesizing per-packet sub-CMSampleBuffers that
+// reference the source block buffer (zero-copy). For the normal shape this
+// delegates to PAL::CMSampleBufferCallBlockForEachSample.
+//
+// The callback is invoked once per sub-sample with the synthesized
+// CMSampleBufferRef and its zero-based index. Returning a non-noErr status
+// from the callback stops iteration; that status is returned to the caller.
+// Returns noErr after a complete walk.
+OSStatus forEachSample(CMSampleBufferRef, NOESCAPE const Function<OSStatus(CMSampleBufferRef, CMItemCount)>&);
+
+// Copy a contiguous range of sub-samples out of a CMSampleBufferRef into a new
+// CMSampleBufferRef. Transparently handles the BufferHasNoSampleSizes shape by
+// slicing the packet description array; otherwise delegates to
+// PAL::CMSampleBufferCopySampleBufferForRange. Returns nullptr on failure.
+RetainPtr<CMSampleBufferRef> copySampleBufferForRange(CMSampleBufferRef, CFRange);
 
 WEBCORE_EXPORT bool isCMSampleBufferRandomAccess(CMSampleBufferRef);
 

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -901,6 +901,164 @@ Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef sam
     return descriptions;
 }
 
+Vector<CMSampleTimingInfo> getSampleTimingInfoArray(CMSampleBufferRef sampleBuffer)
+{
+    CMItemCount entriesNeeded = 0;
+    if (PAL::CMSampleBufferGetSampleTimingInfoArray(sampleBuffer, 0, nullptr, &entriesNeeded) != noErr || !entriesNeeded)
+        return { };
+    Vector<CMSampleTimingInfo> timings(entriesNeeded);
+    if (PAL::CMSampleBufferGetSampleTimingInfoArray(sampleBuffer, entriesNeeded, timings.mutableSpan().data(), nullptr) != noErr)
+        return { };
+    return timings;
+}
+
+static bool sampleBufferHasNoSampleSizes(CMSampleBufferRef sampleBuffer)
+{
+    return PAL::CMSampleBufferGetSampleSizeArray(sampleBuffer, 0, nullptr, nullptr) == kCMSampleBufferError_BufferHasNoSampleSizes;
+}
+
+// Synthesize a single-packet CMSampleBuffer that references a slice of a source
+// block buffer. Used when the source CMSampleBuffer carries per-packet sizes in
+// the audio stream packet description array (kCMSampleBufferError_BufferHasNoSampleSizes
+// shape) and CoreMedia APIs that walk the sample-size array cannot be used.
+static RetainPtr<CMSampleBufferRef> createSinglePacketSampleBuffer(CMBlockBufferRef sourceBlockBuffer, CMFormatDescriptionRef formatDescription, const AudioStreamPacketDescription& desc, const CMSampleTimingInfo& timing)
+{
+    if (desc.mStartOffset < 0)
+        return nullptr;
+
+    CMBlockBufferRef rawSubBlock = nullptr;
+    if (PAL::CMBlockBufferCreateEmpty(kCFAllocatorDefault, 1, 0, &rawSubBlock) != kCMBlockBufferNoErr || !rawSubBlock)
+        return nullptr;
+    RetainPtr subBlock = adoptCF(rawSubBlock);
+    if (PAL::CMBlockBufferAppendBufferReference(subBlock.get(), sourceBlockBuffer, static_cast<size_t>(desc.mStartOffset), desc.mDataByteSize, 0) != kCMBlockBufferNoErr)
+        return nullptr;
+
+    size_t sampleSize = desc.mDataByteSize;
+    CMSampleBufferRef rawSample = nullptr;
+    if (PAL::CMSampleBufferCreateReady(kCFAllocatorDefault, subBlock.get(), formatDescription, 1, 1, &timing, 1, &sampleSize, &rawSample) != noErr || !rawSample)
+        return nullptr;
+    return adoptCF(rawSample);
+}
+
+OSStatus forEachSample(CMSampleBufferRef sampleBuffer, NOESCAPE const Function<OSStatus(CMSampleBufferRef, CMItemCount)>& callback)
+{
+    if (!sampleBufferHasNoSampleSizes(sampleBuffer)) {
+        return PAL::CMSampleBufferCallBlockForEachSample(sampleBuffer, [&](CMSampleBufferRef subSample, CMItemCount index) -> OSStatus {
+            return callback(subSample, index);
+        });
+    }
+
+    auto numSamples = PAL::CMSampleBufferGetNumSamples(sampleBuffer);
+    auto packetDescs = getPacketDescriptions(sampleBuffer);
+    if (packetDescs.size() != static_cast<size_t>(numSamples))
+        return kCMSampleBufferError_CannotSubdivide;
+
+    auto timings = getSampleTimingInfoArray(sampleBuffer);
+    if (timings.isEmpty())
+        return kCMSampleBufferError_CannotSubdivide;
+
+    const bool uniformTiming = timings.size() == 1;
+    const CMSampleTimingInfo& baseTiming = timings[0];
+    CMTime runningPTS = baseTiming.presentationTimeStamp;
+    CMTime runningDTS = baseTiming.decodeTimeStamp;
+
+    RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(sampleBuffer);
+    RetainPtr sourceBlockBuffer = PAL::CMSampleBufferGetDataBuffer(sampleBuffer);
+    if (!formatDescription || !sourceBlockBuffer)
+        return kCMSampleBufferError_CannotSubdivide;
+
+    for (CMItemCount i = 0; i < numSamples; ++i) {
+        CMSampleTimingInfo timing = uniformTiming
+            ? CMSampleTimingInfo { baseTiming.duration, runningPTS, runningDTS }
+            : timings[i];
+        if (uniformTiming && CMTIME_IS_VALID(baseTiming.duration)) {
+            if (CMTIME_IS_VALID(runningPTS))
+                runningPTS = PAL::CMTimeAdd(runningPTS, baseTiming.duration);
+            if (CMTIME_IS_VALID(runningDTS))
+                runningDTS = PAL::CMTimeAdd(runningDTS, baseTiming.duration);
+        }
+
+        RetainPtr subSample = createSinglePacketSampleBuffer(sourceBlockBuffer.get(), formatDescription.get(), packetDescs[i], timing);
+        if (!subSample)
+            return kCMSampleBufferError_CannotSubdivide;
+
+        if (auto status = callback(subSample.get(), i))
+            return status;
+    }
+    return noErr;
+}
+
+RetainPtr<CMSampleBufferRef> copySampleBufferForRange(CMSampleBufferRef sampleBuffer, CFRange range)
+{
+    if (!sampleBufferHasNoSampleSizes(sampleBuffer)) {
+        CMSampleBufferRef rawCopy = nullptr;
+        if (PAL::CMSampleBufferCopySampleBufferForRange(kCFAllocatorDefault, sampleBuffer, range, &rawCopy) != noErr || !rawCopy)
+            return nullptr;
+        return adoptCF(rawCopy);
+    }
+
+    auto numSamples = PAL::CMSampleBufferGetNumSamples(sampleBuffer);
+    if (range.location < 0 || range.length <= 0 || range.location + range.length > numSamples)
+        return nullptr;
+
+    auto packetDescs = getPacketDescriptions(sampleBuffer);
+    if (packetDescs.size() != static_cast<size_t>(numSamples))
+        return nullptr;
+
+    auto timings = getSampleTimingInfoArray(sampleBuffer);
+    if (timings.isEmpty())
+        return nullptr;
+
+    RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(sampleBuffer);
+    RetainPtr sourceBlockBuffer = PAL::CMSampleBufferGetDataBuffer(sampleBuffer);
+    if (!formatDescription || !sourceBlockBuffer)
+        return nullptr;
+
+    CMBlockBufferRef rawSubBlock = nullptr;
+    if (PAL::CMBlockBufferCreateEmpty(kCFAllocatorDefault, range.length, 0, &rawSubBlock) != kCMBlockBufferNoErr || !rawSubBlock)
+        return nullptr;
+    RetainPtr subBlock = adoptCF(rawSubBlock);
+
+    Vector<size_t> sampleSizes;
+    sampleSizes.reserveInitialCapacity(static_cast<size_t>(range.length));
+    for (CFIndex i = 0; i < range.length; ++i) {
+        const auto& desc = packetDescs[range.location + i];
+        if (desc.mStartOffset < 0)
+            return nullptr;
+        if (PAL::CMBlockBufferAppendBufferReference(subBlock.get(), sourceBlockBuffer.get(), static_cast<size_t>(desc.mStartOffset), desc.mDataByteSize, 0) != kCMBlockBufferNoErr)
+            return nullptr;
+        sampleSizes.append(desc.mDataByteSize);
+    }
+
+    Vector<CMSampleTimingInfo> rangeTimings;
+    CMItemCount timingEntries;
+    const CMSampleTimingInfo* timingArray = nullptr;
+    CMSampleTimingInfo uniformTimingForRange;
+    if (timings.size() == 1) {
+        const CMSampleTimingInfo& baseTiming = timings[0];
+        uniformTimingForRange = baseTiming;
+        if (CMTIME_IS_VALID(baseTiming.duration)) {
+            for (CFIndex i = 0; i < range.location; ++i) {
+                if (CMTIME_IS_VALID(uniformTimingForRange.presentationTimeStamp))
+                    uniformTimingForRange.presentationTimeStamp = PAL::CMTimeAdd(uniformTimingForRange.presentationTimeStamp, baseTiming.duration);
+                if (CMTIME_IS_VALID(uniformTimingForRange.decodeTimeStamp))
+                    uniformTimingForRange.decodeTimeStamp = PAL::CMTimeAdd(uniformTimingForRange.decodeTimeStamp, baseTiming.duration);
+            }
+        }
+        timingArray = &uniformTimingForRange;
+        timingEntries = 1;
+    } else {
+        rangeTimings = timings.subspan(range.location, range.length);
+        timingArray = rangeTimings.span().data();
+        timingEntries = rangeTimings.size();
+    }
+
+    CMSampleBufferRef rawSample = nullptr;
+    if (PAL::CMSampleBufferCreateReady(kCFAllocatorDefault, subBlock.get(), formatDescription.get(), range.length, timingEntries, timingArray, sampleSizes.size(), sampleSizes.span().data(), &rawSample) != noErr || !rawSample)
+        return nullptr;
+    return adoptCF(rawSample);
+}
+
 RetainPtr<CMBlockBufferRef> ensureContiguousBlockBuffer(CMBlockBufferRef rawBlockBuffer)
 {
     if (PAL::CMBlockBufferIsRangeContiguous(rawBlockBuffer, 0, 0))


### PR DESCRIPTION
#### 6a4f6ef25f273ad58f645939a38050097967e1aa
<pre>
[MSE][Cocoa] MediaSampleAVFObjC methods other than divide() failed on CMSampleBuffers without a sample-size array
<a href="https://bugs.webkit.org/show_bug.cgi?id=316467">https://bugs.webkit.org/show_bug.cgi?id=316467</a>
<a href="https://rdar.apple.com/178866459">rdar://178866459</a>

Reviewed by Jer Noble.

For some compressed audio (e.g. ADTS-framed AAC), AVStreamDataParser
emits multi-packet CMSampleBuffers whose CMSampleBufferGetSampleSizeArray
returns kCMSampleBufferError_BufferHasNoSampleSizes; per-packet sizes
are carried in the audio stream packet description array instead.

webkit.org/b/316425 fixed MediaSampleAVFObjC::divide() (the no-arg form
used by the IPC encode path) for that shape via an inline
packet-description walk. The other methods that consume the underlying
CMSampleBufferRef were not addressed: isDivisable() returned false for
the shape, divide(time, useEndTime) and divideIntoHomogeneousSamples()
called PAL primitives that required a populated sample-size array, and
createCopyWithAdjustedStartTime duplicated the same timing-array boilerplate
that divide() carried.

The visible consequence was that TrackBuffer could not subdivide these
samples at an arbitrary presentation time. SourceBuffer.remove(start, end)
and the appendWindow trim path therefore treated each multi-packet
sample atomically: removing a sub-range that landed inside one of them
erased the entire sample (or kept it whole when only a tail
should have remained), and SourceBuffer.buffered jumped to the next
sample boundary instead of the requested time.

The BufferHasNoSampleSizes handling now lives in shared helpers in
CMUtilities, and the MediaSampleAVFObjC consumers route through them so
both CMSampleBuffer shapes are handled uniformly. forEachSample replaces
PAL::CMSampleBufferCallBlockForEachSample, and copySampleBufferForRange
replaces PAL::CMSampleBufferCopySampleBufferForRange. For the
BufferHasNoSampleSizes case they walk the packet description array and
synthesize per-packet (or per-range) sub-CMSampleBuffers that reference
the source block buffer via CMBlockBufferAppendBufferReference (zero-copy);
for the normal shape they delegate. getSampleTimingInfoArray collapses
the two-call CMSampleBufferGetSampleTimingInfoArray dance.

* LayoutTests/media/media-source/media-managedmse-adts-aac-remove-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-adts-aac-remove.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::MediaSampleAVFObjC::isDivisable const): Stopped rejecting the
BufferHasNoSampleSizes shape; only the single-sample case is rejected now.
(WebCore::MediaSampleAVFObjC::divide): Replaced the inline
BufferHasNoSampleSizes block and the CMSampleBufferCallBlockForEachSample
call with a single forEachSample walk.
(WebCore::MediaSampleAVFObjC::divide): Routed through forEachSample +
copySampleBufferForRange so the time-based split works on both shapes.
(WebCore::MediaSampleAVFObjC::createCopyWithAdjustedStartTime const):
Routed timing-array fetch through getSampleTimingInfoArray.
(WebCore::MediaSampleAVFObjC::divideIntoHomogeneousSamples): Routed
through copySampleBufferForRange.
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::getSampleTimingInfoArray): Added.
(WebCore::forEachSample): Added.
(WebCore::copySampleBufferForRange): Added.

Canonical link: <a href="https://commits.webkit.org/314845@main">https://commits.webkit.org/314845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04290541f084a5c65cfc4cbff4608b1512115ce5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176350 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c005ca62-cfbb-4f38-a167-18ec66c6b46d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130140 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf4eadae-5c4f-4c8d-a484-581a8bc8ee89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110657 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8307623d-c9ea-4493-8db8-474bd5e339b4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30228 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25089 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178892 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138530 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/166701 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138420 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37283 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149806 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104610 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33670 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26682 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113143 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39459 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4780 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39709 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->