### PR TITLE
Share the percentage distribution loop in AutoTableLayout::calcEffectiveLogicalWidth

### DIFF
--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -440,6 +440,32 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
             }
         }
 
+        // Distribute the spanning cell's min/max widths across [effCol, lastCol) in proportion to
+        // each column's percentage, using the given total as the denominator. percentForColumn
+        // returns std::nullopt for columns that should be skipped.
+        auto distributeByPercent = [&](float totalPercentForDistribution, auto&& percentForColumn) {
+#if ASSERT_ENABLED
+            float allocatedMinLogicalWidth = 0;
+#endif
+            float allocatedMaxLogicalWidth = 0;
+            for (unsigned pos = effCol; pos < lastCol; ++pos) {
+                auto percent = percentForColumn(pos);
+                if (!percent)
+                    continue;
+                float columnMinLogicalWidth = *percent * cellMinLogicalWidth / totalPercentForDistribution;
+                float columnMaxLogicalWidth = *percent * cellMaxLogicalWidth / totalPercentForDistribution;
+                m_layoutStruct[pos].effectiveMinLogicalWidth = std::max(m_layoutStruct[pos].effectiveMinLogicalWidth, columnMinLogicalWidth);
+                m_layoutStruct[pos].effectiveMaxLogicalWidth = columnMaxLogicalWidth;
+#if ASSERT_ENABLED
+                allocatedMinLogicalWidth += columnMinLogicalWidth;
+#endif
+                allocatedMaxLogicalWidth += columnMaxLogicalWidth;
+            }
+            ASSERT(allocatedMinLogicalWidth < cellMinLogicalWidth || WTF::areEssentiallyEqual(allocatedMinLogicalWidth, cellMinLogicalWidth));
+            ASSERT(allocatedMaxLogicalWidth < cellMaxLogicalWidth || WTF::areEssentiallyEqual(allocatedMaxLogicalWidth, cellMaxLogicalWidth));
+            cellMaxLogicalWidth -= allocatedMaxLogicalWidth;
+        };
+
         // make sure minWidth and maxWidth of the spanning cell are honored
         if (cellMinLogicalWidth > spanMinLogicalWidth) {
             if (allColsAreFixed) {
@@ -455,30 +481,14 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                 }
             } else if (allColsArePercent) {
                 // In this case, we just split the colspan's min and max widths following the percentage.
-#if ASSERT_ENABLED
-                float allocatedMinLogicalWidth = 0;
-#endif
-                float allocatedMaxLogicalWidth = 0;
-                for (unsigned pos = effCol; pos < lastCol; ++pos) {
+                // |allColsArePercent| means that either the logicalWidth *or* the effectiveLogicalWidth are percents, handle both of them here.
+                distributeByPercent(totalPercent, [&](unsigned pos) -> std::optional<float> {
                     ASSERT(m_layoutStruct[pos].logicalWidth.isPercent() || m_layoutStruct[pos].effectiveLogicalWidth.isPercent());
-                    // |allColsArePercent| means that either the logicalWidth *or* the effectiveLogicalWidth are percents, handle both of them here.
                     auto percentageLogicalWidth = m_layoutStruct[pos].logicalWidth.tryPercentage();
                     auto percentageEffectiveLogicalWidth = m_layoutStruct[pos].effectiveLogicalWidth.tryPercentage();
                     ASSERT(percentageLogicalWidth || percentageEffectiveLogicalWidth);
-                    float percent = percentageLogicalWidth ? percentageLogicalWidth->value : percentageEffectiveLogicalWidth->value;
-
-                    float columnMinLogicalWidth = percent * cellMinLogicalWidth / totalPercent;
-                    float columnMaxLogicalWidth = percent * cellMaxLogicalWidth / totalPercent;
-                    m_layoutStruct[pos].effectiveMinLogicalWidth = std::max(m_layoutStruct[pos].effectiveMinLogicalWidth, columnMinLogicalWidth);
-                    m_layoutStruct[pos].effectiveMaxLogicalWidth = columnMaxLogicalWidth;
-#if ASSERT_ENABLED
-                    allocatedMinLogicalWidth += columnMinLogicalWidth;
-#endif
-                    allocatedMaxLogicalWidth += columnMaxLogicalWidth;
-                }
-                ASSERT(allocatedMinLogicalWidth < cellMinLogicalWidth || WTF::areEssentiallyEqual(allocatedMinLogicalWidth, cellMinLogicalWidth));
-                ASSERT(allocatedMaxLogicalWidth < cellMaxLogicalWidth || WTF::areEssentiallyEqual(allocatedMaxLogicalWidth, cellMaxLogicalWidth));
-                cellMaxLogicalWidth -= allocatedMaxLogicalWidth;
+                    return percentageLogicalWidth ? percentageLogicalWidth->value : percentageEffectiveLogicalWidth->value;
+                });
             } else if (!allColsAreFixed && fixedWidth <= 0 && totalPercent > 0 && haveAuto) {
                 // This branch handles the case where a percentage colspan cell has already
                 // converted AUTO columns to effective percentages. We need to verify that:
@@ -499,10 +509,6 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                 if (hasConvertedAutoColumns && currentCellIsNotPercentage) {
                     // By this point, the earlier code has converted auto columns to effectiveLogicalWidth percentages,
                     // so we can use the same percentage-based distribution as the allColsArePercent case.
-#if ASSERT_ENABLED
-                    float allocatedMinLogicalWidth = 0;
-#endif
-                    float allocatedMaxLogicalWidth = 0;
 
                     // Calculate total effective percent (includes both original percent columns and converted auto columns)
                     float totalEffectivePercent = 0;
@@ -513,23 +519,11 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
 
                     // If all columns now have effective percentages, distribute accordingly
                     if (totalEffectivePercent > 0) {
-                        for (unsigned pos = effCol; pos < lastCol; ++pos) {
-                            auto percentageEffectiveLogicalWidth = m_layoutStruct[pos].effectiveLogicalWidth.tryPercentage();
-                            if (percentageEffectiveLogicalWidth) {
-                                float percent = percentageEffectiveLogicalWidth->value;
-                                float columnMinLogicalWidth = percent * cellMinLogicalWidth / totalEffectivePercent;
-                                float columnMaxLogicalWidth = percent * cellMaxLogicalWidth / totalEffectivePercent;
-                                m_layoutStruct[pos].effectiveMinLogicalWidth = std::max(m_layoutStruct[pos].effectiveMinLogicalWidth, columnMinLogicalWidth);
-                                m_layoutStruct[pos].effectiveMaxLogicalWidth = columnMaxLogicalWidth;
-#if ASSERT_ENABLED
-                                allocatedMinLogicalWidth += columnMinLogicalWidth;
-#endif
-                                allocatedMaxLogicalWidth += columnMaxLogicalWidth;
-                            }
-                        }
-                        ASSERT(allocatedMinLogicalWidth < cellMinLogicalWidth || WTF::areEssentiallyEqual(allocatedMinLogicalWidth, cellMinLogicalWidth));
-                        ASSERT(allocatedMaxLogicalWidth < cellMaxLogicalWidth || WTF::areEssentiallyEqual(allocatedMaxLogicalWidth, cellMaxLogicalWidth));
-                        cellMaxLogicalWidth -= allocatedMaxLogicalWidth;
+                        distributeByPercent(totalEffectivePercent, [&](unsigned pos) -> std::optional<float> {
+                            if (auto percentageEffectiveLogicalWidth = m_layoutStruct[pos].effectiveLogicalWidth.tryPercentage())
+                                return percentageEffectiveLogicalWidth->value;
+                            return std::nullopt;
+                        });
                     }
                 }
             } else {


### PR DESCRIPTION
#### 2a296bbd1d209a42092f6e66720bbaf9d4b2cf83
<pre>
Share the percentage distribution loop in AutoTableLayout::calcEffectiveLogicalWidth
<a href="https://bugs.webkit.org/show_bug.cgi?id=316662">https://bugs.webkit.org/show_bug.cgi?id=316662</a>
<a href="https://rdar.apple.com/179115241">rdar://179115241</a>

Reviewed by Alan Baradlay.

The allColsArePercent branch and the converted-auto branch ran the same
loop distributing a spanning cell&apos;s min/max widths across its columns in
proportion to each column&apos;s percentage, differing only in the denominator
and how each column&apos;s percentage is sourced. Factor it into a
distributeByPercent() lambda parameterized by the total and a
percentForColumn callback (which returns std::nullopt to skip a column).
No change in behavior.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::calcEffectiveLogicalWidth):

Canonical link: <a href="https://commits.webkit.org/314842@main">https://commits.webkit.org/314842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2e25a15c780bed6ede75b909dba1f4810774ab0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176356 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03b02149-9bdc-4bc2-af19-9c0efc827840) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130145 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e599ddfd-9e79-4198-864d-a3500aa8aa33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110662 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b21dd15-6262-482c-8eed-8dac2d6059a2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30232 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25095 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141516 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178898 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31796 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138535 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138425 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37281 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41564 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104616 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26686 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40068 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113149 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39465 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4784 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->