### PR TITLE
Do not rebuild unnecessary C++ from messages changes [take two]

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -998,7 +998,7 @@ macro(GENERATE_MESSAGE_SOURCES _output_source _inputs)
             list(APPEND _input_files ${WEBKIT_DIR}/${_file}.messages.in)
             file(STRINGS ${WEBKIT_DIR}/${_file}.messages.in _swift_attr REGEX "SwiftReceiver")
             if (_swift_attr)
-                list(APPEND _outputs ${WebKit_DERIVED_SOURCES_DIR}/${_name}MessageReceiver.swift)
+                list(APPEND _outputs ${_name}MessageReceiver.swift)
             endif ()
         else ()
             list(APPEND _input_files ${WebKit_DERIVED_SOURCES_DIR}/${_name}.messages.in)
@@ -1009,23 +1009,35 @@ macro(GENERATE_MESSAGE_SOURCES _output_source _inputs)
             set(_receiver_cpp ${_name}MessageReceiver.cpp)
         endif ()
         list(APPEND _outputs
-            ${WebKit_DERIVED_SOURCES_DIR}/${_receiver_cpp}
-            ${WebKit_DERIVED_SOURCES_DIR}/${_name}Messages.h
+            ${_receiver_cpp}
+            ${_name}Messages.h
         )
         list(APPEND ${_output_source} ${WebKit_DERIVED_SOURCES_DIR}/${_receiver_cpp})
     endforeach ()
+    list(APPEND _outputs
+        MessageArgumentDescriptions.cpp
+        MessageNames.cpp
+        MessageNames.h
+    )
 
     list(APPEND ${_output_source}
         ${WebKit_DERIVED_SOURCES_DIR}/MessageArgumentDescriptions.cpp
         ${WebKit_DERIVED_SOURCES_DIR}/MessageNames.cpp
     )
 
+    set(_messages_stage_dir ${WebKit_DERIVED_SOURCES_DIR}/.messages-stage)
+    # copy_if_different (rather than copy_directory_if_different, which is unavailable on
+    # older CMake versions) copies only changed files back, leaving the timestamps of
+    # unchanged outputs untouched so downstream C++ is not needlessly rebuilt.
+    unset(_absolute_outputs)
+    unset(_messages_copy_commands)
+    foreach (_rel IN LISTS _outputs)
+        list(APPEND _absolute_outputs ${WebKit_DERIVED_SOURCES_DIR}/${_rel})
+        list(APPEND _messages_copy_commands COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_messages_stage_dir}/${_rel} ${WebKit_DERIVED_SOURCES_DIR}/${_rel})
+    endforeach ()
     add_custom_command(
         OUTPUT
-            ${WebKit_DERIVED_SOURCES_DIR}/MessageArgumentDescriptions.cpp
-            ${WebKit_DERIVED_SOURCES_DIR}/MessageNames.cpp
-            ${WebKit_DERIVED_SOURCES_DIR}/MessageNames.h
-            ${_outputs}
+            ${_absolute_outputs}
         MAIN_DEPENDENCY ${WEBKIT_DIR}/Scripts/generate-message-receiver.py
         DEPENDS
             ${WEBKIT_DIR}/Scripts/webkit/__init__.py
@@ -1033,7 +1045,9 @@ macro(GENERATE_MESSAGE_SOURCES _output_source _inputs)
             ${WEBKIT_DIR}/Scripts/webkit/model.py
             ${WEBKIT_DIR}/Scripts/webkit/parser.py
             ${_input_files}
-        COMMAND ${PYTHON_EXECUTABLE} ${WEBKIT_DIR}/Scripts/generate-message-receiver.py --preserve-subdirs ${WEBKIT_DIR} ${_inputs}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${_messages_stage_dir}
+        COMMAND ${PYTHON_EXECUTABLE} ${WEBKIT_DIR}/Scripts/generate-message-receiver.py --preserve-subdirs ${WEBKIT_DIR} ${_inputs} --output-dir ${_messages_stage_dir}
+        ${_messages_copy_commands}
         WORKING_DIRECTORY ${WebKit_DERIVED_SOURCES_DIR}
         VERBATIM
     )
@@ -1117,26 +1131,41 @@ list(APPEND WebKit_DERIVED_SOURCES
     ${WebKit_DERIVED_SOURCES_DIR}/WebKitPlatformGeneratedSerializers.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
 )
 
+set(_serializers_stage_dir ${WebKit_DERIVED_SOURCES_DIR}/.serializers-stage)
+set(_serializers_outputs
+    GeneratedSerializers.h
+    GeneratedSerializersShared.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    GeneratedSerializersWebProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    GeneratedSerializersGPUProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    GeneratedSerializersNetworkProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    GeneratedSerializersPlatform.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    GeneratedSerializersModelProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    GeneratedSerializersUIProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    GeneratedSerializersCommon.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    GeneratedWebKitSecureCoding.h
+    GeneratedWebKitSecureCoding.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    SerializedTypeInfo.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+    WebKitPlatformGeneratedSerializers.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+)
+# copy_if_different (rather than copy_directory_if_different, which is unavailable on
+# older CMake versions) copies only changed files back, leaving the timestamps of
+# unchanged outputs untouched so downstream C++ is not needlessly rebuilt.
+unset(_serializers_absolute_outputs)
+unset(_serializers_copy_commands)
+foreach (_rel IN LISTS _serializers_outputs)
+    list(APPEND _serializers_absolute_outputs ${WebKit_DERIVED_SOURCES_DIR}/${_rel})
+    list(APPEND _serializers_copy_commands COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_serializers_stage_dir}/${_rel} ${WebKit_DERIVED_SOURCES_DIR}/${_rel})
+endforeach ()
 add_custom_command(
     OUTPUT
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializers.h
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersShared.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersWebProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersGPUProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersNetworkProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersPlatform.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersModelProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersUIProcess.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedSerializersCommon.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedWebKitSecureCoding.h
-        ${WebKit_DERIVED_SOURCES_DIR}/GeneratedWebKitSecureCoding.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/SerializedTypeInfo.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
-        ${WebKit_DERIVED_SOURCES_DIR}/WebKitPlatformGeneratedSerializers.${WebKit_GENERATED_SERIALIZERS_SUFFIX}
+        ${_serializers_absolute_outputs}
     MAIN_DEPENDENCY ${WEBKIT_DIR}/Scripts/generate-serializers.py
     DEPENDS
         ${WEBKIT_DIR}/Scripts/webkit/opaque_ipc_types.py
         ${WebKit_SERIALIZATION_DEPENDENCIES}
-    COMMAND ${PYTHON_EXECUTABLE} ${WEBKIT_DIR}/Scripts/generate-serializers.py ${WebKit_GENERATED_SERIALIZERS_SUFFIX} --split-by-directory ${WebKit_SERIALIZATION_DEPENDENCIES}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${_serializers_stage_dir}
+    COMMAND ${PYTHON_EXECUTABLE} ${WEBKIT_DIR}/Scripts/generate-serializers.py ${WebKit_GENERATED_SERIALIZERS_SUFFIX} --split-by-directory ${WebKit_SERIALIZATION_DEPENDENCIES} --output-dir ${_serializers_stage_dir}
+    ${_serializers_copy_commands}
     WORKING_DIRECTORY ${WebKit_DERIVED_SOURCES_DIR}
     VERBATIM
 )


### PR DESCRIPTION
#### 8b4585e896d1c3bce263df829026204e88f35325
<pre>
Do not rebuild unnecessary C++ from messages changes [take two]
<a href="https://bugs.webkit.org/show_bug.cgi?id=316386">https://bugs.webkit.org/show_bug.cgi?id=316386</a>
<a href="https://rdar.apple.com/178795221">rdar://178795221</a>

Reviewed by Geoffrey Garen.

Previously in the cmake build, any change to any messages.in or
serialization.in file would cause all the output C++ files and headers to be
regenerated, which would make all downstream C++ build steps re-run. With this
change, files are only made dirty if they actually change, so a change to any
individual .in file should not cause more incremental rebuilding than strictly
necessary.

The pattern used is:
- The generator&apos;s output is put into a temporary staging directory
- copy_if_different is used to copy only changed files back to the main location,
  without touching timestamps on other unchanged files
- cmake&apos;s ninja generator uses &apos;restat&apos; so is able to cause a rerun of the
  generator when inputs change, even if the outputs hadn&apos;t changed

This is a reland - the first failed because we need to work on some older
versions of cmake which lack the copy_directory_if_different command.

Canonical link: <a href="https://commits.webkit.org/314910@main">https://commits.webkit.org/314910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b1f3b9b3cddb636c98a7df57dd7c3558b74ace9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176639 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4024b96-986b-44ae-b26f-8bc5a55e1b8b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130388 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8a8e286-4b7f-4f15-8d0c-57b2468217b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110905 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99e2a43d-7327-450e-8dfa-4a0817e04b2f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25371 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179179 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29991 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138670 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37334 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41839 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104997 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26944 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40343 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39740 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5045 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->