### PR TITLE
REGRESSION(314648@main):[macOS] Multiple tests are failing in imported/w3c/web-platform-tests/html/browsers/browsing-the-web

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1344,11 +1344,10 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
     RefPtr relatedPage = pageConfiguration->relatedPage();
     bool siteIsolationEnabled = protect(pageConfiguration->preferences())->siteIsolationEnabled();
     if (siteIsolationEnabled) {
-        // These preferences are coupled to Site Isolation here. WebKitTestRunner must
-        // mirror this in TestController::featuresImpliedBySiteIsolation().
-        // FIXME: Find a single shared definition so the product and the test harness
-        // cannot drift out of sync.
         Ref<WebPreferences> preferences = pageConfiguration->preferences();
+        // FIXME: we should enable UseUIProcessForBackForwardItemLoading not only here but also in test infrastructure
+        // when site isolation is enabled, but doing that causes a lot of test failures that we need to investigate.
+        // https://bugs.webkit.org/show_bug.cgi?id=316588
         preferences->setUseUIProcessForBackForwardItemLoading(true);
         preferences->setMultiProcessBackForwardCacheEnabled(true);
     }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2105,22 +2105,7 @@ TestOptions TestController::testOptionsForTest(const TestCommand& command) const
     merge(features, featureDefaultsFromTestHeaderForTest(command, TestOptions::keyTypeMapping()));
     merge(features, featureFromAdditionalHeaderOption(command, TestOptions::keyTypeMapping()));
     merge(features, platformSpecificFeatureOverridesDefaultsForTest(command));
-
-    auto siteIsolation = features.boolWebPreferenceFeatures.find("SiteIsolationEnabled");
-    if (siteIsolation != features.boolWebPreferenceFeatures.end() && siteIsolation->second)
-        merge(features, featuresImpliedBySiteIsolation());
-
     return TestOptions { features };
-}
-
-// Mirror WebProcessPool::createWebPage, which unconditionally enables this under Site
-// Isolation. Merged last so it matches that override and survives WebKitTestRunner's
-// per-test preference reset; a test cannot run Site Isolation with it off, as in production.
-TestFeatures TestController::featuresImpliedBySiteIsolation() const
-{
-    TestFeatures implied;
-    implied.boolWebPreferenceFeatures.insert_or_assign("UseUIProcessForBackForwardItemLoading", true);
-    return implied;
 }
 
 void TestController::updateWebViewSizeForTest(const TestInvocation& test)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -544,7 +544,6 @@ private:
     TestOptions testOptionsForTest(const TestCommand&) const;
     TestFeatures platformSpecificFeatureDefaultsForTest(const TestCommand&) const;
     TestFeatures platformSpecificFeatureOverridesDefaultsForTest(const TestCommand&) const;
-    TestFeatures featuresImpliedBySiteIsolation() const;
 
     void updateWebViewSizeForTest(const TestInvocation&);
     void updateWindowScaleForTest(PlatformWebView*, const TestInvocation&);


### PR DESCRIPTION
#### 8c89e3f9cc08808be74762bd08f1c2856f74d777
<pre>
REGRESSION(314648@main):[macOS] Multiple tests are failing in imported/w3c/web-platform-tests/html/browsers/browsing-the-web
<a href="https://bugs.webkit.org/show_bug.cgi?id=316588">https://bugs.webkit.org/show_bug.cgi?id=316588</a>
<a href="https://rdar.apple.com/179043211">rdar://179043211</a>

Reviewed by Chris Dumez.

314648@main coupled UseUIProcessForBackForwardItemLoading to SiteIsolationEnabled
in the test harness via TestController::featuresImpliedBySiteIsolation, mirroring
the production-side coupling in WebProcessPool::createWebPage. With that flag
auto-enabled under SiteIsolationEnabled, several imported wpt history tests
(the-history-interface/001.html and the overlapping-navigations-and-traversals/*
set) started timing out only in Release under --site-isolation-enabled-by-default;
Debug passes, suggesting a timing-sensitive race in the new path.

Revert the test-infra coupling so unrelated test runs are unblocked while the
regression is investigated. Production keeps the coupling in
WebProcessPool::createWebPage; only the test harness drops it for now.
featuresImpliedBySiteIsolation is removed entirely (declaration, definition,
call site), and the production-side FIXME is updated to point at this bug so
the harness can be re-coupled once the underlying issue is fixed.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage): Update the FIXME to reference this bug.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::testOptionsForTest const): Stop merging
featuresImpliedBySiteIsolation.
(WTR::TestController::featuresImpliedBySiteIsolation const): Deleted.
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/314862@main">https://commits.webkit.org/314862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b21ce149c3ddc9327c29a0e837dc0b9a8f1a408a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176480 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130248 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110765 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25219 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179024 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31920 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138643 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41000 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138531 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37298 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41688 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104765 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33787 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113273 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39589 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4899 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39839 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39734 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->