### PR TITLE
[webkitpy] WPT linter falsely fails when ./wpt logs INFO messages to stderr (e.g. first-run venv creation)

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/wpt_linter.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter.py
@@ -27,10 +27,16 @@
 import json
 import logging
 import os
+import re
 import subprocess
 import tempfile
 
 _log = logging.getLogger(__name__)
+
+# `./wpt` emits Python logging output to stderr (e.g. INFO messages when it
+# creates its virtualenv on first run). Those are not failures — only treat
+# stderr as fatal when it contains lines that aren't DEBUG/INFO log records.
+_BENIGN_STDERR_LINE_RE = re.compile(r'^(?:DEBUG|INFO):')
 
 
 class WPTLinter(object):
@@ -60,9 +66,15 @@ class WPTLinter(object):
         _log.debug('Running WPT linter: %s (cwd=%s)', ' '.join(cmd), self.wpt_path)
         result = subprocess.run(cmd, cwd=self.wpt_path, capture_output=True)
         if result.stderr:
-            raise RuntimeError(
-                'WPT linter wrote to stderr:\n' + result.stderr.decode('utf-8', 'replace')
-            )
+            stderr_text = result.stderr.decode('utf-8', 'replace')
+            problematic = [
+                line for line in stderr_text.splitlines()
+                if line.strip() and not _BENIGN_STDERR_LINE_RE.match(line)
+            ]
+            if problematic:
+                raise RuntimeError(
+                    'WPT linter wrote to stderr:\n' + '\n'.join(problematic)
+                )
         for line in result.stdout.splitlines():
             if not line.strip():
                 continue


### PR DESCRIPTION
#### 53bef7792dca878191c4f1d0e061135ec6f8e2e8
<pre>
[webkitpy] WPT linter falsely fails when ./wpt logs INFO messages to stderr (e.g. first-run venv creation)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316683">https://bugs.webkit.org/show_bug.cgi?id=316683</a>
<a href="https://rdar.apple.com/179137628">rdar://179137628</a>

Reviewed by NOBODY (OOPS!).

Tools/Scripts/webkitpy/w3c/wpt_linter.py treated any output to stderr
from `./wpt lint --json` as a fatal error. The wpt tool, however, emits
Python logging records (DEBUG/INFO) to stderr — most notably
`INFO:tools.wpt.virtualenv:Creating new venv at &apos;...&apos;` on the first run
after the WPT venv directory is missing. As a result, `git webkit pr`
(and any other style-checker invocation that triggers wpt lint) fails
the first time after a fresh checkout or after the venv directory has
been cleaned, with:

    RuntimeError: WPT linter wrote to stderr:
    INFO:tools.wpt.virtualenv:Creating new venv at &apos;.../LayoutTests/imported/w3c/web-platform-tests/_venv3&apos;

A second invocation succeeds because the venv now exists and stderr
stays empty. This makes the pre-PR style check spuriously flaky.

Filter benign DEBUG/INFO logging lines out of stderr before deciding to
raise. Only raise when stderr contains non-logging output (real
tracebacks, WARNING/ERROR records, etc.).

* Tools/Scripts/webkitpy/w3c/wpt_linter.py:
(WPTLinter._run_lint): Skip stderr lines matching the Python logging
DEBUG/INFO prefix; raise only when something else remains.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53bef7792dca878191c4f1d0e061135ec6f8e2e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176406 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125038 "Failed to checkout and rebase branch from PR 66784") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130187 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/125038 "Failed to checkout and rebase branch from PR 66784") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170316 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32595 "Found 1 new test failure: fast/forms/datalist/datalist-textinput-suggestions-order.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110704 "Passed tests") | | ⏳ 🛠 vision-apple 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166678 "Found 1 webkitpy test failure: webkitscmpy.test.land_unittest.TestLandBitBucket.test_no_reviewer") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31578 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30275 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25145 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28063 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178949 "") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29779 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/178949 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34431 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/178949 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41614 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104676 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33721 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26732 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40118 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39515 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4830 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39660 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->