### PR TITLE
[GStreamer] Migrate video sink pad probe to PadProbeHandle

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
@@ -23,111 +23,95 @@
 
 #include "MediaPlayerPrivateGStreamer.h"
 #include <gst/app/gstappsink.h>
-#include <wtf/TZoneMallocInlines.h>
-
-using namespace WebCore;
 
 GST_DEBUG_CATEGORY(webkit_gst_video_sink_common_debug);
 #define GST_CAT_DEFAULT webkit_gst_video_sink_common_debug
 
-class WebKitVideoSinkProbe {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebKitVideoSinkProbe);
-public:
+namespace WebCore {
 
-    WebKitVideoSinkProbe(const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>& player)
-        : m_player(player)
-    {
-    }
+void WebKitVideoSinkProbeOwner::handleFlushEvent([[maybe_unused]] const GRefPtr<GstPad>& pad, GstPadProbeInfo* info)
+{
+    // We need to operate from the main thread, this is a requirement for usage of
+    // AbortableTaskQueue start/finishAborting.
+    ASSERT(isMainThread());
 
-    static void deleteUserData(void* userData)
-    {
-        delete static_cast<WebKitVideoSinkProbe*>(userData);
-    }
+    RefPtr player = m_player.get();
+    if (!player)
+        return;
 
-    void handleFlushEvent([[maybe_unused]] GstPad* pad, GstPadProbeInfo* info)
-    {
-        // We need to operate from the main thread, this is a requirement for usage of
-        // AbortableTaskQueue start/finishAborting.
-        ASSERT(isMainThread());
-
-        RefPtr player = m_player.get();
-        if (!player)
-            return;
-
-        if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_FLUSH_START) {
-            if (!m_isFlushing) {
-                GST_DEBUG_OBJECT(pad, "FLUSH_START received, aborting all pending tasks in the player sinkTaskQueue.");
-                m_isFlushing = true;
-                player->sinkTaskQueue().startAborting();
+    if (GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_FLUSH_START) {
+        if (!m_isFlushing) {
+            GST_DEBUG_OBJECT(pad.get(), "FLUSH_START received, aborting all pending tasks in the player sinkTaskQueue.");
+            m_isFlushing = true;
+            player->sinkTaskQueue().startAborting();
 #if USE(GSTREAMER_GL)
-                    GST_DEBUG_OBJECT(pad, "Flushing current buffer in response to %" GST_PTR_FORMAT, info->data);
-                    player->flushCurrentBuffer();
+            GST_DEBUG_OBJECT(pad.get(), "Flushing current buffer in response to %" GST_PTR_FORMAT, info->data);
+            player->flushCurrentBuffer();
 #endif
-            } else
-                GST_DEBUG_OBJECT(pad, "Received FLUSH_START while already flushing, ignoring.");
-            return;
-        }
-
-        RELEASE_ASSERT(GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_FLUSH_STOP);
-        if (m_isFlushing) {
-            GST_DEBUG_OBJECT(pad, "FLUSH_STOP received, allowing operation in the player sinkTaskQueue again.");
-            m_isFlushing = false;
-            player->sinkTaskQueue().finishAborting();
-            return;
-        }
-
-        GST_DEBUG_OBJECT(pad, "Received FLUSH_STOP without a FLUSH_START, ignoring.");
+        } else
+            GST_DEBUG_OBJECT(pad.get(), "Received FLUSH_START while already flushing, ignoring.");
+        return;
     }
 
-    static GstPadProbeReturn doProbe([[maybe_unused]] GstPad* pad, GstPadProbeInfo* info, gpointer userData)
-    {
-        auto* self = static_cast<WebKitVideoSinkProbe*>(userData);
-        RefPtr player = self->m_player.get();
-        if (!player)
-            return GST_PAD_PROBE_REMOVE;
+    RELEASE_ASSERT(GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_FLUSH_STOP);
+    if (m_isFlushing) {
+        GST_DEBUG_OBJECT(pad.get(), "FLUSH_STOP received, allowing operation in the player sinkTaskQueue again.");
+        m_isFlushing = false;
+        player->sinkTaskQueue().finishAborting();
+        return;
+    }
 
-        // Usually flushes propagate in the main thread as a synchronous consequence of a seek.
-        // However, this doesn't have to be the case:
-        //
-        // As a notable example, when matroskademux receives a seek before it has parsed the
-        // entire file header, it stores the event and returns without flushing anything.
-        // Later, the streaming thread finishes parsing the file header and handles the stored
-        // seek event from that same thread. This sends a flush from the streaming thread.
-        if (info->type & GST_PAD_PROBE_TYPE_EVENT_FLUSH) {
-            callOnMainThreadAndWait([&] {
-                self->handleFlushEvent(pad, info);
-            });
-        }
-        if (self->m_isFlushing)
-            return GST_PAD_PROBE_OK; // do not process regular (non-flush) events during a flush
+    GST_DEBUG_OBJECT(pad.get(), "Received FLUSH_STOP without a FLUSH_START, ignoring.");
+}
 
-        if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM && GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_TAG) {
-            GstTagList* tagList;
-            gst_event_parse_tag(GST_PAD_PROBE_INFO_EVENT(info), &tagList);
-            GST_DEBUG_OBJECT(pad, "Tag event received, video orientation may need to be updated. %" GST_PTR_FORMAT, tagList);
-            player->updateVideoOrientation(tagList);
-        }
+GstPadProbeReturn WebKitVideoSinkProbeOwner::doProbe([[maybe_unused]] const GRefPtr<GstPad>& pad, GstPadProbeInfo* info)
+{
+    RefPtr player = m_player.get();
+    if (!player)
+        return GST_PAD_PROBE_REMOVE;
 
-        if (info->type & GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM && GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info)) == GST_QUERY_ALLOCATION) {
-            auto query = GST_PAD_PROBE_INFO_QUERY(info);
-            gst_query_add_allocation_meta(query, GST_VIDEO_META_API_TYPE, nullptr);
+    // Usually flushes propagate in the main thread as a synchronous consequence of a seek.
+    // However, this doesn't have to be the case:
+    //
+    // As a notable example, when matroskademux receives a seek before it has parsed the
+    // entire file header, it stores the event and returns without flushing anything.
+    // Later, the streaming thread finishes parsing the file header and handles the stored
+    // seek event from that same thread. This sends a flush from the streaming thread.
+    if (info->type & GST_PAD_PROBE_TYPE_EVENT_FLUSH) {
+        callOnMainThreadAndWait([&] {
+            handleFlushEvent(pad, info);
+        });
+    }
+    if (m_isFlushing)
+        return GST_PAD_PROBE_OK; // do not process regular (non-flush) events during a flush
 
-            GstCaps* caps;
-            gboolean needPool;
-            gst_query_parse_allocation(query, &caps, &needPool);
-            if (!caps) [[unlikely]]
-                return GST_PAD_PROBE_OK;
-            if (!needPool)
-                return GST_PAD_PROBE_OK;
+    if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM && GST_EVENT_TYPE(GST_PAD_PROBE_INFO_EVENT(info)) == GST_EVENT_TAG) {
+        GstTagList* tagList;
+        gst_event_parse_tag(GST_PAD_PROBE_INFO_EVENT(info), &tagList);
+        GST_DEBUG_OBJECT(pad.get(), "Tag event received, video orientation may need to be updated. %" GST_PTR_FORMAT, tagList);
+        player->updateVideoOrientation(tagList);
+    }
 
-            unsigned size;
+    if (info->type & GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM && GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info)) == GST_QUERY_ALLOCATION) {
+        auto query = GST_PAD_PROBE_INFO_QUERY(info);
+        gst_query_add_allocation_meta(query, GST_VIDEO_META_API_TYPE, nullptr);
+
+        GstCaps* caps;
+        gboolean needPool;
+        gst_query_parse_allocation(query, &caps, &needPool);
+        if (!caps) [[unlikely]]
+            return GST_PAD_PROBE_OK;
+        if (!needPool)
+            return GST_PAD_PROBE_OK;
+
+        unsigned size;
 #if GST_CHECK_VERSION(1, 24, 0)
-            if (gst_video_is_dma_drm_caps(caps)) {
-                GstVideoInfoDmaDrm drmInfo;
-                if (!gst_video_info_dma_drm_from_caps(&drmInfo, caps))
-                    return GST_PAD_PROBE_OK;
-                size = GST_VIDEO_INFO_SIZE(&drmInfo.vinfo);
-            } else
+        if (gst_video_is_dma_drm_caps(caps)) {
+            GstVideoInfoDmaDrm drmInfo;
+            if (!gst_video_info_dma_drm_from_caps(&drmInfo, caps))
+                return GST_PAD_PROBE_OK;
+            size = GST_VIDEO_INFO_SIZE(&drmInfo.vinfo);
+        } else
 #endif
             {
                 GstVideoInfo info;
@@ -135,28 +119,23 @@ public:
                     return GST_PAD_PROBE_OK;
                 size = GST_VIDEO_INFO_SIZE(&info);
             }
-            gst_query_add_allocation_pool(query, nullptr, size, 3, 0);
-        }
-
-#if USE(GSTREAMER_GL)
-        // In some platforms (e.g. OpenMAX on the Raspberry Pi) when a resolution change occurs the
-        // pipeline has to be drained before a frame with the new resolution can be decoded.
-        // In this context, it's important that we don't hold references to any previous frame
-        // (e.g. m_sample) so that decoding can continue.
-        // We are also not supposed to keep the original frame after a flush.
-        if (info->type & GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM && GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info)) == GST_QUERY_DRAIN) {
-            GST_DEBUG_OBJECT(pad, "Flushing current buffer in response to %" GST_PTR_FORMAT, info->data);
-            player->flushCurrentBuffer();
-        }
-#endif
-
-        return GST_PAD_PROBE_OK;
+        gst_query_add_allocation_pool(query, nullptr, size, 3, 0);
     }
 
-private:
-    ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer> m_player;
-    bool m_isFlushing { false };
-};
+#if USE(GSTREAMER_GL)
+    // In some platforms (e.g. OpenMAX on the Raspberry Pi) when a resolution change occurs the
+    // pipeline has to be drained before a frame with the new resolution can be decoded.
+    // In this context, it's important that we don't hold references to any previous frame
+    // (e.g. m_sample) so that decoding can continue.
+    // We are also not supposed to keep the original frame after a flush.
+    if (info->type & GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM && GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info)) == GST_QUERY_DRAIN) {
+        GST_DEBUG_OBJECT(pad.get(), "Flushing current buffer in response to %" GST_PTR_FORMAT, info->data);
+        player->flushCurrentBuffer();
+    }
+#endif
+
+    return GST_PAD_PROBE_OK;
+}
 
 struct MediaPlayerPrivateNotifier {
     MediaPlayerPrivateNotifier(const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>& player)
@@ -209,9 +188,11 @@ WebKitVideoSinkSignalIdentifiers webKitVideoSinkSetMediaPlayerPrivate(GstElement
 
     GRefPtr<GstPad> pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
 
-    identifiers.padProbeId = gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM
-        | GST_PAD_PROBE_TYPE_EVENT_FLUSH | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
-        WebKitVideoSinkProbe::doProbe, new WebKitVideoSinkProbe(player), WebKitVideoSinkProbe::deleteUserData);
+    identifiers.padProbeOwner = WebKitVideoSinkProbeOwner::create(player);
+    identifiers.padProbeHandle = PadProbeHandle<WebKitVideoSinkProbeOwner>::create(*identifiers.padProbeOwner, GRefPtr(pad), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM | GST_PAD_PROBE_TYPE_EVENT_FLUSH | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
+        [](const auto& probeOwner, const auto& pad, auto info) -> GstPadProbeReturn {
+            return probeOwner->doProbe(pad, info);
+        });
 
     RefPtr strongPlayer = player.get();
     if (!strongPlayer) [[unlikely]]
@@ -237,10 +218,9 @@ void webKitVideoSinkDisconnectSignalHandlers(GstElement* appSink, const WebKitVi
     auto pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
     if (identifiers.notifyCaps)
         g_signal_handler_disconnect(pad.get(), identifiers.notifyCaps);
-
-    if (identifiers.padProbeId)
-        gst_pad_remove_probe(pad.get(), identifiers.padProbeId);
 }
+
+} // namespace WebCore
 
 #undef GST_CAT_DEFAULT
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h
@@ -20,23 +20,48 @@
 
 #if ENABLE(VIDEO)
 
-#include <gst/gst.h>
+#include "GStreamerCommon.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 class MediaPlayerPrivateGStreamer;
 
+class WebKitVideoSinkProbeOwner final : public WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebKitVideoSinkProbeOwner> {
+    WTF_MAKE_TZONE_ALLOCATED(WebKitVideoSinkProbeOwner);
+
+public:
+    static RefPtr<WebKitVideoSinkProbeOwner> create(const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>& player)
+    {
+        return adoptRef(*new WebKitVideoSinkProbeOwner(player));
+    }
+
+    void handleFlushEvent([[maybe_unused]] const GRefPtr<GstPad>&, GstPadProbeInfo*);
+
+    GstPadProbeReturn doProbe([[maybe_unused]] const GRefPtr<GstPad>&, GstPadProbeInfo*);
+
+private:
+    WebKitVideoSinkProbeOwner(const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>& player)
+        : m_player(player)
+    {
+    }
+
+    ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer> m_player;
+    bool m_isFlushing { false };
+};
+
 struct WebKitVideoSinkSignalIdentifiers {
     unsigned long newSample { 0 };
     unsigned long newPreroll { 0 };
     unsigned long notifyCaps { 0 };
-    unsigned long padProbeId { 0 };
+    RefPtr<WebKitVideoSinkProbeOwner> padProbeOwner;
+    RefPtr<PadProbeHandle<WebKitVideoSinkProbeOwner>> padProbeHandle;
 };
 
+WebKitVideoSinkSignalIdentifiers webKitVideoSinkSetMediaPlayerPrivate(GstElement*, const ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&);
+
+void webKitVideoSinkDisconnectSignalHandlers(GstElement*, const WebKitVideoSinkSignalIdentifiers&);
+
 } // namespace WebCore
-
-WebCore::WebKitVideoSinkSignalIdentifiers webKitVideoSinkSetMediaPlayerPrivate(GstElement*, const ThreadSafeWeakPtr<WebCore::MediaPlayerPrivateGStreamer>&);
-
-void webKitVideoSinkDisconnectSignalHandlers(GstElement*, const WebCore::WebKitVideoSinkSignalIdentifiers&);
 
 #endif // ENABLE(VIDEO)


### PR DESCRIPTION
#### 4eab05fe7b77e18d69c2c5b8d9725bdd4726f0cf
<pre>
[GStreamer] Migrate video sink pad probe to PadProbeHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=316684">https://bugs.webkit.org/show_bug.cgi?id=316684</a>

Reviewed by Xabier Rodriguez-Calvar.

Refactoring migrating from gst_pad_add_probe to PadProbeHandle.

* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp:
(WebCore::WebKitVideoSinkProbeOwner::handleFlushEvent):
(WebCore::WebKitVideoSinkProbeOwner::doProbe):
(WebCore::webKitVideoSinkSetMediaPlayerPrivate):
(WebCore::webKitVideoSinkDisconnectSignalHandlers):
(WebKitVideoSinkProbe::WebKitVideoSinkProbe): Deleted.
(WebKitVideoSinkProbe::deleteUserData): Deleted.
(WebKitVideoSinkProbe::handleFlushEvent): Deleted.
(WebKitVideoSinkProbe::doProbe): Deleted.
(): Deleted.
(MediaPlayerPrivateNotifier::MediaPlayerPrivateNotifier): Deleted.
(MediaPlayerPrivateNotifier::destruct): Deleted.
(webKitVideoSinkSetMediaPlayerPrivate): Deleted.
(webKitVideoSinkDisconnectSignalHandlers): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h:

Canonical link: <a href="https://commits.webkit.org/314883@main">https://commits.webkit.org/314883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7f70ee5aa0286d6d55f16d56e8324c38038542b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176580 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130331 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32743 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110848 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25314 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159783 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179121 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32015 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138727 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41095 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138614 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37315 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41783 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104913 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33871 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40287 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113368 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39684 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4985 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->