### PR TITLE
Enhanced Security sites database should gracefully handle statement failures

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
@@ -143,6 +143,8 @@ bool EnhancedSecuritySitesPersistence::openDatabase(const String& directoryPath)
     {
         auto columnCheckStatement = checkedDB->prepareStatement("SELECT COUNT(*) FROM pragma_table_info('sites') WHERE name = 'last_modified'"_s);
         bool hasLastModifiedColumn = columnCheckStatement && columnCheckStatement->step() == SQLITE_ROW && columnCheckStatement->columnInt(0) > 0;
+        columnCheckStatement = nullptr;
+
         if (!hasLastModifiedColumn) {
             if (!checkedDB->executeCommand("ALTER TABLE sites ADD COLUMN last_modified REAL NOT NULL DEFAULT 0"_s))
                 return reportErrorAndCloseDatabase("add last_modified column"_s);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm
@@ -1635,6 +1635,28 @@ TEST(EnhancedSecurityPolicies, MigrationAddsLastModifiedColumnToExistingDatabase
     cleanUpEnhancedSecuritySites();
 }
 
+TEST(EnhancedSecurityPolicies, OpenDatabaseDoesNotCrashWhenMigrationFails)
+{
+    auto dbPath = emptyEnhancedSecuritySitesPath();
+
+    {
+        auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+        EXPECT_TRUE(database->open(dbPath.get()));
+
+        // Create a table with a specific edge case that causes our ALTER TABLE statement to fail
+        // by causing a collision in the column names of the table. This should not crash.
+        EXPECT_TRUE(database->executeCommand("CREATE TABLE sites (site TEXT PRIMARY KEY, enhanced_security_state INT NOT NULL, Last_Modified REAL NOT NULL DEFAULT 0)"_s));
+        EXPECT_TRUE(database->executeCommand("CREATE INDEX idx_sites_enhanced_security_state ON sites(enhanced_security_state)"_s));
+
+        database->close();
+    }
+
+    auto webView = enhancedSecurityTestConfiguration(nullptr, nullptr, /* useSiteIsolation */ false, /* useNonPersistentStore */ false);
+    waitForEnhancedSecurityDatabaseOpen(webView.get());
+
+    cleanUpEnhancedSecuritySites();
+}
+
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/EnhancedSecurityPoliciesAdditions.mm>)
 #import <WebKitAdditions/EnhancedSecurityPoliciesAdditions.mm>
 #endif


### PR DESCRIPTION
#### e67a46f6bda40603a0297dd6eafe390c5f211f98
<pre>
Enhanced Security sites database should gracefully handle statement failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=316690">https://bugs.webkit.org/show_bug.cgi?id=316690</a>
<a href="https://rdar.apple.com/179058026">rdar://179058026</a>

Reviewed by Adrian Taylor.

It seems possible in unusual edge cases for our table altering statements to fail
when setting up the Enhanced Security sites database. In one edge case, we destroyed
the database before a prepared statement causing a crash.

We should handle this more gracefully and ensure we error and close the database
cleanly.

Added an additional test that recreates this scenario.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm

* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp:
(WebKit::EnhancedSecuritySitesPersistence::openDatabase):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EnhancedSecurityPolicies.mm:
(TEST(EnhancedSecurityPolicies, OpenDatabaseDoesNotCrashWhenMigrationFails)):

Canonical link: <a href="https://commits.webkit.org/314921@main">https://commits.webkit.org/314921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f80e8f3f19ff05ee4beb373dbad749d6f8ad33d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125047 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bd26793-77a7-47eb-b13a-c08642358c7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130197 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2f6250c-4034-4a92-89c5-650fcd76f354) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110714 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43ab065d-85c7-4048-bafc-2cffaad73a6b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30284 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25154 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178958 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138591 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138479 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37340 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41623 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104687 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26742 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113208 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39524 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4840 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39774 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39669 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->