### PR TITLE
[Site Isolation] Make Web Inspector frame protocol IDs collision-free and hosting-process-qualified

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/frame-id-collision-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/frame-id-collision-cross-origin-iframe-expected.txt
@@ -1,0 +1,16 @@
+Test that nested cross-origin frame protocol ids are collision-free under site isolation (webkit.org/b/316663).
+
+
+== Running test suite: SiteIsolation.Page.FrameIdCollisionFreeNestedCrossOrigin
+-- Running test case: SiteIsolation.Page.FrameIdCollisionFreeNestedCrossOrigin.DistinctIds
+PASS: Tree should contain main + child + grandchild.
+PASS: Main frame should have a child frame.
+PASS: Child frame should have a grandchild frame.
+PASS: Child frame name should be reported.
+PASS: Grandchild frame name should be reported.
+PASS: Child's parentId should match the main frame id.
+PASS: Grandchild's parentId should match the child frame id.
+PASS: Every frame should have a non-empty id.
+PASS: All frame protocol ids should be unique.
+PASS: Grandchild id should differ from main frame id.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/frame-id-collision-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/frame-id-collision-cross-origin-iframe.html
@@ -1,0 +1,81 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame-with-grandchild.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.FrameIdCollisionFreeNestedCrossOrigin");
+
+    function flattenFrames(node, out = []) {
+        out.push(node);
+        for (let child of node.childFrames || [])
+            flattenFrames(child, out);
+        return out;
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.FrameIdCollisionFreeNestedCrossOrigin.DistinctIds",
+        description: "main(A) -> child(B) -> grandchild(A): every frame protocol id must be distinct, even when co-hosted frames share a per-process counter.",
+        async test() {
+            // Add the nested iframes from within the test. The child commits in a
+            // separate WebContent process (CommitTiming::WaitForLoad), then adds the
+            // grandchild which flips back to host A and commits in yet another
+            // process, so the tree fills in incrementally -- poll until all three
+            // levels are present. Use getResourceTree on the multiplexing
+            // backendTarget: its PageAgent is the UIProcess proxy that sees every
+            // WebContent process; window.PageAgent would only see the local frame.
+            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+
+            let frameTree;
+            let nodes;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                ({ frameTree } = await WI.backendTarget.PageAgent.getResourceTree());
+                nodes = flattenFrames(frameTree);
+                if (nodes.length >= 3)
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 100));
+            }
+
+            InspectorTest.expectEqual(nodes.length, 3, "Tree should contain main + child + grandchild.");
+
+            let main = frameTree;
+            let child = main.childFrames?.[0];
+            let grandchild = child?.childFrames?.[0];
+
+            InspectorTest.expectNotNull(child, "Main frame should have a child frame.");
+            InspectorTest.expectNotNull(grandchild, "Child frame should have a grandchild frame.");
+            if (!child || !grandchild)
+                return;
+
+            InspectorTest.expectEqual(child.frame.name, "child-frame", "Child frame name should be reported.");
+            InspectorTest.expectEqual(grandchild.frame.name, "grandchild-frame", "Grandchild frame name should be reported.");
+            InspectorTest.expectEqual(child.frame.parentId, main.frame.id, "Child's parentId should match the main frame id.");
+            InspectorTest.expectEqual(grandchild.frame.parentId, child.frame.id, "Grandchild's parentId should match the child frame id.");
+
+            // The crux of webkit.org/b/316663: encode the full FrameIdentifier (not
+            // only its lower-32-bit per-process counter) in the protocol id. In this
+            // topology two frames minted in different processes share a per-process
+            // counter and become co-hosted in a single process, so a counter-only
+            // object part would collapse them onto the same id -- a parent/child
+            // cycle in the frontend frame tree. The uniqueness check below is the
+            // regression guard; it fails without the full-FrameIdentifier encoding.
+            let ids = nodes.map((node) => node.frame.id);
+            InspectorTest.expectThat(ids.every((id) => !!id), "Every frame should have a non-empty id.");
+            InspectorTest.expectEqual(new Set(ids).size, ids.length, "All frame protocol ids should be unique.");
+            InspectorTest.expectThat(grandchild.frame.id !== main.frame.id, "Grandchild id should differ from main frame id.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that nested cross-origin frame protocol ids are collision-free under site isolation (webkit.org/b/316663).</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-tree-frame-with-grandchild.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-tree-frame-with-grandchild.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>Cross-origin frame with grandchild</title>
+<p>Cross-origin child that embeds a grandchild back on the original host.</p>
+<script>
+// This page is loaded on the cross-origin host (B). Embed a grandchild iframe
+// back on the original host (A) so the grandchild shares the main frame's
+// process -- the main(A) -> child(B) -> grandchild(A) collision topology.
+let grandchildHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+let iframe = document.createElement("iframe");
+iframe.name = "grandchild-frame";
+iframe.src = `http://${grandchildHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame.html`;
+document.body.appendChild(iframe);
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target-expected.txt
@@ -15,11 +15,13 @@ PASS: Evaluation using context should not throw.
 PASS: Should get a non-empty hostname from the cross-origin frame.
 Frame hostname: localhost
 
--- Running test case: SiteIsolation.Runtime.ExecutionContextCreated.UniqueIds
+-- Running test case: SiteIsolation.Runtime.ExecutionContextCreated.PerTargetContexts
 PASS: Should have at least 2 frame targets (main frame + cross-origin iframe).
-PASS: Execution context id should be unique.
-PASS: Execution context id should be unique.
-PASS: Should have at least 2 unique context ids.
+PASS: Each frame target should own a distinct execution context object.
+PASS: An execution context should be scoped to its own frame target.
+PASS: Each frame target should own a distinct execution context object.
+PASS: An execution context should be scoped to its own frame target.
+PASS: Should have at least 2 distinct execution contexts (one per frame target).
 
 -- Running test case: SiteIsolation.Runtime.ExecutionContextCreated.DynamicIframeReceivesContext
 PASS: Dynamically added cross-origin iframe should have an ExecutionContext.

--- a/LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html
@@ -50,22 +50,23 @@ function test() {
     });
 
     suite.addTestCase({
-        name: "SiteIsolation.Runtime.ExecutionContextCreated.UniqueIds",
-        description: "Each frame target should have unique execution context ids.",
+        name: "SiteIsolation.Runtime.ExecutionContextCreated.PerTargetContexts",
+        description: "Each frame target should own its own execution context. Context ids are per-target namespaces under site isolation (each frame's InjectedScriptManager counts from 1), so two frame targets in different processes may legitimately share a numeric id; the invariant is that each target has a distinct context object scoped to itself.",
         async test() {
             let frameTargets = WI.targets.filter((t) => t instanceof WI.FrameTarget);
             InspectorTest.expectThat(frameTargets.length >= 2, "Should have at least 2 frame targets (main frame + cross-origin iframe).");
 
-            let contextIds = new Set;
+            let contexts = new Set;
             for (let target of frameTargets) {
                 let context = target.executionContext;
-                if (context) {
-                    InspectorTest.expectThat(!contextIds.has(context.id), "Execution context id should be unique.");
-                    contextIds.add(context.id);
-                }
+                if (!context)
+                    continue;
+                InspectorTest.expectThat(!contexts.has(context), "Each frame target should own a distinct execution context object.");
+                InspectorTest.expectEqual(context.target, target, "An execution context should be scoped to its own frame target.");
+                contexts.add(context);
             }
 
-            InspectorTest.expectThat(contextIds.size >= 2, "Should have at least 2 unique context ids.");
+            InspectorTest.expectThat(contexts.size >= 2, "Should have at least 2 distinct execution contexts (one per frame target).");
         }
     });
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2234,7 +2234,6 @@ webkit.org/b/310302 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundar
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Skip ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Skip ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Skip ]
-http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
 webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html [ Pass Failure ]
 

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
@@ -30,6 +30,8 @@
 #include "DocumentLoader.h"
 #include "FrameDestructionObserverInlines.h"
 #include "LocalFrameInlines.h"
+#include "ProcessIdentifier.h"
+#include "RemoteFrame.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -37,6 +39,18 @@ namespace Inspector {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IdentifierRegistry);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyIdentifierRegistry);
+
+// The WebContent process that hosts a frame's content: the current process for a
+// LocalFrame, or the RemoteFrame's recorded hosting process for a remote stub. Both
+// UIProcess and WebContent feed this into protocolFrameId() so they compute matching
+// IDs for the same frame regardless of which process holds it. See webkit.org/b/310164.
+static WebCore::ProcessIdentifier hostingProcessForFrame(const WebCore::Frame& frame)
+{
+    if (auto* remoteFrame = dynamicDowncast<WebCore::RemoteFrame>(frame))
+        return remoteFrame->hostingProcessIdentifier();
+    return WebCore::Process::identifier();
+}
+
 
 LegacyIdentifierRegistry::LegacyIdentifierRegistry() = default;
 LegacyIdentifierRegistry::~LegacyIdentifierRegistry() = default;
@@ -98,7 +112,7 @@ Protocol::Network::FrameId BackendIdentifierRegistry::frameId(const WebCore::Fra
 {
     if (!frame)
         return emptyString();
-    auto identifier = protocolFrameId(frame->frameID());
+    auto identifier = protocolFrameId(frame->frameID(), hostingProcessForFrame(*frame));
     m_identifierToFrame.set(identifier, frame);
     return identifier;
 }
@@ -134,7 +148,7 @@ WebCore::LocalFrame* BackendIdentifierRegistry::assertFrame(Protocol::ErrorStrin
 
 Protocol::Network::FrameId BackendIdentifierRegistry::takeFrame(const WebCore::Frame& frame)
 {
-    auto identifier = protocolFrameId(frame.frameID());
+    auto identifier = protocolFrameId(frame.frameID(), hostingProcessForFrame(frame));
     m_identifierToFrame.remove(identifier);
     return identifier;
 }

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.h
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.h
@@ -75,22 +75,30 @@ public:
     // independently compute the same ID from the same typed identifier.
     // Format: "type-processID.objectID" (e.g., "frame-12345.3", "request-12345.17")
     //
+    // For frames the objectID is the full FrameIdentifier value (globally unique), and the
+    // processID is the frame's *hosting* process. Encoding the full FrameIdentifier (rather
+    // than only its lower 32 bits) keeps IDs collision-free: two frames minted in different
+    // processes can share the same lower-32-bit counter, and once both are hosted in the same
+    // process (e.g. main(A) -> child(B) -> grandchild(A)) a counter-only object part would
+    // collide. See webkit.org/b/310164.
+    //
     // Prefer the 2-arg protocolFrameId(FrameIdentifier, ProcessIdentifier) which uses
     // an explicit hosting process. The 1-arg version extracts the process from the
-    // FrameIdentifier's upper bits, which is incorrect for provisional frames where
-    // the identifier is preserved across process swaps. See webkit.org/b/310164.
+    // FrameIdentifier's upper bits (its creating process), which is incorrect for
+    // provisional frames where the identifier is preserved across process swaps.
     static inline String protocolFrameId(WebCore::FrameIdentifier frameID, WebCore::ProcessIdentifier processID)
     {
-        return makeString("frame-"_s, processID.toUInt64(), '.', static_cast<uint32_t>(frameID.toRawValue()));
+        return makeString("frame-"_s, processID.toUInt64(), '.', frameID.toUInt64());
     }
 
     // FIXME: <https://webkit.org/b/310164> Callers that receive FrameIdentifier via IPC
     // without a separate ProcessIdentifier should be updated to pass one explicitly.
-    // This extracts the process from FrameIdentifier upper bits, which is incorrect
-    // for provisional frames.
+    // This qualifies by the process encoded in the FrameIdentifier's upper bits (its
+    // creating process), which equals the hosting process for frames that have not moved
+    // across processes, so both forms agree in the common case.
     static inline String protocolFrameId(WebCore::FrameIdentifier frameID)
     {
-        return makeString("frame-"_s, frameID.toRawValue() >> 32, '.', static_cast<uint32_t>(frameID.toRawValue()));
+        return protocolFrameId(frameID, ObjectIdentifier<WebCore::ProcessIdentifierType>(frameID.toRawValue() >> 32));
     }
 
     static inline String protocolRequestId(WebCore::ProcessIdentifier pid, WebCore::ResourceLoaderIdentifier resourceID)

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -849,7 +849,7 @@ Ref<Inspector::Protocol::Page::FrameResourceTree> InspectorPageAgent::buildObjec
     if (auto* remoteFrame = dynamicDowncast<RemoteFrame>(frame)) {
         auto& origin = remoteFrame->frameDocumentSecurityOriginOrOpaque();
         auto frameObject = Inspector::Protocol::Page::Frame::create()
-            .setId(Inspector::IdentifierRegistry::protocolFrameId(remoteFrame->frameID()))
+            .setId(Inspector::IdentifierRegistry::protocolFrameId(remoteFrame->frameID(), remoteFrame->hostingProcessIdentifier()))
             .setLoaderId(emptyString())
             .setUrl(origin.toRawString())
             .setMimeType("text/html"_s)

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -66,6 +66,16 @@ RemoteFrame::RemoteFrame(Page& page, ClientCreator&& clientCreator, FrameIdentif
 
 RemoteFrame::~RemoteFrame() = default;
 
+ProcessIdentifier RemoteFrame::hostingProcessIdentifier() const
+{
+    if (m_hostingProcessIdentifier)
+        return *m_hostingProcessIdentifier;
+    // Fallback to the process encoded in the FrameIdentifier's upper bits when the
+    // hosting process has not been recorded. This reproduces the legacy
+    // IdentifierRegistry::protocolFrameId(FrameIdentifier) value. See webkit.org/b/310164.
+    return ObjectIdentifier<ProcessIdentifierType>(frameID().toRawValue() >> 32);
+}
+
 DOMWindow* RemoteFrame::virtualWindow() const
 {
     return &window();

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -28,6 +28,8 @@
 #include <WebCore/AXObjectTypes.h>
 #include <WebCore/Frame.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
+#include <WebCore/ProcessIdentifier.h>
+#include <wtf/Markable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/UniqueRef.h>
@@ -64,6 +66,16 @@ public:
     WEBCORE_EXPORT void setView(RefPtr<RemoteFrameView>&&);
 
     Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
+
+    // The WebContent process whose LocalFrame actually hosts this frame's content.
+    // A RemoteFrame is a stub in every other process, so the hosting process must be
+    // recorded explicitly (it is plumbed in when the stub is created or when a local
+    // frame transitions to remote on a process swap). When it has not been recorded,
+    // this falls back to the process encoded in the FrameIdentifier's upper bits, which
+    // matches the legacy IdentifierRegistry::protocolFrameId(FrameIdentifier) behavior.
+    // See webkit.org/b/310164.
+    WEBCORE_EXPORT ProcessIdentifier hostingProcessIdentifier() const;
+    void setHostingProcessIdentifier(ProcessIdentifier processID) { m_hostingProcessIdentifier = processID; }
 
     String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>);
     void bindRemoteAccessibilityFrames(int processIdentifier, AccessibilityRemoteToken, CompletionHandler<void(AccessibilityRemoteToken, int)>&&);
@@ -123,6 +135,7 @@ private:
     RefPtr<RemoteFrameView> m_view;
     const UniqueRef<RemoteFrameClient> m_client;
     Markable<LayerHostingContextIdentifier> m_layerHostingContextIdentifier;
+    Markable<ProcessIdentifier> m_hostingProcessIdentifier;
     String m_customUserAgent;
     String m_customUserAgentAsSiteSpecificQuirks;
     String m_customNavigatorPlatform;

--- a/Source/WebKit/Shared/FrameTreeCreationParameters.h
+++ b/Source/WebKit/Shared/FrameTreeCreationParameters.h
@@ -36,6 +36,9 @@ struct FrameTreeCreationParameters {
     WebCore::FrameIdentifier frameID;
     std::optional<WebCore::FrameIdentifier> openerFrameID;
     String frameName;
+    // The process that hosts this frame's content, so the process that receives this
+    // tree can record it on the RemoteFrame stub it creates. See webkit.org/b/310164.
+    WebCore::ProcessIdentifier hostingProcessID;
     Ref<WebCore::FrameTreeSyncData> frameTreeSyncData;
     Vector<FrameTreeCreationParameters> children;
 };

--- a/Source/WebKit/Shared/FrameTreeCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/FrameTreeCreationParameters.serialization.in
@@ -24,6 +24,7 @@ struct WebKit::FrameTreeCreationParameters {
     WebCore::FrameIdentifier frameID;
     std::optional<WebCore::FrameIdentifier> openerFrameID;
     String frameName;
+    WebCore::ProcessIdentifier hostingProcessID;
     Ref<WebCore::FrameTreeSyncData> frameTreeSyncData;
     Vector<WebKit::FrameTreeCreationParameters> children;
 };

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -416,7 +416,7 @@ void ProxyingNetworkAgent::requestWillBeSent(ResourceID resourceID, FrameID fram
         return;
 
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
-    auto frameIdString = IdentifierRegistry::protocolFrameId(frameID);
+    auto frameIdString = IdentifierRegistry::protocolFrameId(frameID, resourceID.processIdentifier());
     auto loaderId = IdentifierRegistry::protocolLoaderId(contextID);
     auto requestObject = buildObjectForResourceRequest(request);
 
@@ -438,7 +438,7 @@ void ProxyingNetworkAgent::responseReceived(ResourceID resourceID, FrameID frame
         return;
 
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
-    auto frameIdString = IdentifierRegistry::protocolFrameId(frameID);
+    auto frameIdString = IdentifierRegistry::protocolFrameId(frameID, resourceID.processIdentifier());
     auto loaderId = IdentifierRegistry::protocolLoaderId(contextID);
     auto responseObject = buildObjectForResourceResponse(response);
 
@@ -480,7 +480,7 @@ void ProxyingNetworkAgent::requestServedFromMemoryCache(ResourceID resourceID, F
         return;
 
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
-    auto frameIdString = IdentifierRegistry::protocolFrameId(frameID);
+    auto frameIdString = IdentifierRegistry::protocolFrameId(frameID, resourceID.processIdentifier());
     auto loaderId = IdentifierRegistry::protocolLoaderId(contextID);
     auto requestObject = buildObjectForResourceRequest(request);
     auto responseObject = buildObjectForResourceResponse(response);

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -78,10 +78,22 @@ void ProxyingPageAgent::removeAllRegisteredReceivers()
 
 // MARK: - IPC event handlers
 
+// Resolve a frame's protocol ID from the authoritative UIProcess frame tree so the
+// hosting process matches buildFrameTree() and the WebContent agents. The events
+// carry only a FrameIdentifier; the hosting process can differ from the identifier's
+// creating process after a process swap. Falls back to the identifier-derived process
+// when the frame is no longer in the tree (e.g. already detached). See webkit.org/b/310164.
+static String protocolFrameIdForFrameID(FrameIdentifier frameID)
+{
+    if (RefPtr frame = WebFrameProxy::webFrame(frameID))
+        return IdentifierRegistry::protocolFrameId(frameID, frame->process().coreProcessIdentifier());
+    return IdentifierRegistry::protocolFrameId(frameID);
+}
+
 void ProxyingPageAgent::frameNavigated(FrameIdentifier frameID, const URL& url, const String& mimeType, SecurityOriginData&& securityOrigin, std::optional<FrameIdentifier> parentFrameID, const String& name)
 {
     auto frameObject = Protocol::Page::Frame::create()
-        .setId(IdentifierRegistry::protocolFrameId(frameID))
+        .setId(protocolFrameIdForFrameID(frameID))
         .setLoaderId(String()) // FIXME: <https://webkit.org/b/308895> get loaderId from document identifier
         .setUrl(url.string())
         .setMimeType(mimeType)
@@ -89,7 +101,7 @@ void ProxyingPageAgent::frameNavigated(FrameIdentifier frameID, const URL& url, 
         .release();
 
     if (parentFrameID)
-        frameObject->setParentId(IdentifierRegistry::protocolFrameId(*parentFrameID));
+        frameObject->setParentId(protocolFrameIdForFrameID(*parentFrameID));
     if (!name.isEmpty())
         frameObject->setName(name);
 
@@ -108,7 +120,7 @@ void ProxyingPageAgent::loadEventFired(double timestamp)
 
 void ProxyingPageAgent::frameDetached(FrameIdentifier frameID)
 {
-    m_frontendDispatcher->frameDetached(IdentifierRegistry::protocolFrameId(frameID));
+    m_frontendDispatcher->frameDetached(protocolFrameIdForFrameID(frameID));
 }
 
 // MARK: - Frontend lifecycle
@@ -218,7 +230,7 @@ CommandResult<void> ProxyingPageAgent::disable()
 
 Ref<Protocol::Page::FrameResourceTree> ProxyingPageAgent::buildFrameTree(const WebFrameProxy& frame, const String* parentProtocolId) const
 {
-    auto protocolId = IdentifierRegistry::protocolFrameId(frame.frameID());
+    auto protocolId = IdentifierRegistry::protocolFrameId(frame.frameID(), frame.process().coreProcessIdentifier());
 
     // The UIProcess WebFrameProxy tree is the authoritative cross-process frame
     // tree under Site Isolation: childFrames() spans every WebContent process, so

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -619,7 +619,7 @@ void WebFrameProxy::commitProvisionalFrame(IPC::Connection& connection, FrameIde
 {
     ASSERT(m_page);
     if (m_provisionalFrame) {
-        protect(process())->send(Messages::WebPage::LoadDidCommitInAnotherProcess(frameID, m_layerHostingContextIdentifier, nullptr), *webPageIDInCurrentProcess());
+        protect(process())->send(Messages::WebPage::LoadDidCommitInAnotherProcess(frameID, m_provisionalFrame->process().coreProcessIdentifier(), m_layerHostingContextIdentifier, nullptr), *webPageIDInCurrentProcess());
 
         WebCore::ProcessIdentifier oldProcessID = process().coreProcessIdentifier();
         std::optional<WebCore::PageIdentifier> oldPageID = webPageIDInCurrentProcess();
@@ -703,6 +703,7 @@ FrameTreeCreationParameters WebFrameProxy::frameTreeCreationParameters() const
         m_frameID,
         m_opener ? std::optional(m_opener->frameID()) : std::nullopt,
         m_frameName,
+        process().coreProcessIdentifier(),
         calculateFrameTreeSyncData(),
         WTF::map(m_childFrames, [] (auto& frame) {
             return frame->frameTreeCreationParameters();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5901,7 +5901,7 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
         topDocumentSyncData->documentURL = request.url();
         topDocumentSyncData->documentSecurityOrigin = SecurityOrigin::create(request.url());
         setTopDocumentSyncData(topDocumentSyncData.copyRef());
-        protect(legacyMainFrameProcess())->send(Messages::WebPage::LoadDidCommitInAnotherProcess(*oldMainFrameID, std::nullopt, WTF::move(topDocumentSyncData)), webPageIDInMainFrameProcess());
+        protect(legacyMainFrameProcess())->send(Messages::WebPage::LoadDidCommitInAnotherProcess(*oldMainFrameID, provisionalPage->process().coreProcessIdentifier(), std::nullopt, WTF::move(topDocumentSyncData)), webPageIDInMainFrameProcess());
         protect(m_browsingContextGroup)->transitionPageToRemotePage(*this, *provisionalPage->deferredRemoteTransitionSite());
     }
 
@@ -8539,7 +8539,7 @@ void WebPageProxy::observeAndCreateRemoteSubframesInOtherProcesses(WebFrameProxy
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         if (webProcess.processID() == newFrame.process().processID())
             return;
-        webProcess.send(Messages::WebPage::CreateRemoteSubframe(parent->frameID(), newFrame.frameID(), frameName, newFrame.calculateFrameTreeSyncData()), pageID);
+        webProcess.send(Messages::WebPage::CreateRemoteSubframe(parent->frameID(), newFrame.frameID(), frameName, newFrame.process().coreProcessIdentifier(), newFrame.calculateFrameTreeSyncData()), pageID);
     });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -187,7 +187,7 @@ Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const At
     return frame;
 }
 
-Ref<WebFrame> WebFrame::createRemoteSubframe(WebPage& page, WebFrame& parent, WebCore::FrameIdentifier frameID, const String& frameName, std::optional<WebCore::FrameIdentifier> openerFrameID, Ref<WebCore::FrameTreeSyncData>&& frameTreeSyncData)
+Ref<WebFrame> WebFrame::createRemoteSubframe(WebPage& page, WebFrame& parent, WebCore::FrameIdentifier frameID, const String& frameName, std::optional<WebCore::FrameIdentifier> openerFrameID, WebCore::ProcessIdentifier hostingProcessID, Ref<WebCore::FrameTreeSyncData>&& frameTreeSyncData)
 {
     RefPtr<WebCore::Frame> opener;
     if (openerFrameID) {
@@ -204,6 +204,7 @@ Ref<WebFrame> WebFrame::createRemoteSubframe(WebPage& page, WebFrame& parent, We
     auto coreFrame = RemoteFrame::createSubframe(*corePage, [frame] (auto&) {
         return makeUniqueRef<WebRemoteFrameClient>(frame.copyRef(), frame->makeInvalidator());
     }, frameID, *parentCoreFrame, opener.get(), std::nullopt, WTF::move(frameTreeSyncData), WebCore::Frame::AddToFrameTree::Yes);
+    coreFrame->setHostingProcessIdentifier(hostingProcessID);
     frame->m_coreFrame = coreFrame.get();
     coreFrame->tree().setSpecifiedName(AtomString(frameName));
     return frame;
@@ -390,7 +391,7 @@ uint64_t WebFrame::setUpPolicyListener(WebCore::FramePolicyFunction&& policyFunc
     return policyListenerID;
 }
 
-void WebFrame::loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier)
+void WebFrame::loadDidCommitInAnotherProcess(WebCore::ProcessIdentifier hostingProcessID, std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier)
 {
     RefPtr localFrame = coreLocalFrame();
     if (!localFrame) {
@@ -432,6 +433,7 @@ void WebFrame::loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHosting
 
         return WebCore::RemoteFrame::createMainFrame(*corePage, WTF::move(clientCreator), m_frameID, nullptr, WTF::move(frameTreeSyncData));
     }();
+    newFrame->setHostingProcessIdentifier(hostingProcessID);
     m_coreFrame = newFrame.get();
 
     if (parent)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -116,7 +116,7 @@ class WebFrame : public API::ObjectImpl<API::Object::Type::BundleFrame>, public 
 public:
     static Ref<WebFrame> create(WebPage& page, WebCore::FrameIdentifier frameID) { return adoptRef(*new WebFrame(page, frameID)); }
     static Ref<WebFrame> createSubframe(WebPage&, WebFrame& parent, const AtomString& frameName, WebCore::HTMLFrameOwnerElement&);
-    static Ref<WebFrame> createRemoteSubframe(WebPage&, WebFrame& parent, WebCore::FrameIdentifier, const String& frameName, std::optional<WebCore::FrameIdentifier> openerFrameID, Ref<WebCore::FrameTreeSyncData>&&);
+    static Ref<WebFrame> createRemoteSubframe(WebPage&, WebFrame& parent, WebCore::FrameIdentifier, const String& frameName, std::optional<WebCore::FrameIdentifier> openerFrameID, WebCore::ProcessIdentifier hostingProcessID, Ref<WebCore::FrameTreeSyncData>&&);
     ~WebFrame();
 
     void ref() const final { API::ObjectImpl<API::Object::Type::BundleFrame>::ref(); }
@@ -139,7 +139,7 @@ public:
     void createProvisionalFrame(ProvisionalFrameCreationParameters&&);
     void commitProvisionalFrame();
     void destroyProvisionalFrame();
-    void loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHostingContextIdentifier>);
+    void loadDidCommitInAnotherProcess(WebCore::ProcessIdentifier hostingProcessID, std::optional<WebCore::LayerHostingContextIdentifier>);
     WebCore::LocalFrame* provisionalFrame() { return m_provisionalFrame.get(); }
 
     Awaitable<std::optional<FrameInfoData>> getFrameInfo();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1290,19 +1290,19 @@ void WebPage::updateAfterDrawingAreaCreation(const WebPageCreationParameters& pa
 
 void WebPage::constructFrameTree(WebFrame& parent, const FrameTreeCreationParameters& treeCreationParameters)
 {
-    auto frame = WebFrame::createRemoteSubframe(*this, parent, treeCreationParameters.frameID, treeCreationParameters.frameName, treeCreationParameters.openerFrameID, Ref { treeCreationParameters.frameTreeSyncData });
+    auto frame = WebFrame::createRemoteSubframe(*this, parent, treeCreationParameters.frameID, treeCreationParameters.frameName, treeCreationParameters.openerFrameID, treeCreationParameters.hostingProcessID, Ref { treeCreationParameters.frameTreeSyncData });
     for (auto& parameters : treeCreationParameters.children)
         constructFrameTree(frame, parameters);
 }
 
-void WebPage::createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, const String& newChildFrameName, Ref<WebCore::FrameTreeSyncData>&& frameTreeSyncData)
+void WebPage::createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, const String& newChildFrameName, WebCore::ProcessIdentifier hostingProcessID, Ref<WebCore::FrameTreeSyncData>&& frameTreeSyncData)
 {
     RefPtr parentFrame = WebProcess::singleton().webFrame(parentID);
     if (!parentFrame) {
         ASSERT_NOT_REACHED();
         return;
     }
-    WebFrame::createRemoteSubframe(*this, *parentFrame, newChildID, newChildFrameName, std::nullopt, WTF::move(frameTreeSyncData));
+    WebFrame::createRemoteSubframe(*this, *parentFrame, newChildID, newChildFrameName, std::nullopt, hostingProcessID, WTF::move(frameTreeSyncData));
 }
 
 Awaitable<std::optional<FrameTreeNodeData>> WebPage::getFrameTree()
@@ -2370,13 +2370,13 @@ void WebPage::createProvisionalFrame(ProvisionalFrameCreationParameters&& parame
     frame->createProvisionalFrame(WTF::move(parameters));
 }
 
-void WebPage::loadDidCommitInAnotherProcess(WebCore::FrameIdentifier frameID, std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier, RefPtr<WebCore::DocumentSyncData>&& topDocumentSyncData)
+void WebPage::loadDidCommitInAnotherProcess(WebCore::FrameIdentifier frameID, WebCore::ProcessIdentifier hostingProcessID, std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier, RefPtr<WebCore::DocumentSyncData>&& topDocumentSyncData)
 {
     RefPtr frame = WebProcess::singleton().webFrame(frameID);
     if (!frame)
         return;
     ASSERT(frame->page() == this);
-    frame->loadDidCommitInAnotherProcess(layerHostingContextIdentifier);
+    frame->loadDidCommitInAnotherProcess(hostingProcessID, layerHostingContextIdentifier);
 
     if (topDocumentSyncData) {
         if (RefPtr page = corePage())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -850,7 +850,7 @@ public:
     RefPtr<WebCore::LocalFrame> NODELETE localMainFrame() const;
     RefPtr<WebCore::Document> localTopDocument() const;
 
-    void createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, const String& newChildFrameName, Ref<WebCore::FrameTreeSyncData>&&);
+    void createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, const String& newChildFrameName, WebCore::ProcessIdentifier hostingProcessID, Ref<WebCore::FrameTreeSyncData>&&);
 
     Awaitable<std::optional<FrameTreeNodeData>> getFrameTree();
     Awaitable<std::optional<FrameTreeNodeData>> getFrameTreeForBackForwardCacheEntry(WebCore::BackForwardFrameItemIdentifier);
@@ -2325,7 +2325,7 @@ private:
     void dispatchCrossOriginBeforeUnloadCheckForFrame(WebCore::FrameIdentifier, WebCore::SecurityOriginData&&);
     void platformDidReceiveLoadParameters(const LoadParameters&);
     void createProvisionalFrame(ProvisionalFrameCreationParameters&&);
-    void loadDidCommitInAnotherProcess(WebCore::FrameIdentifier, std::optional<WebCore::LayerHostingContextIdentifier>, RefPtr<WebCore::DocumentSyncData>&&);
+    void loadDidCommitInAnotherProcess(WebCore::FrameIdentifier, WebCore::ProcessIdentifier hostingProcessID, std::optional<WebCore::LayerHostingContextIdentifier>, RefPtr<WebCore::DocumentSyncData>&&);
     [[noreturn]] void NODELETE loadRequestWaitingForProcessLaunch(LoadParameters&&, URL&&, WebPageProxyIdentifier, bool);
     void loadData(LoadParameters&&);
     void loadAlternateHTML(LoadParameters&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -212,12 +212,12 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ApplyMonitorUnloadToIFrameElement(WebCore::FrameIdentifier frameID, enum:bool WebCore::IFrameUnloadReason reason)
 
     LoadRequest(struct WebKit::LoadParameters loadParameters)
-    LoadDidCommitInAnotherProcess(WebCore::FrameIdentifier frameID, std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier, RefPtr<WebCore::DocumentSyncData> topDocumentSyncData)
+    LoadDidCommitInAnotherProcess(WebCore::FrameIdentifier frameID, WebCore::ProcessIdentifier hostingProcessID, std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier, RefPtr<WebCore::DocumentSyncData> topDocumentSyncData)
     LoadRequestWaitingForProcessLaunch(struct WebKit::LoadParameters loadParameters, URL resourceDirectoryURL, WebKit::WebPageProxyIdentifier pageID, bool checkAssumedReadAccessToResourceURL)
     LoadData(struct WebKit::LoadParameters loadParameters)
     LoadSimulatedRequestAndResponse(struct WebKit::LoadParameters loadParameters, WebCore::ResourceResponse simulatedResponse)
     LoadAlternateHTML(struct WebKit::LoadParameters loadParameters)
-    CreateRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, String frameName, Ref<WebCore::FrameTreeSyncData> frameTreeSyncData)
+    CreateRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, String frameName, WebCore::ProcessIdentifier hostingProcessID, Ref<WebCore::FrameTreeSyncData> frameTreeSyncData)
 
     GetFrameTree() -> (struct std::optional<WebKit::FrameTreeNodeData> data)
     GetFrameTreeForBackForwardCacheEntry(WebCore::BackForwardFrameItemIdentifier frameItemID) -> (struct std::optional<WebKit::FrameTreeNodeData> data)


### PR DESCRIPTION
#### 5f655160036b3abc92f65dc8d89db51c87738dca
<pre>
[Site Isolation] Make Web Inspector frame protocol IDs collision-free and hosting-process-qualified
<a href="https://bugs.webkit.org/show_bug.cgi?id=316663">https://bugs.webkit.org/show_bug.cgi?id=316663</a>
<a href="https://rdar.apple.com/179117353">rdar://179117353</a>

Reviewed by BJ Burg.

Under Site Isolation a frame&apos;s protocol ID must be identical no matter which
process computes it, and must stay consistent across the Page and Network
domains. The 1-arg IdentifierRegistry::protocolFrameId(FrameIdentifier) derives
the qualifying process from the FrameIdentifier&apos;s upper bits -- the process that
*created* the frame -- which is wrong for frames hosted in a different process
than the one that minted their identifier (cross-origin children, and frames
preserved across a process swap). Migrate all five call sites to the 2-arg
protocolFrameId(FrameIdentifier, ProcessIdentifier) form, sourcing the frame&apos;s
*hosting* process at each site so the page tree, network events, and per-process
agents all agree.

The 2-arg helper also encoded only the lower 32 bits of the FrameIdentifier (the
per-creating-process counter) as its object part. That is collision-free when
qualified by the creating process, but not when qualified by the hosting process:
two frames minted in different processes can share a counter value and, once both
are hosted in the same process (e.g. main(A) -&gt; child(B) -&gt; grandchild(A)),
collapse to the same ID -- producing a parent/child cycle in the frontend frame
tree. Encode the full FrameIdentifier as the object part so IDs stay unique.

To give WebContent a hosting process for remote-frame stubs (which represent a
frame whose content lives in another process), record the hosting ProcessIdentifier
on RemoteFrame and plumb it in wherever a stub is created or a local frame
transitions to remote: CreateRemoteSubframe, the bulk FrameTreeCreationParameters
tree, and LoadDidCommitInAnotherProcess. The UIProcess is the authority for the
hosting process at each of these points (WebFrameProxy::process()).

* Source/WebCore/inspector/InspectorIdentifierRegistry.h:
Encode the full FrameIdentifier in protocolFrameId(); make the 1-arg form a thin
wrapper over the 2-arg form qualified by the creating process (fallback only).

* Source/WebCore/inspector/InspectorIdentifierRegistry.cpp:
(Inspector::hostingProcessForFrame): New helper -- current process for a LocalFrame,
the recorded hosting process for a RemoteFrame.
(Inspector::BackendIdentifierRegistry::frameId):
(Inspector::BackendIdentifierRegistry::takeFrame):
Qualify by the frame&apos;s hosting process.

* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::buildObjectForFrameTree): Qualify the remote-frame
stub by RemoteFrame::hostingProcessIdentifier().

* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::hostingProcessIdentifier): Store/return the hosting process,
falling back to the creating process encoded in the FrameIdentifier when unset.

* Source/WebKit/Shared/FrameTreeCreationParameters.h:
* Source/WebKit/Shared/FrameTreeCreationParameters.serialization.in:
Carry the per-frame hosting ProcessIdentifier.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::frameTreeCreationParameters): Populate it from process().
(WebKit::WebFrameProxy::commitProvisionalFrame): Send the new host PID in
LoadDidCommitInAnotherProcess.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::observeAndCreateRemoteSubframesInOtherProcesses): Send the
host PID in CreateRemoteSubframe.
(WebKit::WebPageProxy::commitProvisionalPage): Send the new host PID in
LoadDidCommitInAnotherProcess for the main-frame swap.

* Source/WebKit/WebProcess/WebPage/WebFrame.{h,cpp}:
* Source/WebKit/WebProcess/WebPage/WebPage.{h,cpp}:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
Thread the hosting ProcessIdentifier through createRemoteSubframe,
loadDidCommitInAnotherProcess, and constructFrameTree, applying it to the created
RemoteFrame.

* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp:
(Inspector::protocolFrameIdForFrameID): Resolve the hosting process from the
authoritative WebFrameProxy tree for frameNavigated/frameDetached.
(Inspector::ProxyingPageAgent::buildFrameTree): Qualify by frame.process().

* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
Qualify by resourceID.processIdentifier() (the frame&apos;s hosting process).

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html:
* LayoutTests/http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target-expected.txt:
Un-skip executionContextCreated-frame-target.html. The frame-id fix makes the
frame targets consistent, and its uniqueness case is corrected to assert the real
invariant: execution context ids are per-target namespaces under Site Isolation
(each frame&apos;s InjectedScriptManager counts from 1), so two targets in different
processes may share a numeric id -- assert each target owns a distinct context
object scoped to itself rather than asserting globally-unique ids.

* LayoutTests/http/tests/site-isolation/inspector/page/frame-id-collision-cross-origin-iframe.html:
* LayoutTests/http/tests/site-isolation/inspector/page/frame-id-collision-cross-origin-iframe-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-tree-frame-with-grandchild.html:
New test building the main(A) -&gt; child(B) -&gt; grandchild(A) topology that asserts
every frame protocol id is unique. Without the full-FrameIdentifier encoding two
of these frames share a per-process counter once co-hosted in one process and
collapse onto the same id; the uniqueness check is the regression guard.

Canonical link: <a href="https://commits.webkit.org/315052@main">https://commits.webkit.org/315052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bccca87450ea08b1d6bc166fb64b3da04c674292

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177238 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ca6b0ab-80a8-4fc0-85f1-3d33452f26b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41455 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e09baf2-a7c5-451e-bc76-58982ed79e85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170902 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111174 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bdfe1bb-d91e-4d8f-a33d-b60e4769448f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25941 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179838 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30325 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138961 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37423 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150399 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/105479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34251 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40704 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40101 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5381 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40246 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->