### PR TITLE
AX: AXObjectCache::handleAttributeChange never actually handles changes to the type attribute due to ARIA early-return

### DIFF
--- a/LayoutTests/accessibility/mac/input-type-change-without-renderer-expected.txt
+++ b/LayoutTests/accessibility/mac/input-type-change-without-renderer-expected.txt
@@ -1,0 +1,9 @@
+This tests that changing the type attribute of a non-rendered input updates its role description.
+
+PASS: roleDescriptionIncludes('telephone') === true
+PASS: roleDescriptionIncludes('email') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/input-type-change-without-renderer.html
+++ b/LayoutTests/accessibility/mac/input-type-change-without-renderer.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<canvas tabindex="-1">
+    <input id="input" type="tel">
+</canvas>
+
+<script>
+var output = "This tests that changing the type attribute of a non-rendered input updates its role description.\n\n";
+
+function roleDescriptionIncludes(substring) {
+    var input = accessibilityController.accessibleElementById("input");
+    return input && input.roleDescription && input.roleDescription.toLowerCase().includes(substring);
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    document.querySelector("canvas").focus();
+
+    setTimeout(async () => {
+        await waitFor(() => roleDescriptionIncludes("telephone"));
+        output += expect("roleDescriptionIncludes('telephone')", "true");
+
+        document.getElementById("input").type = "email";
+        await waitFor(() => roleDescriptionIncludes("email"));
+        output += expect("roleDescriptionIncludes('email')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3630,6 +3630,8 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         postNotification(element, AXNotification::AbbreviationChanged);
     else if (attrName == hiddenAttr)
         postNotification(element, AXNotification::HiddenStateChanged);
+    else if (attrName == typeAttr)
+        handleInputTypeChanged(*element);
 
     if (!attrName.localName().string().startsWith("aria-"_s))
         return;
@@ -3801,8 +3803,6 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     else if (attrName == aria_brailleroledescriptionAttr)
         postNotification(element, AXNotification::BrailleRoleDescriptionChanged);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    else if (attrName == typeAttr)
-        handleInputTypeChanged(*element);
 }
 
 void AXObjectCache::updateCachedTextOfAssociatedObjects(AccessibilityObject& object)


### PR DESCRIPTION
#### 3432c645638dd236512e712205f0a755ee7b87d0
<pre>
AX: AXObjectCache::handleAttributeChange never actually handles changes to the type attribute due to ARIA early-return
<a href="https://bugs.webkit.org/show_bug.cgi?id=315580">https://bugs.webkit.org/show_bug.cgi?id=315580</a>
<a href="https://rdar.apple.com/177966699">rdar://177966699</a>

Reviewed by Chris Fleizach.

For performance, before checking for any ARIA property, AXObjectCache::handleAttributeChange checks
whether the attribute starts with `aria-` and returns early if it does not. Our handling for the `type`
attribute was after this early return, and thus could not have ever been reached.

Fix this and add a test (accessibility/mac/input-type-change-without-renderer.html) that fails without this fix.

* LayoutTests/accessibility/mac/input-type-change-without-renderer-expected.txt: Added.
* LayoutTests/accessibility/mac/input-type-change-without-renderer.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):

Canonical link: <a href="https://commits.webkit.org/314900@main">https://commits.webkit.org/314900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef80f4f796d8f54ca839f68a2d9162bc45e9d939

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176424 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19fef20e-45c4-45a1-875a-88cd3dcc0ba8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130204 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc892eb4-41ed-4802-9a2d-09ca0b8b035e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110721 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b366e81-98ec-4d0f-b7ec-5218864aa213) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31599 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30293 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25163 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178967 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31864 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138594 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37327 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104701 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33738 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26748 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113217 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39533 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4846 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39783 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->