### PR TITLE
Give JIT helper threads QOS_UTILITY on less powerful devices

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -37,6 +37,11 @@
 #include "VMInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
+#if HAVE(QOS_CLASSES)
+#include <wtf/NumberOfCores.h>
+#include <wtf/Threading.h>
+#endif
+
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITWorklist);
@@ -208,6 +213,21 @@ size_t JITWorklist::totalOngoingCompilations(const AbstractLocker&) const
     return total;
 }
 
+bool JITWorklist::shouldUseTieredCompilerThreadQOS() const
+{
+#if HAVE(QOS_CLASSES)
+    if (!Options::useTieredCompilerThreadQOS())
+        return false;
+#if CPU(ARM64)
+    return WTF::numberOfPerformanceProcessorCores() <= static_cast<int>(Options::smallDeviceMaxPerformanceCores());
+#else
+    return WTF::numberOfProcessorCores() <= static_cast<int>(Options::smallDeviceMaxLogicalCores());
+#endif
+#else
+    return false;
+#endif
+}
+
 void JITWorklist::suspendAllThreads() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     m_suspensionLock.lock();
@@ -216,12 +236,28 @@ void JITWorklist::suspendAllThreads() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
         if (!thread->m_rightToRun.tryLock())
             busyThreads.append(thread.copyRef());
     }
+#if HAVE(QOS_CLASSES)
+    m_donatedThreads.clear();
+    if (shouldUseTieredCompilerThreadQOS()) {
+        for (auto& thread : busyThreads) {
+            if (RefPtr<Thread> underlyingThread = thread->m_underlyingThread.get()) {
+                underlyingThread->startQOSOverride(Thread::defaultQOS);
+                m_donatedThreads.append(underlyingThread.releaseNonNull());
+            }
+        }
+    }
+#endif
     for (auto& thread : busyThreads)
         thread->m_rightToRun.lock();
 }
 
 void JITWorklist::resumeAllThreads() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
+#if HAVE(QOS_CLASSES)
+    for (auto& thread : m_donatedThreads)
+        thread->endQOSOverride();
+    m_donatedThreads.clear();
+#endif
     for (auto& thread : m_threads)
         thread->m_rightToRun.unlock();
     m_suspensionLock.unlock();

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -93,6 +93,8 @@ private:
     void wakeThreads(const AbstractLocker&, unsigned enqueuedTier);
     unsigned planLoad(JITPlan&);
 
+    bool shouldUseTieredCompilerThreadQOS() const;
+
     size_t queueLength(const AbstractLocker&) const;
     size_t NODELETE totalOngoingCompilations(const AbstractLocker&) const;
 
@@ -127,6 +129,10 @@ private:
     Vector<Ref<JITPlan>, 16> m_readyPlans;
 
     Lock m_suspensionLock;
+#if HAVE(QOS_CLASSES)
+    // Threads we donated QoS to; overrides ended and cleared in resumeAllThreads(). Guarded by m_suspensionLock.
+    Vector<Ref<Thread>, 8> m_donatedThreads;
+#endif
     Box<Lock> m_lock;
 
     const Ref<AutomaticThreadCondition> m_planEnqueued;

--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -33,6 +33,11 @@
 #include "VM.h"
 #include <wtf/TZoneMallocInlines.h>
 
+#if HAVE(QOS_CLASSES)
+#include <wtf/Scope.h>
+#include <wtf/Threading.h>
+#endif
+
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITWorklistThread);
@@ -142,7 +147,21 @@ auto JITWorklistThread::work() -> WorkResult
         dataLog("Heap is stopped but here we are! (1)\n");
         RELEASE_ASSERT_NOT_REACHED();
     }
-    m_plan->compileInThread(this);
+    {
+#if HAVE(QOS_CLASSES) && !(PLATFORM(MAC) && CPU(ARM64))
+        // Lower QoS for this compile (FTL only by default) so it runs on the E-cores, then restore.
+        // On Apple Silicon Macs the whole thread is lowered in threadDidStart() instead.
+        bool loweredThreadQOS = m_worklist.shouldUseTieredCompilerThreadQOS()
+            && static_cast<unsigned>(m_plan->tier()) >= Options::compilerThreadQOSMinTier();
+        if (loweredThreadQOS)
+            Thread::setCurrentThreadIsUtility();
+        auto restoreThreadQOS = makeScopeExit([&] {
+            if (loweredThreadQOS)
+                Thread::setCurrentThreadQOS(Thread::defaultQOS);
+        });
+#endif
+        m_plan->compileInThread(this);
+    }
     if (m_plan->stage() != JITPlanStage::Canceled) {
         if (m_plan->vm()->heap.worldIsStopped()) {
             dataLog("Heap is stopped but here we are! (2)\n");
@@ -174,6 +193,16 @@ void JITWorklistThread::threadDidStart()
 {
     dataLogLnIf(Options::verboseCompilationQueue(), m_worklist, ": Thread started");
 
+#if HAVE(QOS_CLASSES)
+    {
+        Locker locker { m_worklist.m_suspensionLock };
+        m_underlyingThread = Thread::currentSingleton();
+    }
+#if PLATFORM(MAC) && CPU(ARM64)
+    if (m_worklist.shouldUseTieredCompilerThreadQOS())
+        Thread::setCurrentThreadIsUtility();
+#endif
+#endif
 }
 
 void JITWorklistThread::threadIsStopping(const AbstractLocker&)

--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -31,6 +31,9 @@
 #include <wtf/AutomaticThread.h>
 #include <wtf/Platform.h>
 #include <wtf/SequesteredAutomaticThread.h>
+#if HAVE(QOS_CLASSES)
+#include <wtf/Threading.h>
+#endif
 
 namespace JSC {
 
@@ -73,6 +76,10 @@ private:
     RefPtr<JITPlan> m_plan { nullptr };
     unsigned m_planLoad { 0 };
     Safepoint* m_safepoint { nullptr };
+#if HAVE(QOS_CLASSES)
+    // Weak ref to our WTF::Thread, published under m_worklist.m_suspensionLock for GC QoS donation.
+    ThreadSafeWeakPtr<Thread> m_underlyingThread;
+#endif
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -299,6 +299,10 @@ bool hasCapacityToUseLargeGigacage();
     v(Int32, priorityDeltaOfDFGCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfFTLCompilerThreads, computePriorityDeltaOfWorkerThreads(-2, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfWasmCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
+    v(Bool, useTieredCompilerThreadQOS, true, Normal, "On small devices, run JIT compiles at lowered QoS (E-cores) and donate UserInitiated to a compiler thread the GC is blocked on."_s) \
+    v(Unsigned, compilerThreadQOSMinTier, 2, Normal, "Lowest JITPlan::Tier lowered to reduced QoS (1=DFG+FTL, 2=FTL only); no effect on Apple Silicon Mac, which lowers the whole thread."_s) \
+    v(Unsigned, smallDeviceMaxPerformanceCores, 2, Normal, nullptr) \
+    v(Unsigned, smallDeviceMaxLogicalCores, 6, Normal, nullptr) \
     \
     v(Bool, useProfiler, false, Normal, nullptr) \
     v(Bool, dumpProfilerDataAtExit, false, Normal, nullptr) \

--- a/Source/WTF/wtf/NumberOfCores.cpp
+++ b/Source/WTF/wtf/NumberOfCores.cpp
@@ -104,4 +104,28 @@ int numberOfPhysicalProcessorCores()
 }
 #endif
 
+#if CPU(ARM64) && OS(DARWIN)
+int numberOfPerformanceProcessorCores()
+{
+    static int s_numberOfCores = 0;
+    if (s_numberOfCores > 0)
+        return s_numberOfCores;
+
+    if (CString coresEnv = getenv("WTF_numberOfPerformanceProcessorCores"); !coresEnv.isNull()) {
+        if (auto numberOfCores = parseInteger<unsigned>(coresEnv.span()); numberOfCores && *numberOfCores > 0) {
+            s_numberOfCores = static_cast<int>(*numberOfCores);
+            return s_numberOfCores;
+        }
+        SAFE_FPRINTF(stderr, "WARNING: failed to parse WTF_numberOfPerformanceProcessorCores=%s\n", coresEnv);
+    }
+
+    int32_t count = 0;
+    size_t valueSize = sizeof(count);
+    int result = sysctlbyname("hw.perflevel0.physicalcpu", &count, &valueSize, nullptr, 0);
+    ASSERT(result >= 0 && count > 0);
+    s_numberOfCores = (result < 0 || count <= 0) ? numberOfProcessorCores() : static_cast<int>(count);
+    return s_numberOfCores;
+}
+#endif
+
 }

--- a/Source/WTF/wtf/NumberOfCores.h
+++ b/Source/WTF/wtf/NumberOfCores.h
@@ -32,4 +32,10 @@ WTF_EXPORT_PRIVATE int numberOfProcessorCores();
 WTF_EXPORT_PRIVATE int numberOfPhysicalProcessorCores();
 #endif
 
+#if CPU(ARM64) && OS(DARWIN)
+// Number of performance ("P") cores on Apple silicon ("hw.perflevel0.physicalcpu"), falling back to
+// numberOfProcessorCores() if unavailable. The WTF_numberOfPerformanceProcessorCores env var overrides it.
+WTF_EXPORT_PRIVATE int numberOfPerformanceProcessorCores();
+#endif
+
 }

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -402,6 +402,47 @@ void Thread::setCurrentThreadIsUserInitiated(int relativePriority)
 #endif
 }
 
+void Thread::setCurrentThreadIsUtility(int relativePriority)
+{
+#if HAVE(QOS_CLASSES)
+    ASSERT(relativePriority <= 0);
+    ASSERT(relativePriority >= QOS_MIN_RELATIVE_PRIORITY);
+    pthread_set_qos_class_self_np(adjustedQOSClass(QOS_CLASS_UTILITY), relativePriority);
+#else
+    UNUSED_PARAM(relativePriority);
+#endif
+}
+
+void Thread::setCurrentThreadQOS(QOS qos)
+{
+#if HAVE(QOS_CLASSES)
+    pthread_set_qos_class_self_np(dispatchQOSClass(qos), 0);
+#else
+    UNUSED_PARAM(qos);
+#endif
+}
+
+#if HAVE(QOS_CLASSES)
+void Thread::startQOSOverride(QOS qos)
+{
+    ASSERT(!m_qosOverride);
+    if (m_qosOverride)
+        return;
+    Locker locker { m_mutex };
+    if (hasExited())
+        return;
+    m_qosOverride = pthread_override_qos_class_start_np(m_handle, dispatchQOSClass(qos), 0);
+}
+
+void Thread::endQOSOverride()
+{
+    if (!m_qosOverride)
+        return;
+    pthread_override_qos_class_end_np(m_qosOverride);
+    m_qosOverride = nullptr;
+}
+#endif
+
 #if HAVE(QOS_CLASSES)
 static Thread::QOS NODELETE toQOS(qos_class_t qosClass)
 {

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -66,6 +66,7 @@
 
 #if HAVE(QOS_CLASSES)
 #include <dispatch/dispatch.h>
+#include <pthread/qos.h>
 #endif
 
 // X11 headers define a bunch of macros with common terms, interfering with WebCore and WTF enum values.
@@ -199,6 +200,12 @@ public:
     // relativePriority is a value in the range [-15, 0] where a lower value indicates a lower priority.
     WTF_EXPORT_PRIVATE static void setCurrentThreadIsUserInteractive(int relativePriority = 0);
     WTF_EXPORT_PRIVATE static void setCurrentThreadIsUserInitiated(int relativePriority = 0);
+    WTF_EXPORT_PRIVATE static void setCurrentThreadIsUtility(int relativePriority = 0);
+    WTF_EXPORT_PRIVATE static void setCurrentThreadQOS(QOS);
+#if HAVE(QOS_CLASSES)
+    WTF_EXPORT_PRIVATE void startQOSOverride(QOS);
+    WTF_EXPORT_PRIVATE void endQOSOverride();
+#endif
     WTF_EXPORT_PRIVATE static QOS currentThreadQOS();
     WTF_EXPORT_PRIVATE static bool currentThreadIsRealtime();
     bool isRealtime() const { return m_isRealtime; }
@@ -382,6 +389,9 @@ protected:
     StackBounds m_stack { StackBounds::emptyBounds() };
     ThreadSafeWeakHashSet<ThreadGroup> m_threadGroups;
     PlatformThreadHandle m_handle;
+#if HAVE(QOS_CLASSES)
+    pthread_override_t m_qosOverride { nullptr };
+#endif
     const uint32_t m_uid;
 #if OS(WINDOWS)
     ThreadIdentifier m_id { 0 };


### PR DESCRIPTION
#### bddfc4b694a5ef3a3685578824a15137795749e7
<pre>
Give JIT helper threads QOS_UTILITY on less powerful devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=315203">https://bugs.webkit.org/show_bug.cgi?id=315203</a>
<a href="https://rdar.apple.com/177532305">rdar://177532305</a>

Reviewed by NOBODY (OOPS!).

On devices with only 2 P-cores, JIT worklist threads run at QOS class
UserInitiated, causing P-core contention. Sustained P-cluster
load also pushes less powerful devices into thermal throttling,
causing performance losses.

This change lowers JIT worklist thread priority to QOS::Utility on
small devices, defined as &lt;=2 P-cores or &lt;=6 logical cores. JIT threads
can then run on E-cores and free the P-cluster. This causes regression
on more powerful devices so we keep existing behavior there.

The original version of this change (<a href="https://commits.webkit.org/313672@main">313672@main</a>) was reverted as it
caused JS regression on some mobile devices. To address this, non-Mac
devices now demote per-compilation and only for FTL, restoring the default
QOS once each compile finishes. Lower tiers keep the same QOS.

This patch also adds infrastructure to address priority inversion concerns.
Previously, when the compiler thread held m_rightToRun we could have been
pre-empted indefinitely while GC waits. This is no longer the case as we
boost QOS to Thread::defaultQOS while we are parked such that if a high
priority thread is blocked on m_rightToRun, the holder is at a high enough
QOS status that it is P-core eligible.

There are no user-apparent functional changes associated with this commit so
correctness will be verified with existing tests.

* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::shouldUseTieredCompilerThreadQOS const):
* Source/JavaScriptCore/jit/JITWorklist.h:
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::work):
(JSC::JITWorklistThread::threadDidStart):
* Source/JavaScriptCore/jit/JITWorklistThread.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/NumberOfCores.cpp:
(WTF::numberOfPerformanceProcessorCores):
* Source/WTF/wtf/NumberOfCores.h:
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::setCurrentThreadIsUtility):
(WTF::Thread::setCurrentThreadQOS):
(WTF::Thread::startQOSOverride):
(WTF::Thread::endQOSOverride):
* Source/WTF/wtf/Threading.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bddfc4b694a5ef3a3685578824a15137795749e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42034 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35623 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126178 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42410 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41996 "Hash bddfc4b6 for PR 66797 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131135 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92234 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111646 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32581 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/41996 "Hash bddfc4b6 for PR 66797 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26501 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161096 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142567 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180405 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29724 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139573 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42046 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/41996 "Hash bddfc4b6 for PR 66797 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139434 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42734 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106387 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27783 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201155 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114494 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54026 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40635 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5866 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->