### PR TITLE
Add initial support for file URLs to Web Extensions

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -313,6 +313,16 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
     return Ref { *_webExtensionContext }->setHasAccessToPrivateData(hasAccess);
 }
 
+- (BOOL)_hasAccessToFileURLs
+{
+    return _webExtensionContext->hasAccessToFileURLs();
+}
+
+- (void)_setHasAccessToFileURLs:(BOOL)hasAccess
+{
+    return Ref { *_webExtensionContext }->setHasAccessToFileURLs(hasAccess);
+}
+
 static inline NSSet<WKWebExtensionPermission> *toAPI(const WebKit::WebExtensionContext::PermissionsMap::KeysConstIteratorRange& permissions)
 {
     if (!permissions.size())

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h
@@ -73,6 +73,10 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  */
 - (nullable _WKWebExtensionSidebar *)sidebarForTab:(nullable id <WKWebExtensionTab>)tab NS_SWIFT_NAME(sidebar(for:));
 
+/*! @abstract Whether the extension context has access to file:// URLs.
+ @discussion When YES, the extension can inject content into and interact with file:// pages. Defaults to NO. */
+@property (nonatomic, setter=_setHasAccessToFileURLs:) BOOL _hasAccessToFileURLs;
+
 @end
 
 WK_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
@@ -235,6 +235,9 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> NODELETE matchPatter
     if (options & WKWebExtensionMatchPatternOptionsMatchBidirectionally)
         result.add(WebKit::WebExtensionMatchPattern::Options::MatchBidirectionally);
 
+    if (options & WKWebExtensionMatchPatternOptionsAllowFileScheme)
+        result.add(WebKit::WebExtensionMatchPattern::Options::AllowFileScheme);
+
     return result;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternPrivate.h
@@ -23,7 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKit/WKFoundation.h>
 #import <WebKit/WKWebExtensionMatchPattern.h>
+
+static const WKWebExtensionMatchPatternOptions WKWebExtensionMatchPatternOptionsAllowFileScheme WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) = 1 << 3;
 
 @interface WKWebExtensionMatchPattern ()
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -728,9 +728,13 @@ void WebExtensionController::updateWebsitePoliciesForNavigation(API::WebsitePoli
         if (!context->hasPermission(WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess))
             continue;
 
+        OptionSet<WebExtensionMatchPattern::Options> expandOptions;
+        if (context->hasAccessToFileURLs())
+            expandOptions.add(WebExtensionMatchPattern::Options::AllowFileScheme);
+
         Vector<String> patterns;
         for (Ref pattern : context->currentPermissionMatchPatterns())
-            patterns.appendVector(pattern->expandedStrings());
+            patterns.appendVector(pattern->expandedStrings(expandOptions));
 
         actionPatterns.set(context->uniqueIdentifier(), WTF::move(patterns));
     }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -255,6 +255,26 @@ void WebExtensionContext::setHasAccessToPrivateData(bool hasAccess)
     }
 }
 
+void WebExtensionContext::setHasAccessToFileURLs(bool hasAccess)
+{
+    if (m_hasAccessToFileURLs == hasAccess)
+        return;
+
+    m_hasAccessToFileURLs = hasAccess;
+
+    if (!safeToInjectContent())
+        return;
+
+    if (m_hasAccessToFileURLs && hasAccessToAllHosts()) {
+        auto filePattern = WebExtensionMatchPattern::getOrCreate("file"_s, "*"_s, "/*"_s);
+        if (filePattern)
+            addInjectedContent(injectedContents(), *filePattern);
+    } else {
+        removeInjectedContent();
+        addInjectedContent();
+    }
+}
+
 const WebExtensionContext::PermissionsMap& WebExtensionContext::grantedPermissions()
 {
     return removeExpired(m_grantedPermissions, m_nextGrantedPermissionsExpirationDate, PermissionNotification::GrantedPermissionsWereRemoved);
@@ -854,6 +874,9 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     if (!WebExtensionMatchPattern::validSchemes().contains(url.protocol().toStringWithoutCopying()))
         return PermissionState::Unknown;
 
+    if (url.protocolIsFile() && !m_hasAccessToFileURLs)
+        return PermissionState::Unknown;
+
     if (tab) {
         auto temporaryPattern = tab->temporaryPermissionMatchPattern();
         if (temporaryPattern && temporaryPattern->matchesURL(url))
@@ -901,10 +924,14 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
 
     // First, check for patterns that are specific to certain domains, ignoring wildcard host patterns that
     // match all hosts. The order is denied, then granted. This makes sure denied takes precedence over granted.
+    OptionSet<WebExtensionMatchPattern::Options> fileOptions;
+    if (m_hasAccessToFileURLs)
+        fileOptions.add(WebExtensionMatchPattern::Options::AllowFileScheme);
+
     auto urlMatchesPatternIgnoringWildcardHostPatterns = [&](WebExtensionMatchPattern& pattern) {
         if (pattern.matchesAllHosts())
             return false;
-        return pattern.matchesURL(url);
+        return pattern.matchesURL(url, fileOptions);
     };
 
     for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
@@ -923,7 +950,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     auto urlMatchesWildcardHostPatterns = [&](WebExtensionMatchPattern& pattern) {
         if (!pattern.matchesAllHosts())
             return false;
-        return pattern.matchesURL(url);
+        return pattern.matchesURL(url, fileOptions);
     };
 
     for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
@@ -979,6 +1006,9 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     if (!pattern.matchesAllURLs() && !WebExtensionMatchPattern::validSchemes().contains(pattern.scheme()))
         return PermissionState::Unknown;
 
+    if (!pattern.matchesAllURLs() && pattern.scheme() == "file"_s && !m_hasAccessToFileURLs)
+        return PermissionState::Unknown;
+
     if (tab) {
         auto temporaryPattern = tab->temporaryPermissionMatchPattern();
         if (temporaryPattern && temporaryPattern->matchesPattern(pattern))
@@ -992,10 +1022,14 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     // First, check for patterns that are specific to certain domains, ignoring wildcard host patterns that
     // match all hosts. The order is denied, then granted. This makes sure denied takes precedence over granted.
 
+    auto fileOptions = m_hasAccessToFileURLs
+        ? OptionSet<WebExtensionMatchPattern::Options> { WebExtensionMatchPattern::Options::AllowFileScheme }
+        : OptionSet<WebExtensionMatchPattern::Options> { };
+
     auto urlMatchesPatternIgnoringWildcardHostPatterns = [&](WebExtensionMatchPattern& otherPattern) {
         if (pattern.matchesAllHosts())
             return false;
-        return pattern.matchesPattern(otherPattern);
+        return pattern.matchesPattern(otherPattern, fileOptions);
     };
 
     for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
@@ -1015,7 +1049,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     auto urlMatchesWildcardHostPatterns = [&](WebExtensionMatchPattern& otherPattern) {
         if (!pattern.matchesAllHosts())
             return false;
-        return pattern.matchesPattern(otherPattern);
+        return pattern.matchesPattern(otherPattern, fileOptions);
     };
 
     for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
@@ -1189,6 +1223,11 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
     // This avoids duplicate injected content if individual hosts are granted in addition to "all hosts".
     if (hasAccessToAllHosts()) {
         addInjectedContent(injectedContents, WebExtensionMatchPattern::allHostsAndSchemesMatchPattern());
+        if (m_hasAccessToFileURLs) {
+            auto filePattern = WebExtensionMatchPattern::getOrCreate("file"_s, "*"_s, "/*"_s);
+            if (filePattern)
+                addInjectedContent(injectedContents, *filePattern);
+        }
         return;
     }
 
@@ -1269,6 +1308,10 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
     if (!safeToInjectContent())
         return;
 
+    OptionSet<WebExtensionMatchPattern::Options> expandOptions;
+    if (m_hasAccessToFileURLs)
+        expandOptions.add(WebExtensionMatchPattern::Options::AllowFileScheme);
+
     auto scriptAddResult = m_injectedScriptsPerPatternMap.ensure(pattern, [&] {
         return UserScriptVector { };
     });
@@ -1295,7 +1338,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
         if (!pattern.matchesPattern(deniedMatchPattern, { WebExtensionMatchPattern::Options::IgnorePaths, WebExtensionMatchPattern::Options::MatchBidirectionally }))
             continue;
 
-        for (const auto& deniedMatchPatternString : deniedMatchPattern->expandedStrings())
+        for (const auto& deniedMatchPatternString : deniedMatchPattern->expandedStrings(expandOptions))
             baseExcludeMatchPatternsSet.add(deniedMatchPatternString);
     }
 
@@ -1315,7 +1358,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
                 if (!restrictedPattern)
                     continue;
 
-                for (const auto& restrictedPattern : restrictedPattern->expandedStrings())
+                for (const auto& restrictedPattern : restrictedPattern->expandedStrings(expandOptions))
                     includeMatchPatternsSet.add(restrictedPattern);
                 continue;
             }
@@ -1335,7 +1378,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
             if (!restrictedPattern)
                 continue;
 
-            for (const auto& restrictedPattern : restrictedPattern->expandedStrings())
+            for (const auto& restrictedPattern : restrictedPattern->expandedStrings(expandOptions))
                 includeMatchPatternsSet.add(restrictedPattern);
         }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -414,6 +414,9 @@ public:
     bool hasAccessToPrivateData() const { return m_hasAccessToPrivateData; }
     void setHasAccessToPrivateData(bool);
 
+    bool hasAccessToFileURLs() const { return m_hasAccessToFileURLs; }
+    void setHasAccessToFileURLs(bool);
+
     void grantPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
     void denyPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
 
@@ -1074,6 +1077,7 @@ private:
 
     bool m_requestedOptionalAccessToAllHosts { false };
     bool m_hasAccessToPrivateData { false };
+    bool m_hasAccessToFileURLs { false };
 
     VoidFunctionVector m_actionsToPerformAfterBackgroundContentLoads;
     EventListenerTypeCountedSet m_backgroundContentEventListeners;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
@@ -284,7 +284,7 @@ WebExtensionMatchPattern::WebExtensionMatchPattern(const String& scheme, const S
 
 bool WebExtensionMatchPattern::isSupported() const
 {
-    return isValid() && (m_matchesAllURLs || supportedSchemes().contains(scheme()));
+    return isValid() && (m_matchesAllURLs || supportedSchemes().contains(scheme()) || scheme() == "file"_s);
 }
 
 bool WebExtensionMatchPattern::operator==(const WebExtensionMatchPattern& other) const
@@ -334,17 +334,22 @@ String WebExtensionMatchPattern::stringWithScheme(const String& differentScheme)
     return makeString(differentScheme.isEmpty() ? scheme() : differentScheme, "://"_s, host(), path());
 }
 
-Vector<String> WebExtensionMatchPattern::expandedStrings() const
+Vector<String> WebExtensionMatchPattern::expandedStrings(OptionSet<Options> options) const
 {
     if (!isValid())
         return { };
 
     if (m_matchesAllURLs) {
-        return compactMap(supportedSchemes(), [&](auto& scheme) -> std::optional<String> {
+        auto strings = compactMap(supportedSchemes(), [&](auto& scheme) -> std::optional<String> {
             if (scheme == "*"_s)
                 return std::nullopt;
             return makeString(scheme, "://*/*"_s);
         });
+
+        if (options.contains(Options::AllowFileScheme))
+            strings.append("file://*/*"_s);
+
+        return strings;
     }
 
     return { string() };
@@ -367,8 +372,11 @@ bool WebExtensionMatchPattern::matchesURL(const URL& urlToMatch, OptionSet<Optio
     if (!isValid() || !urlToMatch.isValid())
         return false;
 
-    if (m_matchesAllURLs)
+    if (m_matchesAllURLs) {
+        if (urlToMatch.protocolIsFile())
+            return options.contains(Options::AllowFileScheme);
         return supportedSchemes().contains(urlToMatch.protocol().toString());
+    }
 
     if (!options.contains(Options::IgnoreSchemes) && !pattern().matchesScheme(urlToMatch))
         return false;
@@ -390,8 +398,12 @@ bool WebExtensionMatchPattern::matchesPattern(const WebExtensionMatchPattern& pa
     if (*this == patternToMatch)
         return true;
 
-    auto compareAllURLs = [](const WebExtensionMatchPattern& a, const WebExtensionMatchPattern& b) {
-        return a.matchesAllURLs() && (b.matchesAllURLs() || supportedSchemes().contains(b.scheme()));
+    auto compareAllURLs = [&options](const WebExtensionMatchPattern& a, const WebExtensionMatchPattern& b) {
+        if (!a.matchesAllURLs())
+            return false;
+        if (b.matchesAllURLs() || supportedSchemes().contains(b.scheme()))
+            return true;
+        return options.contains(Options::AllowFileScheme) && b.scheme() == "file"_s;
     };
 
     if (compareAllURLs(*this, patternToMatch))

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -68,6 +68,7 @@ public:
         IgnoreSchemes        = 1 << 0, // Ignore the scheme component when matching.
         IgnorePaths          = 1 << 1, // Ignore the path component when matching.
         MatchBidirectionally = 1 << 2, // Match two patterns in either direction (A matches B, or B matches A). Invalid for matching URLs.
+        AllowFileScheme      = 1 << 3, // Allow file:// to be considered a match for <all_urls>. The scheme wildcard `*` still does not match file://, matching Chrome and Firefox behavior.
     };
 
     enum class CreateOptions : uint8_t {
@@ -116,7 +117,7 @@ public:
     bool matchesPattern(const WebExtensionMatchPattern&, OptionSet<Options> = { }) const;
 
     String string() const { return stringWithScheme(nullString()); }
-    Vector<String> expandedStrings() const;
+    Vector<String> expandedStrings(OptionSet<Options> = { }) const;
 
     const WebCore::UserContentURLPattern& pattern() const LIFETIME_BOUND { return m_pattern; }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm
@@ -831,10 +831,12 @@ TEST(WKWebExtensionAPIPermissions, ValidMatchPatterns)
         @"await browser.test.assertSafeResolve(() => browser.permissions.contains({ origins: [ 'test-extension://*/*' ] }))",
         @"await browser.test.assertSafeResolve(() => browser.permissions.contains({ origins: [ 'other-extension://*/*' ] }))",
 
+        // File Scheme (recognized but not granted by default)
+        @"await browser.test.assertSafeResolve(() => browser.permissions.contains({ origins: [ 'file:///*' ] }))",
+
         // Invalid Schemes
         @"await browser.test.assertThrows(() => browser.permissions.contains({ origins: [ 'ftp://*.example.com/*' ] }), /not a valid pattern/)",
         @"await browser.test.assertThrows(() => browser.permissions.contains({ origins: [ 'data:*' ] }), /not a valid pattern/)",
-        @"await browser.test.assertThrows(() => browser.permissions.contains({ origins: [ 'file:///*' ] }), /not a valid pattern/)",
         @"await browser.test.assertThrows(() => browser.permissions.contains({ origins: [ 'chrome-extension://*/*' ] }), /not a valid pattern/)",
 
         // Finish
@@ -1341,6 +1343,88 @@ TEST(WKWebExtensionAPIPermissions, CORSFailureFromPageDoesNotPromptExtension)
     [manager run];
 
     EXPECT_EQ(promptCount, 0ul);
+}
+
+TEST(WKWebExtensionAPIPermissions, HasAccessToFileURLsDefaultsToNo)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"host_permissions": @[ @"<all_urls>" ]
+    };
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": @"" });
+    EXPECT_FALSE(manager.get().context._hasAccessToFileURLs);
+}
+
+TEST(WKWebExtensionAPIPermissions, FileURLPermissionGatedByFlag)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"host_permissions": @[ @"<all_urls>" ]
+    };
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": @"" });
+
+    auto *allURLs = [WKWebExtensionMatchPattern allURLsMatchPattern];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:allURLs];
+
+    NSURL *fileURL = [NSURL URLWithString:@"file:///foo/bar.html"];
+    NSURL *httpURL = [NSURL URLWithString:@"http://example.com/foo/bar.html"];
+
+    // Flag off: file URL hits the early-out gate even though <all_urls> is granted.
+    EXPECT_EQ([manager.get().context permissionStatusForURL:fileURL], WKWebExtensionContextPermissionStatusUnknown);
+    // <all_urls> is a wildcard host pattern, so non-file URLs come back as GrantedImplicitly.
+    EXPECT_EQ([manager.get().context permissionStatusForURL:httpURL], WKWebExtensionContextPermissionStatusGrantedImplicitly);
+
+    // Flag on: <all_urls> now covers file:// URLs too.
+    manager.get().context._hasAccessToFileURLs = YES;
+    EXPECT_EQ([manager.get().context permissionStatusForURL:fileURL], WKWebExtensionContextPermissionStatusGrantedImplicitly);
+
+    // Flipping the flag back off restores the gate.
+    manager.get().context._hasAccessToFileURLs = NO;
+    EXPECT_EQ([manager.get().context permissionStatusForURL:fileURL], WKWebExtensionContextPermissionStatusUnknown);
+}
+
+TEST(WKWebExtensionAPIPermissions, FilePatternPermissionGatedByFlag)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"host_permissions": @[ @"file:///*" ]
+    };
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": @"" });
+
+    auto *filePattern = [WKWebExtensionMatchPattern matchPatternWithString:@"file:///*"];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:filePattern];
+
+    // Flag off: querying the file pattern returns Unknown via the pattern early-out gate.
+    EXPECT_EQ([manager.get().context permissionStatusForMatchPattern:filePattern], WKWebExtensionContextPermissionStatusUnknown);
+
+    // Flag on: explicit grant of the same pattern resolves to GrantedExplicitly.
+    manager.get().context._hasAccessToFileURLs = YES;
+    EXPECT_EQ([manager.get().context permissionStatusForMatchPattern:filePattern], WKWebExtensionContextPermissionStatusGrantedExplicitly);
+}
+
+TEST(WKWebExtensionAPIPermissions, GrantingFilePatternRequiresFlag)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"host_permissions": @[ @"file:///*" ]
+    };
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": @"" });
+
+    auto *filePattern = [WKWebExtensionMatchPattern matchPatternWithString:@"file:///*"];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:filePattern];
+
+    NSURL *fileURL = [NSURL URLWithString:@"file:///foo/bar.html"];
+
+    // Even with file:///* granted explicitly, the URL early-out gate still blocks file URLs.
+    EXPECT_EQ([manager.get().context permissionStatusForURL:fileURL], WKWebExtensionContextPermissionStatusUnknown);
+
+    // file:///* is a specific (non-wildcard-host) pattern, so it resolves to GrantedExplicitly with the flag on.
+    manager.get().context._hasAccessToFileURLs = YES;
+    EXPECT_EQ([manager.get().context permissionStatusForURL:fileURL], WKWebExtensionContextPermissionStatusGrantedExplicitly);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionMatchPattern.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionMatchPattern.mm
@@ -406,6 +406,40 @@ TEST(WKWebExtensionMatchPattern, MatchPatternMatchesURL)
     EXPECT_FALSE([toPattern(@"*://*/foo|bar*") matchesURL:[NSURL URLWithString:@"https://example.com/foo"]]);
 }
 
+TEST(WKWebExtensionMatchPattern, AllowFileSchemeOption)
+{
+    constexpr auto kAllowFile = WKWebExtensionMatchPatternOptionsAllowFileScheme;
+    NSURL *fileURL = [NSURL URLWithString:@"file:///foo/bar.html"];
+    NSURL *httpURL = [NSURL URLWithString:@"http://example.com/foo/bar.html"];
+
+    // <all_urls> default: does not match file:// (also covered by MatchPatternMatchesURL).
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesURL:fileURL]);
+
+    // <all_urls> with the option: matches file://.
+    EXPECT_TRUE([toPattern(@"<all_urls>") matchesURL:fileURL options:kAllowFile]);
+
+    // <all_urls> with the option still matches non-file URLs.
+    EXPECT_TRUE([toPattern(@"<all_urls>") matchesURL:httpURL options:kAllowFile]);
+
+    // *://*/* must NOT match file:// even with the option (Chrome and Firefox parity).
+    EXPECT_FALSE([toPattern(@"*://*/*") matchesURL:fileURL]);
+    EXPECT_FALSE([toPattern(@"*://*/*") matchesURL:fileURL options:kAllowFile]);
+
+    // Explicit file pattern matches file:// without the option.
+    EXPECT_TRUE([toPattern(@"file:///*") matchesURL:fileURL]);
+    EXPECT_FALSE([toPattern(@"file:///*") matchesURL:httpURL]);
+
+    // Pattern-vs-pattern: <all_urls> covers file:///* only with the option.
+    EXPECT_FALSE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"file:///*")]);
+    EXPECT_TRUE([toPattern(@"<all_urls>") matchesPattern:toPattern(@"file:///*") options:kAllowFile]);
+
+    // *://*/* does not cover file:///* even with the option.
+    EXPECT_FALSE([toPattern(@"*://*/*") matchesPattern:toPattern(@"file:///*") options:kAllowFile]);
+
+    // file:///* covers more specific file patterns (no option needed).
+    EXPECT_TRUE([toPattern(@"file:///*") matchesPattern:toPattern(@"file:///foo/bar.html")]);
+}
+
 TEST(WKWebExtensionMatchPattern, PatternDescriptions)
 {
     EXPECT_NS_EQUAL(toPattern(@"<all_urls>").description, @"<all_urls>");


### PR DESCRIPTION
#### 51ea20f9818ed956dee01fc46a8b36dfcb94797c
<pre>
Add initial support for file URLs to Web Extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=316682">https://bugs.webkit.org/show_bug.cgi?id=316682</a>
<a href="https://rdar.apple.com/179135449">rdar://179135449</a>

Reviewed by Timothy Hatcher.

This patch adds initial support for file URLs for Web Extensions.
This is added as an internal, opt-in, _hasAccessToFileURLs property
on WKWebExtensionContext. When enabled, the extension can run on file:// pages,
and &lt;all_urls&gt; host grants extent to local file URLs. This property defaults to NO.

The tests added covers the behavior of the new options at the
web extension context level as well as WKWebExtensionMatchPattern level.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext _hasAccessToFileURLs]):
(-[WKWebExtensionContext _setHasAccessToFileURLs:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextPrivate.h:

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm:
(matchPatternOptionsToImpl):

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::updateWebsitePoliciesForNavigation):

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::setHasAccessToFileURLs):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::addInjectedContent):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::hasAccessToFileURLs const):

* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp:
(WebKit::WebExtensionMatchPattern::isSupported const):
(WebKit::WebExtensionMatchPattern::expandedStrings const):
(WebKit::WebExtensionMatchPattern::matchesURL const):
(WebKit::WebExtensionMatchPattern::matchesPattern const):

* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
(WebKit::WebExtensionMatchPattern::expandedStrings):

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, ValidMatchPatterns)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, HasAccessToFileURLsDefaultsToNo)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, FileURLPermissionGatedByFlag)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, FilePatternPermissionGatedByFlag)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, GrantingFilePatternRequiresFlag)):

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionMatchPattern.mm:
(TestWebKitAPI::TEST(WKWebExtensionMatchPattern, AllowFileSchemeOption)):

Canonical link: <a href="https://commits.webkit.org/315548@main">https://commits.webkit.org/315548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2947cdb13132f4867b4d1bc57f73919b1eff9f7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131836 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172226 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112340 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31981 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27323 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181223 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140293 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42845 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140132 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43534 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28572 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107465 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25807 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35405 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115299 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42044 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6662 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->