### PR TITLE
AX: Recent Events table on https://parks.wa.gov is reported as empty by VoiceOver but works fine in other browsers

### DIFF
--- a/LayoutTests/accessibility/aria-grid-with-presentational-sections-expected.txt
+++ b/LayoutTests/accessibility/aria-grid-with-presentational-sections-expected.txt
@@ -1,0 +1,17 @@
+This test ensures an ARIA grid built from native table sections whose rows are wrapped in presentational scaffolding exposes its rows and cells.
+
+PASS: grid.role.toLowerCase().includes('table') === true
+PASS: grid.rowCount === 2
+PASS: grid.columnCount === 3
+#grid cellForColumnAndRow(0, 0).domIdentifier is sun
+#grid cellForColumnAndRow(1, 0).domIdentifier is mon
+#grid cellForColumnAndRow(2, 0).domIdentifier is tue
+#grid cellForColumnAndRow(0, 1).domIdentifier is day1
+#grid cellForColumnAndRow(1, 1).domIdentifier is day2
+#grid cellForColumnAndRow(2, 1).domIdentifier is day3
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Sun	Mon	Tue
+1	2	3

--- a/LayoutTests/accessibility/aria-grid-with-presentational-sections.html
+++ b/LayoutTests/accessibility/aria-grid-with-presentational-sections.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- A role="grid" on a native <table> whose native rowgroups (thead/tbody) contain only
+     presentational rows, with the real role="row" rows wrapped in a nested presentational
+     <table>. This is the structure the FullCalendar JS library generates. -->
+<table role="grid" id="grid">
+    <thead role="rowgroup">
+        <tr role="presentation">
+            <th role="presentation">
+                <table role="presentation">
+                    <thead role="presentation">
+                        <tr role="row">
+                            <th role="columnheader" id="sun">Sun</th>
+                            <th role="columnheader" id="mon">Mon</th>
+                            <th role="columnheader" id="tue">Tue</th>
+                        </tr>
+                    </thead>
+                </table>
+            </th>
+        </tr>
+    </thead>
+    <tbody role="rowgroup">
+        <tr role="presentation">
+            <td role="presentation">
+                <table role="presentation">
+                    <tbody role="presentation">
+                        <tr role="row">
+                            <td role="gridcell" id="day1">1</td>
+                            <td role="gridcell" id="day2">2</td>
+                            <td role="gridcell" id="day3">3</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+<script>
+var output = "This test ensures an ARIA grid built from native table sections whose rows are wrapped in presentational scaffolding exposes its rows and cells.\n\n";
+
+if (window.accessibilityController) {
+    var grid = accessibilityController.accessibleElementById("grid");
+    output += expect("grid.role.toLowerCase().includes('table')", "true");
+    output += expect("grid.rowCount", "2");
+    output += expect("grid.columnCount", "3");
+    output += dumpAXTable(grid);
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2563,13 +2563,21 @@ unsigned AccessibilityNodeObject::computeCellSlots()
 
         // Step 2: For each tr element that is a child of the element being processed,
         // in tree order, run the algorithm for processing rows.
-        if (RefPtr tableSection = dynamicDowncast<HTMLTableSectionElement>(sectionElement)) {
+        RefPtr tableSection = dynamicDowncast<HTMLTableSectionElement>(sectionElement);
+        if (tableSection && !protectedThis->isAriaTable()) {
+            // For native (non-ARIA) tables, the rows are the direct tr children of this section, so
+            // iterate them directly. We deliberately exclude ARIA tables (grid, treegrid, table) here:
+            // their real role="row" rows may be wrapped in presentational scaffolding rather than being
+            // direct tr children, e.g. a presentational tr holding a nested presentational table that
+            // contains the rows (as the FullCalendar JS library produces). Excluding them lets such
+            // tables fall through to the accessibility-tree descent below, which finds rows through
+            // that scaffolding.
             for (Ref row : childrenOfType<HTMLTableRowElement>(*tableSection)) {
                 if (RefPtr tableRow = cache->getOrCreate(row.get()); tableRow && tableRow->isTableRow())
                     processRow(dynamicDowncast<AccessibilityRenderObject>(tableRow).get());
             }
         } else if (RefPtr sectionAxObject = cache->getOrCreate(sectionElement)) {
-            ASSERT_WITH_MESSAGE(hasRole(sectionElement, "rowgroup"_s), "processRowGroup should only be called with native table section elements, or role=rowgroup elements");
+            ASSERT_WITH_MESSAGE(is<HTMLTableSectionElement>(sectionElement) || hasRole(sectionElement, "rowgroup"_s), "processRowGroup should only be called with native table section elements, or role=rowgroup elements");
             for (const auto& child : sectionAxObject->unignoredChildren())
                 processRowDescendingIfNeeded(child.get());
         }


### PR DESCRIPTION
#### 320c6e56b4dfe6e7b5a59864d1ca1399c83bb60f
<pre>
AX: Recent Events table on <a href="https://parks.wa.gov">https://parks.wa.gov</a> is reported as empty by VoiceOver but works fine in other browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=316702">https://bugs.webkit.org/show_bug.cgi?id=316702</a>
<a href="https://rdar.apple.com/179156593">rdar://179156593</a>

Reviewed by Chris Fleizach.

When a native &lt;table role=&quot;grid&quot;&gt; uses native &lt;thead&gt;/&lt;tbody&gt; rowgroups whose
direct &lt;tr&gt; children are role=&quot;presentation&quot;, with the real role=&quot;row&quot; rows
wrapped in a nested presentational &lt;table&gt;, VoiceOver would report the grid
as empty. This is the structure the FullCalendar JS library generates.

This happened because AccessibilityNodeObject::computeCellSlots()&apos;s processRowGroup
had two strategies:

  1. A strict path that only iterates a native section&apos;s direct &lt;tr&gt; children
  2. A forgiving path that descends the accessibility tree (flattening presentational
     scaffolding) for role=&quot;rowgroup&quot; elements. Native elements always took the strict
     path, so presentational &lt;tr&gt; rows were skipped and the real nested rows were never
     found.

With this commit, we route ARIA tables (grid, treegrid, table) through the descent path
even when the rowgroup is a native element, consistent with the forgiving ARIA-grid handling in
processTableDescendant. Native (non-ARIA) data tables keep the strict path.

* LayoutTests/accessibility/aria-grid-with-presentational-sections-expected.txt: Added.
* LayoutTests/accessibility/aria-grid-with-presentational-sections.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::computeCellSlots):

Canonical link: <a href="https://commits.webkit.org/314901@main">https://commits.webkit.org/314901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a909968920eb0bf9a691581bdf6b6396138e274c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176452 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110743 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30316 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25191 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178996 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31892 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138623 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37328 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104735 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33763 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26775 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113245 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39561 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4873 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39811 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39706 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->