### PR TITLE
[Site Isolation] BFCache restore broken for back-navigation through a data: URL

### DIFF
--- a/LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames.html
+++ b/LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames.html
@@ -1,11 +1,11 @@
-<!-- webkit-test-runner [ SiteIsolationEnabled=true MultiProcessBackForwardCacheEnabled=true ] -->
+<!-- webkit-test-runner [ SiteIsolationEnabled=true MultiProcessBackForwardCacheEnabled=true UsesBackForwardCache=true ] -->
 <!DOCTYPE html>
 <head>
 <script src="../../../resources/js-test-pre.js"></script>
 <meta http-equiv="pragma" content="no-cache">
 <meta http-equiv="cache-control" content="no-cache">
 </head>
-<body onload="startTest()">
+<body onpageshow="startTest()">
 <input name="name1" id="input1">
 <iframe id="frame1" src="../resources/form-state-restore-with-frames-1.html">
 </iframe>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -24,15 +24,12 @@ imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-ope
 #######################
 # Tests that time out #
 #######################
-fast/dom/Window/timer-resume-on-navigation-back.html [ Timeout ]
 fast/events/pageshow-pagehide-on-back-cached-with-frames.html [ Timeout ]
 fast/events/pageshow-pagehide-on-back-cached.html [ Timeout ]
 fast/history/back-from-page-with-focused-iframe.html [ Timeout ]
 fast/history/go-back-to-object-subframe.html [ Timeout ]
 fast/history/page-cache-element-state-focused.html [ Timeout ]
-fast/scrolling/iframe-scrollable-after-back.html [ Timeout ]
 fast/scrolling/overflow-scrollable-after-back.html [ Timeout ]
-fast/scrolling/page-cache-back-overflow-scroll-restore.html [ Timeout ]
 fullscreen/exit-full-screen-video-crash.html [ Timeout ]
 http/tests/inspector/dom/cross-domain-inspected-node-access.html [ Timeout ]
 http/tests/local/blob/download-blob-from-iframe.html [ Timeout ]
@@ -47,7 +44,6 @@ fast/loader/stateobjects/pushstate-in-iframe.html [ Timeout ]
 http/tests/navigation/cross-site-iframe-nav-with-bfcache.html [ Timeout ]
 http/tests/navigation/forward-and-cancel.html [ Timeout ]
 http/tests/navigation-api/different-origin-entries-removed-after-bfcache.html [ Failure Timeout ]
-webanimations/animation-page-cache.html [ Timeout ]
 
 ########################
 # Tests that Text fail #

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2172,7 +2172,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
         return completionHandler(sourceProcess.copyRef(), nullptr, "Navigation is treated as same-site (archive load)"_s);
     }
 
-    if (siteIsolationEnabled && !site.isEmpty()) {
+    if (siteIsolationEnabled) {
         if (RefPtr targetItem = navigation.targetItem(); targetItem && frame.isMainFrame()) {
             if (RefPtr suspendedPage = targetItem->suspendedPage()) {
                 Ref process = suspendedPage->process();
@@ -2186,7 +2186,9 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
                 }
             }
         }
+    }
 
+    if (siteIsolationEnabled && !site.isEmpty()) {
         ASSERT(frameInfo.isMainFrame ? site == mainFrameSite : Site(URL(protect(page.pageLoadState())->activeURL())) == mainFrameSite);
         if (!frame.isMainFrame() && site == mainFrameSite) {
             Ref mainFrameProcess = Ref { page.mainFrame()->process() };
@@ -2371,11 +2373,13 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
             return { createNewProcess(), nullptr, "Process swap because this is a first navigation in a DOM popup without opener"_s };
     }
 
-    const bool treatAsSameOriginNavigation = [&targetURL, &navigation, &siteIsolationEnabled] {
-        if (siteIsolationEnabled
-            && targetURL.protocolIsAbout()
-            && !SecurityPolicy::shouldInheritSecurityOriginFromOwner(targetURL))
-            return false;
+    const bool treatAsSameOriginNavigation = [&targetURL, &navigation, &siteIsolationEnabled, &frame] {
+        if (siteIsolationEnabled) {
+            if (targetURL.protocolIsAbout() && !SecurityPolicy::shouldInheritSecurityOriginFromOwner(targetURL))
+                return false;
+            if (frame.isMainFrame() && targetURL.protocolIsData())
+                return false;
+        }
 
         return navigation.treatAsSameOriginNavigation();
     }();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9258,6 +9258,102 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithCrossSiteIframeMultipleCycles
     }
 }
 
+// Cross-site navigation A → data: URL, then back to A. Without the SI carve-out in
+// WebProcessPool::processForNavigationInternal, data: URLs are treated as same-origin
+// (NavigationAction::shouldTreatAsSameOriginNavigation hard-codes that), so no swap,
+// no SuspendedPageProxy, and goBack falls through to a fresh load.
+TEST(SiteIsolation, MultiProcessBFCacheCrossSiteToDataURL)
+{
+    HTTPServer server({
+        { "/a"_s, { "page a"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    [configuration _setAllowTopNavigationToDataURLs:YES];
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker = true"];
+
+    [webView evaluateJavaScript:@"window.location.href = \"data:text/html,<body>data url</body>\"" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_WK_STREQ(@"https://a.com/a", [webView URL].absoluteString);
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false"] boolValue]);
+}
+
+// Multiple sequential data: URL navigations: A -> data:1 -> data:2 -> back -> back.
+// Each cross-origin navigation lands on an empty-Site target, so each step exercises
+// the relaxed (non-isEmpty) suspended-page lookup. Both back-navigations must restore
+// from the correct SuspendedPageProxy.
+TEST(SiteIsolation, MultiProcessBFCacheCrossSiteToMultipleDataURLs)
+{
+    HTTPServer server({
+        { "/a"_s, { "page a"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    [configuration _setAllowTopNavigationToDataURLs:YES];
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView objectByEvaluatingJavaScript:@"window.__marker = 'A'"];
+
+    [webView evaluateJavaScript:@"window.location.href = \"data:text/html,<body>data1</body><script>window.__marker='D1'</script>\"" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"D1", [webView objectByEvaluatingJavaScript:@"window.__marker"]);
+
+    [webView evaluateJavaScript:@"window.location.href = \"data:text/html,<body>data2</body><script>window.__marker='D2'</script>\"" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"D2", [webView objectByEvaluatingJavaScript:@"window.__marker"]);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_TRUE([[webView URL].absoluteString hasPrefix:@"data:text/html,"]);
+    EXPECT_WK_STREQ(@"D1", [webView objectByEvaluatingJavaScript:@"window.__marker"]);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"https://a.com/a", [webView URL].absoluteString);
+    EXPECT_WK_STREQ(@"A", [webView objectByEvaluatingJavaScript:@"window.__marker"]);
+}
+
+// Cross-origin navigation through a string-returning javascript: URL. Top-level
+// navigation to javascript: replaces the document content but does not change the
+// URL or create a back-forward entry; verify that the carve-out (keyed on
+// protocolIsData()) does not accidentally process-swap for this scheme.
+TEST(SiteIsolation, MultiProcessBFCacheCrossSiteToJavaScriptURL)
+{
+    HTTPServer server({
+        { "/a"_s, { "page a"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    [configuration _setAllowTopNavigationToDataURLs:YES];
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    NSUInteger bfListBefore = [[[webView backForwardList] backList] count];
+    pid_t pidBefore = [webView _webProcessIdentifier];
+
+    __block bool jsRan = false;
+    [webView evaluateJavaScript:@"window.location.href = \"javascript:'<body>js url</body>'\"" completionHandler:^(id, NSError *) {
+        jsRan = true;
+    }];
+    TestWebKitAPI::Util::run(&jsRan);
+    TestWebKitAPI::Util::spinRunLoop(10);
+
+    EXPECT_WK_STREQ(@"https://a.com/a", [webView URL].absoluteString);
+    EXPECT_EQ(bfListBefore, [[[webView backForwardList] backList] count]);
+    EXPECT_EQ(pidBefore, [webView _webProcessIdentifier]);
+}
+
 TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithDifferentCrossSiteIframes)
 {
     // m_childFrames pollution under same-site BFCache: when a1 (a.com with


### PR DESCRIPTION
#### 3ad8ffd29cd7df3448ba618f37c5d262a9ed023e
<pre>
[Site Isolation] BFCache restore broken for back-navigation through a data: URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=316534">https://bugs.webkit.org/show_bug.cgi?id=316534</a>
<a href="https://rdar.apple.com/179006334">rdar://179006334</a>

Reviewed by Alex Christensen.

Under Site Isolation, navigating from an http(s) page to a data: URL and then back
to the source page failed to restore the source from BFCache. Two compounding gaps
in WebProcessPool were responsible:

- processForNavigationInternal treated data: URLs as same-origin (the SI carve-out
  only covered about: URLs), so a main-frame navigation to data: never
  process-swapped and the source page was never suspended into BFCache.

- processForNavigation gated the SI-specific suspended-page lookup on
  !site.isEmpty(), which excluded back-navigations whose target URL has an empty
  registrable domain (file://, about:blank). Even when a SuspendedPageProxy existed,
  it was not found for those targets.

Extend the carve-out to main-frame navigations to data: URLs (iframes keep the
same-origin treatment so subframes loading data: stay in their parent&apos;s process),
and split the SI block so the suspended-page lookup runs on targetItem alone
while the site-keyed iframe-process reuse logic keeps its existing !site.isEmpty()
gate.

Together these enable BFCache restore for back-navigation patterns covered by
layout tests in LayoutTests/platform/mac-site-isolation/TestExpectations whose
source page lives at a file:// URL. Four [ Timeout ] entries are removed.

form-state-restore-with-frames.html exercises the same data: → back path. It was
written for the pre-existing same-origin treatment, where the back navigation
reloaded in-process and onload fired again. Under the new BFCache-restore path,
update it to enable UsesBackForwardCache and switch the entry point from onload
to onpageshow, which fires on both the initial load and the BFCache restore.

* LayoutTests/fast/loader/site-isolation/form-state-restore-with-frames.html:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:

Canonical link: <a href="https://commits.webkit.org/314948@main">https://commits.webkit.org/314948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/565c4bbfd44dabdfcfe5d224d082220f58ce6e39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176697 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c071dd5b-71f4-49f5-93a7-3cc68557640d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41150 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2aaa0b15-8132-4161-a87a-96bd6ca7e060) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32852 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/110954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bc2a68e-19a7-4aad-95d6-16bc19c4a2e0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25430 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179237 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30048 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41209 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37352 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150122 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105059 "Hash 565c4bbf for PR 66803 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33977 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40401 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39798 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5102 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40049 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->