### PR TITLE
Implement Table64 in the parser and IPInt tier

### DIFF
--- a/JSTests/wasm/stress/table64-bulk.js
+++ b/JSTests/wasm/stress/table64-bulk.js
@@ -1,0 +1,67 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = (addressType) => `
+(module
+    (memory ${addressType} 1)
+    (table $tbl (export "table1") ${addressType} 10 funcref)
+    (table $tbl2 (export "table2") ${addressType} 10 funcref)
+    (func $f1 (result i32) i32.const 42)
+    (func $f2 (result i32) i32.const 43)
+    (elem $element funcref (ref.func $f1) (ref.func $f2))
+    (func $tableInit (export "tableInit")
+        (${addressType}.const 0) ;; destination
+        (i32.const 0) ;; source
+        (i32.const 2) ;; count 
+        (table.init $tbl $element)
+    )
+    (func $tableFill (export "tableFill")
+        (${addressType}.const 0) ;; destination
+        (ref.func $f1)
+        (${addressType}.const 2) ;; length
+        (table.fill $tbl)
+    )
+    (func $tableCopy (export "tableCopy")
+        (${addressType}.const 0) ;; destination
+        (${addressType}.const 0) ;; source 
+        (${addressType}.const 2) ;; length
+        (table.copy $tbl2 $tbl)
+    )
+    (func $resetTables (export "resetTables")
+        (${addressType}.const 0)
+        (ref.null func)
+        (${addressType}.const 10)
+        (table.fill $tbl)
+        (${addressType}.const 0)
+        (ref.null func)
+        (${addressType}.const 10)
+        (table.fill $tbl2)
+    )
+)`;
+
+function test(initFunc, fillFunc, copyFunc, resetFunc, table1, table2, numOrBig) {
+    resetFunc();
+    assert.eq(table1.get(numOrBig(0)), null);
+    assert.eq(table1.get(numOrBig(1)), null);
+    assert.eq(table2.get(numOrBig(0)), null);
+    assert.eq(table2.get(numOrBig(1)), null);
+    initFunc();
+    assert.eq(table1.get(numOrBig(0))(), 42);
+    assert.eq(table1.get(numOrBig(1))(), 43);
+    fillFunc();
+    assert.eq(table1.get(numOrBig(0))(), 42);
+    assert.eq(table1.get(numOrBig(1))(), 42);
+    copyFunc();
+    assert.eq(table2.get(numOrBig(0))(), 42);
+    assert.eq(table2.get(numOrBig(1))(), 42);
+}
+
+for (const addressType of ["i32", "i64"]) {
+    const instance = await instantiate(wat(addressType), {}, {memory64: true});
+    const { tableInit, tableFill, tableCopy, resetTables, table1, table2 } = instance.exports;
+    const numOrBig = (val) => addressType == "i32" ? Number(val) : BigInt(val);
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        test(tableInit, tableFill, tableCopy, resetTables, table1, table2, numOrBig);
+}

--- a/JSTests/wasm/stress/table64-call-indirect.js
+++ b/JSTests/wasm/stress/table64-call-indirect.js
@@ -1,0 +1,66 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = (addressType) => `
+(module
+    (memory ${addressType} 1)
+    (table $tbl ${addressType} 10 funcref)
+    (type $func_type (func (param i32 i32) (result i32)))
+    (elem (${addressType}.const 0) $addIndirect $subIndirect)
+    (func $add (export "add") (param $lhs i32) (param $rhs i32) (result i32)
+        (local.get $lhs)
+        (local.get $rhs)
+        (${addressType}.const 0)
+        (call_indirect $tbl (type $func_type))
+    )
+    (func $sub (export "sub") (param $lhs i32) (param $rhs i32) (result i32)
+        (local.get $lhs)
+        (local.get $rhs)
+        (${addressType}.const 1)
+        (call_indirect $tbl (type $func_type))
+    )
+    (func $callAt (export "callAt") (param $lhs i32) (param $rhs i32) (param $index ${addressType}) (result i32)
+        (local.get $lhs)
+        (local.get $rhs)
+        (local.get $index)
+        (call_indirect $tbl (type $func_type))
+    )
+    (func $addIndirect (param $lhs i32) (param $rhs i32) (result i32)
+        (local.get $lhs)
+        (local.get $rhs)
+        (i32.add)
+    )
+    (func $subIndirect (param $lhs i32) (param $rhs i32) (result i32)
+        (local.get $lhs)
+        (local.get $rhs)
+        (i32.sub)
+    )
+)`;
+
+function test(addFunc, subFunc, callAt) {
+    assert.eq(addFunc(12, 30), 42);
+    assert.eq(subFunc(53, 11), 42);
+    assert.eq(callAt(12, 30, addressIndex(0)), 42);
+    assert.eq(callAt(53, 11, addressIndex(1)), 42);
+}
+
+const oob = "Out of bounds call_indirect";
+const twoPow32 = 0x1_0000_0000n;
+let addressIndex;
+
+for (const addressType of ["i32", "i64"]) {
+    const instance = await instantiate(wat(addressType), {}, {memory64: true});
+    const { add, sub, callAt } = instance.exports;
+    addressIndex = addressType === "i64" ? (i) => BigInt(i) : (i) => i;
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        test(add, sub, callAt);
+
+    // A table64 index above int32_t::max must trap rather than truncate to a valid slot.
+    if (addressType === "i64") {
+        assert.throws(() => callAt(12, 30, twoPow32), WebAssembly.RuntimeError, oob);
+        assert.throws(() => callAt(12, 30, twoPow32 + 5n), WebAssembly.RuntimeError, oob);
+    }
+}
+

--- a/JSTests/wasm/stress/table64-get-and-set.js
+++ b/JSTests/wasm/stress/table64-get-and-set.js
@@ -1,0 +1,34 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = (addressType) => `
+(module
+    (memory ${addressType} 1)
+    (table $tbl ${addressType} 100 externref)
+    (func $tableSet (export "tableSet") (param $index ${addressType}) (param $setValue externref)
+        (local.get $index)
+        (local.get $setValue)
+        (table.set $tbl)
+    )
+    (func $tableGet (export "tableGet") (param $index ${addressType}) (result externref)
+        (local.get $index)
+        (table.get $tbl)
+    )
+)`;
+
+function test(getFunc, setFunc, index) {
+    const valueToSet = "hello";
+    setFunc(index, valueToSet);
+    assert.eq(getFunc(index), valueToSet);
+}
+
+for (const addressType of ["i32", "i64"]) {
+    const instance = await instantiate(wat(addressType), {}, {memory64: true});
+    const { tableGet, tableSet } = instance.exports;
+    const index = addressType == "i32" ? 42 : 42n;
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        test(tableGet, tableSet, index);
+}
+

--- a/JSTests/wasm/stress/table64-grow-and-size.js
+++ b/JSTests/wasm/stress/table64-grow-and-size.js
@@ -1,0 +1,47 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = (addressType) => `
+(module
+    (memory ${addressType} 1)
+    (table $tbl ${addressType} 1 funcref)
+    (func $tableGrow (export "tableGrow") (param $delta ${addressType}) (result ${addressType})
+        (ref.null func)
+        (local.get $delta)
+        (table.grow $tbl)
+    )
+    (func $tableSize (export "tableSize") (result ${addressType})
+        (table.size $tbl)
+    )
+)`;
+
+function test(growFunc, sizeFunc, numOrBig) {
+    let size = numOrBig(0);
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        size = sizeFunc();
+    assert.eq(size, numOrBig(1));
+
+    let growSize = growFunc(numOrBig(10));
+    assert.eq(growSize, size);
+    assert.eq(sizeFunc(), numOrBig(11));
+    size = sizeFunc();
+
+    growSize = growFunc(numOrBig(10));
+    assert.eq(growSize, size);
+    assert.eq(sizeFunc(), numOrBig(21));
+    size = sizeFunc();
+
+    growSize = growFunc(numOrBig(10));
+    assert.eq(growSize, size);
+    assert.eq(sizeFunc(), numOrBig(31));
+}
+
+for (const addressType of ["i32", "i64"]) {
+    const instance = await instantiate(wat(addressType), {}, {memory64: true});
+    const { tableGrow, tableSize } = instance.exports;
+    const numOrBig = (val) => addressType == "i32" ? Number(val) : BigInt(val);
+    test(tableGrow, tableSize, numOrBig);
+}
+

--- a/JSTests/wasm/stress/table64-overflow.js
+++ b/JSTests/wasm/stress/table64-overflow.js
@@ -1,0 +1,81 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (memory i64 1)
+    (table $tbl i64 100 externref)
+    (table $tbl2 i64 100 externref)
+    (table $tblFunc i64 100 funcref)
+    (table $tblGrow i64 1 funcref)
+    (func $f (result i32) i32.const 42)
+    (elem $element funcref (ref.func $f))
+    (func $tableGet (export "tableGet") (param $index i64) (result externref)
+        (local.get $index)
+        (table.get $tbl)
+    )
+    (func $tableSet (export "tableSet") (param $index i64) (param $value externref)
+        (local.get $index)
+        (local.get $value)
+        (table.set $tbl)
+    )
+    (func $tableFill (export "tableFill") (param $offset i64) (param $count i64)
+        (local.get $offset)
+        (ref.null extern)
+        (local.get $count)
+        (table.fill $tbl)
+    )
+    (func $tableCopy (export "tableCopy") (param $dst i64) (param $src i64) (param $len i64)
+        (local.get $dst)
+        (local.get $src)
+        (local.get $len)
+        (table.copy $tbl2 $tbl)
+    )
+    (func $tableInit (export "tableInit") (param $dst i64) (param $src i32) (param $len i32)
+        (local.get $dst)
+        (local.get $src)
+        (local.get $len)
+        (table.init $tblFunc $element)
+    )
+    (func $tableGrow (export "tableGrow") (param $delta i64) (result i64)
+        (ref.null func)
+        (local.get $delta)
+        (table.grow $tblGrow)
+    )
+    (func $tableGrowSize (export "tableGrowSize") (result i64)
+        (table.size $tblGrow)
+    )
+)`;
+
+const oob = "Out of bounds table access";
+const twoPow32 = 0x1_0000_0000n;
+
+function test(exports) {
+    const { tableGet, tableSet, tableFill, tableCopy, tableInit, tableGrow, tableGrowSize } = exports;
+
+    assert.throws(() => tableGet(twoPow32 + 5n), WebAssembly.RuntimeError, oob);
+    assert.throws(() => tableGet(twoPow32 + 100n), WebAssembly.RuntimeError, oob);
+
+    assert.throws(() => tableSet(twoPow32 + 5n, "x"), WebAssembly.RuntimeError, oob);
+    assert.eq(tableGet(5n), null);
+
+    assert.throws(() => tableFill(twoPow32, 1n), WebAssembly.RuntimeError, oob);
+    assert.throws(() => tableFill(0n, twoPow32 + 1n), WebAssembly.RuntimeError, oob);
+    assert.eq(tableGet(0n), null);
+
+    assert.throws(() => tableCopy(twoPow32, 0n, 1n), WebAssembly.RuntimeError, oob);
+    assert.throws(() => tableCopy(0n, twoPow32, 1n), WebAssembly.RuntimeError, oob);
+    assert.throws(() => tableCopy(0n, 0n, twoPow32 + 1n), WebAssembly.RuntimeError, oob);
+
+    assert.throws(() => tableInit(twoPow32, 0, 1), WebAssembly.RuntimeError, oob);
+
+    const badGrow = tableGrow(twoPow32 + 5n);
+    assert.eq(badGrow, -1n);
+    assert.eq(tableGrowSize(), 1n);
+}
+
+const instance = await instantiate(wat, {}, {memory64: true});
+for (let i = 0; i < wasmTestLoopCount; i++)
+    test(instance.exports);

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table64.wast.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table64_wast_js() {
 
 // table64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_copy64.wast.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_copy64_wast_js() {
 
 // table_copy64.wast:6

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_fill64.wast.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_fill64_wast_js() {
 
 // table_fill64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_get64.wast.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_get64_wast_js() {
 
 // table_get64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_grow64.wast.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_grow64_wast_js() {
 
 // table_grow64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_init64.wast.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_init64_wast_js() {
 
 // table_init64.wast:6

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_set64.wast.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_set64_wast_js() {
 
 // table_set64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/js/memory64/table_size64.wast.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useWasmMemory64=1", "--useBBQJIT=0", "--useOMGJIT=0", "--useWasmIPInt=1")
 (function table_size64_wast_js() {
 
 // table_size64.wast:1

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/align64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/binary_leb128_64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js-expected.txt
@@ -1,12 +1,8 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (call_indirect64.wast:3) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (call_indirect64.wast:3)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (call_indirect64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 76: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-call_indirect64_wast_js@call_indirect64.wast.js:7:18
-global code@call_indirect64.wast.js:12:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (call_indirect64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-call_indirect64_wast_js@call_indirect64.wast.js:10:14
-global code@call_indirect64.wast.js:12:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (call_indirect64.wast:3)
+PASS #5 Test that WebAssembly instantiation succeeds (call_indirect64.wast:3)
+PASS #6 Test that a WebAssembly code returns a specific result (call_indirect64.wast:26)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/call_indirect64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/endianness64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/load64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64-imports.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_fill64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_grow64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_redundancy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js-expected.txt
@@ -19,28 +19,28 @@ PASS #17 Test that WebAssembly compilation succeeds (table_copy64.wast:1303)
 PASS #18 Test that WebAssembly compilation succeeds (table_copy64.wast:1395)
 PASS #19 Test that WebAssembly compilation succeeds (table_copy64.wast:1487)
 PASS #20 Test that WebAssembly compilation succeeds (table_copy64.wast:1579)
-FAIL #21 Test that WebAssembly compilation succeeds (table_copy64.wast:1671) assert_equals: expected false but got true
-FAIL #22 Test that WebAssembly compilation succeeds (table_copy64.wast:1696) assert_equals: expected false but got true
-FAIL #23 Test that WebAssembly compilation succeeds (table_copy64.wast:1721) assert_equals: expected false but got true
-FAIL #24 Test that WebAssembly compilation succeeds (table_copy64.wast:1746) assert_equals: expected false but got true
-FAIL #25 Test that WebAssembly compilation succeeds (table_copy64.wast:1771) assert_equals: expected false but got true
-FAIL #26 Test that WebAssembly compilation succeeds (table_copy64.wast:1796) assert_equals: expected false but got true
-FAIL #27 Test that WebAssembly compilation succeeds (table_copy64.wast:1821) assert_equals: expected false but got true
-FAIL #28 Test that WebAssembly compilation succeeds (table_copy64.wast:1846) assert_equals: expected false but got true
-FAIL #29 Test that WebAssembly compilation succeeds (table_copy64.wast:1871) assert_equals: expected false but got true
-FAIL #30 Test that WebAssembly compilation succeeds (table_copy64.wast:1896) assert_equals: expected false but got true
-FAIL #31 Test that WebAssembly compilation succeeds (table_copy64.wast:1921) assert_equals: expected false but got true
-FAIL #32 Test that WebAssembly compilation succeeds (table_copy64.wast:1946) assert_equals: expected false but got true
-FAIL #33 Test that WebAssembly compilation succeeds (table_copy64.wast:1971) assert_equals: expected false but got true
-FAIL #34 Test that WebAssembly compilation succeeds (table_copy64.wast:1996) assert_equals: expected false but got true
-FAIL #35 Test that WebAssembly compilation succeeds (table_copy64.wast:2021) assert_equals: expected false but got true
-FAIL #36 Test that WebAssembly compilation succeeds (table_copy64.wast:2046) assert_equals: expected false but got true
-FAIL #37 Test that WebAssembly compilation succeeds (table_copy64.wast:2071) assert_equals: expected false but got true
-FAIL #38 Test that WebAssembly compilation succeeds (table_copy64.wast:2096) assert_equals: expected false but got true
-FAIL #39 Test that WebAssembly compilation succeeds (table_copy64.wast:2121) assert_equals: expected false but got true
-FAIL #40 Test that WebAssembly compilation succeeds (table_copy64.wast:2146) assert_equals: expected false but got true
-FAIL #41 Test that WebAssembly compilation succeeds (table_copy64.wast:2171) assert_equals: expected false but got true
-FAIL #42 Test that WebAssembly compilation succeeds (table_copy64.wast:2196) assert_equals: expected false but got true
+PASS #21 Test that WebAssembly compilation succeeds (table_copy64.wast:1671)
+PASS #22 Test that WebAssembly compilation succeeds (table_copy64.wast:1696)
+PASS #23 Test that WebAssembly compilation succeeds (table_copy64.wast:1721)
+PASS #24 Test that WebAssembly compilation succeeds (table_copy64.wast:1746)
+PASS #25 Test that WebAssembly compilation succeeds (table_copy64.wast:1771)
+PASS #26 Test that WebAssembly compilation succeeds (table_copy64.wast:1796)
+PASS #27 Test that WebAssembly compilation succeeds (table_copy64.wast:1821)
+PASS #28 Test that WebAssembly compilation succeeds (table_copy64.wast:1846)
+PASS #29 Test that WebAssembly compilation succeeds (table_copy64.wast:1871)
+PASS #30 Test that WebAssembly compilation succeeds (table_copy64.wast:1896)
+PASS #31 Test that WebAssembly compilation succeeds (table_copy64.wast:1921)
+PASS #32 Test that WebAssembly compilation succeeds (table_copy64.wast:1946)
+PASS #33 Test that WebAssembly compilation succeeds (table_copy64.wast:1971)
+PASS #34 Test that WebAssembly compilation succeeds (table_copy64.wast:1996)
+PASS #35 Test that WebAssembly compilation succeeds (table_copy64.wast:2021)
+PASS #36 Test that WebAssembly compilation succeeds (table_copy64.wast:2046)
+PASS #37 Test that WebAssembly compilation succeeds (table_copy64.wast:2071)
+PASS #38 Test that WebAssembly compilation succeeds (table_copy64.wast:2096)
+PASS #39 Test that WebAssembly compilation succeeds (table_copy64.wast:2121)
+PASS #40 Test that WebAssembly compilation succeeds (table_copy64.wast:2146)
+PASS #41 Test that WebAssembly compilation succeeds (table_copy64.wast:2171)
+PASS #42 Test that WebAssembly compilation succeeds (table_copy64.wast:2196)
 PASS #43 Test that WebAssembly compilation succeeds (table_copy64.wast:2221)
 PASS #44 Test that WebAssembly compilation succeeds (table_copy64.wast:2282)
 PASS #45 Test that WebAssembly compilation succeeds (table_copy64.wast:2343)
@@ -1189,160 +1189,72 @@ PASS #1187 Test that a WebAssembly code returns a specific result (table_copy64.
 PASS #1188 Test that a WebAssembly code traps (table_copy64.wast:1667)
 PASS #1189 Test that a WebAssembly code traps (table_copy64.wast:1668)
 PASS #1190 Test that a WebAssembly code traps (table_copy64.wast:1669)
-FAIL #1191 Test that WebAssembly compilation succeeds (table_copy64.wast:1671) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1192 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3418:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1193 Test that a WebAssembly code traps (table_copy64.wast:1694) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3421:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1194 Test that WebAssembly compilation succeeds (table_copy64.wast:1696) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1195 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3427:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1196 Test that a WebAssembly code traps (table_copy64.wast:1719) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3430:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1197 Test that WebAssembly compilation succeeds (table_copy64.wast:1721) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1198 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3436:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1199 Test that a WebAssembly code traps (table_copy64.wast:1744) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3439:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1200 Test that WebAssembly compilation succeeds (table_copy64.wast:1746) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1201 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3445:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1202 Test that a WebAssembly code traps (table_copy64.wast:1769) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3448:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1203 Test that WebAssembly compilation succeeds (table_copy64.wast:1771) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1204 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3454:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1205 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_copy64_wast_js@table_copy64.wast.js:3457:4
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1206 Test that WebAssembly compilation succeeds (table_copy64.wast:1796) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1207 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3463:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1208 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_copy64_wast_js@table_copy64.wast.js:3466:4
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1209 Test that WebAssembly compilation succeeds (table_copy64.wast:1821) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1210 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3472:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1211 Test that a WebAssembly code traps (table_copy64.wast:1844) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3475:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1212 Test that WebAssembly compilation succeeds (table_copy64.wast:1846) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1213 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3481:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1214 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_copy64_wast_js@table_copy64.wast.js:3484:4
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1215 Test that WebAssembly compilation succeeds (table_copy64.wast:1871) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1216 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3490:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1217 Test that a WebAssembly code traps (table_copy64.wast:1894) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3493:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1218 Test that WebAssembly compilation succeeds (table_copy64.wast:1896) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1219 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3499:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1220 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_copy64_wast_js@table_copy64.wast.js:3502:4
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1221 Test that WebAssembly compilation succeeds (table_copy64.wast:1921) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1222 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3508:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1223 Test that a WebAssembly code traps (table_copy64.wast:1944) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3511:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1224 Test that WebAssembly compilation succeeds (table_copy64.wast:1946) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1225 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3517:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1226 Test that a WebAssembly code traps (table_copy64.wast:1969) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3520:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1227 Test that WebAssembly compilation succeeds (table_copy64.wast:1971) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1228 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3526:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1229 Test that a WebAssembly code traps (table_copy64.wast:1994) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3529:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1230 Test that WebAssembly compilation succeeds (table_copy64.wast:1996) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1231 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3535:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1232 Test that a WebAssembly code traps (table_copy64.wast:2019) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3538:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1233 Test that WebAssembly compilation succeeds (table_copy64.wast:2021) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1234 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3544:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1235 Test that a WebAssembly code traps (table_copy64.wast:2044) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3547:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1236 Test that WebAssembly compilation succeeds (table_copy64.wast:2046) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1237 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3553:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1238 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_copy64_wast_js@table_copy64.wast.js:3556:4
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1239 Test that WebAssembly compilation succeeds (table_copy64.wast:2071) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1240 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3562:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1241 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_copy64_wast_js@table_copy64.wast.js:3565:4
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1242 Test that WebAssembly compilation succeeds (table_copy64.wast:2096) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1243 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3571:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1244 Test that a WebAssembly code traps (table_copy64.wast:2119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3574:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1245 Test that WebAssembly compilation succeeds (table_copy64.wast:2121) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1246 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3580:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1247 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_copy64_wast_js@table_copy64.wast.js:3583:4
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1248 Test that WebAssembly compilation succeeds (table_copy64.wast:2146) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1249 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3589:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1250 Test that a WebAssembly code traps (table_copy64.wast:2169) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3592:12
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1251 Test that WebAssembly compilation succeeds (table_copy64.wast:2171) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1252 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3598:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1253 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_copy64_wast_js@table_copy64.wast.js:3601:4
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1254 Test that WebAssembly compilation succeeds (table_copy64.wast:2196) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 80: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #1255 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy64_wast_js@table_copy64.wast.js:3607:19
-global code@table_copy64.wast.js:5343:3 expected true got false
-FAIL #1256 Test that a WebAssembly code traps (table_copy64.wast:2219) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_copy64_wast_js@table_copy64.wast.js:3610:12
-global code@table_copy64.wast.js:5343:3 expected true got false
+PASS #1191 Test that WebAssembly compilation succeeds (table_copy64.wast:1671)
+PASS #1192 Test that WebAssembly instantiation succeeds (table_copy64.wast:1671)
+PASS #1193 Test that a WebAssembly code traps (table_copy64.wast:1694)
+PASS #1194 Test that WebAssembly compilation succeeds (table_copy64.wast:1696)
+PASS #1195 Test that WebAssembly instantiation succeeds (table_copy64.wast:1696)
+PASS #1196 Test that a WebAssembly code traps (table_copy64.wast:1719)
+PASS #1197 Test that WebAssembly compilation succeeds (table_copy64.wast:1721)
+PASS #1198 Test that WebAssembly instantiation succeeds (table_copy64.wast:1721)
+PASS #1199 Test that a WebAssembly code traps (table_copy64.wast:1744)
+PASS #1200 Test that WebAssembly compilation succeeds (table_copy64.wast:1746)
+PASS #1201 Test that WebAssembly instantiation succeeds (table_copy64.wast:1746)
+PASS #1202 Test that a WebAssembly code traps (table_copy64.wast:1769)
+PASS #1203 Test that WebAssembly compilation succeeds (table_copy64.wast:1771)
+PASS #1204 Test that WebAssembly instantiation succeeds (table_copy64.wast:1771)
+PASS #1205 Run a WebAssembly test without special assertions (table_copy64.wast:1794)
+PASS #1206 Test that WebAssembly compilation succeeds (table_copy64.wast:1796)
+PASS #1207 Test that WebAssembly instantiation succeeds (table_copy64.wast:1796)
+PASS #1208 Run a WebAssembly test without special assertions (table_copy64.wast:1819)
+PASS #1209 Test that WebAssembly compilation succeeds (table_copy64.wast:1821)
+PASS #1210 Test that WebAssembly instantiation succeeds (table_copy64.wast:1821)
+PASS #1211 Test that a WebAssembly code traps (table_copy64.wast:1844)
+PASS #1212 Test that WebAssembly compilation succeeds (table_copy64.wast:1846)
+PASS #1213 Test that WebAssembly instantiation succeeds (table_copy64.wast:1846)
+PASS #1214 Run a WebAssembly test without special assertions (table_copy64.wast:1869)
+PASS #1215 Test that WebAssembly compilation succeeds (table_copy64.wast:1871)
+PASS #1216 Test that WebAssembly instantiation succeeds (table_copy64.wast:1871)
+PASS #1217 Test that a WebAssembly code traps (table_copy64.wast:1894)
+PASS #1218 Test that WebAssembly compilation succeeds (table_copy64.wast:1896)
+PASS #1219 Test that WebAssembly instantiation succeeds (table_copy64.wast:1896)
+PASS #1220 Run a WebAssembly test without special assertions (table_copy64.wast:1919)
+PASS #1221 Test that WebAssembly compilation succeeds (table_copy64.wast:1921)
+PASS #1222 Test that WebAssembly instantiation succeeds (table_copy64.wast:1921)
+PASS #1223 Test that a WebAssembly code traps (table_copy64.wast:1944)
+PASS #1224 Test that WebAssembly compilation succeeds (table_copy64.wast:1946)
+PASS #1225 Test that WebAssembly instantiation succeeds (table_copy64.wast:1946)
+PASS #1226 Test that a WebAssembly code traps (table_copy64.wast:1969)
+PASS #1227 Test that WebAssembly compilation succeeds (table_copy64.wast:1971)
+PASS #1228 Test that WebAssembly instantiation succeeds (table_copy64.wast:1971)
+PASS #1229 Test that a WebAssembly code traps (table_copy64.wast:1994)
+PASS #1230 Test that WebAssembly compilation succeeds (table_copy64.wast:1996)
+PASS #1231 Test that WebAssembly instantiation succeeds (table_copy64.wast:1996)
+PASS #1232 Test that a WebAssembly code traps (table_copy64.wast:2019)
+PASS #1233 Test that WebAssembly compilation succeeds (table_copy64.wast:2021)
+PASS #1234 Test that WebAssembly instantiation succeeds (table_copy64.wast:2021)
+PASS #1235 Test that a WebAssembly code traps (table_copy64.wast:2044)
+PASS #1236 Test that WebAssembly compilation succeeds (table_copy64.wast:2046)
+PASS #1237 Test that WebAssembly instantiation succeeds (table_copy64.wast:2046)
+PASS #1238 Run a WebAssembly test without special assertions (table_copy64.wast:2069)
+PASS #1239 Test that WebAssembly compilation succeeds (table_copy64.wast:2071)
+PASS #1240 Test that WebAssembly instantiation succeeds (table_copy64.wast:2071)
+PASS #1241 Run a WebAssembly test without special assertions (table_copy64.wast:2094)
+PASS #1242 Test that WebAssembly compilation succeeds (table_copy64.wast:2096)
+PASS #1243 Test that WebAssembly instantiation succeeds (table_copy64.wast:2096)
+PASS #1244 Test that a WebAssembly code traps (table_copy64.wast:2119)
+PASS #1245 Test that WebAssembly compilation succeeds (table_copy64.wast:2121)
+PASS #1246 Test that WebAssembly instantiation succeeds (table_copy64.wast:2121)
+PASS #1247 Run a WebAssembly test without special assertions (table_copy64.wast:2144)
+PASS #1248 Test that WebAssembly compilation succeeds (table_copy64.wast:2146)
+PASS #1249 Test that WebAssembly instantiation succeeds (table_copy64.wast:2146)
+PASS #1250 Test that a WebAssembly code traps (table_copy64.wast:2169)
+PASS #1251 Test that WebAssembly compilation succeeds (table_copy64.wast:2171)
+PASS #1252 Test that WebAssembly instantiation succeeds (table_copy64.wast:2171)
+PASS #1253 Run a WebAssembly test without special assertions (table_copy64.wast:2194)
+PASS #1254 Test that WebAssembly compilation succeeds (table_copy64.wast:2196)
+PASS #1255 Test that WebAssembly instantiation succeeds (table_copy64.wast:2196)
+PASS #1256 Test that a WebAssembly code traps (table_copy64.wast:2219)
 PASS #1257 Test that WebAssembly compilation succeeds (table_copy64.wast:2221)
 PASS #1258 Test that WebAssembly instantiation succeeds (table_copy64.wast:2221)
 PASS #1259 Test that a WebAssembly code traps (table_copy64.wast:2247)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js-expected.txt
@@ -1,18 +1,13 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (table_copy_mixed.wast:2) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (table_copy_mixed.wast:2)
 PASS #3 Test that WebAssembly compilation fails (table_copy_mixed.wast:20)
-FAIL #4 Test that WebAssembly compilation fails (table_copy_mixed.wast:30) assert_equals: expected true but got false
+PASS #4 Test that WebAssembly compilation fails (table_copy_mixed.wast:30)
 PASS #5 Test that WebAssembly compilation fails (table_copy_mixed.wast:40)
 PASS #6 Reinitialize the default imports
-FAIL #7 Test that WebAssembly compilation succeeds (table_copy_mixed.wast:2) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.copy dst_offset to type I64 expected I32, in function at index 1 at {loc} expected true got false
-FAIL #8 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_copy_mixed_wast_js@table_copy_mixed.wast.js:7:18
-global code@table_copy_mixed.wast.js:18:3 expected true got false
+PASS #7 Test that WebAssembly compilation succeeds (table_copy_mixed.wast:2)
+PASS #8 Test that WebAssembly instantiation succeeds (table_copy_mixed.wast:2)
 PASS #9 Test that WebAssembly compilation fails (table_copy_mixed.wast:20)
-FAIL #10 Test that WebAssembly compilation fails (table_copy_mixed.wast:30) assert_true: module@async_index.js:175:29
-assert_invalid@async_index.js:204:9
-table_copy_mixed_wast_js@table_copy_mixed.wast.js:13:15
-global code@table_copy_mixed.wast.js:18:3 expected true got false
+PASS #10 Test that WebAssembly compilation fails (table_copy_mixed.wast:30)
 PASS #11 Test that WebAssembly compilation fails (table_copy_mixed.wast:40)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_copy_mixed.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (table_fill64.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (table_fill64.wast:1)
 PASS #3 Test that WebAssembly compilation fails (table_fill64.wast:139)
 PASS #4 Test that WebAssembly compilation fails (table_fill64.wast:148)
 PASS #5 Test that WebAssembly compilation fails (table_fill64.wast:157)
@@ -11,220 +11,78 @@ PASS #9 Test that WebAssembly compilation fails (table_fill64.wast:193)
 PASS #10 Test that WebAssembly compilation fails (table_fill64.wast:203)
 PASS #11 Test that WebAssembly compilation fails (table_fill64.wast:214)
 PASS #12 Reinitialize the default imports
-FAIL #13 Test that WebAssembly compilation succeeds (table_fill64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.fill expects an i32 offset value, got I64, in function at index 3 at {loc} expected true got false
-FAIL #14 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_fill64_wast_js@table_fill64.wast.js:7:18
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (table_fill64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:10:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (table_fill64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:13:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (table_fill64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:16:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (table_fill64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:19:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (table_fill64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:22:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (table_fill64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:25:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (table_fill64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:28:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (table_fill64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:31:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (table_fill64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:34:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (table_fill64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:37:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (table_fill64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:40:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (table_fill64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:43:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (table_fill64.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:46:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (table_fill64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:49:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (table_fill64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:52:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (table_fill64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:55:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (table_fill64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:58:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (table_fill64.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:61:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (table_fill64.wast:48) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:64:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (table_fill64.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:67:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (table_fill64.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:70:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (table_fill64.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:73:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (table_fill64.wast:53) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:76:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (table_fill64.wast:54) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:79:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (table_fill64.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:82:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (table_fill64.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:85:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (table_fill64.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:88:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (table_fill64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:91:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (table_fill64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:94:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #44 Test that a WebAssembly code traps (table_fill64.wast:63) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_fill64_wast_js@table_fill64.wast.js:97:12
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (table_fill64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:100:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (table_fill64.wast:68) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:103:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (table_fill64.wast:69) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:106:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #48 Test that a WebAssembly code traps (table_fill64.wast:71) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_fill64_wast_js@table_fill64.wast.js:109:12
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #49 Test that a WebAssembly code traps (table_fill64.wast:76) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_fill64_wast_js@table_fill64.wast.js:112:12
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (table_fill64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:115:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (table_fill64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:118:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (table_fill64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:121:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (table_fill64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:124:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (table_fill64.wast:87) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:127:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (table_fill64.wast:89) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:130:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (table_fill64.wast:90) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:133:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #57 Test that a WebAssembly code returns a specific result (table_fill64.wast:91) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:136:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (table_fill64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:139:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #59 Test that a WebAssembly code returns a specific result (table_fill64.wast:93) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:142:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #60 Test that a WebAssembly code returns a specific result (table_fill64.wast:94) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:145:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #61 Test that a WebAssembly code returns a specific result (table_fill64.wast:96) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:148:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #62 Test that a WebAssembly code returns a specific result (table_fill64.wast:97) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:151:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #63 Test that a WebAssembly code returns a specific result (table_fill64.wast:98) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:154:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #64 Test that a WebAssembly code returns a specific result (table_fill64.wast:99) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:157:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #65 Test that a WebAssembly code returns a specific result (table_fill64.wast:100) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:160:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #66 Test that a WebAssembly code returns a specific result (table_fill64.wast:102) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:163:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (table_fill64.wast:103) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:166:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (table_fill64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:169:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (table_fill64.wast:105) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:172:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (table_fill64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:175:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (table_fill64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:178:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (table_fill64.wast:109) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:181:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (table_fill64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:184:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (table_fill64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:187:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (table_fill64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:190:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (table_fill64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:193:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (table_fill64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:196:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (table_fill64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:199:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #79 Test that a WebAssembly code traps (table_fill64.wast:119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_fill64_wast_js@table_fill64.wast.js:202:12
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (table_fill64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:205:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (table_fill64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:208:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (table_fill64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_fill64_wast_js@table_fill64.wast.js:211:14
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #83 Test that a WebAssembly code traps (table_fill64.wast:127) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_fill64_wast_js@table_fill64.wast.js:214:12
-global code@table_fill64.wast.js:246:3 expected true got false
-FAIL #84 Test that a WebAssembly code traps (table_fill64.wast:132) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_fill64_wast_js@table_fill64.wast.js:217:12
-global code@table_fill64.wast.js:246:3 expected true got false
+PASS #13 Test that WebAssembly compilation succeeds (table_fill64.wast:1)
+PASS #14 Test that WebAssembly instantiation succeeds (table_fill64.wast:1)
+PASS #15 Test that a WebAssembly code returns a specific result (table_fill64.wast:27)
+PASS #16 Test that a WebAssembly code returns a specific result (table_fill64.wast:28)
+PASS #17 Test that a WebAssembly code returns a specific result (table_fill64.wast:29)
+PASS #18 Test that a WebAssembly code returns a specific result (table_fill64.wast:30)
+PASS #19 Test that a WebAssembly code returns a specific result (table_fill64.wast:31)
+PASS #20 Test that a WebAssembly code returns a specific result (table_fill64.wast:33)
+PASS #21 Test that a WebAssembly code returns a specific result (table_fill64.wast:34)
+PASS #22 Test that a WebAssembly code returns a specific result (table_fill64.wast:35)
+PASS #23 Test that a WebAssembly code returns a specific result (table_fill64.wast:36)
+PASS #24 Test that a WebAssembly code returns a specific result (table_fill64.wast:37)
+PASS #25 Test that a WebAssembly code returns a specific result (table_fill64.wast:38)
+PASS #26 Test that a WebAssembly code returns a specific result (table_fill64.wast:40)
+PASS #27 Test that a WebAssembly code returns a specific result (table_fill64.wast:41)
+PASS #28 Test that a WebAssembly code returns a specific result (table_fill64.wast:42)
+PASS #29 Test that a WebAssembly code returns a specific result (table_fill64.wast:43)
+PASS #30 Test that a WebAssembly code returns a specific result (table_fill64.wast:44)
+PASS #31 Test that a WebAssembly code returns a specific result (table_fill64.wast:46)
+PASS #32 Test that a WebAssembly code returns a specific result (table_fill64.wast:47)
+PASS #33 Test that a WebAssembly code returns a specific result (table_fill64.wast:48)
+PASS #34 Test that a WebAssembly code returns a specific result (table_fill64.wast:49)
+PASS #35 Test that a WebAssembly code returns a specific result (table_fill64.wast:51)
+PASS #36 Test that a WebAssembly code returns a specific result (table_fill64.wast:52)
+PASS #37 Test that a WebAssembly code returns a specific result (table_fill64.wast:53)
+PASS #38 Test that a WebAssembly code returns a specific result (table_fill64.wast:54)
+PASS #39 Test that a WebAssembly code returns a specific result (table_fill64.wast:56)
+PASS #40 Test that a WebAssembly code returns a specific result (table_fill64.wast:57)
+PASS #41 Test that a WebAssembly code returns a specific result (table_fill64.wast:58)
+PASS #42 Test that a WebAssembly code returns a specific result (table_fill64.wast:60)
+PASS #43 Test that a WebAssembly code returns a specific result (table_fill64.wast:61)
+PASS #44 Test that a WebAssembly code traps (table_fill64.wast:63)
+PASS #45 Test that a WebAssembly code returns a specific result (table_fill64.wast:67)
+PASS #46 Test that a WebAssembly code returns a specific result (table_fill64.wast:68)
+PASS #47 Test that a WebAssembly code returns a specific result (table_fill64.wast:69)
+PASS #48 Test that a WebAssembly code traps (table_fill64.wast:71)
+PASS #49 Test that a WebAssembly code traps (table_fill64.wast:76)
+PASS #50 Test that a WebAssembly code returns a specific result (table_fill64.wast:83)
+PASS #51 Test that a WebAssembly code returns a specific result (table_fill64.wast:84)
+PASS #52 Test that a WebAssembly code returns a specific result (table_fill64.wast:85)
+PASS #53 Test that a WebAssembly code returns a specific result (table_fill64.wast:86)
+PASS #54 Test that a WebAssembly code returns a specific result (table_fill64.wast:87)
+PASS #55 Test that a WebAssembly code returns a specific result (table_fill64.wast:89)
+PASS #56 Test that a WebAssembly code returns a specific result (table_fill64.wast:90)
+PASS #57 Test that a WebAssembly code returns a specific result (table_fill64.wast:91)
+PASS #58 Test that a WebAssembly code returns a specific result (table_fill64.wast:92)
+PASS #59 Test that a WebAssembly code returns a specific result (table_fill64.wast:93)
+PASS #60 Test that a WebAssembly code returns a specific result (table_fill64.wast:94)
+PASS #61 Test that a WebAssembly code returns a specific result (table_fill64.wast:96)
+PASS #62 Test that a WebAssembly code returns a specific result (table_fill64.wast:97)
+PASS #63 Test that a WebAssembly code returns a specific result (table_fill64.wast:98)
+PASS #64 Test that a WebAssembly code returns a specific result (table_fill64.wast:99)
+PASS #65 Test that a WebAssembly code returns a specific result (table_fill64.wast:100)
+PASS #66 Test that a WebAssembly code returns a specific result (table_fill64.wast:102)
+PASS #67 Test that a WebAssembly code returns a specific result (table_fill64.wast:103)
+PASS #68 Test that a WebAssembly code returns a specific result (table_fill64.wast:104)
+PASS #69 Test that a WebAssembly code returns a specific result (table_fill64.wast:105)
+PASS #70 Test that a WebAssembly code returns a specific result (table_fill64.wast:107)
+PASS #71 Test that a WebAssembly code returns a specific result (table_fill64.wast:108)
+PASS #72 Test that a WebAssembly code returns a specific result (table_fill64.wast:109)
+PASS #73 Test that a WebAssembly code returns a specific result (table_fill64.wast:110)
+PASS #74 Test that a WebAssembly code returns a specific result (table_fill64.wast:112)
+PASS #75 Test that a WebAssembly code returns a specific result (table_fill64.wast:113)
+PASS #76 Test that a WebAssembly code returns a specific result (table_fill64.wast:114)
+PASS #77 Test that a WebAssembly code returns a specific result (table_fill64.wast:116)
+PASS #78 Test that a WebAssembly code returns a specific result (table_fill64.wast:117)
+PASS #79 Test that a WebAssembly code traps (table_fill64.wast:119)
+PASS #80 Test that a WebAssembly code returns a specific result (table_fill64.wast:123)
+PASS #81 Test that a WebAssembly code returns a specific result (table_fill64.wast:124)
+PASS #82 Test that a WebAssembly code returns a specific result (table_fill64.wast:125)
+PASS #83 Test that a WebAssembly code traps (table_fill64.wast:127)
+PASS #84 Test that a WebAssembly code traps (table_fill64.wast:132)
 PASS #85 Test that WebAssembly compilation fails (table_fill64.wast:139)
 PASS #86 Test that WebAssembly compilation fails (table_fill64.wast:148)
 PASS #87 Test that WebAssembly compilation fails (table_fill64.wast:157)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_fill64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js-expected.txt
@@ -1,39 +1,17 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (table_get64.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (table_get64.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (table_get64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 136: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_get64_wast_js@table_get64.wast.js:7:18
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #6 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_get64_wast_js@table_get64.wast.js:10:4
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (table_get64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_get64_wast_js@table_get64.wast.js:13:14
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (table_get64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_get64_wast_js@table_get64.wast.js:16:14
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (table_get64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_get64_wast_js@table_get64.wast.js:19:14
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (table_get64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_get64_wast_js@table_get64.wast.js:22:14
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (table_get64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_get64_wast_js@table_get64.wast.js:25:14
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #12 Test that a WebAssembly code traps (table_get64.wast:33) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_get64_wast_js@table_get64.wast.js:28:12
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #13 Test that a WebAssembly code traps (table_get64.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_get64_wast_js@table_get64.wast.js:31:12
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #14 Test that a WebAssembly code traps (table_get64.wast:35) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_get64_wast_js@table_get64.wast.js:34:12
-global code@table_get64.wast.js:39:3 expected true got false
-FAIL #15 Test that a WebAssembly code traps (table_get64.wast:36) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_get64_wast_js@table_get64.wast.js:37:12
-global code@table_get64.wast.js:39:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (table_get64.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (table_get64.wast:1)
+PASS #6 Run a WebAssembly test without special assertions (table_get64.wast:24)
+PASS #7 Test that a WebAssembly code returns a specific result (table_get64.wast:26)
+PASS #8 Test that a WebAssembly code returns a specific result (table_get64.wast:27)
+PASS #9 Test that a WebAssembly code returns a specific result (table_get64.wast:29)
+PASS #10 Test that a WebAssembly code returns a specific result (table_get64.wast:30)
+PASS #11 Test that a WebAssembly code returns a specific result (table_get64.wast:31)
+PASS #12 Test that a WebAssembly code traps (table_get64.wast:33)
+PASS #13 Test that a WebAssembly code traps (table_get64.wast:34)
+PASS #14 Test that a WebAssembly code traps (table_get64.wast:35)
+PASS #15 Test that a WebAssembly code traps (table_get64.wast:36)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_get64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js-expected.txt
@@ -1,72 +1,28 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (table_grow64.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (table_grow64.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (table_grow64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.get index to type I64 expected I32, in function at index 0 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_grow64_wast_js@table_grow64.wast.js:7:18
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (table_grow64.wast:12) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:10:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #7 Test that a WebAssembly code traps (table_grow64.wast:13) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_grow64_wast_js@table_grow64.wast.js:13:12
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #8 Test that a WebAssembly code traps (table_grow64.wast:14) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_grow64_wast_js@table_grow64.wast.js:16:12
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (table_grow64.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:19:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (table_grow64.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:22:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (table_grow64.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:25:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (table_grow64.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:28:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (table_grow64.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:31:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #14 Test that a WebAssembly code traps (table_grow64.wast:21) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_grow64_wast_js@table_grow64.wast.js:34:12
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #15 Test that a WebAssembly code traps (table_grow64.wast:22) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_grow64_wast_js@table_grow64.wast.js:37:12
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (table_grow64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:40:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (table_grow64.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:43:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (table_grow64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:46:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (table_grow64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:49:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (table_grow64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:52:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (table_grow64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:55:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (table_grow64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:58:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (table_grow64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:61:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (table_grow64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_grow64_wast_js@table_grow64.wast.js:64:14
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #25 Test that a WebAssembly code traps (table_grow64.wast:33) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_grow64_wast_js@table_grow64.wast.js:67:12
-global code@table_grow64.wast.js:72:3 expected true got false
-FAIL #26 Test that a WebAssembly code traps (table_grow64.wast:34) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_grow64_wast_js@table_grow64.wast.js:70:12
-global code@table_grow64.wast.js:72:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (table_grow64.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (table_grow64.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (table_grow64.wast:12)
+PASS #7 Test that a WebAssembly code traps (table_grow64.wast:13)
+PASS #8 Test that a WebAssembly code traps (table_grow64.wast:14)
+PASS #9 Test that a WebAssembly code returns a specific result (table_grow64.wast:16)
+PASS #10 Test that a WebAssembly code returns a specific result (table_grow64.wast:17)
+PASS #11 Test that a WebAssembly code returns a specific result (table_grow64.wast:18)
+PASS #12 Test that a WebAssembly code returns a specific result (table_grow64.wast:19)
+PASS #13 Test that a WebAssembly code returns a specific result (table_grow64.wast:20)
+PASS #14 Test that a WebAssembly code traps (table_grow64.wast:21)
+PASS #15 Test that a WebAssembly code traps (table_grow64.wast:22)
+PASS #16 Test that a WebAssembly code returns a specific result (table_grow64.wast:24)
+PASS #17 Test that a WebAssembly code returns a specific result (table_grow64.wast:25)
+PASS #18 Test that a WebAssembly code returns a specific result (table_grow64.wast:26)
+PASS #19 Test that a WebAssembly code returns a specific result (table_grow64.wast:27)
+PASS #20 Test that a WebAssembly code returns a specific result (table_grow64.wast:28)
+PASS #21 Test that a WebAssembly code returns a specific result (table_grow64.wast:29)
+PASS #22 Test that a WebAssembly code returns a specific result (table_grow64.wast:30)
+PASS #23 Test that a WebAssembly code returns a specific result (table_grow64.wast:31)
+PASS #24 Test that a WebAssembly code returns a specific result (table_grow64.wast:32)
+PASS #25 Test that a WebAssembly code traps (table_grow64.wast:33)
+PASS #26 Test that a WebAssembly code traps (table_grow64.wast:34)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_grow64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js-expected.txt
@@ -7,9 +7,9 @@ PASS #5 Test that WebAssembly compilation succeeds (table_init64.wast:133)
 PASS #6 Test that WebAssembly compilation succeeds (table_init64.wast:200)
 PASS #7 Test that WebAssembly compilation succeeds (table_init64.wast:259)
 PASS #8 Test that WebAssembly compilation succeeds (table_init64.wast:318)
-FAIL #9 Test that WebAssembly compilation succeeds (table_init64.wast:385) assert_equals: expected false but got true
-FAIL #10 Test that WebAssembly compilation succeeds (table_init64.wast:444) assert_equals: expected false but got true
-FAIL #11 Test that WebAssembly compilation succeeds (table_init64.wast:503) assert_equals: expected false but got true
+PASS #9 Test that WebAssembly compilation succeeds (table_init64.wast:385)
+PASS #10 Test that WebAssembly compilation succeeds (table_init64.wast:444)
+PASS #11 Test that WebAssembly compilation succeeds (table_init64.wast:503)
 PASS #12 Test that WebAssembly compilation fails (table_init64.wast:569)
 PASS #13 Test that WebAssembly compilation fails (table_init64.wast:575)
 PASS #14 Test that WebAssembly compilation fails (table_init64.wast:581)
@@ -110,7 +110,7 @@ PASS #108 Test that WebAssembly compilation succeeds (table_init64.wast:2103)
 PASS #109 Test that WebAssembly compilation succeeds (table_init64.wast:2293)
 PASS #110 Test that WebAssembly compilation succeeds (table_init64.wast:2387)
 PASS #111 Test that WebAssembly compilation succeeds (table_init64.wast:2433)
-FAIL #112 Test that WebAssembly compilation succeeds (table_init64.wast:2457) assert_equals: expected false but got true
+PASS #112 Test that WebAssembly compilation succeeds (table_init64.wast:2457)
 PASS #113 Reinitialize the default imports
 PASS #114 Test that WebAssembly compilation succeeds (table_init64.wast:6)
 PASS #115 Test that WebAssembly instantiation succeeds (table_init64.wast:6)
@@ -312,297 +312,105 @@ PASS #310 Test that a WebAssembly code traps (table_init64.wast:380)
 PASS #311 Test that a WebAssembly code traps (table_init64.wast:381)
 PASS #312 Test that a WebAssembly code traps (table_init64.wast:382)
 PASS #313 Test that a WebAssembly code traps (table_init64.wast:383)
-FAIL #314 Test that WebAssembly compilation succeeds (table_init64.wast:385) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #315 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_init64_wast_js@table_init64.wast.js:610:18
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #316 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_init64_wast_js@table_init64.wast.js:613:4
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #317 Test that a WebAssembly code traps (table_init64.wast:413) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:616:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #318 Test that a WebAssembly code traps (table_init64.wast:414) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:619:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #319 Test that a WebAssembly code returns a specific result (table_init64.wast:415) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:622:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #320 Test that a WebAssembly code returns a specific result (table_init64.wast:416) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:625:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #321 Test that a WebAssembly code returns a specific result (table_init64.wast:417) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:628:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #322 Test that a WebAssembly code returns a specific result (table_init64.wast:418) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:631:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #323 Test that a WebAssembly code traps (table_init64.wast:419) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:634:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #324 Test that a WebAssembly code returns a specific result (table_init64.wast:420) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:637:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #325 Test that a WebAssembly code returns a specific result (table_init64.wast:421) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:640:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #326 Test that a WebAssembly code returns a specific result (table_init64.wast:422) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:643:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #327 Test that a WebAssembly code returns a specific result (table_init64.wast:423) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:646:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #328 Test that a WebAssembly code traps (table_init64.wast:424) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:649:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #329 Test that a WebAssembly code returns a specific result (table_init64.wast:425) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:652:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #330 Test that a WebAssembly code returns a specific result (table_init64.wast:426) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:655:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #331 Test that a WebAssembly code returns a specific result (table_init64.wast:427) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:658:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #332 Test that a WebAssembly code returns a specific result (table_init64.wast:428) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:661:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #333 Test that a WebAssembly code returns a specific result (table_init64.wast:429) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:664:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #334 Test that a WebAssembly code traps (table_init64.wast:430) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:667:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #335 Test that a WebAssembly code traps (table_init64.wast:431) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:670:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #336 Test that a WebAssembly code traps (table_init64.wast:432) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:673:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #337 Test that a WebAssembly code traps (table_init64.wast:433) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:676:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #338 Test that a WebAssembly code traps (table_init64.wast:434) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:679:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #339 Test that a WebAssembly code traps (table_init64.wast:435) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:682:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #340 Test that a WebAssembly code traps (table_init64.wast:436) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:685:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #341 Test that a WebAssembly code traps (table_init64.wast:437) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:688:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #342 Test that a WebAssembly code traps (table_init64.wast:438) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:691:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #343 Test that a WebAssembly code traps (table_init64.wast:439) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:694:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #344 Test that a WebAssembly code traps (table_init64.wast:440) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:697:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #345 Test that a WebAssembly code traps (table_init64.wast:441) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:700:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #346 Test that a WebAssembly code traps (table_init64.wast:442) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:703:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #347 Test that WebAssembly compilation succeeds (table_init64.wast:444) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #348 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_init64_wast_js@table_init64.wast.js:709:18
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #349 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_init64_wast_js@table_init64.wast.js:712:4
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #350 Test that a WebAssembly code traps (table_init64.wast:472) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:715:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #351 Test that a WebAssembly code traps (table_init64.wast:473) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:718:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #352 Test that a WebAssembly code returns a specific result (table_init64.wast:474) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:721:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #353 Test that a WebAssembly code returns a specific result (table_init64.wast:475) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:724:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #354 Test that a WebAssembly code returns a specific result (table_init64.wast:476) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:727:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #355 Test that a WebAssembly code returns a specific result (table_init64.wast:477) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:730:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #356 Test that a WebAssembly code traps (table_init64.wast:478) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:733:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #357 Test that a WebAssembly code traps (table_init64.wast:479) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:736:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #358 Test that a WebAssembly code traps (table_init64.wast:480) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:739:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #359 Test that a WebAssembly code traps (table_init64.wast:481) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:742:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #360 Test that a WebAssembly code traps (table_init64.wast:482) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:745:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #361 Test that a WebAssembly code traps (table_init64.wast:483) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:748:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #362 Test that a WebAssembly code returns a specific result (table_init64.wast:484) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:751:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #363 Test that a WebAssembly code returns a specific result (table_init64.wast:485) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:754:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #364 Test that a WebAssembly code returns a specific result (table_init64.wast:486) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:757:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #365 Test that a WebAssembly code returns a specific result (table_init64.wast:487) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:760:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #366 Test that a WebAssembly code returns a specific result (table_init64.wast:488) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:763:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #367 Test that a WebAssembly code returns a specific result (table_init64.wast:489) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:766:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #368 Test that a WebAssembly code traps (table_init64.wast:490) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:769:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #369 Test that a WebAssembly code traps (table_init64.wast:491) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:772:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #370 Test that a WebAssembly code traps (table_init64.wast:492) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:775:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #371 Test that a WebAssembly code traps (table_init64.wast:493) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:778:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #372 Test that a WebAssembly code traps (table_init64.wast:494) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:781:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #373 Test that a WebAssembly code traps (table_init64.wast:495) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:784:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #374 Test that a WebAssembly code traps (table_init64.wast:496) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:787:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #375 Test that a WebAssembly code traps (table_init64.wast:497) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:790:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #376 Test that a WebAssembly code traps (table_init64.wast:498) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:793:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #377 Test that a WebAssembly code traps (table_init64.wast:499) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:796:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #378 Test that a WebAssembly code traps (table_init64.wast:500) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:799:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #379 Test that a WebAssembly code traps (table_init64.wast:501) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:802:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #380 Test that WebAssembly compilation succeeds (table_init64.wast:503) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 141: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #381 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_init64_wast_js@table_init64.wast.js:808:19
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #382 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@async_index.js:260:29
-table_init64_wast_js@table_init64.wast.js:811:4
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #383 Test that a WebAssembly code traps (table_init64.wast:539) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:814:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #384 Test that a WebAssembly code traps (table_init64.wast:540) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:817:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #385 Test that a WebAssembly code returns a specific result (table_init64.wast:541) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:820:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #386 Test that a WebAssembly code returns a specific result (table_init64.wast:542) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:823:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #387 Test that a WebAssembly code returns a specific result (table_init64.wast:543) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:826:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #388 Test that a WebAssembly code returns a specific result (table_init64.wast:544) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:829:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #389 Test that a WebAssembly code traps (table_init64.wast:545) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:832:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #390 Test that a WebAssembly code returns a specific result (table_init64.wast:546) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:835:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #391 Test that a WebAssembly code returns a specific result (table_init64.wast:547) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:838:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #392 Test that a WebAssembly code returns a specific result (table_init64.wast:548) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:841:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #393 Test that a WebAssembly code returns a specific result (table_init64.wast:549) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:844:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #394 Test that a WebAssembly code traps (table_init64.wast:550) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:847:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #395 Test that a WebAssembly code returns a specific result (table_init64.wast:551) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:850:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #396 Test that a WebAssembly code traps (table_init64.wast:552) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:853:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #397 Test that a WebAssembly code returns a specific result (table_init64.wast:553) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:856:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #398 Test that a WebAssembly code returns a specific result (table_init64.wast:554) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:859:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #399 Test that a WebAssembly code returns a specific result (table_init64.wast:555) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:862:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #400 Test that a WebAssembly code returns a specific result (table_init64.wast:556) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:865:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #401 Test that a WebAssembly code traps (table_init64.wast:557) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:868:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #402 Test that a WebAssembly code returns a specific result (table_init64.wast:558) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:871:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #403 Test that a WebAssembly code traps (table_init64.wast:559) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:874:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #404 Test that a WebAssembly code returns a specific result (table_init64.wast:560) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:877:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #405 Test that a WebAssembly code traps (table_init64.wast:561) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:880:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #406 Test that a WebAssembly code returns a specific result (table_init64.wast:562) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:883:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #407 Test that a WebAssembly code returns a specific result (table_init64.wast:563) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:886:14
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #408 Test that a WebAssembly code traps (table_init64.wast:564) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:889:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #409 Test that a WebAssembly code traps (table_init64.wast:565) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:892:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #410 Test that a WebAssembly code traps (table_init64.wast:566) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:895:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #411 Test that a WebAssembly code traps (table_init64.wast:567) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:898:12
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #412 Test that a WebAssembly code traps (table_init64.wast:568) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_init64_wast_js@table_init64.wast.js:901:12
-global code@table_init64.wast.js:2799:3 expected true got false
+PASS #314 Test that WebAssembly compilation succeeds (table_init64.wast:385)
+PASS #315 Test that WebAssembly instantiation succeeds (table_init64.wast:385)
+PASS #316 Run a WebAssembly test without special assertions (table_init64.wast:412)
+PASS #317 Test that a WebAssembly code traps (table_init64.wast:413)
+PASS #318 Test that a WebAssembly code traps (table_init64.wast:414)
+PASS #319 Test that a WebAssembly code returns a specific result (table_init64.wast:415)
+PASS #320 Test that a WebAssembly code returns a specific result (table_init64.wast:416)
+PASS #321 Test that a WebAssembly code returns a specific result (table_init64.wast:417)
+PASS #322 Test that a WebAssembly code returns a specific result (table_init64.wast:418)
+PASS #323 Test that a WebAssembly code traps (table_init64.wast:419)
+PASS #324 Test that a WebAssembly code returns a specific result (table_init64.wast:420)
+PASS #325 Test that a WebAssembly code returns a specific result (table_init64.wast:421)
+PASS #326 Test that a WebAssembly code returns a specific result (table_init64.wast:422)
+PASS #327 Test that a WebAssembly code returns a specific result (table_init64.wast:423)
+PASS #328 Test that a WebAssembly code traps (table_init64.wast:424)
+PASS #329 Test that a WebAssembly code returns a specific result (table_init64.wast:425)
+PASS #330 Test that a WebAssembly code returns a specific result (table_init64.wast:426)
+PASS #331 Test that a WebAssembly code returns a specific result (table_init64.wast:427)
+PASS #332 Test that a WebAssembly code returns a specific result (table_init64.wast:428)
+PASS #333 Test that a WebAssembly code returns a specific result (table_init64.wast:429)
+PASS #334 Test that a WebAssembly code traps (table_init64.wast:430)
+PASS #335 Test that a WebAssembly code traps (table_init64.wast:431)
+PASS #336 Test that a WebAssembly code traps (table_init64.wast:432)
+PASS #337 Test that a WebAssembly code traps (table_init64.wast:433)
+PASS #338 Test that a WebAssembly code traps (table_init64.wast:434)
+PASS #339 Test that a WebAssembly code traps (table_init64.wast:435)
+PASS #340 Test that a WebAssembly code traps (table_init64.wast:436)
+PASS #341 Test that a WebAssembly code traps (table_init64.wast:437)
+PASS #342 Test that a WebAssembly code traps (table_init64.wast:438)
+PASS #343 Test that a WebAssembly code traps (table_init64.wast:439)
+PASS #344 Test that a WebAssembly code traps (table_init64.wast:440)
+PASS #345 Test that a WebAssembly code traps (table_init64.wast:441)
+PASS #346 Test that a WebAssembly code traps (table_init64.wast:442)
+PASS #347 Test that WebAssembly compilation succeeds (table_init64.wast:444)
+PASS #348 Test that WebAssembly instantiation succeeds (table_init64.wast:444)
+PASS #349 Run a WebAssembly test without special assertions (table_init64.wast:471)
+PASS #350 Test that a WebAssembly code traps (table_init64.wast:472)
+PASS #351 Test that a WebAssembly code traps (table_init64.wast:473)
+PASS #352 Test that a WebAssembly code returns a specific result (table_init64.wast:474)
+PASS #353 Test that a WebAssembly code returns a specific result (table_init64.wast:475)
+PASS #354 Test that a WebAssembly code returns a specific result (table_init64.wast:476)
+PASS #355 Test that a WebAssembly code returns a specific result (table_init64.wast:477)
+PASS #356 Test that a WebAssembly code traps (table_init64.wast:478)
+PASS #357 Test that a WebAssembly code traps (table_init64.wast:479)
+PASS #358 Test that a WebAssembly code traps (table_init64.wast:480)
+PASS #359 Test that a WebAssembly code traps (table_init64.wast:481)
+PASS #360 Test that a WebAssembly code traps (table_init64.wast:482)
+PASS #361 Test that a WebAssembly code traps (table_init64.wast:483)
+PASS #362 Test that a WebAssembly code returns a specific result (table_init64.wast:484)
+PASS #363 Test that a WebAssembly code returns a specific result (table_init64.wast:485)
+PASS #364 Test that a WebAssembly code returns a specific result (table_init64.wast:486)
+PASS #365 Test that a WebAssembly code returns a specific result (table_init64.wast:487)
+PASS #366 Test that a WebAssembly code returns a specific result (table_init64.wast:488)
+PASS #367 Test that a WebAssembly code returns a specific result (table_init64.wast:489)
+PASS #368 Test that a WebAssembly code traps (table_init64.wast:490)
+PASS #369 Test that a WebAssembly code traps (table_init64.wast:491)
+PASS #370 Test that a WebAssembly code traps (table_init64.wast:492)
+PASS #371 Test that a WebAssembly code traps (table_init64.wast:493)
+PASS #372 Test that a WebAssembly code traps (table_init64.wast:494)
+PASS #373 Test that a WebAssembly code traps (table_init64.wast:495)
+PASS #374 Test that a WebAssembly code traps (table_init64.wast:496)
+PASS #375 Test that a WebAssembly code traps (table_init64.wast:497)
+PASS #376 Test that a WebAssembly code traps (table_init64.wast:498)
+PASS #377 Test that a WebAssembly code traps (table_init64.wast:499)
+PASS #378 Test that a WebAssembly code traps (table_init64.wast:500)
+PASS #379 Test that a WebAssembly code traps (table_init64.wast:501)
+PASS #380 Test that WebAssembly compilation succeeds (table_init64.wast:503)
+PASS #381 Test that WebAssembly instantiation succeeds (table_init64.wast:503)
+PASS #382 Run a WebAssembly test without special assertions (table_init64.wast:538)
+PASS #383 Test that a WebAssembly code traps (table_init64.wast:539)
+PASS #384 Test that a WebAssembly code traps (table_init64.wast:540)
+PASS #385 Test that a WebAssembly code returns a specific result (table_init64.wast:541)
+PASS #386 Test that a WebAssembly code returns a specific result (table_init64.wast:542)
+PASS #387 Test that a WebAssembly code returns a specific result (table_init64.wast:543)
+PASS #388 Test that a WebAssembly code returns a specific result (table_init64.wast:544)
+PASS #389 Test that a WebAssembly code traps (table_init64.wast:545)
+PASS #390 Test that a WebAssembly code returns a specific result (table_init64.wast:546)
+PASS #391 Test that a WebAssembly code returns a specific result (table_init64.wast:547)
+PASS #392 Test that a WebAssembly code returns a specific result (table_init64.wast:548)
+PASS #393 Test that a WebAssembly code returns a specific result (table_init64.wast:549)
+PASS #394 Test that a WebAssembly code traps (table_init64.wast:550)
+PASS #395 Test that a WebAssembly code returns a specific result (table_init64.wast:551)
+PASS #396 Test that a WebAssembly code traps (table_init64.wast:552)
+PASS #397 Test that a WebAssembly code returns a specific result (table_init64.wast:553)
+PASS #398 Test that a WebAssembly code returns a specific result (table_init64.wast:554)
+PASS #399 Test that a WebAssembly code returns a specific result (table_init64.wast:555)
+PASS #400 Test that a WebAssembly code returns a specific result (table_init64.wast:556)
+PASS #401 Test that a WebAssembly code traps (table_init64.wast:557)
+PASS #402 Test that a WebAssembly code returns a specific result (table_init64.wast:558)
+PASS #403 Test that a WebAssembly code traps (table_init64.wast:559)
+PASS #404 Test that a WebAssembly code returns a specific result (table_init64.wast:560)
+PASS #405 Test that a WebAssembly code traps (table_init64.wast:561)
+PASS #406 Test that a WebAssembly code returns a specific result (table_init64.wast:562)
+PASS #407 Test that a WebAssembly code returns a specific result (table_init64.wast:563)
+PASS #408 Test that a WebAssembly code traps (table_init64.wast:564)
+PASS #409 Test that a WebAssembly code traps (table_init64.wast:565)
+PASS #410 Test that a WebAssembly code traps (table_init64.wast:566)
+PASS #411 Test that a WebAssembly code traps (table_init64.wast:567)
+PASS #412 Test that a WebAssembly code traps (table_init64.wast:568)
 PASS #413 Test that WebAssembly compilation fails (table_init64.wast:569)
 PASS #414 Test that WebAssembly compilation fails (table_init64.wast:575)
 PASS #415 Test that WebAssembly compilation fails (table_init64.wast:581)
@@ -1232,11 +1040,9 @@ PASS #1038 Test that a WebAssembly code traps (table_init64.wast:2430)
 PASS #1039 Test that a WebAssembly code traps (table_init64.wast:2431)
 PASS #1040 Test that WebAssembly compilation succeeds (table_init64.wast:2433)
 PASS #1041 Test that WebAssembly instantiation succeeds (table_init64.wast:2433)
-FAIL #1042 Test that WebAssembly compilation succeeds (table_init64.wast:2457) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: table.init dst_offset to type I64 expected I32, in function at index 0 at {loc} expected true got false
-FAIL #1043 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_init64_wast_js@table_init64.wast.js:2794:19
-global code@table_init64.wast.js:2799:3 expected true got false
-FAIL #1044 Test that a WebAssembly code returns a specific result (table_init64.wast:2471) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_init64_wast_js@table_init64.wast.js:2797:14
-global code@table_init64.wast.js:2799:3 expected true got false
+PASS #1042 Test that WebAssembly compilation succeeds (table_init64.wast:2457)
+PASS #1043 Test that WebAssembly instantiation succeeds (table_init64.wast:2457)
+FAIL #1044 Test that a WebAssembly code returns a specific result (table_init64.wast:2471) assert_equals: assert_return@async_index.js:324:29
+table_init64_wast_js@table_init64.wast.js:2798:14
+global code@table_init64.wast.js:2800:3 expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_init64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js-expected.txt
@@ -1,63 +1,25 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (table_set64.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (table_set64.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (table_set64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 191: Element init_expr must produce an i32 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_set64_wast_js@table_set64.wast.js:7:18
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (table_set64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:10:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (table_set64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:13:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (table_set64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:16:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (table_set64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:19:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (table_set64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:22:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (table_set64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:25:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (table_set64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:28:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (table_set64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:31:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (table_set64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:34:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (table_set64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_set64_wast_js@table_set64.wast.js:37:14
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #16 Test that a WebAssembly code traps (table_set64.wast:41) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_set64_wast_js@table_set64.wast.js:40:12
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #17 Test that a WebAssembly code traps (table_set64.wast:42) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_set64_wast_js@table_set64.wast.js:43:12
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #18 Test that a WebAssembly code traps (table_set64.wast:43) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_set64_wast_js@table_set64.wast.js:46:12
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #19 Test that a WebAssembly code traps (table_set64.wast:44) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_set64_wast_js@table_set64.wast.js:49:12
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #20 Test that a WebAssembly code traps (table_set64.wast:46) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_set64_wast_js@table_set64.wast.js:52:12
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #21 Test that a WebAssembly code traps (table_set64.wast:47) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_set64_wast_js@table_set64.wast.js:55:12
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #22 Test that a WebAssembly code traps (table_set64.wast:48) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_set64_wast_js@table_set64.wast.js:58:12
-global code@table_set64.wast.js:63:3 expected true got false
-FAIL #23 Test that a WebAssembly code traps (table_set64.wast:49) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@async_index.js:281:29
-table_set64_wast_js@table_set64.wast.js:61:12
-global code@table_set64.wast.js:63:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (table_set64.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (table_set64.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (table_set64.wast:29)
+PASS #7 Test that a WebAssembly code returns a specific result (table_set64.wast:30)
+PASS #8 Test that a WebAssembly code returns a specific result (table_set64.wast:31)
+PASS #9 Test that a WebAssembly code returns a specific result (table_set64.wast:32)
+PASS #10 Test that a WebAssembly code returns a specific result (table_set64.wast:33)
+PASS #11 Test that a WebAssembly code returns a specific result (table_set64.wast:35)
+PASS #12 Test that a WebAssembly code returns a specific result (table_set64.wast:36)
+PASS #13 Test that a WebAssembly code returns a specific result (table_set64.wast:37)
+PASS #14 Test that a WebAssembly code returns a specific result (table_set64.wast:38)
+PASS #15 Test that a WebAssembly code returns a specific result (table_set64.wast:39)
+PASS #16 Test that a WebAssembly code traps (table_set64.wast:41)
+PASS #17 Test that a WebAssembly code traps (table_set64.wast:42)
+PASS #18 Test that a WebAssembly code traps (table_set64.wast:43)
+PASS #19 Test that a WebAssembly code traps (table_set64.wast:44)
+PASS #20 Test that a WebAssembly code traps (table_set64.wast:46)
+PASS #21 Test that a WebAssembly code traps (table_set64.wast:47)
+PASS #22 Test that a WebAssembly code traps (table_set64.wast:48)
+PASS #23 Test that a WebAssembly code traps (table_set64.wast:49)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_set64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js-expected.txt
@@ -1,117 +1,43 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (table_size64.wast:1) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (table_size64.wast:1)
 PASS #3 Reinitialize the default imports
-FAIL #4 Test that WebAssembly compilation succeeds (table_size64.wast:1) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't validate: control flow returns with unexpected type. I32 is not a I64, in function at index 0 at {loc} expected true got false
-FAIL #5 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@async_index.js:219:29
-table_size64_wast_js@table_size64.wast.js:7:18
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #6 Test that a WebAssembly code returns a specific result (table_size64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:10:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #7 Test that a WebAssembly code returns a specific result (table_size64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:13:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #8 Test that a WebAssembly code returns a specific result (table_size64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:16:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #9 Test that a WebAssembly code returns a specific result (table_size64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:19:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #10 Test that a WebAssembly code returns a specific result (table_size64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:22:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #11 Test that a WebAssembly code returns a specific result (table_size64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:25:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #12 Test that a WebAssembly code returns a specific result (table_size64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:28:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #13 Test that a WebAssembly code returns a specific result (table_size64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:31:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #14 Test that a WebAssembly code returns a specific result (table_size64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:34:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #15 Test that a WebAssembly code returns a specific result (table_size64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:37:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #16 Test that a WebAssembly code returns a specific result (table_size64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:40:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #17 Test that a WebAssembly code returns a specific result (table_size64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:43:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #18 Test that a WebAssembly code returns a specific result (table_size64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:46:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #19 Test that a WebAssembly code returns a specific result (table_size64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:49:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #20 Test that a WebAssembly code returns a specific result (table_size64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:52:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #21 Test that a WebAssembly code returns a specific result (table_size64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:55:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #22 Test that a WebAssembly code returns a specific result (table_size64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:58:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #23 Test that a WebAssembly code returns a specific result (table_size64.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:61:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #24 Test that a WebAssembly code returns a specific result (table_size64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:64:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #25 Test that a WebAssembly code returns a specific result (table_size64.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:67:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #26 Test that a WebAssembly code returns a specific result (table_size64.wast:48) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:70:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (table_size64.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:73:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (table_size64.wast:50) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:76:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (table_size64.wast:51) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:79:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (table_size64.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:82:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (table_size64.wast:54) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:85:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (table_size64.wast:55) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:88:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #33 Test that a WebAssembly code returns a specific result (table_size64.wast:56) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:91:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (table_size64.wast:57) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:94:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (table_size64.wast:58) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:97:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (table_size64.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:100:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (table_size64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:103:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (table_size64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:106:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (table_size64.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:109:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (table_size64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:112:14
-global code@table_size64.wast.js:117:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (table_size64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@async_index.js:324:29
-table_size64_wast_js@table_size64.wast.js:115:14
-global code@table_size64.wast.js:117:3 expected true got false
+PASS #4 Test that WebAssembly compilation succeeds (table_size64.wast:1)
+PASS #5 Test that WebAssembly instantiation succeeds (table_size64.wast:1)
+PASS #6 Test that a WebAssembly code returns a specific result (table_size64.wast:26)
+PASS #7 Test that a WebAssembly code returns a specific result (table_size64.wast:27)
+PASS #8 Test that a WebAssembly code returns a specific result (table_size64.wast:28)
+PASS #9 Test that a WebAssembly code returns a specific result (table_size64.wast:29)
+PASS #10 Test that a WebAssembly code returns a specific result (table_size64.wast:30)
+PASS #11 Test that a WebAssembly code returns a specific result (table_size64.wast:31)
+PASS #12 Test that a WebAssembly code returns a specific result (table_size64.wast:32)
+PASS #13 Test that a WebAssembly code returns a specific result (table_size64.wast:34)
+PASS #14 Test that a WebAssembly code returns a specific result (table_size64.wast:35)
+PASS #15 Test that a WebAssembly code returns a specific result (table_size64.wast:36)
+PASS #16 Test that a WebAssembly code returns a specific result (table_size64.wast:37)
+PASS #17 Test that a WebAssembly code returns a specific result (table_size64.wast:38)
+PASS #18 Test that a WebAssembly code returns a specific result (table_size64.wast:39)
+PASS #19 Test that a WebAssembly code returns a specific result (table_size64.wast:40)
+PASS #20 Test that a WebAssembly code returns a specific result (table_size64.wast:42)
+PASS #21 Test that a WebAssembly code returns a specific result (table_size64.wast:43)
+PASS #22 Test that a WebAssembly code returns a specific result (table_size64.wast:44)
+PASS #23 Test that a WebAssembly code returns a specific result (table_size64.wast:45)
+PASS #24 Test that a WebAssembly code returns a specific result (table_size64.wast:46)
+PASS #25 Test that a WebAssembly code returns a specific result (table_size64.wast:47)
+PASS #26 Test that a WebAssembly code returns a specific result (table_size64.wast:48)
+PASS #27 Test that a WebAssembly code returns a specific result (table_size64.wast:49)
+PASS #28 Test that a WebAssembly code returns a specific result (table_size64.wast:50)
+PASS #29 Test that a WebAssembly code returns a specific result (table_size64.wast:51)
+PASS #30 Test that a WebAssembly code returns a specific result (table_size64.wast:52)
+PASS #31 Test that a WebAssembly code returns a specific result (table_size64.wast:54)
+PASS #32 Test that a WebAssembly code returns a specific result (table_size64.wast:55)
+PASS #33 Test that a WebAssembly code returns a specific result (table_size64.wast:56)
+PASS #34 Test that a WebAssembly code returns a specific result (table_size64.wast:57)
+PASS #35 Test that a WebAssembly code returns a specific result (table_size64.wast:58)
+PASS #36 Test that a WebAssembly code returns a specific result (table_size64.wast:59)
+PASS #37 Test that a WebAssembly code returns a specific result (table_size64.wast:60)
+PASS #38 Test that a WebAssembly code returns a specific result (table_size64.wast:61)
+PASS #39 Test that a WebAssembly code returns a specific result (table_size64.wast:62)
+PASS #40 Test that a WebAssembly code returns a specific result (table_size64.wast:63)
+PASS #41 Test that a WebAssembly code returns a specific result (table_size64.wast:64)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/table_size64.wast.js.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ jscOptions=--useBBQJIT=false,--useOMGJIT=false ] -->
 <html>
     <head>
         <meta charset="UTF-8">

--- a/Source/JavaScriptCore/wasm/WasmAddressType.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.cpp
@@ -80,6 +80,18 @@ TypeKind AddressType::asWasmTypeKind() const
     RELEASE_ASSERT_NOT_REACHED(invalidAddressTypeConversion);
 }
 
+Wasm::Type AddressType::asWasmType() const
+{
+    switch (m_type) {
+    case AddressType::I32:
+        return Type { TypeKind::I32, 0 };
+    case AddressType::I64:
+        return Type { TypeKind::I64, 0 };
+    }
+
+    RELEASE_ASSERT_NOT_REACHED(invalidAddressTypeConversion);
+}
+
 #if !PLATFORM(PLAYSTATION)
 B3::TypeKind AddressType::asB3TypeKind() const
 {

--- a/Source/JavaScriptCore/wasm/WasmAddressType.h
+++ b/Source/JavaScriptCore/wasm/WasmAddressType.h
@@ -34,6 +34,7 @@ enum TypeKind : uint32_t;
 
 namespace Wasm {
 enum class TypeKind : int8_t;
+struct Type;
 
 class AddressType {
 public:
@@ -52,6 +53,7 @@ public:
 
     AddressType::Kind type() const { return m_type; }
     TypeKind NODELETE asWasmTypeKind() const;
+    Wasm::Type asWasmType() const;
     B3::TypeKind NODELETE asB3TypeKind() const;
 
     friend bool NODELETE operator==(const AddressType& lhs, const AddressType& rhs);

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "WasmOps.h"
 #include <wtf/Platform.h>
 
 #if ENABLE(WEBASSEMBLY)
@@ -2183,7 +2184,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         TypedExpression index;
         WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "table.get"_s);
-        WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "table.get index to type "_s, index.type(), " expected "_s, TypeKind::I32);
+        Wasm::TypeKind tableAddressType = m_info.tables[tableIndex].addressType().asWasmTypeKind();
+        WASM_VALIDATOR_FAIL_IF(tableAddressType != index.type().kind, "table.get index to type "_s, index.type(), " expected "_s, tableAddressType);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addTableGet(tableIndex, index, result));
@@ -2199,7 +2201,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         TypedExpression value, index;
         WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "table.set"_s);
         WASM_TRY_POP_EXPRESSION_STACK_INTO(index, "table.set"_s);
-        WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != index.type().kind, "table.set index to type "_s, index.type(), " expected "_s, TypeKind::I32);
+        Wasm::TypeKind tableAddressType = m_info.tables[tableIndex].addressType().asWasmTypeKind();
+        WASM_VALIDATOR_FAIL_IF(tableAddressType != index.type().kind, "table.set index to type "_s, index.type(), " expected "_s, tableAddressType);
         Type type = m_info.tables[tableIndex].wasmType();
         WASM_VALIDATOR_FAIL_IF(!isSubtype(value.type(), type), "table.set value to type "_s, value.type(), " expected "_s, type);
         RELEASE_ASSERT(m_info.tables[tableIndex].type() == TableElementType::Externref || m_info.tables[tableIndex].type() == TableElementType::Funcref);
@@ -2226,7 +2229,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "table.init"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "table.init"_s);
 
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "table.init dst_offset to type "_s, dstOffset.type(), " expected "_s, TypeKind::I32);
+            Wasm::TypeKind tableAddressType = m_info.tables[immediates.tableIndex].addressType().asWasmTypeKind();
+            WASM_VALIDATOR_FAIL_IF(dstOffset.type().kind != tableAddressType, "table.init dst_offset to type "_s, dstOffset.type(), " expected "_s, tableAddressType);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "table.init src_offset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
             WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind, "table.init length to type "_s, length.type(), " expected "_s, TypeKind::I32);
 
@@ -2246,7 +2250,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addTableSize(tableIndex, result));
-            m_expressionStack.constructAndAppend(Types::I32, result);
+
+            Wasm::Type tableAddressType = m_info.table(tableIndex).addressType().asWasmType();
+            m_expressionStack.constructAndAppend(tableAddressType, result);
             break;
         }
         case Ext1OpType::TableGrow: {
@@ -2260,11 +2266,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
             Type tableType = m_info.tables[tableIndex].wasmType();
             WASM_VALIDATOR_FAIL_IF(!isSubtype(fill.type(), tableType), "table.grow expects fill value of type "_s, tableType, " got "_s, fill.type());
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != delta.type().kind, "table.grow expects an i32 delta value, got "_s, delta.type());
+            AddressType addressType = m_info.table(tableIndex).addressType();
+            WASM_VALIDATOR_FAIL_IF(delta.type().kind != addressType.asWasmTypeKind(), "table.grow expects an "_s, addressType.is64Bit() ? "i64"_s : "i32"_s, " delta value, got "_s, delta.type());
 
             ExpressionType result;
             WASM_TRY_ADD_TO_CONTEXT(addTableGrow(tableIndex, fill, delta, result));
-            m_expressionStack.constructAndAppend(Types::I32, result);
+
+            Wasm::Type tableAddressType = m_info.table(tableIndex).addressType().asWasmType();
+            m_expressionStack.constructAndAppend(tableAddressType, result);
             break;
         }
         case Ext1OpType::TableFill: {
@@ -2276,10 +2285,12 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(fill, "table.fill"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(offset, "table.fill"_s);
 
-            Type tableType = m_info.tables[tableIndex].wasmType();
+            auto table = m_info.tables[tableIndex];
+            auto tableType = table.wasmType();
+            auto addressTypeKind = table.addressType().asWasmTypeKind();
             WASM_VALIDATOR_FAIL_IF(!isSubtype(fill.type(), tableType), "table.fill expects fill value of type "_s, tableType, " got "_s, fill.type());
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != offset.type().kind, "table.fill expects an i32 offset value, got "_s, offset.type());
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != count.type().kind, "table.fill expects an i32 count value, got "_s, count.type());
+            WASM_VALIDATOR_FAIL_IF(offset.type().kind != addressTypeKind, "table.fill expects an "_s, addressTypeKind, " offset value, got "_s, offset.type());
+            WASM_VALIDATOR_FAIL_IF(count.type().kind != addressTypeKind, "table.fill expects an "_s, addressTypeKind, " count value, got "_s, count.type());
 
             WASM_TRY_ADD_TO_CONTEXT(addTableFill(tableIndex, offset, fill, count));
             break;
@@ -2299,9 +2310,15 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(srcOffset, "table.copy"_s);
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstOffset, "table.copy"_s);
 
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstOffset.type().kind, "table.copy dst_offset to type "_s, dstOffset.type(), " expected "_s, TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != srcOffset.type().kind, "table.copy src_offset to type "_s, srcOffset.type(), " expected "_s, TypeKind::I32);
-            WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != length.type().kind, "table.copy length to type "_s, length.type(), " expected "_s, TypeKind::I32);
+            auto dstTableAddressType = m_info.tables[immediates.dstTableIndex].addressType();
+            auto srcTableAddressType = m_info.tables[immediates.srcTableIndex].addressType();
+            WASM_VALIDATOR_FAIL_IF(dstOffset.type().kind != dstTableAddressType.asWasmTypeKind(), "table.copy dst_offset to type "_s, dstOffset.type(), " expected "_s, dstTableAddressType.asWasmTypeKind());
+            WASM_VALIDATOR_FAIL_IF(srcOffset.type().kind != srcTableAddressType.asWasmTypeKind(), "table.copy src_offset to type "_s, srcOffset.type(), " expected "_s, srcTableAddressType.asWasmTypeKind());
+
+            if (dstTableAddressType.is64Bit() && srcTableAddressType.is64Bit())
+                WASM_VALIDATOR_FAIL_IF(length.type().kind != TypeKind::I64, "table.copy length to type "_s, length.type(), " expected "_s, TypeKind::I64);
+            else
+                WASM_VALIDATOR_FAIL_IF(length.type().kind != TypeKind::I32, "table.copy length to type "_s, length.type(), " expected "_s, TypeKind::I32);
 
             WASM_TRY_ADD_TO_CONTEXT(addTableCopy(immediates.dstTableIndex, immediates.srcTableIndex, dstOffset, srcOffset, length));
             break;
@@ -3367,7 +3384,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         size_t argumentCount = calleeSignature.argumentCount() + 1; // Add the callee's index.
         WASM_PARSER_FAIL_IF(argumentCount > m_expressionStack.size() - m_currentStackBegin, "call_indirect expects "_s, argumentCount, " arguments, but the expression stack currently holds "_s, m_expressionStack.size() - m_currentStackBegin, " values"_s);
 
-        WASM_VALIDATOR_FAIL_IF(!m_expressionStack.last().type().isI32(), "non-i32 call_indirect index "_s, m_expressionStack.last().type());
+        Wasm::Type tableAddressType = m_info.table(tableIndex).addressType().asWasmType();
+        WASM_VALIDATOR_FAIL_IF(tableAddressType!= m_expressionStack.last().type(), "call_indirect index to type "_s, m_expressionStack.last().type().kind, " expected "_s, tableAddressType.kind);
 
         ArgumentList args;
         WASM_ALLOCATOR_FAIL_IF(!args.tryReserveInitialCapacity(argumentCount), "can't allocate enough memory for "_s, argumentCount, " call_indirect arguments"_s);

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -45,6 +45,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmCallee.h"
 #include "WasmCallingConvention.h"
 #include "WasmDebugServer.h"
+#include "WasmExceptionType.h"
 #include "WasmExecutionHandler.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmModuleInformation.h"
@@ -54,6 +55,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "WasmWorklist.h"
 #include "WebAssemblyFunction.h"
 #include <bit>
+#include <limits>
 #include <wtf/LEBDecoder.h>
 
 namespace JSC { namespace IPInt {
@@ -552,50 +554,85 @@ WASM_IPINT_EXTERN_CPP_DECL(throw_ref, CallFrame* callFrame, EncodedJSValue exnre
     WASM_RETURN_TWO(vm.targetMachinePCForThrow, nullptr);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_get, unsigned tableIndex, unsigned index)
+static ALWAYS_INLINE std::optional<uint32_t> checkedTableOperand(uint64_t value, bool isTable64)
 {
-    EncodedJSValue result = Wasm::tableGet(instance, tableIndex, index);
+    if (!isTable64)
+        value = static_cast<uint32_t>(value);
+    if (value > std::numeric_limits<int32_t>::max()) [[unlikely]]
+        return std::nullopt;
+    return static_cast<uint32_t>(value);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(table_get, unsigned tableIndex, uint64_t index)
+{
+    const auto& info = instance->module().moduleInformation();
+    auto checkedIndex = checkedTableOperand(index, info.table(tableIndex).addressType().is64Bit());
+    if (!checkedIndex)
+        IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
+
+    EncodedJSValue result = Wasm::tableGet(instance, tableIndex, *checkedIndex);
     if (!result)
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
     IPINT_RETURN(result);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value)
+WASM_IPINT_EXTERN_CPP_DECL(table_set, unsigned tableIndex, uint64_t index, EncodedJSValue value)
 {
-    if (!Wasm::tableSet(instance, tableIndex, index, value))
+    const auto& info = instance->module().moduleInformation();
+    auto checkedIndex = checkedTableOperand(index, info.table(tableIndex).addressType().is64Bit());
+    if (!checkedIndex)
+        IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
+
+    if (!Wasm::tableSet(instance, tableIndex, *checkedIndex, value))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
     IPINT_END();
 }
 
 WASM_IPINT_EXTERN_CPP_DECL(table_init, IPIntStackEntry* sp, TableInitMetadata* metadata)
 {
+    const auto& info = instance->module().moduleInformation();
+
     int32_t n = sp[0].i32;
     int32_t src = sp[1].i32;
-    int32_t dst = sp[2].i32;
+    auto dst = checkedTableOperand(sp[2].i64, info.table(metadata->tableIndex).addressType().is64Bit());
+
+    if (!dst)
+        IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
 
     WasmSlowPathWithoutCallFrameTracer tracer(instance->vm());
-    if (!Wasm::tableInit(instance, metadata->elementIndex, metadata->tableIndex, dst, src, n))
+    if (!Wasm::tableInit(instance, metadata->elementIndex, metadata->tableIndex, *dst, src, n))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
     IPINT_END();
 }
 
 WASM_IPINT_EXTERN_CPP_DECL(table_fill, IPIntStackEntry* sp, TableFillMetadata* metadata)
 {
-    int32_t n = sp[0].i32;
-    EncodedJSValue fill = sp[1].ref;
-    int32_t offset = sp[2].i32;
+    const auto& info = instance->module().moduleInformation();
+    const bool isTable64 = info.table(metadata->tableIndex).addressType().is64Bit();
 
-    if (!Wasm::tableFill(instance, metadata->tableIndex, offset, fill, n))
+    auto n = checkedTableOperand(sp[0].i64, isTable64);
+    EncodedJSValue fill = sp[1].ref;
+    auto offset = checkedTableOperand(sp[2].i64, isTable64);
+
+    if (!n || !offset)
+        IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
+
+    if (!Wasm::tableFill(instance, metadata->tableIndex, *offset, fill, *n))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
     IPINT_END();
 }
 
 WASM_IPINT_EXTERN_CPP_DECL(table_grow, IPIntStackEntry* sp, TableGrowMetadata* metadata)
 {
-    int32_t n = sp[0].i32;
+    const auto& info = instance->module().moduleInformation();
+
+    auto n = checkedTableOperand(sp[0].i64, info.table(metadata->tableIndex).addressType().is64Bit());
     EncodedJSValue fill = sp[1].ref;
 
-    WASM_RETURN_TWO(std::bit_cast<void*>(Wasm::tableGrow(instance, metadata->tableIndex, fill, n)), 0);
+    if (!n)
+        IPINT_RETURN(static_cast<intptr_t>(-1));
+
+    WASM_RETURN_TWO(std::bit_cast<void*>(Wasm::tableGrow(instance, metadata->tableIndex, fill, *n)), 0);
 }
 
 WASM_IPINT_EXTERN_CPP_DECL(memory_grow, int64_t delta, uint8_t memoryIndex)
@@ -664,11 +701,18 @@ WASM_IPINT_EXTERN_CPP_DECL(elem_drop, int32_t dataIndex)
 
 WASM_IPINT_EXTERN_CPP_DECL(table_copy, IPIntStackEntry* sp, TableCopyMetadata* metadata)
 {
-    int32_t n = sp[0].i32;
-    int32_t src = sp[1].i32;
-    int32_t dst = sp[2].i32;
+    const auto& info = instance->module().moduleInformation();
+    const bool dstIsTable64 = info.table(metadata->dstTableIndex).addressType().is64Bit();
+    const bool srcIsTable64 = info.table(metadata->srcTableIndex).addressType().is64Bit();
 
-    if (!Wasm::tableCopy(instance, metadata->dstTableIndex, metadata->srcTableIndex, dst, src, n))
+    auto n = checkedTableOperand(sp[0].i64, dstIsTable64 && srcIsTable64);
+    auto src = checkedTableOperand(sp[1].i64, srcIsTable64);
+    auto dst = checkedTableOperand(sp[2].i64, dstIsTable64);
+
+    if (!n || !src || !dst)
+        IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
+
+    if (!Wasm::tableCopy(instance, metadata->dstTableIndex, metadata->srcTableIndex, *dst, *src, *n))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
     IPINT_END();
 }
@@ -1136,16 +1180,22 @@ static ALWAYS_INLINE UGPRPair prepareCallIndirectImpl(JSWebAssemblyInstance* ins
     auto& callProfile = instance->ensureBaselineData(callee->functionIndex()).at(callProfileIndex);
     callProfile.incrementCount();
 
+    auto checkedIndex = checkedTableOperand(*std::bit_cast<uint64_t*>(functionIndex), instance->module().moduleInformation().table(tableIndex).addressType().is64Bit());
+    if (!checkedIndex) [[unlikely]]
+        IPINT_THROW(Wasm::ExceptionType::OutOfBoundsCallIndirect);
+
+    Wasm::FunctionSpaceIndex callIndex(*checkedIndex);
+
     const Wasm::FuncRefTable::Function* function = nullptr;
     if (!tableIndex) {
-        if (*functionIndex >= instance->cachedTable0Length()) [[unlikely]]
+        if (callIndex >= instance->cachedTable0Length()) [[unlikely]]
             IPINT_THROW(Wasm::ExceptionType::OutOfBoundsCallIndirect);
-        function = &instance->cachedTable0Buffer()[*functionIndex];
+        function = &instance->cachedTable0Buffer()[callIndex];
     } else {
         Wasm::FuncRefTable* table = instance->table(tableIndex)->asFuncrefTable();
-        if (*functionIndex >= table->length()) [[unlikely]]
+        if (callIndex >= table->length()) [[unlikely]]
             IPINT_THROW(Wasm::ExceptionType::OutOfBoundsCallIndirect);
-        function = &table->function(*functionIndex);
+        function = &table->function(callIndex);
     }
 
     if (!function->rtt) [[unlikely]]
@@ -1155,7 +1205,7 @@ static ALWAYS_INLINE UGPRPair prepareCallIndirectImpl(JSWebAssemblyInstance* ins
         IPINT_THROW(Wasm::ExceptionType::BadSignature);
 
     auto boxedCallee = function->boxedCallee.encodedBits();
-    Wasm::FunctionSpaceIndex savedFunctionIndex = *functionIndex;
+    Wasm::FunctionSpaceIndex savedFunctionIndex = callIndex;
     Register* calleeReturn = std::bit_cast<Register*>(functionIndex);
     *calleeReturn = boxedCallee;
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -82,8 +82,8 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, unsigned tryDep
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_ref, CallFrame* callFrame, EncodedJSValue exnref);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, unsigned);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, uint64_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, uint64_t index, EncodedJSValue value);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_init, IPIntStackEntry* sp, TableInitMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_fill, IPIntStackEntry* sp, TableFillMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_grow, IPIntStackEntry* sp, TableGrowMetadata* metadata);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -339,7 +339,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
     uint64_t initial;
     std::optional<uint64_t> maximum;
     bool isShared = false;
-    bool isTable64;
+    bool isTable64 = false;
     PartialResult limits = parseResizableLimits<LimitsType::Table>(initial, maximum, isShared, isTable64);
     ASSERT(!isShared);
     if (!limits) [[unlikely]]
@@ -586,7 +586,10 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_FAIL_IF_HELPER_FAILS(validateElementTableIdx(tableIndex, nonNullFuncrefType()));
 
             std::optional<I32InitExpr> initExpr;
-            WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
+            if (m_info->table(tableIndex).addressType().is64Bit())
+                WASM_FAIL_IF_HELPER_FAILS(parseI64InitExprForElementSection(initExpr));
+            else
+                WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
 
             uint32_t indexCount;
             WASM_FAIL_IF_HELPER_FAILS(parseIndexCountForElementSection(indexCount, elementNum));
@@ -620,7 +623,10 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_FAIL_IF_HELPER_FAILS(validateElementTableIdx(tableIndex, nonNullFuncrefType()));
 
             std::optional<I32InitExpr> initExpr;
-            WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
+            if (m_info->table(tableIndex).addressType().is64Bit())
+                WASM_FAIL_IF_HELPER_FAILS(parseI64InitExprForElementSection(initExpr));
+            else
+                WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
 
             uint8_t elementKind;
             WASM_FAIL_IF_HELPER_FAILS(parseElementKind(elementKind));
@@ -656,7 +662,10 @@ auto SectionParser::parseElement() -> PartialResult
             WASM_FAIL_IF_HELPER_FAILS(validateElementTableIdx(tableIndex, funcrefType()));
 
             std::optional<I32InitExpr> initExpr;
-            WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
+            if (m_info->table(tableIndex).addressType().is64Bit())
+                WASM_FAIL_IF_HELPER_FAILS(parseI64InitExprForElementSection(initExpr));
+            else
+                WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
 
             uint32_t indexCount;
             WASM_FAIL_IF_HELPER_FAILS(parseIndexCountForElementSection(indexCount, elementNum));
@@ -688,9 +697,13 @@ auto SectionParser::parseElement() -> PartialResult
         case 0x06: {
             uint32_t tableIndex;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't get "_s, elementNum, "th Element table index"_s);
+            WASM_PARSER_FAIL_IF(tableIndex >= m_info->tableCount(), "Element section for Table "_s, tableIndex, " exceeds available Table "_s, m_info->tableCount());
 
             std::optional<I32InitExpr> initExpr;
-            WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
+            if (m_info->table(tableIndex).addressType().is64Bit())
+                WASM_FAIL_IF_HELPER_FAILS(parseI64InitExprForElementSection(initExpr));
+            else
+                WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForElementSection(initExpr));
 
             Type refType;
             WASM_PARSER_FAIL_IF(!parseRefType(m_info, refType), "can't parse reftype in elem section"_s);
@@ -1237,6 +1250,11 @@ auto SectionParser::parseSubtype(uint32_t position, ParsedDef& subtype, Vector<T
 auto SectionParser::parseI32InitExprForElementSection(std::optional<I32InitExpr>& initExpr) -> PartialResult
 {
     return parseI32InitExpr(initExpr, "Element init_expr must produce an i32"_s);
+}
+
+auto SectionParser::parseI64InitExprForElementSection(std::optional<I64InitExpr>& initExpr) -> PartialResult
+{
+    return parseI64InitExpr(initExpr, "Element init_expr must produce an i64"_s);
 }
 
 auto SectionParser::parseElementKind(uint8_t& resultElementKind) -> PartialResult

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -83,6 +83,7 @@ private:
 
     [[nodiscard]] PartialResult validateElementTableIdx(uint32_t, Type);
     [[nodiscard]] PartialResult parseI32InitExprForElementSection(std::optional<I32InitExpr>&);
+    [[nodiscard]] PartialResult parseI64InitExprForElementSection(std::optional<I64InitExpr>&);
     [[nodiscard]] PartialResult parseElementKind(uint8_t& elementKind);
     [[nodiscard]] PartialResult parseIndexCountForElementSection(uint32_t&, const unsigned);
     [[nodiscard]] PartialResult parseElementSegmentVectorOfExpressions(Type, Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);


### PR DESCRIPTION
#### 9f221020aa88928636be08e34139c47a803f08af
<pre>
Implement Table64 in the parser and IPInt tier
<a href="https://bugs.webkit.org/show_bug.cgi?id=316710">https://bugs.webkit.org/show_bug.cgi?id=316710</a>
<a href="https://rdar.apple.com/179159629">rdar://179159629</a>

Reviewed by Keith Miller.

In this patch, I allow parsing of the Table64 functions for tables with i64
address types and ensure that the functions work in the IPInt tier.

InPlaceInterpreter64.asm already passes the values as i64, but they
were being truncated in the slow path functions. To fix this, I read the
values as i64s in the table64 case. I also added overflow checks.

Test: JSTests/wasm/stress/table64-get-and-set.js

* JSTests/wasm/stress/table64-bulk.js: Added.
(1.table.tbl):
(10.funcref.table.tbl2):
(10.funcref.func.f1.result.i32.i32.const.42.func.f2.result.i32.i32.const.43.elem.element.funcref.ref.func.f1.ref.func.f2.func.tableInit.export.string_appeared_here):
(count.table.init.tbl.element.func.tableFill.export.string_appeared_here):
(destination.ref.func.f1):
(length.table.fill.tbl.func.tableCopy.export.string_appeared_here):
(length.table.copy.tbl2.tbl.func.resetTables.export.string_appeared_here):
(const.0.ref.null.func):
(const.10.table.fill.tbl):
(test):
(string_appeared_here.const.instance.await.instantiate.wat):
* JSTests/wasm/stress/table64-call-indirect.js: Added.
(const.0.addIndirect.subIndirect.func.add.export.string_appeared_here.param.lhs.i32.param.rhs.i32.result.i32.local.lhs.local.rhs):
(const.0.call_indirect.tbl.type.func_type.func.sub.export.string_appeared_here.param.lhs.i32.param.rhs.i32.result.i32.local.lhs.local.rhs):
(test):
(string_appeared_here.const.instance.await.instantiate.wat):
* JSTests/wasm/stress/table64-get-and-set.js: Added.
(test):
(string_appeared_here.const.instance.await.instantiate.wat):
* JSTests/wasm/stress/table64-grow-and-size.js: Added.
(test):
(string_appeared_here.const.instance.await.instantiate.wat):
* JSTests/wasm/stress/table64-overflow.js: Added.
(test):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseTableHelper):
(JSC::Wasm::SectionParser::parseElement):
(JSC::Wasm::SectionParser::parseI64InitExprForElementSection):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:

Canonical link: <a href="https://commits.webkit.org/317590@main">https://commits.webkit.org/317590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0fdc831123d6da2cbae2cbad3d15cc5be9f0456

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185265 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f18d3a2-ab94-444e-bce8-a1b925c234b4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136790 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3471a39-1dd5-4b53-9f23-67f27a85b7f2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38872 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37254 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6062 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37045 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33735 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36937 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187687 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145770 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39235 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49953 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145609 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40413 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122148 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115974 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48460 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12023 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47862 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48094 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47919 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->