### PR TITLE
[webkitscmpy] Unit tests should avoid relying on Tracker._tracker's global state

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
@@ -40,6 +40,9 @@ class TestCherryPick(testing.PathTestCase):
         super(TestCherryPick, self).setUp()
         os.mkdir(os.path.join(self.path, '.git'))
         os.mkdir(os.path.join(self.path, '.svn'))
+        patcher = patch.object(Tracker, '_trackers', [])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_none(self):
         with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(), MockTime:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -68,6 +68,9 @@ class TestLand(testing.PathTestCase):
         super(TestLand, self).setUp()
         os.mkdir(os.path.join(self.path, '.git'))
         os.mkdir(os.path.join(self.path, '.svn'))
+        patcher = patch.object(Tracker, '_trackers', [])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_none(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(), mocks.local.Svn():
@@ -392,6 +395,9 @@ class TestLandGitHub(testing.PathTestCase):
         super(TestLandGitHub, self).setUp()
         os.mkdir(os.path.join(self.path, '.git'))
         os.mkdir(os.path.join(self.path, '.svn'))
+        patcher = patch.object(Tracker, '_trackers', [])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     @classmethod
     def webserver(cls, approved=None, labels=None, environment=None):
@@ -620,6 +626,9 @@ class TestLandBitBucket(testing.PathTestCase):
         super(TestLandBitBucket, self).setUp()
         os.mkdir(os.path.join(self.path, '.git'))
         os.mkdir(os.path.join(self.path, '.svn'))
+        patcher = patch.object(Tracker, '_trackers', [])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     @classmethod
     def webserver(cls, approved=None):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
@@ -148,6 +148,12 @@ class TestRelationship(TestCase):
 
 
 class TestCommitsStory(TestCase):
+    def setUp(self):
+        super(TestCommitsStory, self).setUp()
+        patcher = patch('webkitbugspy.Tracker._trackers', [])
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_cherry_pick(self):
         with bmocks.Radar(issues=bmocks.ISSUES), patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
             commit = Commit(
@@ -203,6 +209,9 @@ class TestTrace(testing.PathTestCase):
         super(TestTrace, self).setUp()
         os.mkdir(os.path.join(self.path, '.git'))
         os.mkdir(os.path.join(self.path, '.svn'))
+        patcher = patch('webkitbugspy.Tracker._trackers', [])
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_none(self):
         with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(), Terminal.override_atty(sys.stdin, isatty=False):


### PR DESCRIPTION
#### c1d25a2ab560cf3df5f0d1d2b5708e3a446d5de1
<pre>
[webkitscmpy] Unit tests should avoid relying on Tracker._tracker&apos;s global state
<a href="https://bugs.webkit.org/show_bug.cgi?id=316708">https://bugs.webkit.org/show_bug.cgi?id=316708</a>

Reviewed by Jonathan Bedard.

Per <a href="https://bugs.webkit.org/show_bug.cgi?id=316264">https://bugs.webkit.org/show_bug.cgi?id=316264</a>, a number of tests
became flaky due to running tests in parallel with nondeterministic
sharding as a result of Tracker._trackers being mutated before they
ran.

We isolate these by using unittest.mock.patch to reset it to an empty
list before running tests in these test classes.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py:
(TestCherryPick.setUp):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(TestLand.setUp):
(TestLandGitHub.setUp):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
(TestCommitsStory.setUp):
(TestTrace.setUp):

Canonical link: <a href="https://commits.webkit.org/314864@main">https://commits.webkit.org/314864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69870df68d2007c03e360f32ed6c93186e418055

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176464 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110751 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166736 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30322 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25203 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179008 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138630 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/166815 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138518 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41672 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104747 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26781 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40176 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39573 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4879 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39823 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39718 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->