### PR TITLE
Restrict DocumentPrefetcher redirects to same-origin like we do with the original fetch

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-redirect-expected.txt
@@ -1,4 +1,4 @@
 
-PASS redirect-received-before-navigation-start
-PASS redirect-received-after-navigation-start
+FAIL redirect-received-before-navigation-start assert_in_array: Prefetched response should be used by navigation. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
+FAIL redirect-received-after-navigation-start assert_in_array: Prefetched response should be used by navigation. value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL same-site to cross-site redirection prefetch should not have Sec-Speculation-Tags be sent assert_equals: expected "__no_tags__" but got "\"tag1\""
+FAIL same-site to cross-site redirection prefetch should not have Sec-Speculation-Tags be sent assert_in_array: must be prefetched value undefined not in array ["prefetch", "prefetch;anonymous-client-ip"]
 

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -14,12 +14,6 @@ http/tests/security/referrer-policy-header-strict-origin-when-cross-origin.html 
 http/tests/security/referrer-policy-header-strict-origin.html [ Crash ]
 http/tests/security/referrer-policy-header-unsafe-url.html [ Crash ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Crash ]
-imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect [ Crash ]
-imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https.html [ Crash ]
-imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https.html?cross-site [ Crash ] 
-imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-a-element.sub.https.html?same-site [ Crash ]
-imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html?cross-site [ Crash ]
-imported/w3c/web-platform-tests/speculation-rules/prefetch/initiators-window-open.sub.https.html?same-site [ Crash ]
 
 #######################
 # Tests that time out #

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -46,8 +46,8 @@
 
 namespace WebCore {
 
-DocumentPrefetcher::DocumentPrefetcher(FrameLoader& frameLoader)
-    : m_frameLoader(frameLoader)
+DocumentPrefetcher::DocumentPrefetcher(LocalFrame& frame)
+    : m_frame(frame)
 {
 }
 
@@ -121,10 +121,7 @@ static ResourceRequest makePrefetchRequest(URL&& url, const Vector<String>& tags
 
 void DocumentPrefetcher::prefetch(const URL& url, const Vector<String>& tags, std::optional<ReferrerPolicy> referrerPolicy, bool lowPriority)
 {
-    WeakRef<FrameLoader> frameLoader = m_frameLoader;
-    if (!frameLoader.ptr())
-        return;
-    RefPtr<Document> document = frameLoader->frame().document();
+    RefPtr document = m_frame ? m_frame->document() : nullptr;
     if (!document)
         return;
 
@@ -134,14 +131,14 @@ void DocumentPrefetcher::prefetch(const URL& url, const Vector<String>& tags, st
     if (m_prefetchedData.contains(url))
         return;
 
-    if (!isPassingSecurityChecks(url, *document.get()))
+    if (!isPassingSecurityChecks(url, *document))
         return;
 
     // TODO: This needs to be specified.
     if (url.hasFragmentIdentifier() && equalIgnoringFragmentIdentifier(url, document->url()))
         return;
 
-    ResourceRequest request = makePrefetchRequest(URL { url }, tags, referrerPolicy, frameLoader->outgoingReferrerURL(), *document);
+    ResourceRequest request = makePrefetchRequest(URL { url }, tags, referrerPolicy, m_frame->loader().outgoingReferrerURL(), *document);
 
     ResourceLoaderOptions prefetchOptions(
         SendCallbackPolicy::SendCallbacks,
@@ -169,6 +166,14 @@ void DocumentPrefetcher::prefetch(const URL& url, const Vector<String>& tags, st
     auto& prefetchedResource = resourceErrorOr.value();
     m_prefetchedData.set(url, PrefetchedResourceData { CachedResourceHandle { prefetchedResource.get() }, { } });
     prefetchedResource->addClient(*this);
+}
+
+void DocumentPrefetcher::redirectReceived(CachedResource&, ResourceRequest&& request, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
+{
+    RefPtr document = m_frame ? m_frame->document() : nullptr;
+    if (!document || !isPassingSecurityChecks(request.url(), *document))
+        return completionHandler({ });
+    completionHandler(WTF::move(request));
 }
 
 void DocumentPrefetcher::responseReceived(const CachedResource& resource, const ResourceResponse& response, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebCore/loader/DocumentPrefetcher.h
+++ b/Source/WebCore/loader/DocumentPrefetcher.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 class CachedRawResource;
 class DocumentLoader;
-class FrameLoader;
+class LocalFrame;
 class ResourceRequest;
 class SecurityOrigin;
 
@@ -51,7 +51,7 @@ public:
         CachedResourceHandle<CachedRawResource> resource;
         Box<NetworkLoadMetrics> metrics;
     };
-    static Ref<DocumentPrefetcher> create(FrameLoader& frameLoader) { return adoptRef(*new DocumentPrefetcher(frameLoader)); }
+    static Ref<DocumentPrefetcher> create(LocalFrame& frame) { return adoptRef(*new DocumentPrefetcher(frame)); }
     ~DocumentPrefetcher();
 
     // CachedResourceClient.
@@ -69,13 +69,14 @@ public:
     // CachedRawResourceClient
     void responseReceived(const CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) override;
+    void redirectReceived(CachedResource&, ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&) override;
     CachedResourceClientType resourceClientType() const override { return RawResourceType; }
 
 
 private:
-    explicit DocumentPrefetcher(FrameLoader&);
+    explicit DocumentPrefetcher(LocalFrame&);
 
-    WeakRef<FrameLoader> m_frameLoader;
+    WeakPtr<LocalFrame> m_frame;
     HashMap<URL, PrefetchedResourceData> m_prefetchedData;
 };
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -389,7 +389,7 @@ FrameLoader::FrameLoader(LocalFrame& frame, CompletionHandler<UniqueRef<LocalFra
     , m_state(FrameState::Provisional)
     , m_loadType(FrameLoadType::Standard)
     , m_checkTimer(*this, &FrameLoader::checkTimerFired)
-    , m_documentPrefetcher(DocumentPrefetcher::create(*this))
+    , m_documentPrefetcher(DocumentPrefetcher::create(frame))
 {
 }
 


### PR DESCRIPTION
#### cf40e124d0d26f90fc47e7ecf36434319bcbb47f
<pre>
Restrict DocumentPrefetcher redirects to same-origin like we do with the original fetch
<a href="https://bugs.webkit.org/show_bug.cgi?id=316722">https://bugs.webkit.org/show_bug.cgi?id=316722</a>
<a href="https://rdar.apple.com/173711135">rdar://173711135</a>

Reviewed by Brady Eidson.

We restrict document prefetching to the same origin.  Before this change, a same-origin fetch could redirect
to a different origin and we would fetch documents of other origins with the other origin&apos;s cookies.
This was causing crashes with site isolation because those origins&apos; processes weren&apos;t allowed to access their cookies,
but it&apos;s also something we don&apos;t want to do with site isolation off.  Add the missing security check on redirects.

Also, make DocumentPrefetcher&apos;s m_frameLoader a WeakPtr instead of a WeakRef because DocumentPrefetcher is
RefCounted and has no guarantee it won&apos;t outlive the FrameLoader.  Make it a WeakPtr&lt;LocalFrame&gt; instead of
a WeakPtr&lt;FrameLoader&gt; to make it pass the safer-cpp checks.

This intentionally makes a wpt go from passing to failing.  That is ok and desirable because the wpt verifies
that cross-site redirects are successfully prefetched, but we have made the decision not to support cross-site
prefetches unlike other browsers to improve privacy and make it so a site is unable to use the cookies of another
site.  Allowing redirects was just an oversight in this additional privacy, and we need to fix it to actually
have the privacy benefits.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https_origin=cross-site-redirect-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/speculation-tags/same-site-to-cross-site-redirection-prefetch.https-expected.txt:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::DocumentPrefetcher):
(WebCore::DocumentPrefetcher::prefetch):
(WebCore::DocumentPrefetcher::redirectReceived):
* Source/WebCore/loader/DocumentPrefetcher.h:
(WebCore::DocumentPrefetcher::create):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::FrameLoader):

Canonical link: <a href="https://commits.webkit.org/314970@main">https://commits.webkit.org/314970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47ca4f07a003b1441870070ccecc1747f522163a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176667 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb2116dc-c644-4303-8295-fc4fc05bce44) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130411 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ab34057-9c7a-401a-b474-823a9b74d4bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110928 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9dac3ab-aaa2-4d05-92c5-a952f02c0771) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30506 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25400 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141796 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179207 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32248 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138809 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34663 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138694 "Found 1 new API test failure: WebKitGTK/TestFrame:/webkit/WebKitFrame/main-frame (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41867 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105027 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26965 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113617 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39768 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5066 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40019 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39913 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->