### PR TITLE
[Site Isolation] Avoid Ref<T> bridging crash in Swift WebBackForwardList::completeFrameStateForNavigation

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -1079,5 +1079,12 @@ Ref<WebKit::WebBackForwardListItem> createItemFromState(const WebKit::BackForwar
     return WebKit::WebBackForwardListItem::create(WTF::move(stateCopy), pageIdentifier, itemState.navigatedFrameID);
 }
 
+void setBackForwardItemIdentifierForSwift(WebKit::FrameState& frameState, WebCore::BackForwardItemIdentifier itemID)
+{
+    frameState.itemID = itemID;
+    for (auto& child : frameState.children)
+        setBackForwardItemIdentifierForSwift(child, itemID);
+}
+
 
 #endif // ENABLE(BACK_FORWARD_LIST_SWIFT)

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -904,13 +904,6 @@ final class WebBackForwardList {
         parentItem.setChild(consuming: frameState)
     }
 
-    func setBackForwardItemIdentifier(frameState: WebKit.FrameState, itemID: WebCore.BackForwardItemIdentifier) {
-        frameState.itemID = WebCore.MarkableBackForwardItemIdentifier(itemID)
-        for child in CxxVectorIterator(vec: frameState.children) {
-            setBackForwardItemIdentifier(frameState: child.ptr(), itemID: itemID)
-        }
-    }
-
     func completeFrameStateForNavigation(navigatedFrameState: WebKit.FrameState) -> WebKit.FrameState {
         guard let currentItem = currentItem() else {
             return navigatedFrameState
@@ -928,8 +921,9 @@ final class WebBackForwardList {
         if mainFrameItem.childItemForFrameID(navigatedFrameID) == nil {
             return navigatedFrameState
         }
-        let frameState = currentItem.copyMainFrameStateWithChildren().ptr()
-        setBackForwardItemIdentifier(frameState: frameState, itemID: navigatedFrameState.itemID.pointee)
+        let frameStateRef = currentItem.copyMainFrameStateWithChildren()
+        let frameState = frameStateRef.ptr()
+        setBackForwardItemIdentifierForSwift(frameState, navigatedFrameState.itemID.pointee)
         frameState.replaceChildFrameState(consuming: WebKit.RefFrameState(navigatedFrameState))
         return frameState
     }

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -77,4 +77,8 @@ inline WebKit::FrameState* getFrameState(WebKit::WebBackForwardListFrameItem& it
 void appendToBackForwardStateItems(Vector<WebKit::BackForwardListItemState>& items, const WebKit::WebBackForwardListItem& entry);
 Ref<WebKit::WebBackForwardListItem> createItemFromState(const WebKit::BackForwardListItemState&, WebKit::WebPageProxyIdentifier pageIdentifier);
 
+// Recursing through FrameState::children in Swift triggers a Ref<T> bridging issue
+// (see rdar://173815363 / bug 311253). Keep the recursion in C++.
+void setBackForwardItemIdentifierForSwift(WebKit::FrameState&, WebCore::BackForwardItemIdentifier);
+
 #endif // ENABLE(BACK_FORWARD_LIST_SWIFT)


### PR DESCRIPTION
#### 08a943e7e4d5b95b7eb9f0c7cc6e42db02386272
<pre>
[Site Isolation] Avoid Ref&lt;T&gt; bridging crash in Swift WebBackForwardList::completeFrameStateForNavigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=316715">https://bugs.webkit.org/show_bug.cgi?id=316715</a>
<a href="https://rdar.apple.com/179163452">rdar://179163452</a>

Reviewed by NOBODY (OOPS!).

For an iframe (non-main-frame) navigation through
WebBackForwardList::backForwardAddItem, completeFrameStateForNavigation copies
the current main frame&apos;s FrameState tree and re-stamps every node&apos;s itemID via
a recursive Swift helper that walks frameState.children. That recursion crashes
in debug with &quot;ASSERTION FAILED: m_ptr&quot; on Ref&lt;FrameState&gt;::get() during
CxxVectorIterator.next() — the same Swift Ref&lt;T&gt; bridging issue that
<a href="https://bugs.webkit.org/show_bug.cgi?id=311253">https://bugs.webkit.org/show_bug.cgi?id=311253</a> worked around for the
session-restore path by moving its recursion to C++. Apply the same
workaround: drop the Swift recursion, add a small C++ helper
setBackForwardItemIdentifierForSwift, and call it from Swift. Bind the Ref
returned by copyMainFrameStateWithChildren() to a local before .ptr() so the
underlying FrameState is unambiguously held across the call.

This was uncovered while investigating
<a href="https://bugs.webkit.org/show_bug.cgi?id=316588">https://bugs.webkit.org/show_bug.cgi?id=316588</a>, where the test-infra coupling
of UseUIProcessForBackForwardItemLoading under Site Isolation drove an iframe
BFCache path that exercises this Swift helper.

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(setBackForwardItemIdentifierForSwift): Added.
* Source/WebKit/UIProcess/WebBackForwardList.swift:
(WebBackForwardList.setBackForwardItemIdentifier): Deleted.
(WebBackForwardList.completeFrameStateForNavigation): Call the C++ helper and
hold the Ref&lt;FrameState&gt; in a local.
* Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08a943e7e4d5b95b7eb9f0c7cc6e42db02386272

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176485 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130255 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110772 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31649 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30344 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25224 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141635 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179029 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138649 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138537 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41693 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104774 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33793 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26804 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40197 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113278 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39594 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4902 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->