### PR TITLE
[Build Speed] Reduce #includes of StyleComputedStyle+GettersInlines.h

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1563,7 +1563,7 @@ fileapi/ThreadableBlobRegistry.cpp
 fileapi/URLKeepingBlobAlive.cpp
 history/BackForwardCache.cpp
 history/BackForwardController.cpp
-history/CachedFrame.cpp @header:RenderStyleGetters
+history/CachedFrame.cpp
 history/CachedPage.cpp
 history/HistoryItem.cpp
 html/AttachmentAssociatedElement.cpp
@@ -2006,9 +2006,9 @@ layout/formattingContexts/flex/FlexFormattingContext.cpp @header:RenderStyleGett
 layout/formattingContexts/flex/FlexFormattingUtils.cpp @header:RenderStyleGetters
 layout/formattingContexts/flex/FlexLayout.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/GridFormattingContext.cpp @header:RenderStyleGetters
-layout/formattingContexts/grid/GridLayout.cpp @header:RenderStyleGetters
+layout/formattingContexts/grid/GridLayout.cpp
 layout/formattingContexts/grid/GridLayoutUtils.cpp @header:RenderStyleGetters
-layout/formattingContexts/grid/ImplicitGrid.cpp @header:RenderStyleGetters
+layout/formattingContexts/grid/ImplicitGrid.cpp
 layout/formattingContexts/grid/PlacedGridItem.cpp @header:RenderStyleGetters
 layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
 layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -2304,7 +2304,7 @@ page/SettingsBase.cpp @header:RenderStyleGetters @cost:6
 page/ShadowRealmGlobalScope.cpp
 page/ShareDataReader.cpp
 page/SpatialNavigation.cpp @header:RenderStyleGetters @cost:6
-page/TextIndicator.cpp @header:RenderStyleGetters @cost:6
+page/TextIndicator.cpp @cost:6
 page/UndoItem.cpp
 page/UndoManager.cpp
 page/UserContentController.cpp
@@ -2910,7 +2910,7 @@ plugins/DOMPlugin.cpp
 plugins/DOMPluginArray.cpp
 plugins/PluginData.cpp
 plugins/PluginInfoProvider.cpp
-rendering/AccessibilityRegionContext.cpp @header:RenderStyleGetters @cost:6
+rendering/AccessibilityRegionContext.cpp @cost:6
 rendering/AncestorSubgridIterator.cpp @header:RenderStyleGetters @cost:5
 rendering/AutoTableLayout.cpp @header:RenderStyleGetters @cost:6
 rendering/BackgroundPainter.cpp @header:RenderStyleGetters @cost:7
@@ -2951,7 +2951,7 @@ rendering/RelayoutScopeForScrollbarChange.cpp @header:RenderStyleGetters @cost:5
 rendering/ScrollbarUpdateScope.cpp @header:RenderStyleGetters
 rendering/LayoutDisallowedScope.cpp
 rendering/LayoutRepainter.cpp
-rendering/LegacyInlineBox.cpp @header:RenderStyleGetters @cost:5
+rendering/LegacyInlineBox.cpp @cost:5
 rendering/LegacyInlineFlowBox.cpp @header:RenderStyleGetters @cost:6
 rendering/LegacyInlineIterator.cpp @header:RenderStyleGetters @cost:4
 rendering/LegacyInlineTextBox.cpp @header:RenderStyleGetters @cost:7
@@ -2986,7 +2986,7 @@ rendering/RenderFragmentedFlow.cpp @header:RenderStyleGetters @cost:6
 rendering/RenderFrame.cpp @header:RenderStyleGetters @cost:5
 rendering/RenderFrameBase.cpp @header:RenderStyleGetters @cost:5
 rendering/RenderFrameSet.cpp @header:RenderStyleGetters @cost:6
-rendering/RenderGeometryMap.cpp @header:RenderStyleGetters @cost:5
+rendering/RenderGeometryMap.cpp @cost:5
 rendering/RenderGrid.cpp @header:RenderStyleGetters @cost:7
 rendering/RenderHTMLCanvas.cpp @header:RenderStyleGetters @cost:6
 rendering/RenderHighlight.cpp
@@ -3316,7 +3316,7 @@ style/values/backgrounds/StyleBorderImage.cpp @cost:5
 style/values/backgrounds/StyleLineWidth.cpp @header:RenderStyleGetters @cost:5
 style/values/backgrounds/StyleRepeatStyle.cpp
 style/values/borders/StyleBorderRadius.cpp
-style/values/borders/StyleBoxShadow.cpp @header:RenderStyleGetters @cost:5
+style/values/borders/StyleBoxShadow.cpp @cost:5
 style/values/borders/StyleCornerShapeValue.cpp
 style/values/box/StyleMarginTrim.cpp
 style/values/break/StyleOrphans.cpp
@@ -3383,7 +3383,7 @@ style/values/grid/StyleGridNamedLinesMap.cpp
 style/values/grid/StyleGridPosition.cpp
 style/values/grid/StyleGridPositionsResolver.cpp @header:RenderStyleGetters @cost:5
 style/values/grid/StyleGridTemplateAreas.cpp
-style/values/grid/StyleGridTemplateList.cpp @header:RenderStyleGetters @cost:6
+style/values/grid/StyleGridTemplateList.cpp @cost:6
 style/values/grid/StyleGridTrackBreadth.cpp
 style/values/grid/StyleGridTrackSize.cpp
 style/values/grid/StyleGridTrackSizes.cpp
@@ -3487,7 +3487,7 @@ style/values/text-decoration/StyleTextDecorationLine.cpp
 style/values/text-decoration/StyleTextDecorationThickness.cpp @header:RenderStyleGetters @cost:5
 style/values/text-decoration/StyleTextEmphasisPosition.cpp
 style/values/text-decoration/StyleTextEmphasisStyle.cpp
-style/values/text-decoration/StyleTextShadow.cpp @header:RenderStyleGetters @cost:5
+style/values/text-decoration/StyleTextShadow.cpp @cost:5
 style/values/text-decoration/StyleTextUnderlineOffset.cpp @header:RenderStyleGetters @cost:5
 style/values/text-decoration/StyleTextUnderlinePosition.cpp
 style/values/text/StyleHangingPunctuation.cpp

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -49,7 +49,6 @@
 #include "SVGDocumentExtensions.h"
 #include "ScriptController.h"
 #include "SerializedScriptValue.h"
-#include "StyleComputedStyle+GettersInlines.h"
 #include "StyleTreeResolver.h"
 #include "WindowEventLoop.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -35,7 +35,6 @@
 #include "LayoutElementBox.h"
 #include "NotImplemented.h"
 #include "PlacedGridItem.h"
-#include "StyleComputedStyle+GettersInlines.h"
 #include "TrackSizingAlgorithm.h"
 #include "TrackSizingFunctions.h"
 #include "UnplacedGridItem.h"

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -29,7 +29,6 @@
 #include "GridAreaLines.h"
 #include "GridLayout.h"
 #include "PlacedGridItem.h"
-#include "StyleComputedStyle+GettersInlines.h"
 #include "UnplacedGridItem.h"
 #include <wtf/Assertions.h>
 #include <wtf/Range.h>

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -52,7 +52,6 @@
 #include "RenderLayer.h"
 #include "RenderObject.h"
 #include "RenderText.h"
-#include "StyleComputedStyle+GettersInlines.h"
 #include "TextIterator.h"
 #include "TextPaintStyle.h"
 #include "FrameDestructionObserverInlines.h"

--- a/Source/WebCore/rendering/AccessibilityRegionContext.cpp
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.cpp
@@ -36,7 +36,6 @@
 #include "RenderObjectDocument.h"
 #include "RenderText.h"
 #include "RenderView.h"
-#include "StyleComputedStyle+GettersInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -29,7 +29,6 @@
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
-#include "StyleComputedStyle+GettersInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -31,7 +31,6 @@
 #include "RenderLayer.h"
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
-#include "StyleComputedStyle+GettersInlines.h"
 #include "TransformState.h"
 #include <wtf/SetForScope.h>
 

--- a/Source/WebCore/style/values/borders/StyleBoxShadow.cpp
+++ b/Source/WebCore/style/values/borders/StyleBoxShadow.cpp
@@ -29,7 +29,7 @@
 #include "CSSKeywordValue.h"
 #include "ColorBlending.h"
 #include "StyleBuilderChecking.h"
-#include "StyleComputedStyle+GettersInlines.h"
+#include "StyleColorResolver.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"

--- a/Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
@@ -27,7 +27,7 @@
 
 #include "CSSGridTemplateListValue.h"
 #include "CSSKeywordValue.h"
-#include "StyleComputedStyle+GettersInlines.h"
+#include "StyleGridPosition.h"
 #include "StyleKeyword+Logging.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"

--- a/Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
@@ -30,7 +30,7 @@
 #include "CSSTextShadowPropertyValue.h"
 #include "ColorBlending.h"
 #include "StyleBuilderChecking.h"
-#include "StyleComputedStyle+GettersInlines.h"
+#include "StyleColorResolver.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -123,7 +123,6 @@
 #import <WebCore/SecurityOrigin.h>
 #import <WebCore/SimpleRange.h>
 #import <WebCore/SmartReplace.h>
-#import <WebCore/StyleComputedStyle+GettersInlines.h>
 #import <WebCore/SubframeLoader.h>
 #import <WebCore/TextIterator.h>
 #import <WebCore/ThreadCheck.h>


### PR DESCRIPTION
#### 9c0a7f7904c3a43d6e5765d7ed0b52c0d9b0b3a4
<pre>
[Build Speed] Reduce #includes of StyleComputedStyle+GettersInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=316717">https://bugs.webkit.org/show_bug.cgi?id=316717</a>
<a href="https://rdar.apple.com/179163396">rdar://179163396</a>

Reviewed by NOBODY (OOPS!).

StyleComputedStyle+GettersInlines.h takes 6s per translation unit.

Step 1: Remove StyleComputedStyle+GettersInlines.h from files where
it&apos;s present but unused.

* Source/WebCore/history/CachedFrame.cpp
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
* Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp
* Source/WebCore/page/TextIndicator.cpp
* Source/WebCore/rendering/AccessibilityRegionContext.cpp
* Source/WebCore/rendering/LegacyInlineBox.cpp
* Source/WebCore/rendering/RenderGeometryMap.cpp
* Source/WebCore/style/values/borders/StyleBoxShadow.cpp
* Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
* Source/WebCore/style/values/text-decoration/StyleTextShadow.cpp
* Source/WebKitLegacy/mac/WebView/WebFrame.mm: Don&apos;t #include what you don&apos;t use.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c0a7f7904c3a43d6e5765d7ed0b52c0d9b0b3a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167439 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40934 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34529 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176488 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169305 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41370 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40948 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170398 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/41370 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/34529 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110774 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/41370 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/40948 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25227 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/41370 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/34529 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179032 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/34529 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41008 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/40948 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138539 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41696 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/34529 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104777 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/41696 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/34529 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40200 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39597 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/34529 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39847 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39742 "Hash 9c0a7f79 for PR 66819 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->