### PR TITLE
Update touch and gesture tests after 314731@main

### DIFF
--- a/LayoutTests/fast/events/touch/gesture/gesture-scroll.html
+++ b/LayoutTests/fast/events/touch/gesture/gesture-scroll.html
@@ -129,7 +129,7 @@ function runTest()
         description('This tests scroll gesture events. ' +
             'Square is (mostly) green on pass');
 
-        if (eventSender.clearTouchPoints)
+        if (eventSender.gestureScrollBegin)
             firstGestureScrollSequence();
         else
             exitIfNecessary();

--- a/LayoutTests/fast/events/touch/gesture/resources/gesture-helpers.js
+++ b/LayoutTests/fast/events/touch/gesture/resources/gesture-helpers.js
@@ -14,10 +14,7 @@ function recordScroll(event)
         if (gesturesOccurred == expectedGesturesTotal) {
             shouldBe('scrollEventsOccurred', expectedScrollEventsOccurred);
             // If we've got here, we've passed.
-            successfullyParsed = true;
-            isSuccessfullyParsed();
-            if (window.testRunner)
-                testRunner.notifyDone();
+            finishJSTest();
         }
     }
 }
@@ -25,10 +22,7 @@ function recordScroll(event)
 function exitIfNecessary()
 {
     debug('gesture events not implemented on this platform or gesture event scrolling of a document is broken');
-    successfullyParsed = true;
-    isSuccessfullyParsed();
-    if (window.testRunner)
-        testRunner.notifyDone();
+    finishJSTest();
 }
 
 function checkTestDependencies()

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-propagated.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-propagated.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -122,8 +122,7 @@ function secondGestureScroll()
     finishTest();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {
@@ -146,10 +145,7 @@ function finishTest()
     if (window.eventSender) {
         if (gesturesOccurred == expectedGesturesTotal) {
             shouldBe('scrollEventsOccurred', expectedScrollEventsOccurred);
-            successfullyParsed = true;
-            isSuccessfullyParsed();
-            if (window.testRunner)
-                testRunner.notifyDone();
+            finishJSTest();
         }
     }
 }

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-xhidden.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-xhidden.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -124,8 +124,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-yhidden.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-yhidden.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -124,8 +124,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -130,8 +130,7 @@ function secondGestureScroll()
     finishTest();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {
@@ -153,10 +152,7 @@ function finishTest()
     if (window.eventSender) {
         if (gesturesOccurred == expectedGesturesTotal) {
             shouldBe('scrollEventsOccurred', expectedScrollEventsOccurred);
-            successfullyParsed = true;
-            isSuccessfullyParsed();
-            if (window.testRunner)
-                testRunner.notifyDone();
+            finishJSTest();
         }
     }
 }

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-div.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-div.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -94,8 +94,7 @@ function secondGestureScroll()
     finishTest();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {
@@ -120,10 +119,7 @@ function finishTest()
     if (window.eventSender) {
         if (gesturesOccurred == expectedGesturesTotal) {
             shouldBe('scrollEventsOccurred', expectedScrollEventsOccurred);
-            successfullyParsed = true;
-            isSuccessfullyParsed();
-            if (window.testRunner)
-                testRunner.notifyDone();
+            finishJSTest();
         }
     }
 }

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-iframe.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-iframe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -63,8 +63,7 @@ function secondGestureScroll()
     finishTest();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {
@@ -88,10 +87,7 @@ function finishTest()
     if (window.eventSender) {
         if (gesturesOccurred == expectedGesturesTotal) {
             shouldBe('scrollEventsOccurred', expectedScrollEventsOccurred);
-            successfullyParsed = true;
-            isSuccessfullyParsed();
-            if (window.testRunner)
-                testRunner.notifyDone();
+            finishJSTest();
         }
     }
 }

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-not-propagated.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-not-propagated.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 
@@ -114,8 +114,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-propagated.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-propagated.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 
@@ -114,8 +114,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-scaled.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-scaled.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -100,8 +100,7 @@ function firstGestureScroll()
      checkScrollOffset();
  }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 async function runTest()
 {
@@ -125,8 +124,7 @@ async function runTest()
     } else {
         debug("This test requires DumpRenderTree.  Touch scroll the red rect to log.");
     }
-    if (window.testRunner)
-        window.testRunner.notifyDone();
+    finishJSTest();
 }
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-twice-propagated.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-twice-propagated.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 
@@ -139,8 +139,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -100,8 +100,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-editable.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-editable.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -64,8 +64,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
         
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
     
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-not-propagated.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-not-propagated.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 
@@ -93,8 +93,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-propagated.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-propagated.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 
@@ -93,8 +93,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 #touchtarget {
@@ -57,8 +57,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page-not-propagated.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page-not-propagated.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 ::-webkit-scrollbar {
@@ -126,8 +126,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page-propagated.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page-propagated.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 ::-webkit-scrollbar {
@@ -126,8 +126,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 ::-webkit-scrollbar {
@@ -60,10 +60,7 @@ function recordScroll(event) {
 	    if (gesturesOccurred == expectedGesturesTotal) {
 			shouldBe('scrollEventsOccurred', expectedScrollEventsOccurred);
 	        // If we've got here, we've passed.
-	        successfullyParsed = true;
-	        isSuccessfullyParsed();
-	        if (window.testRunner)
-	            testRunner.notifyDone();
+	        finishJSTest();
 		}
     }
 }
@@ -113,8 +110,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-shy-target.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-shy-target.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="resources/gesture-helpers.js"></script>
 <style type="text/css">
 ::-webkit-scrollbar {
@@ -123,8 +123,7 @@ function secondGestureScroll()
     checkScrollOffset();
 }
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.jsTestIsAsync = true;
 
 function runTest()
 {

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-sideways.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-sideways.html
@@ -87,6 +87,8 @@ var scrollEventsOccurred = 0;
 var expectedScrollEventsOccurred = '1';
 var scrolledElement = 'movingdiv'
 
+window.jsTestIsAsync = true;
+
 function checkWheelScrollOffset()
 {
     if (!window.eventSender)
@@ -138,7 +140,6 @@ function runTest()
 
     if (window.eventSender) {
         description('This tests that precise scrolls on a horizontal scroll bar move vertically.');
-        window.jsTestIsAsync = true;
 
         if (checkTestDependencies())
             firstWheelScroll();

--- a/LayoutTests/fast/events/touch/ios/gesture-node-move-between-documents-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/gesture-node-move-between-documents-expected.txt
@@ -1,1 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This test should not crash or assert.

--- a/LayoutTests/fast/events/touch/ios/overflow-node-move-between-documents-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/overflow-node-move-between-documents-expected.txt
@@ -1,1 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This test should not crash or assert.

--- a/LayoutTests/fast/events/touch/ios/slider-node-move-between-documents-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/slider-node-move-between-documents-expected.txt
@@ -1,1 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This test should not crash or assert.

--- a/LayoutTests/fast/events/touch/ios/touch-node-move-between-documents-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-node-move-between-documents-expected.txt
@@ -1,1 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This test should not crash or assert.

--- a/LayoutTests/http/tests/fast/events/touch/ios/gesture-node-move-between-documents-expected.txt
+++ b/LayoutTests/http/tests/fast/events/touch/ios/gesture-node-move-between-documents-expected.txt
@@ -3,4 +3,7 @@
 --------
 Frame: '<!--frame1-->'
 --------
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This test should not crash or assert.

--- a/LayoutTests/http/tests/fast/events/touch/ios/overflow-node-move-between-documents-expected.txt
+++ b/LayoutTests/http/tests/fast/events/touch/ios/overflow-node-move-between-documents-expected.txt
@@ -3,4 +3,7 @@
 --------
 Frame: '<!--frame1-->'
 --------
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This test should not crash or assert.

--- a/LayoutTests/http/tests/fast/events/touch/ios/slider-node-move-between-documents-expected.txt
+++ b/LayoutTests/http/tests/fast/events/touch/ios/slider-node-move-between-documents-expected.txt
@@ -3,4 +3,7 @@
 --------
 Frame: '<!--frame1-->'
 --------
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This test should not crash or assert.

--- a/LayoutTests/http/tests/fast/events/touch/ios/touch-node-move-between-documents-expected.txt
+++ b/LayoutTests/http/tests/fast/events/touch/ios/touch-node-move-between-documents-expected.txt
@@ -3,4 +3,7 @@
 --------
 Frame: '<!--frame1-->'
 --------
+PASS successfullyParsed is true
+
+TEST COMPLETE
 This test should not crash or assert.


### PR DESCRIPTION
#### 8394b38b23afaaffeb72c727a60900ba274dce47
<pre>
Update touch and gesture tests after 314731@main
<a href="https://rdar.apple.com/179137323">rdar://179137323</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316697">https://bugs.webkit.org/show_bug.cgi?id=316697</a>

Unreviewed.

* LayoutTests/fast/events/touch/gesture/gesture-scroll.html: This test guarded on
eventSender.clearTouchPoints but needed eventSender.gestureScrollBegin — clearTouchPoints
exists on iOS while gestureScrollBegin does not, so the test threw instead of calling
exitIfNecessary().
* LayoutTests/fast/events/touch/gesture/resources/gesture-helpers.js: Stop using
testRunner.notifyDone().

* LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-propagated.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-xhidden.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body-yhidden.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-body.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-div.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-noscroll-iframe.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-not-propagated.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-propagated.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-scaled.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-twice-propagated.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-editable.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-not-propagated.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe-propagated.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-iframe.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page-not-propagated.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page-propagated.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-page.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-shy-target.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-sideways.html:
* LayoutTests/fast/events/touch/ios/gesture-node-move-between-documents-expected.txt:
* LayoutTests/fast/events/touch/ios/overflow-node-move-between-documents-expected.txt:
* LayoutTests/fast/events/touch/ios/slider-node-move-between-documents-expected.txt:
* LayoutTests/fast/events/touch/ios/touch-node-move-between-documents-expected.txt:
* LayoutTests/http/tests/fast/events/touch/ios/gesture-node-move-between-documents-expected.txt:
* LayoutTests/http/tests/fast/events/touch/ios/overflow-node-move-between-documents-expected.txt:
* LayoutTests/http/tests/fast/events/touch/ios/slider-node-move-between-documents-expected.txt:
* LayoutTests/http/tests/fast/events/touch/ios/touch-node-move-between-documents-expected.txt:
Mechanical updates to adapt to changes in 314731@main and to gesture-helpers.js changes here.

Canonical link: <a href="https://commits.webkit.org/314869@main">https://commits.webkit.org/314869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28edbbcd53058f3a66d69167ec5a2df5059d8624

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40989 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/34584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176547 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41003 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170453 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/110818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25282 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/28183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179087 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/29901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41063 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41751 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/149975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104857 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25485 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/33840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40255 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39652 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/4953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39903 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->