### PR TITLE
[LinkedIn] Tapping a video in the feed on iPad does not surface media controls

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -51,6 +51,7 @@
 #include "HTMLDialogElement.h"
 #include "HTMLElement.h"
 #include "HTMLImageElement.h"
+#include "HTMLMediaElement.h"
 #include "HTMLSlotElement.h"
 #include "HTMLStyleElement.h"
 #include "InputEvent.h"
@@ -2847,6 +2848,11 @@ bool Node::willRespondToMouseClickEventsWithEditability(Editability editability)
 #endif
     if (editability != Editability::ReadOnly)
         return true;
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(TOUCH_EVENTS)
+    if (is<HTMLMediaElement>(*this) && document().quirks().shouldTreatMediaElementsAsRespondingToClicks())
+        return true;
+#endif
 
     auto& eventNames = WebCore::eventNames();
     return eventTypes().containsIf([&](const auto& type) {

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -676,6 +676,22 @@ bool Quirks::shouldPreventDispatchOfTouchEvent(const AtomString& touchEventType,
     return false;
 }
 
+bool Quirks::shouldTreatMediaElementsAsRespondingToClicks() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.isLinkedIn;
+}
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(IOS_TOUCH_EVENTS)
+bool Quirks::shouldAllowNativeTapsOnMediaElements() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.isLinkedIn;
+}
+#endif
+
 #endif
 
 // live.com rdar://52116170
@@ -3487,6 +3503,13 @@ static void handleIMDBQuirks(QuirksData& quirksData, const URL& /* quirksURL */,
 
 }
 
+static void handleLinkedInQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
+{
+    QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("linkedin.com"_s);
+
+    quirksData.isLinkedIn = true;
+}
+
 static void handleLiveQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& /* documentURL */)
 {
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("live.com"_s);
@@ -4031,6 +4054,7 @@ void Quirks::determineRelevantQuirks()
         { "imdb"_s, &handleIMDBQuirks },
         { "instagram"_s, &handleInstagramQuirks },
         { "invideo"_s, &handleInVideoQuirks },
+        { "linkedin"_s, &handleLinkedInQuirks },
         { "live"_s, &handleLiveQuirks },
 #if PLATFORM(MAC)
         { "madisoncityk12"_s, &handleMadisonCityK12Quirks },

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -85,6 +85,7 @@ public:
     bool shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTarget*) const;
     bool shouldComputeSimulatedMouseEventMovementDelta() const;
     bool shouldPreventDispatchOfTouchEvent(const AtomString&, EventTarget*) const;
+    bool shouldTreatMediaElementsAsRespondingToClicks() const;
 #endif
     bool NODELETE shouldDisablePointerEventsQuirk() const;
     bool NODELETE needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const;
@@ -351,6 +352,10 @@ public:
     void clearLogoutSurvivingIdentityCookiesIfNeeded(const URL& fetchURL, int httpStatusCode);
 
     void determineRelevantQuirks();
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(IOS_TOUCH_EVENTS)
+    WEBCORE_EXPORT bool shouldAllowNativeTapsOnMediaElements() const;
+#endif
 
 #if PLATFORM(IOS_FAMILY)
     bool NODELETE shouldSendFakeTouchForceChangeEvent() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -46,6 +46,7 @@ struct QuirksData {
     bool isGoogleMaps : 1 { false };
     bool isIHeart : 1 { false };
     bool isInVideo : 1 { false };
+    bool isLinkedIn : 1 { false };
     bool isNBA : 1 { false };
     bool isNetflix : 1 { false };
     bool isOutlook : 1 { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4231,6 +4231,18 @@ Expected<bool, WebCore::RemoteFrameGeometryTransformer> WebPage::dispatchTouchEv
     CurrentEvent currentEvent(touchEvent);
     auto handleTouchEventResult = handleTouchEvent(frameID, touchEvent, m_page.get());
     updatePotentialTapSecurityOrigin(touchEvent, handleTouchEventResult.value_or(false));
+
+    if (touchEvent.type() == WebEventType::TouchEnd && handleTouchEventResult.value_or(false)) {
+        if (RefPtr localMainFrame = this->localMainFrame()) {
+            if (RefPtr document = localMainFrame->document(); document && document->quirks().shouldAllowNativeTapsOnMediaElements()) {
+                FloatPoint adjustedPoint;
+                RefPtr responder = localMainFrame->nodeRespondingToClickEvents(FloatPoint(touchEvent.position()), adjustedPoint);
+                if (responder && is<HTMLMediaElement>(*responder))
+                    handleTouchEventResult = false;
+            }
+        }
+    }
+
     return handleTouchEventResult;
 }
 


### PR DESCRIPTION
#### aa1b828c8a56976383e756d78a853b24cd9729f9
<pre>
[LinkedIn] Tapping a video in the feed on iPad does not surface media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=316707">https://bugs.webkit.org/show_bug.cgi?id=316707</a>
<a href="https://rdar.apple.com/171231918">rdar://171231918</a>

Reviewed by NOBODY (OOPS!).

LinkedIn calls preventDefault() on touchend for taps inside the feed, including taps targeting the
&lt;video&gt;. iOS treats that as &quot;page handled&quot; and cancels UITapGestureRecognizer, so no synthetic
click fires and the player&apos;s user-active toggle never flips.

Add a linkedin.com quirk that overrides the touchend &quot;handled&quot; result to false in
WebPage::dispatchTouchEvent when the target hit-tests to an HTMLMediaElement, so the tap commits
normally. Pair with a node-level gate so the resulting click lands on the &lt;video&gt;.
The page&apos;s touchend handler still runs; only the gesture-cancellation signal is suppressed.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::willRespondToMouseClickEventsWithEditability const):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::dispatchTouchEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e7f95d2a7e7e51244a3dec3d443c08be226d494

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167457 "Failed to checkout and rebase branch from PR 66822") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40952 "Failed to checkout and rebase branch from PR 66822") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34547 "Failed to checkout and rebase branch from PR 66822") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176506 "Failed to checkout and rebase branch from PR 66822") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169323 "Failed to checkout and rebase branch from PR 66822") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41388 "Failed to checkout and rebase branch from PR 66822") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40966 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/176506 "Failed to checkout and rebase branch from PR 66822") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170416 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/41388 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/34547 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/176506 "Failed to checkout and rebase branch from PR 66822") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/41388 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/40966 "Failed to checkout and rebase branch from PR 66822") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25245 "Failed to checkout and rebase branch from PR 66822") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/41388 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/34547 "Failed to checkout and rebase branch from PR 66822") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179050 "Failed to checkout and rebase branch from PR 66822") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/31946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/34547 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/179050 "Failed to checkout and rebase branch from PR 66822") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41026 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/40966 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/179050 "Failed to checkout and rebase branch from PR 66822") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41714 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/34547 "Failed to checkout and rebase branch from PR 66822") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104805 "Failed to checkout and rebase branch from PR 66822") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/41714 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/34547 "Failed to checkout and rebase branch from PR 66822") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40218 "Failed to checkout and rebase branch from PR 66822") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39615 "Failed to checkout and rebase branch from PR 66822") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/34547 "Failed to checkout and rebase branch from PR 66822") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39865 "Failed to checkout and rebase branch from PR 66822") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39760 "Failed to checkout and rebase branch from PR 66822") | | | | 
<!--EWS-Status-Bubble-End-->