### PR TITLE
[AppKit Gestures] Storyboards with WKWebView fail to compile (`init(coder:) has not been implemented`)

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -188,11 +188,12 @@ typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
 
 #endif
 
-#if !HAVE(NSGESTURERECOGNIZER_MODIFIER_FLAGS)
 @interface NSGestureRecognizer (SPI)
+@property (readwrite) BOOL shouldBeArchived;
+#if !HAVE(NSGESTURERECOGNIZER_MODIFIER_FLAGS)
 - (NSEventModifierFlags)modifierFlags;
-@end
 #endif
+@end
 
 @protocol NSGestureRecognizerDelegatePrivate <NSGestureRecognizerDelegate>
 

--- a/Source/WebKit/UIProcess/Cocoa/WKDeferringGestureRecognizer.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKDeferringGestureRecognizer.swift
@@ -36,12 +36,14 @@ extension WKDeferringGestureRecognizer {
         super.init(target: nil, action: nil)
     }
 
+    // -initWithCoder: is only a designated initializer for NSGestureRecognizer
+#if WTF_PLATFORM_MAC
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @objc
-    @available(*, unavailable)
     public required dynamic init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
+#endif
 
     @objc
     override init(target: Any?, action: Selector?) {

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -242,6 +242,7 @@ static NSString *gestureLogName(NSGestureRecognizer *gesture)
     [self setUpGestureRecognizers];
     [self addGesturesToWebView];
     [self enableGesturesIfNeeded];
+    [self ensureGesturesAreNotArchived];
 
     return self;
 }
@@ -361,6 +362,22 @@ static NSString *gestureLogName(NSGestureRecognizer *gesture)
     [self enableGestureIfNeeded:_dragPressGestureRecognizer.get()];
 
     // The deferring gesture recognizers are intentionally not enabled.
+}
+
+- (void)ensureGesturesAreNotArchived
+{
+    // The set of gestures managed by WKAppKitGestureController are configured
+    // and installed freshly for every web view initialization, and as such we
+    // want to avoid duplicate sets when views are decoded.
+
+    [_panGestureRecognizer setShouldBeArchived:NO];
+    [_mouseTrackingGestureRecognizer setShouldBeArchived:NO];
+    [_singleClickGestureRecognizer setShouldBeArchived:NO];
+    [_doubleClickGestureRecognizer setShouldBeArchived:NO];
+    [_secondaryClickGestureRecognizer setShouldBeArchived:NO];
+    [_secondaryClickDeferringGestureRecognizer setShouldBeArchived:NO];
+    [_dragPressGestureRecognizer setShouldBeArchived:NO];
+    [_dragDeferringGestureRecognizer setShouldBeArchived:NO];
 }
 
 - (void)enableGestureIfNeeded:(NSGestureRecognizer *)gesture


### PR DESCRIPTION
#### ce60187356b8b655d8e236a9b8e08ba1efa45cc8
<pre>
[AppKit Gestures] Storyboards with WKWebView fail to compile (`init(coder:) has not been implemented`)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316716">https://bugs.webkit.org/show_bug.cgi?id=316716</a>
<a href="https://rdar.apple.com/179048302">rdar://179048302</a>

Reviewed by Megan Gardner and Richard Robinson.

Any storyboard with a web view in it will invoke ibtool and fatally
error out when trying to call `-initWithCoder:` on the deferring gesture
recognizer. While we don&apos;t necessarily support being serialized here, we
do not need to be so catastrophic with the failure.

Instead, we delegate initialization to the parent class&apos; `init(coder:)`
implementation. Plus, we opt out the WKAppKitGestureController-managed
gesture recognizers from being archived. Since we configure and install
these gestures on every web view initialization, decode-based init path
would generate an unnecessary set of (orphaned) gestures.

* Source/WebKit/UIProcess/Cocoa/WKDeferringGestureRecognizer.swift:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController initWithPage:viewImpl:]):
(-[WKAppKitGestureController ensureGesturesAreNotArchived]):

Canonical link: <a href="https://commits.webkit.org/314908@main">https://commits.webkit.org/314908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a525169a2a321393593569f9b7f6be7674c77858

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167485 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176534 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/544efdc0-a3dc-4d48-9b25-f3a60b688a00) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130293 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d152d0ec-7346-439b-90c0-244320f3a4cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110810 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30382 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25273 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141674 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179078 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138690 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138577 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41742 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104842 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25500 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26843 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40246 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113327 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39643 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4942 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39894 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39788 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->