### PR TITLE
Implement Table64 JS API

### DIFF
--- a/JSTests/wasm/js-api/table.js
+++ b/JSTests/wasm/js-api/table.js
@@ -398,25 +398,29 @@ assert.throws(() => WebAssembly.Table.prototype.grow(undefined), TypeError, `exp
     }, TypeError, "expected |this| value to be an instance of WebAssembly.Table");
 
     const t0 = new WebAssembly.Table({minimum: 5, element: "funcref"}).type();
-    assert.eq(Object.keys(t0).length, 2);
+    assert.eq(Object.keys(t0).length, 3);
     assert.eq(t0.minimum, 5);
     assert.eq(t0.element, "funcref");
+    assert.eq(t0.address, "i32");
 
     const t1 = new WebAssembly.Table({minimum: 5, maximum: 10, element: "funcref"}).type();
-    assert.eq(Object.keys(t1).length, 3);
+    assert.eq(Object.keys(t1).length, 4);
     assert.eq(t1.minimum, 5);
     assert.eq(t1.maximum, 10)
     assert.eq(t1.element, "funcref");
+    assert.eq(t1.address, "i32");
 
     const t2 = new WebAssembly.Table({minimum: 5, maximum: 10, element: "externref"}).type();
-    assert.eq(Object.keys(t2).length, 3);
+    assert.eq(Object.keys(t2).length, 4);
     assert.eq(t2.minimum, 5);
     assert.eq(t2.maximum, 10)
     assert.eq(t2.element, "externref");
+    assert.eq(t2.address, "i32");
 
     const t3 = new WebAssembly.Table(t2).type();
     assert.eq(Object.keys(t2).length, Object.keys(t3).length);
     assert.eq(t2.minimum, t3.minimum);
     assert.eq(t2.maximum, t3.maximum)
     assert.eq(t2.element, t3.element);
+    assert.eq(t2.address, "i32");
 }

--- a/JSTests/wasm/js-api/table64-js-api.js
+++ b/JSTests/wasm/js-api/table64-js-api.js
@@ -1,0 +1,109 @@
+//@ runDefaultWasm("-m", "--useWasmMemory64=1")
+import * as assert from "../assert.js";
+
+{
+    const table = new WebAssembly.Table({ initial: 1n, address: "i64", element: "externref" });
+    assert.eq(table.type().minimum, 1n);
+    assert.eq(table.type().address, "i64");
+}
+
+{
+    const table = new WebAssembly.Table({ initial: 1, address: "i32", element: "externref" });
+    assert.eq(table.type().minimum, 1);
+    assert.eq(table.type().address, "i32");
+}
+
+{
+    assert.throws(
+        () => new WebAssembly.Table({ initial: 1, address: "i64", element: "externref" }),
+        TypeError,
+        "Invalid argument type in ToBigInt operation"
+    )
+}
+
+{
+    const table = new WebAssembly.Table({ initial: 1n, maximum: 10n, address: "i64", element: "externref" });
+    assert.eq(table.type().maximum, 10n);
+    assert.eq(table.type().address, "i64");
+}
+
+{
+    const table = new WebAssembly.Table({ initial: 1, maximum: 10, address: "i32", element: "externref" });
+    assert.eq(table.type().maximum, 10);
+    assert.eq(table.type().address, "i32");
+}
+
+{
+    const table = new WebAssembly.Table({ initial: 1, element: "externref"});
+    assert.eq(table.type().minimum, 1);
+    assert.eq(table.type().address, "i32");
+}
+
+{
+    assert.throws(
+        () => new WebAssembly.Table({ initial: 1n, maximum: 10, address: "i64", element: "externref" }),
+        TypeError,
+        "Invalid argument type in ToBigInt operation"
+    )
+}
+
+{
+    const table = new WebAssembly.Table({ initial: 1n, maximum: 10n, address: "i64", element: "externref" });
+
+    const copy = new WebAssembly.Table(table.type());
+    assert.eq(copy.type().minimum, 1n);
+    assert.eq(copy.type().maximum, 10n);
+    assert.eq(copy.type().address, "i64");
+    assert.eq(copy.type().element, "externref");
+}
+
+{
+    assert.throws(
+        () => new WebAssembly.Table({initial: 10000001n, maximum: 0n, address: "i64", element: "funcref"}),
+        RangeError,
+        "WebAssembly.Table 'initial' value is above the upper bound 10000000"
+    );
+}
+
+{
+    // This should not throw
+    new WebAssembly.Table({initial: BigInt(2**20), maximum: BigInt(2**64) - 1n, element: "funcref", address: "i64"});
+}
+
+{
+    const table = new WebAssembly.Table({element: "funcref", initial: 20n, maximum: 30n, address: "i64"});
+    assert.eq(20n, table.grow(0n));
+    assert.eq(20, table.length);
+    assert.eq(20n, table.grow(1n));
+    assert.eq(21, table.length);
+}
+
+{
+    const table = new WebAssembly.Table({element: "funcref", initial: 20n, maximum: 30n, address: "i64"});
+    assert.eq(20n, table.grow(10n));
+    assert.eq(30n, table.grow(0n));
+    assert.throws(() => table.grow(1n), RangeError, "WebAssembly.Table.prototype.grow could not grow the table");
+}
+
+{
+    const table = new WebAssembly.Table({element: "funcref", initial: 20n, address: "i64"});
+    let called = false;
+    table.grow({valueOf() { called = true; return 42n; }});
+    assert.truthy(called);
+    assert.eq(62, table.length);
+}
+
+{
+    const table = new WebAssembly.Table({element: "funcref", initial: 20n, address: "i64"});
+    assert.throws(() => table.get(20n), RangeError, "WebAssembly.Table.prototype.get expects an integer less than the length of the table");
+    for (let i = 0; i < 20; i++)
+        assert.eq(table.get(BigInt(i)), null);
+}
+
+{
+    const table = new WebAssembly.Table({element: "funcref", initial: 20n, address: "i64"});
+    assert.throws(() => table.set(20n, null), RangeError, "WebAssembly.Table.prototype.set expects an integer less than the length of the table");
+    for (let i = 0; i < 20; i++)
+        table.set(BigInt(i), null);
+}
+

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/MathCommon.h>
 #include <JavaScriptCore/PageCount.h>
 #include <JavaScriptCore/RegisterAtOffsetList.h>
+#include <JavaScriptCore/WasmAddressType.h>
 #include <JavaScriptCore/WasmMemoryInformation.h>
 #include <JavaScriptCore/WasmName.h>
 #include <JavaScriptCore/WasmNameSection.h>
@@ -793,15 +794,16 @@ public:
         ASSERT(!*this);
     }
 
-    TableInformation(uint32_t initial, std::optional<uint32_t> maximum, bool isImport, TableElementType type, Type wasmType, InitializationType initType, uint64_t initialBitsOrImportNumber)
-        : m_initial(initial)
+    TableInformation(uint32_t initial, std::optional<uint32_t> maximum, bool isImport, TableElementType type, Type wasmType, InitializationType initType, uint64_t initialBitsOrImportNumber, bool isTable64)
+        : m_wasmType(wasmType)
         , m_maximum(maximum)
+        , m_initialBitsOrImportNumber(initialBitsOrImportNumber)
+        , m_initial(initial)
+        , m_type(type)
+        , m_addressType(isTable64)
+        , m_initType(initType)
         , m_isImport(isImport)
         , m_isValid(true)
-        , m_type(type)
-        , m_wasmType(wasmType)
-        , m_initType(initType)
-        , m_initialBitsOrImportNumber(initialBitsOrImportNumber)
     {
         ASSERT(*this);
     }
@@ -814,16 +816,18 @@ public:
     Type wasmType() const { return m_wasmType; }
     InitializationType initType() const { return m_initType; }
     uint64_t initialBitsOrImportNumber() const { return m_initialBitsOrImportNumber; }
+    Wasm::AddressType addressType() const { return m_addressType; }
 
 private:
-    uint32_t m_initial;
+    Type m_wasmType;
     std::optional<uint32_t> m_maximum;
+    uint64_t m_initialBitsOrImportNumber;
+    uint32_t m_initial;
+    TableElementType m_type;
+    Wasm::AddressType m_addressType;
+    InitializationType m_initType { Default };
     bool m_isImport { false };
     bool m_isValid { false };
-    TableElementType m_type;
-    Type m_wasmType;
-    InitializationType m_initType { Default };
-    uint64_t m_initialBitsOrImportNumber;
 };
     
 struct CustomSection {

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -369,7 +369,7 @@ auto SectionParser::parseTableHelper(bool isImport) -> PartialResult
     }
 
     TableElementType tableType = isSubtype(type, funcrefType()) ? TableElementType::Funcref : TableElementType::Externref;
-    m_info->tables.append(TableInformation(initial, maximum, isImport, tableType, type, tableInitType, initialBitsOrImportNumber));
+    m_info->tables.append(TableInformation(initial, maximum, isImport, tableType, type, tableInitType, initialBitsOrImportNumber, isTable64));
 
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -82,31 +82,32 @@ void Table::operator delete(Table* table, std::destroying_delete_t)
     });
 }
 
-Table::Table(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType, TableElementType type)
+Table::Table(uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, Wasm::AddressType addressType, TableElementType type)
     : m_maximum(maximum)
     , m_type(type)
     , m_wasmType(wasmType)
     , m_wasmTypeRTT(TypeInformation::tryGetRTT(wasmType.index))
     , m_isFixedSized(maximum && maximum.value() == initial)
+    , m_addressType(addressType)
     , m_owner(nullptr)
 {
     setLength(initial);
     ASSERT(!m_maximum || *m_maximum >= m_length);
 }
 
-RefPtr<Table> Table::tryCreate(VM& vm, uint32_t initial, std::optional<uint32_t> maximum, TableElementType type, Type wasmType)
+RefPtr<Table> Table::tryCreate(VM& vm, uint32_t initial, std::optional<uint64_t> maximum, TableElementType type, Type wasmType, Wasm::AddressType addressType)
 {
     if (!isValidLength(initial))
         return nullptr;
     switch (type) {
     case TableElementType::Externref:
-        return adoptRef(new ExternOrAnyRefTable(initial, maximum, wasmType));
+        return adoptRef(new ExternOrAnyRefTable(initial, maximum, wasmType, addressType));
     case TableElementType::Funcref: {
         if (maximum && maximum.value() == initial) {
             // If the table is fixed-sized, we should put table slots inline to avoid one-level indirection.
-            return FuncRefTable::createFixedSized(vm, initial, wasmType);
+            return FuncRefTable::createFixedSized(vm, initial, wasmType, addressType);
         }
-        return adoptRef(new FuncRefTable(vm, initial, maximum, wasmType));
+        return adoptRef(new FuncRefTable(vm, initial, maximum, wasmType, addressType));
     }
     }
 
@@ -253,8 +254,8 @@ FuncRefTable* Table::asFuncrefTable()
     return m_type == TableElementType::Funcref ? static_cast<FuncRefTable*>(this) : nullptr;
 }
 
-ExternOrAnyRefTable::ExternOrAnyRefTable(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType)
-    : Table(initial, maximum, wasmType, TableElementType::Externref)
+ExternOrAnyRefTable::ExternOrAnyRefTable(uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, Wasm::AddressType addressType)
+    : Table(initial, maximum, wasmType, addressType, TableElementType::Externref)
 {
     RELEASE_ASSERT(isRefType(wasmType));
     // FIXME: It might be worth trying to pre-allocate maximum here. The spec recommends doing so.
@@ -275,8 +276,8 @@ void ExternOrAnyRefTable::set(uint32_t index, JSValue value)
     m_jsValues.get()[index].set(m_owner->vm(), m_owner, value);
 }
 
-FuncRefTable::FuncRefTable(VM& vm, uint32_t initial, std::optional<uint32_t> maximum, Type wasmType)
-    : Table(initial, maximum, wasmType, TableElementType::Funcref)
+FuncRefTable::FuncRefTable(VM& vm, uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, Wasm::AddressType addressType)
+    : Table(initial, maximum, wasmType, addressType, TableElementType::Funcref)
     , m_instances(vm)
 {
     ASSERT(isSubtype(wasmType, funcrefType()));
@@ -306,9 +307,9 @@ FuncRefTable::~FuncRefTable()
     }
 }
 
-Ref<FuncRefTable> FuncRefTable::createFixedSized(VM& vm, uint32_t size, Type wasmType)
+Ref<FuncRefTable> FuncRefTable::createFixedSized(VM& vm, uint32_t size, Type wasmType, Wasm::AddressType addressType)
 {
-    return adoptRef(*new (NotNull, fastMalloc(allocationSize(allocatedLength(size)))) FuncRefTable(vm, size, size, wasmType));
+    return adoptRef(*new (NotNull, fastMalloc(allocationSize(allocatedLength(size)))) FuncRefTable(vm, size, size, wasmType, addressType));
 }
 
 void FuncRefTable::setFunction(uint32_t index, WebAssemblyFunctionBase* function)

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -30,6 +30,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/WasmAddressType.h>
 #include <JavaScriptCore/WasmCallee.h>
 #include <JavaScriptCore/WasmFormat.h>
 #include <JavaScriptCore/WasmLimits.h>
@@ -54,11 +55,11 @@ class Table : public ThreadSafeRefCounted<Table> {
     WTF_MAKE_NONCOPYABLE(Table);
     WTF_MAKE_TZONE_ALLOCATED(Table);
 public:
-    static RefPtr<Table> tryCreate(VM&, uint32_t initial, std::optional<uint32_t> maximum, TableElementType, Type);
+    static RefPtr<Table> tryCreate(VM&, uint32_t initial, std::optional<uint64_t> maximum, TableElementType, Type, Wasm::AddressType);
 
     JS_EXPORT_PRIVATE ~Table() = default;
 
-    std::optional<uint32_t> maximum() const { return m_maximum; }
+    std::optional<uint64_t> maximum() const { return m_maximum; }
     uint32_t length() const { return m_length; }
 
     static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(Table, m_length); }
@@ -77,6 +78,7 @@ public:
     bool isExternrefTable() const { return m_type == TableElementType::Externref; }
     bool isFuncrefTable() const { return m_type == TableElementType::Funcref; }
     Type wasmType() const { return m_wasmType; }
+    Wasm::AddressType addressType() const { return m_addressType; }
     FuncRefTable* NODELETE asFuncrefTable();
 
     static bool isValidLength(uint32_t length) { return length < maxTableEntries; }
@@ -93,7 +95,7 @@ public:
     void operator delete(Table*, std::destroying_delete_t);
 
 protected:
-    Table(uint32_t initial, std::optional<uint32_t> maximum, Type, TableElementType = TableElementType::Externref);
+    Table(uint32_t initial, std::optional<uint64_t> maximum, Type, Wasm::AddressType, TableElementType = TableElementType::Externref);
 
     template<typename Visitor> constexpr decltype(auto) NODELETE visitDerived(Visitor&&);
     template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&) const;
@@ -103,13 +105,14 @@ protected:
     bool isFixedSized() const { return m_isFixedSized; }
 
     uint32_t m_length;
-    NO_UNIQUE_ADDRESS const std::optional<uint32_t> m_maximum;
+    NO_UNIQUE_ADDRESS const std::optional<uint64_t> m_maximum;
     const TableElementType m_type;
     Type m_wasmType;
     // For concrete (RTT-bearing) heap types, retain the canonical RTT so the
     // pointer embedded in m_wasmType does not dangle.
     RefPtr<const RTT> m_wasmTypeRTT;
     bool m_isFixedSized { false };
+    Wasm::AddressType m_addressType;
     JSWebAssemblyTable* m_owner;
 };
 
@@ -123,7 +126,7 @@ public:
     JSValue get(uint32_t index) const { return m_jsValues.get()[index].get(); }
 
 private:
-    ExternOrAnyRefTable(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType);
+    ExternOrAnyRefTable(uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, Wasm::AddressType);
 
     MallocPtr<WriteBarrier<Unknown>, VMMalloc> m_jsValues;
 };
@@ -166,11 +169,11 @@ public:
     void registerInstance(JSWebAssemblyInstance&);
 
 private:
-    FuncRefTable(VM&, uint32_t initial, std::optional<uint32_t> maximum, Type wasmType);
+    FuncRefTable(VM&, uint32_t initial, std::optional<uint64_t> maximum, Type wasmType, Wasm::AddressType);
 
     Function* tailPointer() { return std::bit_cast<Function*>(std::bit_cast<uint8_t*>(this) + offsetOfTail()); }
 
-    static Ref<FuncRefTable> createFixedSized(VM&, uint32_t size, Type wasmType);
+    static Ref<FuncRefTable> createFixedSized(VM&, uint32_t size, Type wasmType, Wasm::AddressType);
 
     MallocPtr<Function, VMMalloc> m_importableFunctions;
     // FIXME: It seems like we should be able to recover this from the Wasm::Callee + instance but there might be problems for JS

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp
@@ -28,7 +28,9 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "ExceptionScope.h"
 #include "JSCInlines.h"
+#include "JSString.h"
 #include "JSWebAssemblyHelpers.h"
 #include "JSWebAssemblyInstance.h"
 #include "ObjectConstructor.h"
@@ -139,6 +141,7 @@ void JSWebAssemblyTable::clear(uint32_t index)
 JSObject* JSWebAssemblyTable::type(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     Wasm::TableElementType element = m_table->type();
     JSString* elementString = nullptr;
@@ -160,16 +163,32 @@ JSObject* JSWebAssemblyTable::type(JSGlobalObject* globalObject)
     }
 
     JSObject* result;
+    auto numberOrBigInt = [&](uint32_t value) {
+        return m_table->addressType().is64Bit()
+            ? JSBigInt::createFrom(globalObject, value)
+            : jsNumber(value);
+    };
+
     auto maximum = m_table->maximum();
     if (maximum) {
         result = constructEmptyObject(globalObject, globalObject->objectPrototype(), 3);
-        result->putDirect(vm, Identifier::fromString(vm, "maximum"_s), jsNumber(*maximum));
+        auto maxValue = numberOrBigInt(*maximum);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        result->putDirect(vm, Identifier::fromString(vm, "maximum"_s), maxValue);
     } else
         result = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
 
-    uint32_t minimum = m_table->length();
-    result->putDirect(vm, Identifier::fromString(vm, "minimum"_s), jsNumber(minimum));
+    uint64_t minimum = m_table->length();
+    auto minValue = numberOrBigInt(minimum);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    result->putDirect(vm, Identifier::fromString(vm, "minimum"_s), minValue);
     result->putDirect(vm, Identifier::fromString(vm, "element"_s), elementString);
+
+    JSString* address = m_table->addressType().is64Bit()
+        ? jsNontrivialString(vm, "i64"_s)
+        : jsNontrivialString(vm, "i32"_s);
+    result->putDirect(vm, Identifier::fromString(vm, "address"_s), address);
+
     return result;
 }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -570,7 +570,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         if (!m_instance->table(i)) {
             RELEASE_ASSERT(!moduleInformation.tables[i].isImport());
             // We create a Table when it's a Table definition.
-            RefPtr<Wasm::Table> wasmTable = Wasm::Table::tryCreate(vm, moduleInformation.tables[i].initial(), moduleInformation.tables[i].maximum(), moduleInformation.tables[i].type(), moduleInformation.tables[i].wasmType());
+            RefPtr<Wasm::Table> wasmTable = Wasm::Table::tryCreate(vm, moduleInformation.tables[i].initial(), moduleInformation.tables[i].maximum(), moduleInformation.tables[i].type(), moduleInformation.tables[i].wasmType(), moduleInformation.tables[i].addressType() );
             if (!wasmTable)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, "couldn't create Table"_s));
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
@@ -28,12 +28,16 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "Error.h"
+#include "ExceptionScope.h"
 #include "JSCJSValueInlines.h"
 #include "JSGlobalObjectInlines.h"
 #include "JSObjectInlines.h"
 #include "JSWebAssemblyHelpers.h"
 #include "JSWebAssemblyTable.h"
 #include "StructureCreateInlines.h"
+#include "WasmAddressType.h"
+#include "WasmLimits.h"
 #include "WebAssemblyTablePrototype.h"
 
 namespace JSC {
@@ -58,6 +62,22 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTable, (JSGlobalObject* globalObj
         if (!argument.isObject())
             return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table expects its first argument to be an object"_s);
         memoryDescriptor = uncheckedDowncast<JSObject>(argument);
+    }
+
+    Wasm::AddressType addressType = Wasm::AddressType::I32;
+    Identifier addressIdent = Identifier::fromString(vm, "address"_s);
+    JSValue addressTypeValue = memoryDescriptor->get(globalObject, addressIdent);
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+    if (!addressTypeValue.isUndefined()) {
+        String addressTypeString = addressTypeValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+
+        if (addressTypeString == "i64"_s)
+            addressType =  Wasm::AddressType::I64;
+        else if (addressTypeString != "i32"_s) {
+            throwTypeError(globalObject, throwScope, "WebAssembly.Table 'address' must be a string of value 'i32' or 'i64'"_s);
+            return { };
+        }
     }
 
     Wasm::TableElementType type;
@@ -87,24 +107,29 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTable, (JSGlobalObject* globalObj
     if (!minSizeValue.isUndefined())
         initialSizeValue = minSizeValue;
 
-    uint32_t initial = toNonWrappingUint32(globalObject, initialSizeValue);
+    uint64_t initial64 = addressValueToUint64(globalObject, initialSizeValue, addressType);
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+
+    if (initial64 > Wasm::maxTableInitializationEntries)
+        return throwVMRangeError(globalObject, throwScope, WTF::makeString("WebAssembly.Table 'initial' value is above the upper bound "_s, Wasm::maxTableInitializationEntries));
+
+    uint32_t initial = initial64;
 
     // In WebIDL, "present" means that [[Get]] result is undefined, not [[HasProperty]] result.
     // https://webidl.spec.whatwg.org/#idl-dictionaries
-    std::optional<uint32_t> maximum;
+    std::optional<uint64_t> maximum;
     Identifier maximumIdent = Identifier::fromString(vm, "maximum"_s);
     JSValue maxSizeValue = memoryDescriptor->get(globalObject, maximumIdent);
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
     if (!maxSizeValue.isUndefined()) {
-        maximum = toNonWrappingUint32(globalObject, maxSizeValue);
+        maximum = addressValueToUint64(globalObject, maxSizeValue, addressType);
         RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-
         if (initial > *maximum)
             return throwVMRangeError(globalObject, throwScope, "'maximum' property must be greater than or equal to the 'initial' property"_s);
     }
 
-    RefPtr<Wasm::Table> wasmTable = Wasm::Table::tryCreate(vm, initial, maximum, type, type == Wasm::TableElementType::Funcref ? Wasm::funcrefType() : Wasm::externrefType());
+
+    RefPtr<Wasm::Table> wasmTable = Wasm::Table::tryCreate(vm, initial, maximum, type, type == Wasm::TableElementType::Funcref ? Wasm::funcrefType() : Wasm::externrefType(), addressType);
     if (!wasmTable)
         return throwVMRangeError(globalObject, throwScope, "couldn't create Table"_s);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "AuxiliaryBarrierInlines.h"
+#include "ExceptionScope.h"
 #include "JSCJSValueInlines.h"
 #include "JSGlobalObjectInlines.h"
 #include "JSObjectInlines.h"
@@ -36,6 +37,7 @@
 #include "JSWebAssemblyTable.h"
 #include "StructureCreateInlines.h"
 #include "WasmTypeDefinition.h"
+#include <limits>
 
 namespace JSC {
 static JSC_DECLARE_CUSTOM_GETTER(webAssemblyTableProtoGetterLength);
@@ -91,7 +93,12 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncGrow, (JSGlobalObject* globalO
     JSWebAssemblyTable* table = getTable(globalObject, vm, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
-    uint32_t delta = toNonWrappingUint32(globalObject, callFrame->argument(0));
+    uint64_t delta64 = addressValueToUint64(globalObject, callFrame->argument(0), table->table()->addressType());
+    if (delta64 > std::numeric_limits<uint32_t>::max())
+        return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.grow requires first argument to be greater than 0 and less than 2^32"_s);
+
+    uint32_t delta = delta64;
+
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
     JSValue defaultValue = jsNull();
@@ -109,6 +116,9 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncGrow, (JSGlobalObject* globalO
     if (!didGrow)
         return throwVMRangeError(globalObject, throwScope, "WebAssembly.Table.prototype.grow could not grow the table"_s);
 
+    if (table->table()->addressType().is64Bit())
+        RELEASE_AND_RETURN(throwScope, JSValue::encode(JSBigInt::createFrom(globalObject, oldLength)));
+
     return JSValue::encode(jsNumber(oldLength));
 }
 
@@ -120,7 +130,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncGet, (JSGlobalObject* globalOb
     JSWebAssemblyTable* table = getTable(globalObject, vm, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
-    uint32_t index = toNonWrappingUint32(globalObject, callFrame->argument(0));
+    uint64_t index = addressValueToUint64(globalObject, callFrame->argument(0), table->table()->addressType());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
     if (index >= table->length())
         return throwVMRangeError(globalObject, throwScope, "WebAssembly.Table.prototype.get expects an integer less than the length of the table"_s);
@@ -136,7 +146,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncSet, (JSGlobalObject* globalOb
     JSWebAssemblyTable* table = getTable(globalObject, vm, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
-    uint32_t index = toNonWrappingUint32(globalObject, callFrame->argument(0));
+    uint64_t index = addressValueToUint64(globalObject, callFrame->argument(0), table->table()->addressType());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
 
     if (index >= table->length())
@@ -162,6 +172,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncType, (JSGlobalObject* globalO
     JSWebAssemblyTable* table = getTable(globalObject, vm, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
     JSObject* typeDescriptor = table->type(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
     if (!typeDescriptor)
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.type unable to produce type descriptor for the given table"_s);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(typeDescriptor));


### PR DESCRIPTION
#### 1152f3717e9b65ac9c329f3966e3733d62ce27d4
<pre>
Implement Table64 JS API
<a href="https://bugs.webkit.org/show_bug.cgi?id=316725">https://bugs.webkit.org/show_bug.cgi?id=316725</a>
<a href="https://rdar.apple.com/179172629">rdar://179172629</a>

Reviewed by Yusuke Suzuki.

Implement the Table64 JS API.

Test: JSTests/wasm/js-api/table64-js-api.js

* JSTests/wasm/js-api/table.js:
(assert.truthy):
* JSTests/wasm/js-api/table64-js-api.js: Added.
(assert.eq.table.type):
(assert.eq):
(assert.throws):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::TableInformation::TableInformation):
(JSC::Wasm::TableInformation::isTable64 const):
(JSC::Wasm::TableInformation::addressType const):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseTableHelper):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::Table):
(JSC::Wasm::Table::tryCreate):
(JSC::Wasm::ExternOrAnyRefTable::ExternOrAnyRefTable):
(JSC::Wasm::FuncRefTable::FuncRefTable):
(JSC::Wasm::FuncRefTable::createFixedSized):
* Source/JavaScriptCore/wasm/WasmTable.h:
(JSC::Wasm::Table::addressType const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.cpp:
(JSC::JSWebAssemblyTable::type):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):
* Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/316389@main">https://commits.webkit.org/316389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0227b935d75886137492ba721bbc54cdbf915d93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129620 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b89a838-11a1-40c7-904c-695dc13be503) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133843 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0688a0b4-3cac-4de7-b0e2-8f686cc9838c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114316 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd8c40f4-665d-4235-b750-68a8295d99a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35894 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30119 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2919 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184039 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33325 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142582 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45650 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142471 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38488 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46330 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110993 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37557 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118018 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204744 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44848 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8827 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54664 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44248 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44480 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->