### PR TITLE
[GFC] Layout out-of-flow descendants in the modern grid path

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-001-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-001.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 100px; height: 100px; grid-template-columns: 100px; grid-template-rows: 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; width: 100px; height: 100px; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-002-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-002.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 100px; height: 100px; grid-template-columns: 100px; grid-template-rows: 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div>
+      <div>
+        <div style="position: absolute; width: 100px; height: 100px; background: green;"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-003-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-003.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 200px; height: 200px; grid-template-columns: 200px; grid-template-rows: 200px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; width: 50%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-004-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-004.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 200px; height: 200px; grid-template-columns: 100px 100px; grid-template-rows: 100px 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; top: 0; left: 0; right: 100px; bottom: 100px; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-005-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-005.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 100px; height: 100px; grid-template-columns: 100px; grid-template-rows: 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; left: 0; right: 0; top: 0; bottom: 0; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-006-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-006.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<!-- grid-column: span 2 / span 3 — both sides are spans, per spec "If the placement
+     only contains a grid span, replace it with the two auto lines in that axis."
+     The containing block is then the full padding edges (100px). -->
+<div style="position: relative; display: grid; width: 100px; height: 100px; grid-template-columns: 50px 50px; grid-template-rows: 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; grid-column: span 2 / span 3; width: 100%; height: 100%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-007-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-007-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-007.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<!-- grid-column: 1 / 10 — line 10 is beyond the explicit grid (only 2 columns = 3 lines),
+     so it is treated as auto (padding edge). The containing block goes from line 1 to the
+     end padding edge, which is the full 100px width. -->
+<div style="position: relative; display: grid; width: 100px; height: 100px; grid-template-columns: 50px 50px; grid-template-rows: 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; grid-column: 1 / 10; width: 100%; height: 100%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 150px; height: 150px; padding: 25px; grid-template-columns: 150px; grid-template-rows: 150px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; width: 50%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 200px; height: 200px; padding: 20px; grid-template-columns: 200px; grid-template-rows: 200px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 400px; height: 400px; padding: 20px; grid-template-columns: 200px 200px; grid-template-rows: 200px 200px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-011-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-011-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-011.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-011.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 200px; grid-template-columns: 200px; grid-template-rows: 200px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; width: 50%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 150px; padding: 25px; grid-template-columns: 150px; grid-template-rows: 150px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; width: 50%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 400px; padding: 20px; grid-template-columns: 200px 200px; grid-template-rows: 200px 200px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-014-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-014-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-014.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-014.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 200px; height: 200px; grid-template-columns: 100px 100px; grid-template-rows: 100px 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; grid-column: 1/3; grid-row: 1/2; width: 50%; height: 100%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-015-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-015-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-015.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-015.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 200px; height: 200px; grid-template-columns: 100px 100px; grid-template-rows: 100px 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; grid-column: 1/2; grid-row: 1/3; width: 100%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-016-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-016-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-016.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-016.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="position: relative; display: grid; width: 200px; height: 200px; grid-template-columns: 100px 100px; grid-template-rows: 100px 100px;">
+  <div style="grid-column: 1/2; grid-row: 1/2;">
+    <div style="position: absolute; grid-column: 1/3; grid-row: 1/3; width: 50%; height: 50%; background: green;"></div>
+  </div>
+</div>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -179,8 +179,9 @@ void GridLayout::updateFormattingContextRootRenderer(const Layout::GridLayoutCon
         auto& rowSizes = usedTrackSizes.rowSizes;
         auto usedRowGutter = Layout::GridFormattingContext::usedGapValue(renderGrid->style().rowGap());
         auto blockContentSize = std::reduce(rowSizes.begin(), rowSizes.end()) + Layout::GridLayoutUtils::totalGuttersSize(rowSizes.size(), usedRowGutter);
-        renderGrid->setHeight(blockContentSize);
-    }
+        renderGrid->setHeight(blockContentSize + renderGrid->borderAndPaddingLogicalHeight());
+    } else
+        renderGrid->setHeight(layoutConstraints.blockAxis.availableSpace() + renderGrid->borderAndPaddingLogicalHeight());
 
     for (CheckedRef layoutBox : formattingContextBoxes(gridBox()))
         orderIteratorPopulator.collectChild(CheckedRef { downcast<RenderBox>(*layoutBox->rendererForIntegration()) });
@@ -199,6 +200,54 @@ void GridLayout::layout()
     auto usedTrackSizes = Layout::GridFormattingContext { gridBox(), layoutState() }.layout(gridLayoutConstraints);
     updateGridItemRenderers();
     updateFormattingContextRootRenderer(gridLayoutConstraints, usedTrackSizes);
+    layoutOutOfFlowBoxes(usedTrackSizes);
+}
+
+void GridLayout::layoutOutOfFlowBoxes(const Layout::UsedTrackSizes& usedTrackSizes)
+{
+    CheckedRef renderGrid = gridBoxRenderer();
+    auto* outOfFlowDescendants = renderGrid->outOfFlowBoxes();
+    if (!outOfFlowDescendants)
+        return;
+
+    // Populate grid positions so that gridAreaRangeForOutOfFlow (called from
+    // PositionedLayoutConstraints::captureGridArea during positioned layout)
+    // can resolve grid lines to their positions in the grid.
+    populateGridPositionsForOutOfFlowLayout(usedTrackSizes);
+
+    // FIXME: Determine whether we should conditionally use RelayoutChildren::No
+    // based on whether the grid container size changed, matching the legacy path's
+    // logic (which uses RelayoutChildren::Yes only when size changed).
+    renderGrid->layoutOutOfFlowBoxes(RelayoutChildren::Yes);
+}
+
+void GridLayout::populateGridPositionsForOutOfFlowLayout(const Layout::UsedTrackSizes& usedTrackSizes)
+{
+    CheckedRef renderGrid = gridBoxRenderer();
+
+    // Ensure numTracks() returns the correct value for each direction.
+    renderGrid->currentGrid().ensureGridSize(usedTrackSizes.rowSizes.size(), usedTrackSizes.columnSizes.size());
+
+    auto populate = [&](Style::GridTrackSizingDirection direction) {
+        bool isColumns = direction == Style::GridTrackSizingDirection::Columns;
+        auto& trackSizes = isColumns ? usedTrackSizes.columnSizes : usedTrackSizes.rowSizes;
+        auto gap = Layout::GridFormattingContext::usedGapValue(isColumns ? renderGrid->style().columnGap() : renderGrid->style().rowGap());
+        auto borderAndPadding = isColumns ? renderGrid->borderAndPaddingStart() : renderGrid->borderAndPaddingBefore();
+        auto numberOfTracks = trackSizes.size();
+        bool hasMultipleTracks = numberOfTracks > 1;
+
+        auto& positions = renderGrid->positions(direction);
+        positions.resize(numberOfTracks + 1);
+        positions[0] = borderAndPadding;
+        for (auto [trackIndex, trackSize] : WTF::indexedRange(trackSizes)) {
+            bool isLastTrack = trackIndex == numberOfTracks - 1;
+            auto gapAfterTrack = (!isLastTrack && hasMultipleTracks) ? gap : 0_lu;
+            positions[trackIndex + 1] = positions[trackIndex] + trackSize + gapAfterTrack;
+        }
+    };
+
+    populate(Style::GridTrackSizingDirection::Columns);
+    populate(Style::GridTrackSizingDirection::Rows);
 }
 
 TextStream& operator<<(TextStream& stream, const GridLayout& layout)

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -60,6 +60,8 @@ public:
 private:
     void updateGridItemRenderers();
     void updateFormattingContextRootRenderer(const Layout::GridLayoutConstraints&, const Layout::UsedTrackSizes&);
+    void layoutOutOfFlowBoxes(const Layout::UsedTrackSizes&);
+    void populateGridPositionsForOutOfFlowLayout(const Layout::UsedTrackSizes&);
 
     const Layout::ElementBox& gridBox() const { return *m_gridBox; }
     Layout::ElementBox& gridBox() { return *m_gridBox; }

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -166,6 +166,7 @@ private:
     friend class GridTrackSizingAlgorithmStrategy;
     friend class GridMasonryLayout;
     friend class PositionedLayoutConstraints;
+    friend class LayoutIntegration::GridLayout;
 
     inline void updateGridAreaWithEstimate(RenderBox& gridItem, const GridTrackSizingAlgorithm&) const;
     inline void updateGridAreaIncludingAlignment(RenderBox& gridItem) const;


### PR DESCRIPTION
#### a0e66562a406842faba3ce1ef40acc671cf0a1f7
<pre>
[GFC] Layout out-of-flow descendants in the modern grid path
<a href="https://bugs.webkit.org/show_bug.cgi?id=316727">https://bugs.webkit.org/show_bug.cgi?id=316727</a>
<a href="https://rdar.apple.com/179129558">rdar://179129558</a>

Reviewed by Alan Baradlay.

One of the things that we currently bail on when deciding whether or not
we can run layout via GFC is if any of the children of the grid are out
of flow. If we find such a box then we decide that we cannot run GFC.
One scenario we currently fail to take into consideration is when some
out of flow descendant ends up having the grid as the containing block.
Unfortunately, this results in that box not running layout which means a
crash in debug builds due to a dirty render tree at the end of layout
and blank content in release.

To fix this we can call back into the old layoutOutOfFlowBoxes API on
RenderGrid during integration. In order to properly due so we need to
make sure the renderer has its columns and rows positions set correctly
so that it can map any positions the OOF box may have to the correct
location in the grid.

Also fix the grid container height not being set for the definite block-axis case in
updateFormattingContextRootRenderer, which caused positioned descendants to compute
incorrect containing block sizes since they relied on the renderer&apos;s
height. We already did this in the case where the grid had an
indefinite/intrinsic height but did not when it was fixed.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-001.html: Added.
One explicit row and column. Descendant has auto row and column
placement with fixed width and height.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-002.html: Added.
Same as 001 but the descendant is a bit more nested.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-003.html: Added.
One explicit row and column. Descendant has auto row and column
placement along with percent width and height.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-004.html: Added.
Two explicit rows and columns. Descendant has auto row and column
placement along with auto width and height. It also has 0 for the top
and left insets and 100px for the right and bottom insets.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-005-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-005.html: Added.
Same as 004 but 0 for all the insets.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-006-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-006.html: Added.
Two explicit columns and one explicit row. Descendant has auto row
placement with column placement specified as span 2 / span 3. According
to the spec this should be treated as auto. Also has percent width and
height.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-007-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-007.html: Added.
Two explicit columns and one explicit row. Descendant has auto row
placement along with column placement that spans outside the grid which
should be treated as auto according to the spec. Also has percent width
and height.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html: Added.
One explicit column and row along with padding on the grid. Descendant
has auto row and column placement with percent width and height.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009.html: Added.
One explicit column and row along with padding on the grid. Descendant
has explicit row and column placement with percent width and height.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010.html: Added.
Two explicit columns and rows along with padding on the grid. Descendant
has explicit placement in the first row and column along with percent
width and height.

Tests 011-013 exercise similar to the above but with auto height on the
grid.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-011-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-011.html: Added.
One fixed column and row. Descendant has auto rows and columns along
with percent width and height.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html: Added.
One fixed column and row and padding on the grid. Desendant has auto
row and columns with percent width and height.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013.html: Added.
Two fixed rows and columns along with padding. Descendant has explicit
row and column position in the first row and column. Also has percent
width and height.

Tests 014-016 are similar to above but are testing items that span
multiple rows/columns.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-014.html: Added.
Two fixed row and columns. Descendant is placed in two columns and one
row.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-015.html: Added.
Two fixed rows and columns. Descendant is placed in one column and two
rows.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-016.html: Added.
Two fixed rows and columns. Descendant is placed in both rows and
columns.

Canonical link: <a href="https://commits.webkit.org/315156@main">https://commits.webkit.org/315156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adb0fcef9b71e1392d449a2a769b8221bba56e7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125672 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2fa2f9f-f410-4cd9-894e-bfaac2a445f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130687 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91847 "3 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/313a01c3-2ead-421c-b08e-47848d17c9ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111204 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b793c74-c257-4635-9c6b-cf414f25404f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32134 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30843 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25977 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179874 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32626 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139113 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138992 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37491 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150434 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105516 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27316 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40740 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113992 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40137 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5416 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40388 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->