### PR TITLE
[MathML] Operators routed through MathOperator are invisible when their glyph only exists in a fallback font

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Operator glyph resolved from a fallback font (reference)</title>
+<script src="/mathml/support/fonts.js"></script>
+<style>
+  @font-face {
+    font-family: hasminus;
+    src: url("/fonts/GentiumPlus-R.woff"); /* Contains U+2212 MINUS SIGN. */
+  }
+  .operator {
+    font-size: 50px;
+    /* Render the same minus directly from the font that provides the glyph. */
+    font-family: hasminus;
+  }
+</style>
+<script>
+  window.addEventListener("load", () => {
+    loadAllFonts().then(() => document.documentElement.classList.remove("reftest-wait"));
+  });
+</script>
+</head>
+<body>
+  <p>Test passes if there are two minus signs below.</p>
+  <math><mo class="operator">&#x2212;</mo></math>
+  <math><mo class="operator">&#x2212;</mo></math>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Operator glyph resolved from a fallback font (reference)</title>
+<script src="/mathml/support/fonts.js"></script>
+<style>
+  @font-face {
+    font-family: hasminus;
+    src: url("/fonts/GentiumPlus-R.woff"); /* Contains U+2212 MINUS SIGN. */
+  }
+  .operator {
+    font-size: 50px;
+    /* Render the same minus directly from the font that provides the glyph. */
+    font-family: hasminus;
+  }
+</style>
+<script>
+  window.addEventListener("load", () => {
+    loadAllFonts().then(() => document.documentElement.classList.remove("reftest-wait"));
+  });
+</script>
+</head>
+<body>
+  <p>Test passes if there are two minus signs below.</p>
+  <math><mo class="operator">&#x2212;</mo></math>
+  <math><mo class="operator">&#x2212;</mo></math>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<title>Operator glyph resolved from a fallback font</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#layout-of-operators">
+<link rel="match" href="mo-fallback-font-ref.html">
+<meta name="assert" content="An operator glyph is rendered from a fallback font when the primary font does not contain it. Both an explicit U+2212 MINUS SIGN and a U+002D HYPHEN-MINUS (which WebKit promotes to U+2212) are routed through the special minus operator rendering.">
+<script src="/mathml/support/fonts.js"></script>
+<style>
+  @font-face {
+    font-family: nominus;
+    src: url("/fonts/math/math-text.woff"); /* Does not contain U+2212 MINUS SIGN. */
+  }
+  @font-face {
+    font-family: hasminus;
+    src: url("/fonts/GentiumPlus-R.woff"); /* Contains U+2212 MINUS SIGN. */
+  }
+  .operator {
+    font-size: 50px;
+    /* The primary font lacks U+2212, so the minus must resolve to "hasminus". */
+    font-family: nominus, hasminus;
+  }
+</style>
+<script>
+  window.addEventListener("load", () => {
+    loadAllFonts().then(() => document.documentElement.classList.remove("reftest-wait"));
+  });
+</script>
+</head>
+<body>
+  <p>Test passes if there are two minus signs below.</p>
+  <!-- Explicit U+2212 MINUS SIGN. -->
+  <math><mo class="operator">&#x2212;</mo></math>
+  <!-- U+002D HYPHEN-MINUS, promoted to U+2212 by the minus operator handling. -->
+  <math><mo class="operator">-</mo></math>
+</body>
+</html>

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -133,7 +133,17 @@ LayoutUnit MathOperator::stretchSize() const
 bool MathOperator::getGlyph(const Style::ComputedStyle& style, char32_t character, GlyphData& glyph) const
 {
     glyph = style.fontCascade().glyphDataForCharacter(character, style.writingMode().isBidiRTL());
-    return glyph.font && glyph.font == &style.fontCascade().primaryFont();
+    if (!glyph.font)
+        return false;
+
+    // Stretchy and large operators pull size variants and assemblies from the primary
+    // font's MATH table, so their base glyph must come from the primary font. A plain
+    // operator (e.g. the minus sign) just paints its base glyph, so a fallback-font glyph
+    // is fine when the primary text font lacks the character.
+    if (m_operatorType == Type::NormalOperator)
+        return true;
+
+    return glyph.font == &style.fontCascade().primaryFont();
 }
 
 bool MathOperator::getBaseGlyph(const Style::ComputedStyle& style, GlyphData& glyph)


### PR DESCRIPTION
#### 49d63bf1b1297677e0eef6d7e4a91bd61f1bd826
<pre>
[MathML] Operators routed through MathOperator are invisible when their glyph only exists in a fallback font
<a href="https://bugs.webkit.org/show_bug.cgi?id=316728">https://bugs.webkit.org/show_bug.cgi?id=316728</a>
<a href="https://rdar.apple.com/178096170">rdar://178096170</a>

Reviewed by Frédéric Wang Nélar.

MathOperator::getGlyph() required the operator&apos;s base glyph to come from the
primary font. That is only needed for stretchy and large operators, which build
size variants and glyph assemblies from the primary font&apos;s OpenType MATH table.
A plain (NormalOperator) operator just paints its base glyph, so any cascade font
is fine. The minus sign is always routed through MathOperator (to promote a DOM
hyphen to U+2212), so on pages whose primary font is a text font lacking U+2212
the minus resolved to a fallback font but was discarded, leaving the operator
empty and invisible.

Accept a fallback-font glyph for NormalOperator; keep the primary-font
requirement for stretchy and large operators.

Tests: imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font-ref.html
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font.html

* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-fallback-font.html: Added.
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::getGlyph const):

Canonical link: <a href="https://commits.webkit.org/314928@main">https://commits.webkit.org/314928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cce70d876ae14e37c0f4ef247c2a58254276ca5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176571 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130323 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170477 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32735 "Found 1 new test failure: fast/forms/datalist/datalist-textinput-suggestions-order.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110840 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31718 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30416 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25306 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179112 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32007 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138605 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37344 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104898 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33864 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26878 "Found 6 new test failures: http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html http/tests/workers/service/basic-install-event-sw-fetch-third-party.html http/tests/xmlhttprequest/abort-should-cancel-load.html http/wpt/2dcontext/imagebitmap/createImageBitmap-sizing.html http/wpt/audio-output/setSinkId.https.html imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113360 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39676 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4977 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39927 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39821 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->