### PR TITLE
iframes don't respect the color-scheme CSS property of the parent document.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-cross-origin.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-cross-origin.sub-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe src="support/light-dark-frame.html?colorSchemeOverride=light"></iframe>
+<iframe src="support/light-dark-frame.html?colorSchemeOverride=dark"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-cross-origin.sub.html
@@ -1,0 +1,15 @@
+<!doctype html>
+
+<title>Setting color-scheme on a cross-origin iframe affects light-dark() function in the iframe document</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="color-scheme-iframe-affects-light-dark-ref.html">
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe style="color-scheme: light" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/light-dark/support/light-dark-frame.html"></iframe>
+<iframe style="color-scheme: dark" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/light-dark/support/light-dark-frame.html"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe src="support/light-dark-frame.html?colorSchemeOverride=light"></iframe>
+<iframe src="support/light-dark-frame.html?colorSchemeOverride=dark"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-same-origin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-same-origin-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe src="support/light-dark-frame.html?colorSchemeOverride=light"></iframe>
+<iframe src="support/light-dark-frame.html?colorSchemeOverride=dark"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-same-origin.html
@@ -1,0 +1,15 @@
+<!doctype html>
+
+<title>Setting color-scheme on a same-origin iframe affects light-dark() function in the iframe document</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="color-scheme-iframe-affects-light-dark-ref.html">
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe style="color-scheme: light" src="support/light-dark-frame.html"></iframe>
+<iframe style="color-scheme: dark" src="support/light-dark-frame.html"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/support/light-dark-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/support/light-dark-frame.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+<meta id="colorSchemeMeta" name="color-scheme" content="light dark">
+
+<style>
+  body {
+    background-color: Canvas;
+  }
+
+  #box {
+    width: 100px;
+    height: 100px;
+    background-color: light-dark(cyan, green);
+  }
+</style>
+
+<p>Box is cyan if light-dark() resolves to light, and green if it resolves to dark.</p>
+<div id="box"></div>
+
+<script>
+  const params = new URLSearchParams(window.location.search);
+  const colorSchemeOverride = params.get("colorSchemeOverride");
+  if (colorSchemeOverride)
+    colorSchemeMeta.content = colorSchemeOverride;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-cross-origin.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-cross-origin.sub-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe src="support/system-color-frame.html?colorSchemeOverride=light"></iframe>
+<iframe src="support/system-color-frame.html?colorSchemeOverride=dark"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-cross-origin.sub.html
@@ -1,0 +1,15 @@
+<!doctype html>
+
+<title>Setting color-scheme on a same-origin iframe affects the chosen system color in the iframe document</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="color-scheme-iframe-affects-system-color-ref.html">
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe style="color-scheme: light" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/system-color/support/system-color-frame.html"></iframe>
+<iframe style="color-scheme: dark" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/system-color/support/system-color-frame.html"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe src="support/system-color-frame.html?colorSchemeOverride=light"></iframe>
+<iframe src="support/system-color-frame.html?colorSchemeOverride=dark"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-same-origin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-same-origin-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe src="support/system-color-frame.html?colorSchemeOverride=light"></iframe>
+<iframe src="support/system-color-frame.html?colorSchemeOverride=dark"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-same-origin.html
@@ -1,0 +1,15 @@
+<!doctype html>
+
+<title>Setting color-scheme on a same-origin iframe affects the chosen system color in the iframe document</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="color-scheme-iframe-affects-system-color-ref.html">
+<style>
+  iframe {
+    width: 300px;
+    height: 300px;
+  }
+</style>
+
+<iframe style="color-scheme: light" src="support/system-color-frame.html"></iframe>
+<iframe style="color-scheme: dark" src="support/system-color-frame.html"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/support/system-color-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/support/system-color-frame.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+
+<meta id="colorSchemeMeta" name="color-scheme" content="light dark">
+
+<style>
+  body {
+    background-color: Canvas;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  table,
+  tr,
+  td {
+    border: 1px solid CanvasText;
+  }
+
+  td {
+    min-width: 50px;
+  }
+
+  td {
+    padding: 10px;
+  }
+</style>
+
+<h3>System colors</h3>
+
+<table>
+  <tr>
+    <td>ButtonText</td>
+    <td style="background-color: ButtonText"></td>
+  </tr>
+  <tr>
+    <td>Canvas</td>
+    <td style="background-color: Canvas"></td>
+  </tr>
+  <tr>
+    <td>CanvasText</td>
+    <td style="background-color: CanvasText"></td>
+  </tr>
+  <tr>
+    <td>FieldText</td>
+    <td style="background-color: FieldText"></td>
+  </tr>
+</table>
+
+<script>
+  const params = new URLSearchParams(window.location.search);
+  const colorSchemeOverride = params.get("colorSchemeOverride");
+  if (colorSchemeOverride)
+    colorSchemeMeta.content = colorSchemeOverride;
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9946,6 +9946,34 @@ bool Document::useDarkAppearance([[maybe_unused]] const Style::ComputedStyle* st
     UNUSED_PARAM(style);
 #endif
 
+    // https://drafts.csswg.org/css-color-adjust-1/#color-scheme-page
+    // > If this document is embedded in another document (e.g using <iframe>), its
+    // > preferred color scheme is from its embedding element's element color scheme.
+    // We go up the frame tree to find the first embedding element that has an explicitly
+    // set element color scheme, and that's this document's preferred color scheme.
+    //
+    // FIXME: this logic should really be in Frame/FrameView/LocalFrameView (there's
+    // already a LocalFrameView::useDarkAppearance). However pretty much anywhere that
+    // checks for dark appearance calls this method (even LocalFrameView::useDarkAppearance!),
+    // so for now this will have to live here.
+    if (RefPtr<const Frame> child = this->frame()) {
+        RefPtr<const Frame> parent = child->parent();
+
+        while (parent) {
+            ASSERT(child);
+
+            auto ownerElementAppearance = protect(parent->virtualView())->appearanceOfOwnerElementOfChildFrame(*child);
+            if (ownerElementAppearance.contains(FrameOwnerElementAppearance::ExplicitlySet))
+                return ownerElementAppearance.contains(FrameOwnerElementAppearance::IsDark);
+
+            child = parent;
+            parent = child->parent();
+        }
+    }
+
+    // If this document is the main document (not embedded), or none of its embedding
+    // elements have an element color scheme, fall back to page color scheme.
+
     bool pageUsesDarkAppearance = false;
     if (RefPtr documentPage = page())
         pageUsesDarkAppearance = documentPage->useDarkAppearance();


### PR DESCRIPTION
#### 29f2eacd2bed60d1093451f6de2e17be155198a7
<pre>
iframes don&apos;t respect the color-scheme CSS property of the parent document.
<a href="https://rdar.apple.com/179176395">rdar://179176395</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316680">https://bugs.webkit.org/show_bug.cgi?id=316680</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Tests: imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-cross-origin.sub.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-same-origin.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-cross-origin.sub.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-same-origin.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-cross-origin.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-same-origin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/color-scheme-iframe-affects-light-dark-same-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/light-dark/support/light-dark-frame.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-cross-origin.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-same-origin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/color-scheme-iframe-affects-system-color-same-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/system-color/support/system-color-frame.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::useDarkAppearance const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29f2eacd2bed60d1093451f6de2e17be155198a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125628 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bd91b32-03a9-46c2-b3b7-b2b6f7e53f08) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41447 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130651 "Found 1 new test failure: fast/frames/frame-depth-limit.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91833 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/204ee344-6a9f-405e-af0c-aab93c735148) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170894 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33121 "Found 1 new test failure: fast/frames/frame-depth-limit.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111168 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6cbe6787-f62c-4607-a57f-33c467696b4c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32102 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30804 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25933 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179830 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32582 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30315 "Found 1 new test failure: fast/frames/frame-depth-limit.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139072 "Found 1 new test failure: fast/frames/frame-depth-limit.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41504 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34961 "Found 1 new test failure: fast/frames/frame-depth-limit.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138954 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105471 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34242 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27271 "Found 2 new test failures: fast/frames/frame-depth-limit.html imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113948 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40093 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5371 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40238 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->