### PR TITLE
[MathML] Use MathML Core fallback values for script layout constants

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing-expected.txt
@@ -5,29 +5,29 @@ FAIL Spacing inside an <mfrac> child of <mrow>. assert_less_than_equal: expected
 PASS Spacing around an <mfrac> child of an <mrow>.
 FAIL Spacing inside an <mfrac> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 227
 PASS Spacing around an <mfrac> child of an <mtd>.
-FAIL Spacing inside an <msub> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msub> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msub> child of an <math>.
-FAIL Spacing inside an <msub> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msub> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msub> child of an <mrow>.
-FAIL Spacing inside an <msub> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msub> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msub> child of an <mtd>.
-FAIL Spacing inside an <msup> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msup> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msup> child of an <math>.
-FAIL Spacing inside an <msup> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msup> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msup> child of an <mrow>.
-FAIL Spacing inside an <msup> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msup> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msup> child of an <mtd>.
-FAIL Spacing inside an <msubsup> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msubsup> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msubsup> child of an <math>.
-FAIL Spacing inside an <msubsup> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msubsup> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msubsup> child of an <mrow>.
-FAIL Spacing inside an <msubsup> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
+FAIL Spacing inside an <msubsup> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 451.03125
 PASS Spacing around an <msubsup> child of an <mtd>.
-FAIL Spacing inside an <mmultiscripts> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 685
+FAIL Spacing inside an <mmultiscripts> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 677.0625
 PASS Spacing around an <mmultiscripts> child of an <math>.
-FAIL Spacing inside an <mmultiscripts> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 685
+FAIL Spacing inside an <mmultiscripts> child of <mrow>. assert_less_than_equal: expected a number less than or equal to 100 but got 677.0625
 PASS Spacing around an <mmultiscripts> child of an <mrow>.
-FAIL Spacing inside an <mmultiscripts> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 685
+FAIL Spacing inside an <mmultiscripts> child of <mtd>. assert_less_than_equal: expected a number less than or equal to 100 but got 677.0625
 PASS Spacing around an <mmultiscripts> child of an <mtd>.
 FAIL Spacing inside an <munder> child of <math>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
 PASS Spacing around an <munder> child of an <math>.

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-2-expected.txt
@@ -2,7 +2,7 @@
 PASS Respective horizontal positions
 PASS Alignment of the base on the baseline
 PASS Vertical position of scripts
-FAIL Width of scripted elements assert_approx_equals: width is determined by the left/right sides of base/script (+ some space after script) expected 40 +/- 3 but got 45
-FAIL Height of scripted elements assert_approx_equals: msup height is determined by the top/bottom sides of base/scripts expected 40 +/- 5 but got 50
+PASS Width of scripted elements
+PASS Height of scripted elements
 PASS Size of empty elements
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-3-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Alignment of the base on the baseline
-FAIL Dimensions of the scripted elements assert_approx_equals: height of multi0 expected 30 +/- 5 but got 45
+PASS Dimensions of the scripted elements
 FAIL Vertical positions of scripts assert_approx_equals: multi2 1 presup script expected 21 +/- 3 but got 26
 PASS Horizontal alignment of scripts
 PASS Horizontal positions of scripts

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
@@ -29,19 +29,19 @@ PASS checking dynamic accent/accentunder
 
 0
 1
+
 0
 1
 2
-
 0
 1
 
 0
 1
+
 0
 1
 2
-
 0
 1
 2

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL block display assert_approx_equals: block size expected 49 +/- 1 but got 45
 FAIL block display with contrained width assert_approx_equals: block size expected 78 +/- 1 but got 70
-FAIL list display inside display block assert_approx_equals: block size expected 194 +/- 1 but got 78
+FAIL list display inside display block assert_approx_equals: block size expected 194 +/- 1 but got 70
 FAIL inline display assert_approx_equals: block size expected 29 +/- 1 but got 41
 FAIL inline-block display assert_approx_equals: block size expected 29 +/- 1 but got 41
 FAIL table display (math) assert_approx_equals: block size expected 78 +/- 1 but got 95

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL block display assert_approx_equals: block size expected 49 +/- 1 but got 45
 FAIL block display with contrained width assert_approx_equals: block size expected 78 +/- 1 but got 70
-FAIL list display inside display block assert_approx_equals: block size expected 194 +/- 1 but got 78
+FAIL list display inside display block assert_approx_equals: block size expected 194 +/- 1 but got 70
 FAIL inline display assert_approx_equals: block size expected 29 +/- 1 but got 41
 FAIL inline-block display assert_approx_equals: block size expected 29 +/- 1 but got 41
 FAIL table display (math) assert_approx_equals: block size expected 78 +/- 1 but got 95

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL block display assert_approx_equals: block size expected 49 +/- 1 but got 45
 FAIL block display with contrained width assert_approx_equals: block size expected 78 +/- 1 but got 70
-FAIL list display inside display block assert_approx_equals: block size expected 194 +/- 1 but got 78
+FAIL list display inside display block assert_approx_equals: block size expected 194 +/- 1 but got 70
 FAIL inline display assert_approx_equals: block size expected 29 +/- 1 but got 41
 FAIL inline-block display assert_approx_equals: block size expected 29 +/- 1 but got 41
 FAIL table display (math) assert_approx_equals: block size expected 78 +/- 1 but got 95

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -171,7 +171,8 @@ LayoutUnit RenderMathMLScripts::spaceAfterScript()
     Ref primaryFont = style().fontCascade().primaryFont();
     if (RefPtr mathData = primaryFont->mathData())
         return LayoutUnit(mathData->getMathConstant(primaryFont, OpenTypeMathData::MathConstant::SpaceAfterScript));
-    return LayoutUnit(style().fontCascade().size() / 5);
+    // https://w3c.github.io/mathml-core/#layout-constants-mathconstants suggests 1/24em.
+    return LayoutUnit(style().fontCascade().size() / 24);
 }
 
 LayoutUnit RenderMathMLScripts::italicCorrection(const ReferenceChildren& reference)
@@ -259,12 +260,15 @@ auto RenderMathMLScripts::verticalParameters() const -> VerticalParameters
         parameters.superscriptBottomMaxWithSubscript = mathData->getMathConstant(primaryFont, OpenTypeMathData::MathConstant::SuperscriptBottomMaxWithSubscript);
     } else {
         // Default heuristic values when you do not have a font.
+        // https://w3c.github.io/mathml-core/#layout-constants-mathconstants specifies fallback
+        // values for these constants; subscriptShiftDown/superscriptShiftUp fall back to the
+        // OS/2 sub/superscript Y offsets, which are approximated here with the x-height.
         float xHeight = style().metricsOfPrimaryFont().xHeight().value_or(0);
         parameters.subscriptShiftDown = xHeight / 3;
         parameters.superscriptShiftUp = xHeight;
-        parameters.subscriptBaselineDropMin = xHeight / 2;
-        parameters.superScriptBaselineDropMax = xHeight / 2;
-        parameters.subSuperscriptGapMin = style().fontCascade().size() / 5;
+        parameters.subscriptBaselineDropMin = 0;
+        parameters.superScriptBaselineDropMax = 0;
+        parameters.subSuperscriptGapMin = 4 * ruleThicknessFallback();
         parameters.superscriptBottomMin = xHeight / 4;
         parameters.subscriptTopMax = 4 * xHeight / 5;
         parameters.superscriptBottomMaxWithSubscript = 4 * xHeight / 5;


### PR DESCRIPTION
#### c699c8f329f4c16fdeb45075787d00ec4b976c30
<pre>
[MathML] Use MathML Core fallback values for script layout constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=316737">https://bugs.webkit.org/show_bug.cgi?id=316737</a>
<a href="https://rdar.apple.com/179177178">rdar://179177178</a>

Reviewed by Frédéric Wang Nélar.

This patch aligns WebKit with Gecko / Firefox.

When the font has no OpenType MATH table, RenderMathMLScripts used
heuristic constants that deviated from the fallbacks per spec [1].
Align them with the spec:

- spaceAfterScript: 1/5em -&gt; 1/24em
- subSuperscriptGapMin: 1/5em -&gt; 4 x default rule thickness
- subscriptBaselineDropMin: x-height/2 -&gt; 0
- superscriptBaselineDropMax: x-height/2 -&gt; 0

[1] <a href="https://w3c.github.io/mathml-core/#layout-constants-mathconstants">https://w3c.github.io/mathml-core/#layout-constants-mathconstants</a>

* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-2-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/subsup-3-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt: Rebaselined.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt: Rebaselined.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt: Ditto
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/display-2-expected.txt: Ditto
* Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
(WebCore::RenderMathMLScripts::spaceAfterScript):
(WebCore::RenderMathMLScripts::verticalParameters const):

Canonical link: <a href="https://commits.webkit.org/315004@main">https://commits.webkit.org/315004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4ff600d5c45512e83178164c50ed67e4ccc3d90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125382 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130479 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110996 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31887 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30586 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25491 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179298 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138880 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138765 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37392 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41958 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105134 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34032 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27050 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40462 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113713 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39859 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5153 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40004 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->