### PR TITLE
Remove unnecessary `std::optional` initialization in WebCore

### DIFF
--- a/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
@@ -66,7 +66,7 @@ ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawReques
             DigitalCredentialsRawRequests { WTF::move(rawRequestStrings) });
     });
 
-    std::optional<ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawRequests>>> firstException = std::nullopt;
+    std::optional<ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawRequests>>> firstException;
     for (auto result : results) {
         // return the first matching result without exception
         if (!result.hasException())

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -137,7 +137,7 @@ static bool isValidEncoderConfig(const WebCodecsAudioEncoderConfig& config)
 
 static ExceptionOr<AudioEncoder::Config> createAudioEncoderConfig(const WebCodecsAudioEncoderConfig& config)
 {
-    std::optional<AudioEncoder::OpusConfig> opusConfig = std::nullopt;
+    std::optional<AudioEncoder::OpusConfig> opusConfig;
     if (config.opus) {
         opusConfig = {
             .isOggBitStream = config.opus->format == OpusBitstreamFormat::Ogg,
@@ -149,11 +149,11 @@ static ExceptionOr<AudioEncoder::Config> createAudioEncoderConfig(const WebCodec
         };
     }
 
-    std::optional<bool> isAacADTS = std::nullopt;
+    std::optional<bool> isAacADTS;
     if (config.aac)
         isAacADTS = config.aac->format == AacBitstreamFormat::Adts;
 
-    std::optional<AudioEncoder::FlacConfig> flacConfig = std::nullopt;
+    std::optional<AudioEncoder::FlacConfig> flacConfig;
     if (config.flac)
         flacConfig = { config.flac->blockSize, config.flac->compressLevel };
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -767,7 +767,7 @@ void WebAnimation::setEffectiveFrameRate(std::optional<FramesPerSecond> effectiv
     if (m_effectiveFrameRate == effectiveFrameRate)
         return;
 
-    std::optional<FramesPerSecond> maximumFrameRate = std::nullopt;
+    std::optional<FramesPerSecond> maximumFrameRate;
     if (RefPtr timeline = dynamicDowncast<DocumentTimeline>(m_timeline))
         maximumFrameRate = timeline->maximumFrameRate();
 

--- a/Source/WebCore/css/values/color/CSSPlatformColorResolutionState.h
+++ b/Source/WebCore/css/values/color/CSSPlatformColorResolutionState.h
@@ -61,7 +61,7 @@ struct PlatformColorResolutionState {
 
     // Conversion data needed to evaluate `calc()` expressions with relative length units.
     // If unset, colors that require conversion data will return the invalid Color.
-    std::optional<CSSToLengthConversionData> conversionData = std::nullopt;
+    std::optional<CSSToLengthConversionData> conversionData;
 
     // Whether links should be resolved to the visited style.
     Style::ForVisitedLink forVisitedLink = Style::ForVisitedLink::No;
@@ -71,19 +71,19 @@ struct PlatformColorResolutionState {
 
     // Appearance used to select from a light-dark() color function.
     // If unset, light-dark() colors will return the invalid Color.
-    std::optional<LightDarkColorAppearance> appearance = std::nullopt;
+    std::optional<LightDarkColorAppearance> appearance;
 
     // Colors are resolved:
     //   1. Checking if the color is set below, and if it is, returning it.
     //   2. If a delegate has been set, calling the associated delegate function,
     //      storing the result below, and returning that color.
     //   3. Returning the invalid `Color` value.
-    mutable std::optional<WebCore::Color> resolvedCurrentColor = std::nullopt;
-    mutable std::optional<WebCore::Color> resolvedInternalDocumentTextColor = std::nullopt;
-    mutable std::optional<WebCore::Color> resolvedWebkitLink = std::nullopt;
-    mutable std::optional<WebCore::Color> resolvedWebkitLinkVisited = std::nullopt;
-    mutable std::optional<WebCore::Color> resolvedWebkitActiveLink = std::nullopt;
-    mutable std::optional<WebCore::Color> resolvedWebkitFocusRingColor = std::nullopt;
+    mutable std::optional<WebCore::Color> resolvedCurrentColor;
+    mutable std::optional<WebCore::Color> resolvedInternalDocumentTextColor;
+    mutable std::optional<WebCore::Color> resolvedWebkitLink;
+    mutable std::optional<WebCore::Color> resolvedWebkitLinkVisited;
+    mutable std::optional<WebCore::Color> resolvedWebkitActiveLink;
+    mutable std::optional<WebCore::Color> resolvedWebkitFocusRingColor;
 
     WebCore::Color currentColor() const
     {

--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -269,7 +269,7 @@ unsigned CachedMatchFinder::countMatches(const std::optional<SimpleRange>& searc
 
 unsigned CachedMatchFinder::bufferOffsetForBoundaryPoint(StringView buffer, const Vector<TextRun>& runs, const BoundaryPoint& point, FindOptions options)
 {
-    std::optional<unsigned> lastChunkEnd = std::nullopt;
+    std::optional<unsigned> lastChunkEnd;
     for (auto [i, run] : indexedRange(runs)) {
         if (&run.range.start.container.get() != &point.container.get())
             continue;

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -183,7 +183,7 @@ static UniqueRef<CaretAnimator> createCaretAnimator(FrameSelection* frameSelecti
 {
 #if PLATFORM(MAC) && HAVE(REDESIGNED_TEXT_CURSOR)
     if (redesignedTextCursorEnabled()) {
-        std::optional<LayoutRect> existingExpansionRect = std::nullopt;
+        std::optional<LayoutRect> existingExpansionRect;
         if (optionalCaretType)
             existingExpansionRect = frameSelection->caretAnimator().caretRepaintRectForLocalRect(LayoutRect());
 

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -549,7 +549,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(const Render
     auto rect = bounds;
     float cornerRadius = 0;
     OptionSet<InteractionRegion::CornerMask> maskedCorners { };
-    std::optional<Path> clipPath = std::nullopt;
+    std::optional<Path> clipPath;
 
     CheckedRef style = regionRenderer.style();
     CheckedPtr<const RenderBox> regionRendererBox;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -698,7 +698,7 @@ void Navigation::recursivelyDisposeOfForwardEntriesInParents(BackForwardItemIden
     if (frame() == navigatedFrame)
         return;
 
-    std::optional<size_t> index = std::nullopt;
+    std::optional<size_t> index;
     for (size_t i = 0; i < m_entries.size(); i++) {
         if (m_entries[i]->associatedHistoryItem().itemID() == itemID) {
             index = i;

--- a/Source/WebCore/platform/AbortableTaskQueue.h
+++ b/Source/WebCore/platform/AbortableTaskQueue.h
@@ -148,7 +148,7 @@ public:
         if (m_aborting)
             return std::nullopt;
 
-        std::optional<R> response = std::nullopt;
+        std::optional<R> response;
         postTask([this, &response, &mainThreadTaskHandler]() {
             R responseValue = mainThreadTaskHandler();
             Locker locker { m_lock };


### PR DESCRIPTION
#### a26cc29546f03ec192cc1e2c6c0f83692c6507f9
<pre>
Remove unnecessary `std::optional` initialization in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=316739">https://bugs.webkit.org/show_bug.cgi?id=316739</a>
<a href="https://rdar.apple.com/179180921">rdar://179180921</a>

Reviewed by Chris Dumez.

ISO C++ Standard explicitly guarantees that a default-initialized std::optional
does not contain a value. So, initializing one with std::nullopt is redundant.

* Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp:
(WebCore::DigitalCredentialsRequestDataBuilder::build):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::createAudioEncoderConfig):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setEffectiveFrameRate):
* Source/WebCore/css/values/color/CSSPlatformColorResolutionState.h:
* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::CachedMatchFinder::bufferOffsetForBoundaryPoint):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::createCaretAnimator):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::recursivelyDisposeOfForwardEntriesInParents):
* Source/WebCore/platform/AbortableTaskQueue.h:

Canonical link: <a href="https://commits.webkit.org/314897@main">https://commits.webkit.org/314897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dcb9da48e961598290f0da64cf108d4192c7883

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176537 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130294 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110811 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31686 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30384 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179080 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138691 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138578 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37325 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41744 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104849 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33832 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26845 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40248 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39645 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4944 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->