### PR TITLE
[iOS] WKWebView stuck on a blank/white screen after a quick app-switch away and back

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -109,6 +109,14 @@ static bool processHasActiveRunTimeLimitation()
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationWillEnterForegroundNotification object:[UIApplication sharedApplication] queue:nil usingBlock:^(NSNotification *) {
         [self _cancelPendingReleaseTask];
         [self _updateBackgroundTask];
+
+        // The ProcessStateMonitor may have proactively suspended the Web processes (e.g. when RunningBoard
+        // started the suspension timer as the app was about to get backgrounded). If the app comes back to
+        // the foreground before RunningBoard delivers the asynchronous "no longer time-limited" state update,
+        // we need to let the Web processes resume right away. Otherwise they stay unable to take foreground
+        // activities and the WebView is left showing stale / blank content.
+        if (RefPtr processStateMonitor = self->m_processStateMonitor)
+            processStateMonitor->processDidBecomeRunning();
     }];
 
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidEnterBackgroundNotification object:[UIApplication sharedApplication] queue:nil usingBlock:^(NSNotification *) {

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
@@ -46,11 +46,11 @@ public:
 
     ~ProcessStateMonitor();
     void processWillBeSuspendedImmediately();
+    void processDidBecomeRunning();
 
 private:
     ProcessStateMonitor(Function<void(bool)>&& becomeSuspendedHandler);
 
-    void processDidBecomeRunning();
     void processWillBeSuspended(Seconds timeout);
     void suspendTimerFired();
     void checkRemainingRunTime();

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm
@@ -77,6 +77,8 @@ void ProcessStateMonitor::processDidBecomeRunning()
     if (m_state == State::Running)
         return;
 
+    RELEASE_LOG(ProcessSuspension, "%p - ProcessStateMonitor::processDidBecomeRunning", this);
+
     if (m_state == State::Suspended)
         m_becomeSuspendedHandler(false);
     else {


### PR DESCRIPTION
#### 870c656abd058a0c01d59d592813ad47029760c0
<pre>
[iOS] WKWebView stuck on a blank/white screen after a quick app-switch away and back
<a href="https://bugs.webkit.org/show_bug.cgi?id=316741">https://bugs.webkit.org/show_bug.cgi?id=316741</a>
<a href="https://rdar.apple.com/176252756">rdar://176252756</a>

Reviewed by Per Arne Vollan.

On iOS, ProcessStateMonitor proactively parks the WebContent (and GPU /
Networking) processes when RunningBoard signals that the app is about to be
suspended: processWillBeSuspendedImmediately() calls the handler that does
WebProcessPool::setProcessesShouldSuspend(true), which calls
ProcessThrottler::setAllowsActivities(false) on every web process. While in
that state the page cannot take any foreground activity (foreground assertion,
&quot;view is visible&quot;, runJavaScriptInFrameInScriptWorld, ...) and the drawing area
blanks the layer tree via hideContentUntilPendingUpdate().

The only paths that reset setProcessesShouldSuspend(false) were
ProcessStateMonitor::checkRemainingRunTime() observing that the runtime is no
longer limited -- which is driven by the *asynchronous* RBSProcessMonitor update
handler -- and the monitor being destroyed. The
UIApplicationWillEnterForegroundNotification handler in
WKProcessAssertionBackgroundTaskManager did not touch the ProcessStateMonitor at
all.

As a result, if the user flicks the app into the App Switcher and back to the
foreground before RunningBoard delivers its asynchronous &quot;no longer
time-limited&quot; state update, the web process is left with activities disallowed:
foreground activity requests keep getting rejected, the blanked layer tree is
never replaced with a fresh commit, and the WKWebView is stuck showing a white
screen. This was confirmed in a device sysdiagnose where, on a fast
background-&gt;foreground bounce, the log showed setProcessesShouldSuspend(1) /
setAllowsActivities 0 followed by repeated &quot;not allowed to add foreground
activity WebPageProxy::runJavaScriptInFrameInScriptWorld&quot; and no subsequent
&quot;Unhiding layer tree&quot;.

Fix this by letting the foreground transition reset the monitor synchronously
rather than relying solely on the late, asynchronous RunningBoard callback. When
the app enters the foreground we now call ProcessStateMonitor::
processDidBecomeRunning(), which resumes the web processes right away.
processDidBecomeRunning() early-returns when already in the Running state, so the
call is idempotent with respect to the RBSProcessMonitor-driven reset.

* Source/WebKit/UIProcess/ios/ProcessStateMonitor.h:
Make processDidBecomeRunning() public so it can be driven from the foreground
notification, mirroring the already-public processWillBeSuspendedImmediately().

* Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm:
(WebKit::ProcessStateMonitor::processDidBecomeRunning): Add a release log on the
running transition for observability, consistent with the other state methods.

 * Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(-[WKProcessAssertionBackgroundTaskManager init]): On
UIApplicationWillEnterForegroundNotification, tell the ProcessStateMonitor that
the process is running again so suspended web processes resume immediately
instead of waiting on the asynchronous RunningBoard state update.

Canonical link: <a href="https://commits.webkit.org/314960@main">https://commits.webkit.org/314960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd3ffd451f6bdd7857208a7d07c15b5791a2003e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125170 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110878 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31690 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30387 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25277 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141677 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179082 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31978 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138692 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41058 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34543 "Found 1 new test failure: media/media-source/media-source-real-scrub-then-play.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37358 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41746 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104851 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26848 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113331 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39647 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4947 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->