### PR TITLE
Prevent re-entrant calls to dispatchPlayPauseEventsIfNeedsQuirks()

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3214,9 +3214,15 @@ void HTMLMediaElement::dispatchPlayPauseEventsIfNeedsQuirks()
     if (!protect(document())->quirks().needsAutoplayPlayPauseEvents())
         return;
 
+    if (m_isDispatchingAutoplayPlayPauseQuirkEvents)
+        return;
+
     HTMLMEDIAELEMENT_RELEASE_LOG(DispatchPlayPauseEventsIfNeedsQuirks);
-    scheduleEvent(eventNames().playingEvent);
-    scheduleEvent(eventNames().pauseEvent);
+    queueCancellableTaskKeepingObjectAlive(*this, TaskSource::MediaElement, m_asyncEventsCancellationGroup, [](auto& element) {
+        SetForScope dispatching(element.m_isDispatchingAutoplayPlayPauseQuirkEvents, true);
+        element.dispatchEvent(Event::create(eventNames().playingEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
+        element.dispatchEvent(Event::create(eventNames().pauseEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
+    });
 }
 
 void HTMLMediaElement::durationChanged()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1370,6 +1370,7 @@ private:
     ControlsState m_controlsState { ControlsState::None };
 
     AutoplayEventPlaybackState m_autoplayEventPlaybackState { AutoplayEventPlaybackState::None };
+    bool m_isDispatchingAutoplayPlayPauseQuirkEvents { false };
 
     String m_subtitleTrackLanguage;
     std::optional<String> m_languageOfPrimaryAudioTrack;

--- a/Tools/TestWebKitAPI/Resources/cocoa/autoplay-quirk-pause-fires-once.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/autoplay-quirk-pause-fires-once.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+<script>
+var pauseCount = 0;
+
+function setup() {
+    var video = document.getElementById("video");
+    video.addEventListener("pause", function() {
+        pauseCount++;
+        // Simulate a site that retries play() on pause.
+        video.play().catch(function() { });
+    });
+    video.play().catch(function() {
+        // One-time result post after first play.
+        setTimeout(function() {
+            try {
+                window.webkit.messageHandlers.testHandler.postMessage("pause-count:" + pauseCount);
+            } catch(e) { }
+        }, 100);
+    });
+}
+</script>
+</head>
+<body onload="setup()">
+<video id="video" playsinline src="test.mp4"></video>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -836,6 +836,41 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
     [webView waitForMessage:@"playing"];
 }
 
+TEST(WebpagePreferences, WebsitePoliciesSynthesizedPauseEventFiresOnce)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+#if PLATFORM(IOS_FAMILY)
+    configuration.get().allowsInlineMediaPlayback = YES;
+    configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
+#endif
+    [configuration preferences].siteSpecificQuirksModeEnabled = YES;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [delegate setAllowedAutoplayQuirksForURL:^_WKWebsiteAutoplayQuirk(NSURL *) {
+        return _WKWebsiteAutoplayQuirkSynthesizedPauseEvents;
+    }];
+    [delegate setAutoplayPolicyForURL:^(NSURL *) {
+        return _WKWebsiteAutoplayPolicyDeny;
+    }];
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-quirk-pause-fires-once" withExtension:@"html"]];
+    [webView loadRequest:request];
+
+    __block bool done = false;
+    __block RetainPtr<NSString> receivedMessage;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        if ([message hasPrefix:@"pause-count:"]) {
+            receivedMessage = message;
+            done = true;
+        }
+    }];
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_WK_STREQ(@"pause-count:1", receivedMessage.get());
+}
+
 TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorQuirks)
 {
     auto* configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];


### PR DESCRIPTION
#### 412a8234329f8c748aadc6e99062aabf1700c84b
<pre>
Prevent re-entrant calls to dispatchPlayPauseEventsIfNeedsQuirks()
<a href="https://bugs.webkit.org/show_bug.cgi?id=316746">https://bugs.webkit.org/show_bug.cgi?id=316746</a>
<a href="https://rdar.apple.com/179191475">rdar://179191475</a>

Reviewed by Ryosuke Niwa.

dispatchPlayPauseEventsIfNeedsQuirks() dispatches synthesized `playing` and `pause` events to satisfy sites whose JS
player state machines rely on these events to detect that autoplay was prevented (SynthesizedPauseEvents), or to
recover after being restored from the back/forward cache (<a href="https://rdar.apple.com/68938833">rdar://68938833</a>).

The function was not re-entrant-safe because a common JS pattern is to call video.play() from a `pause` event handler to
retry playback. When autoplay was blocked, the sequence was:
1. setAutoplayEventPlaybackState(PreventedAutoplay) =&gt; dispatchPlayPauseEventsIfNeedsQuirks() // schedule playing +
pause events
2. `pause` event fires, JS handler calls video.play() // autoplay blocked again
3. setAutoplayEventPlaybackState(PreventedAutoplay) =&gt; dispatchPlayPauseEventsIfNeedsQuirks()  // schedule playing +
pause events again, and cause infinite loop

This can produce hundreds of log entries per millisecond and could trigger logd&apos;s per-process quarantine on affected
pages. To fix this, this patch adds a bool guard m_isDispatchingAutoplayPlayPauseQuirkEvents and consolidates two
scheduleEvent() calls into a single queued task that ispatches both events synchronously via dispatchEvent(). A
SetForScope sets the guard for the duration of the task, covering the entire JS execution window. Any re-entrant call to
dispatchPlayPauseEventsIfNeedsQuirks() during that window — whether from the `playing` or the `pause` handler — returns
immediately.

API Test: WebpagePreferences.WebsitePoliciesSynthesizedPauseEventFiresOnce

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::dispatchPlayPauseEventsIfNeedsQuirks):
* Source/WebCore/html/HTMLMediaElement.h:
* Tools/TestWebKitAPI/Resources/cocoa/autoplay-quirk-pause-fires-once.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm:
(TEST(WebpagePreferences, WebsitePoliciesSynthesizedPauseEventFiresOnce)):

Canonical link: <a href="https://commits.webkit.org/314984@main">https://commits.webkit.org/314984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4314c341ed32e7afec5b60cdda8f4971e38833a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125320 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6021bfd6-a4cc-45c4-a99e-e28f01141cfe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130432 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0fabf26a-7eaa-4d2a-a5aa-be39221bcb62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110949 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f69b8cf-ddd3-476f-994a-bc34713026f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30535 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25429 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179236 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32277 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138837 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138722 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37377 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41896 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105058 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26995 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113646 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39797 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5096 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40048 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39942 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->