### PR TITLE
[PDF] WKPDFPageNumberIndicator should not capture originMoved by reference

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -174,19 +174,20 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
     point.x += indicatorMargin;
     point.y += indicatorMargin;
 
-    bool originMoved = false;
+    // Compute this up front and capture it by value below. The asynchronous animation completion
+    // block outlives this stack frame, so it must not capture a stack variable by reference. The
+    // frame's origin does not change between here and when the animations block runs, so this is
+    // equivalent to computing it inside that block.
+    bool originMoved = !CGPointEqualToPoint([self frame].origin, point);
 
-    auto animations = [view = retainPtr(self), point, &originMoved] {
+    auto animations = [view = retainPtr(self), point] {
         CGRect frame = [view frame];
-        originMoved = !CGPointEqualToPoint(frame.origin, point);
-        if (!originMoved)
-            return;
         frame.origin = point;
         [view setFrame:frame];
     };
 
     if (animated) {
-        [UIView animateWithDuration:indicatorMoveDuration.seconds() animations:animations completion:makeBlockPtr([&originMoved, completionHandler = WTF::move(completionHandler)](BOOL finished) mutable {
+        [UIView animateWithDuration:indicatorMoveDuration.seconds() animations:animations completion:makeBlockPtr([originMoved, completionHandler = WTF::move(completionHandler)](BOOL finished) mutable {
             completionHandler(originMoved, static_cast<bool>(finished));
         }).get()];
     } else {


### PR DESCRIPTION
#### f0afe0e8864d8fe6d62424d80298398cd6a71e67
<pre>
[PDF] WKPDFPageNumberIndicator should not capture originMoved by reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=316748">https://bugs.webkit.org/show_bug.cgi?id=316748</a>

Reviewed by Abrar Rahman Protyasha.

-[WKPDFPageNumberIndicator _moveToPoint:animated:completionHandler:] declared a
stack-local `originMoved` that was written by the synchronous `animations` block
and then read by the UIView animation `completion` block via a by-reference
capture. On the animated path, UIKit copies the completion block and invokes it
after the animation finishes, by which point this method&apos;s stack frame (and thus
`originMoved`) is gone, resulting in a use-after-free read.

The only in-tree caller passes animated:NO, so this is currently a latent bug,
but it would trigger as soon as the method is used with animated:YES.

Fix this by computing `originMoved` up front and capturing it by value. The
frame&apos;s origin does not change between method entry and when the `animations`
block runs, so this is equivalent to the previous computation.

* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator _moveToPoint:animated:completionHandler:]):
Compute originMoved before starting the animation and capture it by value in the
completion block rather than capturing the stack variable by reference. The
no-move case still honors the `animated` argument and funnels through

-animateWithDuration:... rather than returning early.
Canonical link: <a href="https://commits.webkit.org/315008@main">https://commits.webkit.org/315008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90aebbaa2ddc021e3c4845ea0661ab4ca42b72ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125456 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2df9a5cc-9f22-43ff-aaad-2f1cb7c13625) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130535 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71382b4c-a9c3-4274-83d5-77edc28f815d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111052 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b274500-e86c-4673-b7d4-87519513106c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25565 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179374 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32422 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138947 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138832 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37397 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42032 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105220 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34104 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40536 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113787 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39933 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5228 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40078 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->