### PR TITLE
NavigateEvent finish handles null documentElement

### DIFF
--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -216,16 +216,15 @@ void NavigateEvent::finish(Document& document, InterceptionHandlersDidFulfill di
 
     ASSERT(m_interceptionState == InterceptionState::Committed || m_interceptionState == InterceptionState::Scrolled);
     if (focusChanged == FocusDidChange::No && m_focusReset != NavigationFocusReset::Manual) {
-        RefPtr documentElement = document.documentElement();
-        ASSERT(documentElement);
+        if (RefPtr documentElement = document.documentElement()) {
+            RefPtr<Element> focusTarget = documentElement->findAutofocusDelegate();
+            if (!focusTarget)
+                focusTarget = document.body();
+            if (!focusTarget)
+                focusTarget = documentElement;
 
-        RefPtr<Element> focusTarget = documentElement->findAutofocusDelegate();
-        if (!focusTarget)
-            focusTarget = document.body();
-        if (!focusTarget)
-            focusTarget = documentElement;
-
-        document.setFocusedElement(focusTarget.get());
+            document.setFocusedElement(focusTarget.get());
+        }
     }
 
     if (didFulfill == InterceptionHandlersDidFulfill::Yes)


### PR DESCRIPTION
#### e61dd5cf7e61c18ae2ca5e73a7fb065ed430a21c
<pre>
NavigateEvent finish handles null documentElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=316749">https://bugs.webkit.org/show_bug.cgi?id=316749</a>
<a href="https://rdar.apple.com/179003965">rdar://179003965</a>

Reviewed by NOBODY (OOPS!).

The fix replaces the assert with if (RefPtr documentElement = document.documentElement()), which:
- Correctly skips auto-focus when there&apos;s no document element — there&apos;s nothing to focus
- Preserves all existing behavior when documentElement is non-null — the wrapped block is identical

No new tests (OOPS!).

* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::finish):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e61dd5cf7e61c18ae2ca5e73a7fb065ed430a21c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34594 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176557 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125185 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2f51001-f491-4e4f-a4f7-d24445c51a29) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41013 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/176557 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91641 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ceeb2d4-080c-4e66-a1ef-8da44c9a737e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150499 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/176557 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afc81bf3-2f2f-4a68-9a7e-a9ee0c9b36be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30399 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179097 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31993 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138705 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138592 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41761 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104875 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26865 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40265 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113346 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39662 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4964 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->