### PR TITLE
CtapAuthenticator strands an internal continuation handler when restarting PIN during a silent credential check

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -173,7 +173,7 @@ void CtapAuthenticator::makeCredential()
         continueMakeCredentialAfterCheckExcludedCredentials();
 }
 
-void CtapAuthenticator::continueSilentlyCheckCredentials(Vector<uint8_t>&& data, CompletionHandler<void(bool)>&& completionHandler)
+void CtapAuthenticator::continueSilentlyCheckCredentials(Vector<uint8_t>&& data, Function<void(bool)>&& completionHandler)
 {
     auto error = getResponseCode(data);
     CTAP_RELEASE_LOG("continueSilentlyCheckCredentials: Got error code: %hhu from authenticator.", std::to_underlying(error));

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -58,7 +58,7 @@ private:
     void continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&&);
     void continueMakeCredentialAfterCheckExcludedCredentials(bool includeCurrentBatch = false);
     void getAssertion() final;
-    void continueSilentlyCheckCredentials(Vector<uint8_t>&&, CompletionHandler<void(bool)>&&);
+    void continueSilentlyCheckCredentials(Vector<uint8_t>&&, Function<void(bool)>&&);
     void continueGetAssertionAfterCheckAllowCredentials();
     void continueGetAssertionAfterResponseReceived(Vector<uint8_t>&&);
     void continueGetNextAssertionAfterResponseReceived(Vector<uint8_t>&&);


### PR DESCRIPTION
#### 38dda747791f37dc504551dcafdeb4b1926f8930
<pre>
CtapAuthenticator strands an internal continuation handler when restarting PIN during a silent credential check
<a href="https://bugs.webkit.org/show_bug.cgi?id=316752">https://bugs.webkit.org/show_bug.cgi?id=316752</a>

Reviewed by Pascoe.

continueSilentlyCheckCredentials() takes an internal continuation that, on
success/failure, advances the request via continueMakeCredentialAfterCheckExcludedCredentials()
or continueGetAssertionAfterCheckAllowCredentials(). When the authenticator
returns a PIN error, the code calls tryRestartPin() and returns early without
invoking that continuation. Because the continuation was typed as a
CompletionHandler -- which asserts in its destructor if never called -- this
path tripped the &quot;Completion handler should always be called&quot; assertion (and
leaked the continuation in release builds). The same strand existed on the
dead-ish kCtap2ErrNoCredentials path.

There are two ways to satisfy CompletionHandler&apos;s exactly-once contract, and
only one is correct:

  - Calling the continuation here is WRONG: tryRestartPin() restarts the whole
    request from scratch by issuing its own driver transaction (getRetries() /
    performAuthenticatorSelectionForSetupPin()). The driver processes a single
    transaction at a time, so advancing the stale continuation -- which issues
    yet another transaction -- would put two transactions in flight at once.
    The early return is therefore the intended behavior; the continuation must
    be abandoned.

  - Abandoning a CompletionHandler is what trips the assertion. The real defect
    is the type: a callback that is legitimately not invoked on some paths
    should be a Function, not a CompletionHandler.

Change the continuation parameter from CompletionHandler&lt;void(bool)&gt; to
Function&lt;void(bool)&gt;, which carries no exactly-once contract. Behavior on all
paths is unchanged; only the spurious assertion/leak is removed.

* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::continueSilentlyCheckCredentials):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:

Canonical link: <a href="https://commits.webkit.org/314962@main">https://commits.webkit.org/314962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63890866b78e2c2cf5077c59981fd3776d501c86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125189 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f2dcf82-252a-43dc-995b-9eb9983df82d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130311 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b328be5-1049-4ec2-aba7-3b351964c859) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110828 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58fd2d15-e11f-4d13-b25d-80673e804d4b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31709 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30406 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25296 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141696 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179102 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31997 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138707 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37364 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41765 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104880 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33854 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26868 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113350 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39666 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4967 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39917 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39811 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->