### PR TITLE
[MathML] -webkit-* text-align values spread MathML row content

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2214,8 +2214,6 @@ webkit.org/b/308410 imported/w3c/web-platform-tests/mathml/presentation-markup/o
 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/legacy-mrow-like-elements-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/semantics-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/munder-mover-align-accent-false.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/munder-mover-align-accent-true.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/munderover-align-accent-false.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/munderover-align-accent-true.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/stretchy-munderover-1e.html [ ImageOnlyFailure Pass ]

--- a/LayoutTests/mathml/presentation/mtd-webkit-text-align-expected.html
+++ b/LayoutTests/mathml/presentation/mtd-webkit-text-align-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Reference: mtd alignment of MathML content</title>
+<style>
+  mtd { width: 30em; }
+  #a { text-align: right; }
+  #b { text-align: center; }
+</style>
+</head>
+<body>
+<math display="block"><mtable><mtr><mtd id="a"><mrow><mi>m</mi><mo>+</mo><mi>n</mi></mrow></mtd></mtr></mtable></math>
+<math display="block"><mtable><mtr><mtd id="b"><mrow><mi>m</mi><mo>+</mo><mi>n</mi></mrow></mtd></mtr></mtable></math>
+</body>
+</html>

--- a/LayoutTests/mathml/presentation/mtd-webkit-text-align.html
+++ b/LayoutTests/mathml/presentation/mtd-webkit-text-align.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>-webkit-left/right/center on mtd must align MathML content, not spread it</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#tabular-math-mtable-mtr-mtd">
+<!--
+  A cell wider than its content gives the alignment room to act. The legacy
+  -webkit-right / -webkit-center text-align values must align the math the same
+  way the standard right / center values do, rather than synthesizing per-child
+  block-alignment margins that spread the row's content.
+  See Also: https://github.com/w3c/mathml-core/issues/156
+-->
+<style>
+  mtd { width: 30em; }
+  #a { text-align: -webkit-right; }
+  #b { text-align: -webkit-center; }
+</style>
+</head>
+<body>
+<math display="block"><mtable><mtr><mtd id="a"><mrow><mi>m</mi><mo>+</mo><mi>n</mi></mrow></mtd></mtr></mtable></math>
+<math display="block"><mtable><mtr><mtd id="b"><mrow><mi>m</mi><mo>+</mo><mi>n</mi></mrow></mtd></mtr></mtable></math>
+</body>
+</html>

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -44,6 +44,7 @@
 #include "RenderTableInlines.h"
 #include "RenderView.h"
 #include "Settings.h"
+#include "StylePrimitiveNumericTypes+EvaluationMinimum.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -178,6 +179,9 @@ void RenderMathMLBlock::layoutItems(RelayoutChildren relayoutChildren)
         updateBlockChildDirtyBitsBeforeLayout(relayoutChildren, *child);
         child->layoutIfNeeded();
 
+        // Covers the anonymous block wrapping a token's text, which is laid out by generic CSS.
+        resetInlineMarginsToSpecified(*child);
+
         LayoutUnit childVerticalMarginBoxExtent;
         childVerticalMarginBoxExtent = child->height() + child->verticalMarginExtent();
 
@@ -228,6 +232,34 @@ void RenderMathMLBlock::computeAndSetBlockDirectionMarginsOfChildren()
 {
     for (auto* child = firstInFlowChildBox(); child; child = child->nextInFlowSiblingBox())
         child->computeAndSetBlockDirectionMargins(*this);
+}
+
+void RenderMathMLBlock::resetInlineMarginsToSpecified(RenderBox& child) const
+{
+    // MathML lays out and offsets its own in-flow children, so resolve their inline margins to the
+    // specified values (auto resolves to zero) rather than letting generic CSS layout distribute
+    // leftover inline space into auto / legacy -webkit-* text-align margins.
+    auto& childStyle = child.style();
+    auto availableWidth = child.containingBlockLogicalWidthForContent();
+    const auto& zoomFactor = childStyle.usedZoomForLength();
+    child.setMarginStart(Style::evaluateMinimum<LayoutUnit>(childStyle.marginStart(writingMode()), availableWidth, zoomFactor));
+    child.setMarginEnd(Style::evaluateMinimum<LayoutUnit>(childStyle.marginEnd(writingMode()), availableWidth, zoomFactor));
+}
+
+void RenderMathMLBlock::updateLogicalWidth()
+{
+    RenderBlock::updateLogicalWidth();
+
+    // Reset our inline margins when our containing block is a MathML box that lays us out. Math
+    // embedded in non-MathML content (e.g. a <math> with margin:auto inside a <div>) is left to
+    // regular CSS. The anonymous block wrapping a token's text is not a RenderMathMLBlock and is
+    // handled in RenderMathMLBlock::layoutItems instead.
+    if (isFloatingOrOutOfFlowPositioned())
+        return;
+    CheckedPtr containingBlock = dynamicDowncast<RenderMathMLBlock>(this->containingBlock());
+    if (!containingBlock)
+        return;
+    containingBlock->resetInlineMarginsToSpecified(*this);
 }
 
 void RenderMathMLBlock::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
@@ -71,7 +71,9 @@ protected:
     static inline LayoutUnit ascentForChild(const RenderBox& child);
 
     void layoutBlock(RelayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) override;
+    void updateLogicalWidth() override;
     void computeAndSetBlockDirectionMarginsOfChildren();
+    void resetInlineMarginsToSpecified(RenderBox& child) const;
     void insertPositionedChildrenIntoContainingBlock();
     void layoutFloatingChildren();
 


### PR DESCRIPTION
#### 9878316eb06d44a65ab521d6e361bc94196c7649
<pre>
[MathML] -webkit-* text-align values spread MathML row content
<a href="https://bugs.webkit.org/show_bug.cgi?id=307993">https://bugs.webkit.org/show_bug.cgi?id=307993</a>
<a href="https://rdar.apple.com/170485090">rdar://170485090</a>

Reviewed by NOBODY (OOPS!).

A MathML element wider than its content (e.g. an &lt;mtd&gt; with an explicit
width, which inherits text-align: -webkit-right/-webkit-center down to its
math descendants) spread or shifted the math content instead of just
aligning it.

MathML elements are laid out as block-level boxes but their containers
(RenderMathMLRow, RenderMathMLBlock, etc.) compute their own content size,
lay out their in-flow children, and position them while honoring the
children&apos;s inline margins. The math content box is sized to its content, so
a child is generally narrower than its container. When that happens
RenderBox::computeInlineDirectionMargins resolves auto margins and the
legacy -webkit-left/right/center text-align values by distributing the
leftover inline space into the child&apos;s margins. Those synthesized margins
were then summed back into the row width (RenderMathMLRow::getContentBoundingBox)
and used to place children (RenderMathMLRow::layoutRowItems,
RenderMathMLBlock::layoutItems), spreading the row and shifting operator
glyphs. Standard left/right/center have no such margin path, so only the
auto / -webkit-* values were affected.

This is not specific to the -webkit-* values: any inline-margin
distribution (e.g. margin: auto) would trigger the same bug. Neither the
MathML Core layout algorithms nor other engines distribute inline space
into in-flow math item margins: Gecko uses the child&apos;s used margins and
Blink (LayoutNG) resolves margins without auto-distribution.

Rather than special-casing MathML in generic CSS layout, keep the
specialization in the MathML renderers: resolve an in-flow MathML child&apos;s
inline margins to their specified values (auto resolves to zero), mirroring
the existing computeAndSetBlockDirectionMarginsOfChildren() handling for the
block axis. RenderMathMLBlock::updateLogicalWidth() does this for math boxes
whose containing block is itself a MathML box (so math embedded in
non-MathML content, e.g. a &lt;math&gt; with margin: auto inside a &lt;div&gt;, keeps
regular CSS behavior). RenderMathMLBlock::layoutItems() does the same for
the anonymous block that wraps a token&apos;s text, which is laid out by generic
CSS and is not a RenderMathMLBlock.

Test: mathml/presentation/mtd-webkit-text-align.html (not WPT due to -webkit-)

* LayoutTests/TestExpectations: Progressions.
* LayoutTests/mathml/presentation/mtd-webkit-text-align-expected.html: Added.
* LayoutTests/mathml/presentation/mtd-webkit-text-align.html: Added.
NOTE: These tests are not web platform because of an open specification
issue and also using -webkit- prefixes. See
<a href="https://github.com/w3c/mathml-core/issues/156">https://github.com/w3c/mathml-core/issues/156</a>

* Source/WebCore/rendering/mathml/RenderMathMLBlock.h:
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
(WebCore::RenderMathMLBlock::resetInlineMarginsToSpecified): Added. Resolve
an in-flow child&apos;s inline margins to their specified values (auto -&gt; 0),
overwriting any inline space distributed by RenderBox::computeInlineDirectionMargins.
(WebCore::RenderMathMLBlock::updateLogicalWidth): Added. After computing the
width, reset this box&apos;s inline margins when its containing block is a MathML
box that lays it out.
(WebCore::RenderMathMLBlock::layoutItems): Reset the inline margins of each
child (covers the anonymous text block inside token/operator elements).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9878316eb06d44a65ab521d6e361bc94196c7649

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126100 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa302313-67c2-411f-b5e8-74fb1c9d5066) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131059 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92152 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/964c2e57-97c7-40cd-baf6-738d721413ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111570 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3840d3f2-016b-49eb-8077-1809a3efa3fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32511 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31213 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26423 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142497 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180327 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139494 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41968 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35374 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139358 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106248 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27707 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40557 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5792 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40808 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40702 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->