### PR TITLE
REGRESSION(259426@main): [WebAuthn] CcidConnection fails to detect legacy U2F-only keys because the applet-selection fallback sends the wrong command

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid-legacy-u2f.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid-legacy-u2f.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS PublicKeyCredential's [[create]] with a legacy U2F-only contactless authenticator requiring the U2F_VERSION fallback over ccid.
+

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid-legacy-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid-legacy-u2f.https.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html><!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<title>Web Authentication API: PublicKeyCredential's [[create]] with a legacy U2F-only mock ccid authenticator.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/util.js"></script>
+<script src="./resources/cbor.js"></script>
+<script>
+    // A legacy U2F-only contactless key does not understand the FIDO applet selection command and answers
+    // it with a non-match (testCcidUnknownInsBase64). The connection must then fall back to the U2F_VERSION
+    // command, which the key answers with the U2F version (testNfcU2fVersionBase64), and the tag is connected.
+    // If the fallback sent the wrong command, the tag would never connect and the request would time out.
+    promise_test(t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ ccid: {
+                payloadBase64: [testCcidValidUidBase64, testGetInfoResponseApduBase64, testCreationMessageApduBase64],
+                appletSelectionResponseBase64: testCcidUnknownInsBase64,
+                u2fVersionResponseBase64: testNfcU2fVersionBase64,
+            } });
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }]
+            }
+        };
+
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true /* isNoneAttestation */, ["nfc"]);
+        });
+    }, "PublicKeyCredential's [[create]] with a legacy U2F-only contactless authenticator requiring the U2F_VERSION fallback over ccid.");
+</script>

--- a/LayoutTests/http/wpt/webauthn/resources/util.js
+++ b/LayoutTests/http/wpt/webauthn/resources/util.js
@@ -145,6 +145,9 @@ const testAssertionMessageApduBase64 =
     "QoJ1L7Fe64G9uBeQAA==";
 const testCcidNoUidBase64 = "aIE=";
 const testCcidValidUidBase64 = "CH+d1ZAA";
+// APDU status word 0x6D00 ("instruction not supported"); not a FIDO applet selection match, as returned
+// by a legacy U2F-only key that does not understand the applet selection command.
+const testCcidUnknownInsBase64 = "bQA=";
 const testCreateMessageFullKeyStoreBase64 = "KA==";
 
 // hmac-secret test constants

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
@@ -107,6 +107,8 @@ struct MockWebAuthenticationConfiguration {
 
     struct CcidConfiguration {
         Vector<String> payloadBase64;
+        String appletSelectionResponseBase64;
+        String u2fVersionResponseBase64;
     };
 
     bool silentFailure { false };

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -125,4 +125,6 @@
     Conditional=WEB_AUTHN,
 ] dictionary MockCcidConfiguration {
     sequence<DOMString> payloadBase64 = [];
+    DOMString appletSelectionResponseBase64 = "";
+    DOMString u2fVersionResponseBase64 = "";
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6056,6 +6056,8 @@ header: <WebCore/ISOVTTCue.h>
 
 [Nested] struct WebCore::MockWebAuthenticationConfiguration::CcidConfiguration {
     Vector<String> payloadBase64;
+    String appletSelectionResponseBase64;
+    String u2fVersionResponseBase64;
 };
 
 struct WebCore::MockWebAuthenticationConfiguration {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -154,7 +154,10 @@ void CcidConnection::trySelectFidoApplet()
                 service->didConnectTag();
             return;
         }
-        protectedThis->transact(Vector(std::span { kCtapNfcAppletSelectionCommand }), [weakThis = WTF::move(weakThis)] (Vector<uint8_t>&& response) mutable {
+        // Some legacy U2F keys don't understand the FIDO applet selection command and are configured to
+        // only have the FIDO applet. When applet selection fails, use the U2F_VERSION command to check
+        // whether the connected tag can speak U2F, indicating one of these legacy keys.
+        protectedThis->transact(Vector(std::span { kCtapNfcU2fVersionCommand }), [weakThis = WTF::move(weakThis)] (Vector<uint8_t>&& response) mutable {
             ASSERT(RunLoop::isMain());
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h
@@ -38,7 +38,7 @@ class MockCcidService final : public CcidService {
 public:
     static Ref<MockCcidService> create(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);
 
-    RetainPtr<NSData> nextReply();
+    RetainPtr<NSData> nextReply(NSData *request);
 
 private:
     MockCcidService(AuthenticatorTransportServiceObserver&, const WebCore::MockWebAuthenticationConfiguration&);

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
@@ -29,7 +29,10 @@
 #if ENABLE(WEB_AUTHN)
 
 #import <CryptoTokenKit/TKSmartCard.h>
+#include <WebCore/FidoConstants.h>
 #include <wtf/RunLoop.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/cocoa/VectorCocoa.h>
 
 @interface _WKMockTKSmartCard : TKSmartCard
 - (instancetype)initWithService:(WeakPtr<WebKit::MockCcidService>&&)service;
@@ -60,12 +63,20 @@
 
 - (void)transmitRequest:(NSData *)request reply:(void(^)(NSData * response, NSError * error))reply
 {
-    reply(Ref { *m_service }->nextReply().get(), nil);
+    reply(Ref { *m_service }->nextReply(request).get(), nil);
 }
 
 @end
 
 namespace WebKit {
+using namespace fido;
+
+static RetainPtr<NSData> dataFromBase64(const String& base64String)
+{
+    if (base64String.isEmpty())
+        return nil;
+    return adoptNS([[NSData alloc] initWithBase64EncodedString:base64String.createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+}
 
 Ref<MockCcidService> MockCcidService::create(AuthenticatorTransportServiceObserver& observer, const WebCore::MockWebAuthenticationConfiguration& configuration)
 {
@@ -88,12 +99,20 @@ void MockCcidService::platformStartDiscovery()
     LOG_ERROR("No ccid authenticators is available.");
 }
 
-RetainPtr<NSData> MockCcidService::nextReply()
+RetainPtr<NSData> MockCcidService::nextReply(NSData *request)
 {
+    // Command-aware replies let a test model a legacy U2F-only key: the applet selection command can be
+    // answered with a non-match, forcing the connection to fall back to the U2F_VERSION command.
+    auto requestVector = makeVector(request);
+    if (!m_configuration.ccid->appletSelectionResponseBase64.isEmpty() && equalSpans(requestVector.span(), std::span { kCtapNfcAppletSelectionCommand }))
+        return dataFromBase64(m_configuration.ccid->appletSelectionResponseBase64);
+    if (!m_configuration.ccid->u2fVersionResponseBase64.isEmpty() && equalSpans(requestVector.span(), std::span { kCtapNfcU2fVersionCommand }))
+        return dataFromBase64(m_configuration.ccid->u2fVersionResponseBase64);
+
     if (m_configuration.ccid->payloadBase64.isEmpty())
         return nil;
 
-    auto result = adoptNS([[NSData alloc] initWithBase64EncodedString:m_configuration.ccid->payloadBase64[0].createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]);
+    auto result = dataFromBase64(m_configuration.ccid->payloadBase64[0]);
     m_configuration.ccid->payloadBase64.removeAt(0);
     return result;
 }


### PR DESCRIPTION
#### cdd711f31c78da207d5978a9dd7a1b6a5dc06dba
<pre>
REGRESSION(259426@main): [WebAuthn] CcidConnection fails to detect legacy U2F-only keys because the applet-selection fallback sends the wrong command
<a href="https://bugs.webkit.org/show_bug.cgi?id=316758">https://bugs.webkit.org/show_bug.cgi?id=316758</a>

Reviewed by Pascoe.

Some legacy U2F-only contactless keys do not understand the FIDO applet
selection command and are configured to only have the FIDO applet. To detect
these, CcidConnection::trySelectFidoApplet() is supposed to fall back to the
U2F_VERSION command when applet selection fails -- which is what the NFC path
(NfcConnection.mm) does. Instead, the fallback re-sends kCtapNfcAppletSelectionCommand,
the same command that just failed, so these keys are never detected over CCID.

This is a regression from 259426@main (cef8b0cbe101), which refactored
trySelectFidoApplet() from direct -[TKSmartCard transmitRequest:] calls to the
transact() helper. That change was about session management, but in the rewrite
the fallback&apos;s command was changed from kCtapNfcU2fVersionCommand to
kCtapNfcAppletSelectionCommand. As originally shipped in 252425@main
(c0f5fc64aac3), the fallback correctly sent kCtapNfcU2fVersionCommand.

The fix is confirmed correct on several independent grounds:
- The fallback&apos;s success check is unchanged: it compares the response against
  kCtapNfcAppletSelectionU2f, i.e. the ASCII bytes &quot;U2F_V2&quot; followed by APDU
  status word 0x9000. Per the FIDO U2F Raw Message Formats spec (section 6.1,
  &quot;GetVersion Request and Response - U2F_VERSION&quot;), that is exactly the response
  a U2F token returns to the U2F_VERSION command (CLA=00 INS=03 P1=00 P2=00
  Le=00, which is kCtapNfcU2fVersionCommand). A SELECT-by-AID cannot produce
  that response, so the command and the response-check only correspond for
  U2F_VERSION.
- Re-sending the applet-selection command (the regressed behavior) is dead code:
  the first attempt already rejected that response, and a smart card is
  deterministic, so the identical second command can never match.

Send kCtapNfcU2fVersionCommand on the fallback, matching the originally shipped
behavior and the NFC implementation.

To make this testable, the mock CCID authenticator is taught to answer based on
the transmitted command. Previously _WKMockTKSmartCard returned scripted
payloads strictly in sequence and ignored the request bytes, so the regressed
and fixed fallbacks were indistinguishable. Two optional fields,
appletSelectionResponseBase64 and u2fVersionResponseBase64, let a test model a
legacy U2F-only key: applet selection is answered with a non-match (forcing the
fallback) and U2F_VERSION with the U2F version response. When unset, the mock
keeps its previous sequential behavior, so existing tests are unaffected. The
new regression test connects (create() succeeds) only when the fallback sends
the correct command; with the bug the tag never connects and the request times
out.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
(WebKit::CcidConnection::trySelectFidoApplet): Send kCtapNfcU2fVersionCommand on
the applet-selection fallback instead of re-sending kCtapNfcAppletSelectionCommand.
* Source/WebCore/testing/MockWebAuthenticationConfiguration.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
Add appletSelectionResponseBase64 and u2fVersionResponseBase64 to the mock CCID
configuration.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Serialize the new fields.
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm:
(-[_WKMockTKSmartCard transmitRequest:reply:]):
(WebKit::dataFromBase64):
(WebKit::MockCcidService::nextReply): Answer the applet-selection and U2F_VERSION
commands specifically when configured, falling through to the sequential
payloads otherwise.
* LayoutTests/http/wpt/webauthn/resources/util.js:
Add testCcidUnknownInsBase64 (APDU 0x6D00, a non-match).
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid-legacy-u2f.https.html: Added.
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid-legacy-u2f.https-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/314961@main">https://commits.webkit.org/314961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0ccb1d4d050877cd96e55554cf71069dfacfe19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125235 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8883b8f-f0e7-4636-8d05-d699df5c8b96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130359 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d6c4f4c-e449-4481-b7f9-911632cdbcae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150546 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110876 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13c4f13e-4317-498f-937a-39d2a0e48ffa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31752 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30450 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25342 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179150 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32043 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138754 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138640 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37363 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104958 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33897 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26912 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113396 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39712 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5013 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39857 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->