### PR TITLE
ImageOrientation::Orientation TextStream operator swaps top/bottom for all non-default orientations

### DIFF
--- a/Source/WebCore/platform/graphics/ImagePaintingOptions.cpp
+++ b/Source/WebCore/platform/graphics/ImagePaintingOptions.cpp
@@ -68,25 +68,25 @@ TextStream& operator<<(TextStream& ts, ImageOrientation::Orientation orientation
         ts << "origin-top-left"_s;
         break;
     case Orientation::OriginTopRight:
-        ts << "origin-bottom-right"_s;
-        break;
-    case Orientation::OriginBottomRight:
         ts << "origin-top-right"_s;
         break;
+    case Orientation::OriginBottomRight:
+        ts << "origin-bottom-right"_s;
+        break;
     case Orientation::OriginBottomLeft:
-        ts << "origin-top-left"_s;
+        ts << "origin-bottom-left"_s;
         break;
     case Orientation::OriginLeftTop:
-        ts << "origin-left-bottom"_s;
+        ts << "origin-left-top"_s;
         break;
     case Orientation::OriginRightTop:
-        ts << "origin-right-bottom"_s;
-        break;
-    case Orientation::OriginRightBottom:
         ts << "origin-right-top"_s;
         break;
+    case Orientation::OriginRightBottom:
+        ts << "origin-right-bottom"_s;
+        break;
     case Orientation::OriginLeftBottom:
-        ts << "origin-left-top"_s;
+        ts << "origin-left-bottom"_s;
         break;
     }
     return ts;


### PR DESCRIPTION
#### a1399ba8e3b5c0e9e1764f365dcd20d8f7d6ccb1
<pre>
ImageOrientation::Orientation TextStream operator swaps top/bottom for all non-default orientations
<a href="https://bugs.webkit.org/show_bug.cgi?id=316762">https://bugs.webkit.org/show_bug.cgi?id=316762</a>
<a href="https://rdar.apple.com/179208460">rdar://179208460</a>

Reviewed by Pascoe.

Every case except OriginTopLeft streamed a label with top/bottom inverted. Make each label match its
enum value.

* Source/WebCore/platform/graphics/ImagePaintingOptions.cpp:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/314940@main">https://commits.webkit.org/314940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee780cf623a5d8e8c7f91807e1c850c88374b88c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176586 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b3888c8-98af-40f9-afb2-c0da2d760623) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130337 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c8468e7-484d-43fb-8532-46956f934e98) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110854 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61ce90a3-b031-4de3-af32-6edf5cddaa7b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30428 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25319 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179127 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32020 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138733 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138619 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41788 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104918 "Built successfully") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25515 "Failed to push commit to Webkit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26889 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113373 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39689 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4990 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->