### PR TITLE
REGRESSION(306393@main): SelectFallbackButtonElement should have styling in none appearance mode

### DIFF
--- a/LayoutTests/fast/forms/select/select-fallback-button-vertical-position-expected.html
+++ b/LayoutTests/fast/forms/select/select-fallback-button-vertical-position-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>select fallback button text follows host with appearance:none and asymmetric block padding</title>
+<style>
+.fake {
+    display: inline-block;
+    box-sizing: border-box;
+    width: 200px;
+    height: 100px;
+    padding: 0 16px 20px 16px;
+    line-height: 100px;
+    font: 30px/100px Ahem;
+    color: black;
+    background: lightblue;
+}
+</style>
+</head>
+<body>
+<div class=fake>X</div>
+</body>
+</html>

--- a/LayoutTests/fast/forms/select/select-fallback-button-vertical-position.html
+++ b/LayoutTests/fast/forms/select/select-fallback-button-vertical-position.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>select fallback button text follows host with appearance:none and asymmetric block padding</title>
+<style>
+select {
+    appearance: none;
+    box-sizing: border-box;
+    width: 200px;
+    height: 100px;
+    padding: 0 16px 20px 16px;
+    line-height: 100px;
+    font: 30px/100px Ahem;
+    color: black;
+    border: 0;
+    border-radius: 0;
+    background: lightblue;
+}
+</style>
+</head>
+<body>
+<select><option>X</option></select>
+</body>
+</html>

--- a/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
@@ -130,13 +130,6 @@ std::optional<Style::UnadjustedStyle> SelectFallbackButtonElement::resolveCustom
     auto elementStyle = resolveStyle(resolutionContext);
     CheckedRef style = *elementStyle.style;
 
-    if (hostStyle->usedAppearance() != StyleAppearance::Base) {
-        style->setFlexGrow(1);
-        style->setFlexShrink(1);
-        // min-width: 0; is needed for correct shrinking.
-        style->setLogicalMinWidth(0_css_px);
-    }
-
     auto hostTextAlign = hostStyle->textAlign();
     if (hostTextAlign == Style::TextAlign::Start)
         style->setTextAlign(hostStyle->writingMode().isBidiLTR() ? Style::TextAlign::Left : Style::TextAlign::Right);
@@ -159,19 +152,18 @@ std::optional<Style::UnadjustedStyle> SelectFallbackButtonElement::resolveCustom
         break;
     }
 
-    switch (hostStyle->usedAppearance()) {
-    case StyleAppearance::Menulist:
-    case StyleAppearance::MenulistButton: {
+    if (hostStyle->usedAppearance() != StyleAppearance::Base) {
+        style->setFlexGrow(1);
+        style->setFlexShrink(1);
+        // min-width: 0; is needed for correct shrinking.
+        style->setLogicalMinWidth(0_css_px);
+
         style->setMarginBefore(CSS::Keyword::Auto { });
         style->setMarginAfter(CSS::Keyword::Auto { });
         style->setAlignSelf(CSS::Keyword::FlexStart { });
 
         auto paddingBox = RenderTheme::singleton().popupInternalPaddingBox(*hostStyle);
         style->setPaddingBox(WTF::move(paddingBox));
-        break;
-    }
-    default:
-        break;
     }
 
     return elementStyle;


### PR DESCRIPTION
#### 845226913aeb7309136f55499f36880c1f7ab86a
<pre>
REGRESSION(306393@main): SelectFallbackButtonElement should have styling in none appearance mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=316780">https://bugs.webkit.org/show_bug.cgi?id=316780</a>
<a href="https://rdar.apple.com/178160969">rdar://178160969</a>

Reviewed by Megan Gardner and Tim Nguyen.

The select button text needs to appear centered for appearance: none as
well, as RenderMenuList used to have it.

Test: fast/forms/select/select-fallback-button-vertical-position.html
Canonical link: <a href="https://commits.webkit.org/314926@main">https://commits.webkit.org/314926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6610098e1e2ca93a0cd2fc4be1ef0f996a5158c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176685 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6184286b-d277-4c98-b8ef-ff5c5adbf28a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41137 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72e17e7c-eb37-4853-bc50-d5552ca4c60e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170587 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/110940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ff9f1dc-1a20-4eb7-9735-44275fbbca50) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25418 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179225 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30032 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41197 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37339 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105046 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33969 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40389 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39786 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/5086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40037 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->