### PR TITLE
Diagnostic services should be accessible in local builds

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in
@@ -21,6 +21,9 @@
 ; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE(DEVELOPMENT_SANDBOX_FALLBACK)
+#include "Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in"
+#else
 #include "Shared/Sandbox/iOS/common.sb"
 #include "Shared/Sandbox/iOS/gpu-defines.sb"
 
@@ -215,3 +218,4 @@
         (syscall-number
             SYS_mkdirat
             SYS_rmdir)))
+#endif // !ENABLE(DEVELOPMENT_SANDBOX_FALLBACK)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in
@@ -21,6 +21,9 @@
 ; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE(DEVELOPMENT_SANDBOX_FALLBACK)
+#include "Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in"
+#else
 #include "Shared/Sandbox/iOS/common.sb"
 #include "Shared/Sandbox/iOS/networking-defines.sb"
 
@@ -181,3 +184,5 @@
 #if HAVE(ENHANCED_SECURITY_LINKS) && __has_include(<WebKitAdditions/EnhancedSecurityLinks-ios.sb>)
 #include <WebKitAdditions/EnhancedSecurityLinks-ios.sb>
 #endif
+
+#endif // !ENABLE(DEVELOPMENT_SANDBOX_FALLBACK)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in
@@ -21,6 +21,9 @@
 ; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
+#if ENABLE(DEVELOPMENT_SANDBOX_FALLBACK)
+#include "Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in"
+#else
 #include "Shared/Sandbox/iOS/common.sb"
 #include "Shared/Sandbox/iOS/webcontent-defines.sb"
 
@@ -302,4 +305,5 @@
         (extension-class "com.apple.mediaserverd.read")
         (require-any
             (apply subpath issue-extension-secondary-paths))))
-#endif
+#endif // ENABLE(SYSTEM_CONTENT_PATH_SANDBOX_RULES)
+#endif // !ENABLE(DEVELOPMENT_SANDBOX_FALLBACK)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -351,12 +351,13 @@
             (xpc-service-name "com.apple.MTLCompilerService"))))
 #endif
 
-(with-filter (system-attribute apple-internal)
-    (allow mach-lookup (global-name "com.apple.diagnosticd")))
-
+#if !RC_XBS
 (with-filter (system-attribute apple-internal)
     (allow mach-lookup
-        (global-name "com.apple.osanalytics.osanalyticshelper")))
+        (global-name
+            "com.apple.diagnosticd"
+            "com.apple.osanalytics.osanalyticshelper")))
+#endif
 
 (disable-syscall-inference)
 

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1031,10 +1031,12 @@
     (global-name "com.apple.coreservices.launchservicesd")
     (global-name "com.apple.linkd.autoShortcut"))
 
+#if !RC_XBS
 (with-filter (system-attribute apple-internal)
     (allow mach-lookup
         (global-name "com.apple.analyticsd")
         (global-name "com.apple.diagnosticd")))
+#endif
 
 (deny mach-lookup (with telemetry-backtrace)
     (global-name "com.apple.webinspector"))


### PR DESCRIPTION
#### 21b0579b979dc20f62f7f4bf9c07bf0594813bd9
<pre>
Diagnostic services should be accessible in local builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=316783">https://bugs.webkit.org/show_bug.cgi?id=316783</a>
<a href="https://rdar.apple.com/179233979">rdar://179233979</a>

Reviewed by Brent Fulgham.

This patch makes sure diagnostic services are available in local builds for debugging purposes.
For the development sandboxes, it also adds a fallback to the standard sandboxes in certain
scenarios.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/315020@main">https://commits.webkit.org/315020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a2294324a381547f6ed6f4fcafffdf425286b87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125246 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/572a1581-5896-484a-931e-1611e2ade147) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130371 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91657 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110888 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30462 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25354 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141750 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179161 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32054 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138765 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138651 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41822 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104976 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26925 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113407 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39723 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5026 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39974 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39868 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->