### PR TITLE
REGRESSION(314840@main): WPT linter crashes instead of reporting lint errors

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/wpt_linter.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter.py
@@ -70,7 +70,7 @@ class WPTLinter(object):
             # actual failure.
             if e.returncode != 1:
                 raise RuntimeError(
-                    'WPT linter failed:\n' + result.stderr.decode('utf-8', 'replace')
+                    'WPT linter failed:\n' + e.stderr.decode('utf-8', 'replace')
                 ) from e
             result = e
         for line in result.stdout.splitlines():


### PR DESCRIPTION
#### a47428dc96430c8d373f8a7481b756d7eec3ccbb
<pre>
REGRESSION(314840@main): WPT linter crashes instead of reporting lint errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=316784">https://bugs.webkit.org/show_bug.cgi?id=316784</a>
<a href="https://rdar.apple.com/179237557">rdar://179237557</a>

Reviewed by Tim Nguyen.

The exception handler in WPTLinter._run_lint builds its error message from
result, but result is never assigned when subprocess.run() raises
CalledProcessError, so it dies with &quot;UnboundLocalError: local variable
&apos;result&apos; referenced before assignment&quot;. Use the caught exception&apos;s stderr
(e.stderr) instead.

* Tools/Scripts/webkitpy/w3c/wpt_linter.py:
(WPTLinter._run_lint):

Canonical link: <a href="https://commits.webkit.org/314899@main">https://commits.webkit.org/314899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd49db92f2cfc09c7b656504bd1ee1b5165a0123

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41073 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/34668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176635 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa91a7a8-1104-403c-8ddb-cd1eb765e8b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41087 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6975e64-72de-4e29-980f-1e895a434dec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32796 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110901 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81f3eda3-1945-4292-9032-bf0015ee4ba4) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166899 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25367 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/28269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179175 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/29987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138665 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/37326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41835 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/150061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104993 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25495 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33920 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40339 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39736 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/5041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->