### PR TITLE
border-shape-ignore-radius-computed.html asserts keyword serialization for corner-shape computed value, but spec requires superellipse() form

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-ignore-radius-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-ignore-radius-computed-expected.txt
@@ -1,3 +1,3 @@
 
-PASS border-radius and corner-shape are NOT reset in computed style when border-shape is specified
+FAIL border-radius and corner-shape are NOT reset in computed style when border-shape is specified assert_equals: expected "superellipse(0)" but got "bevel"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-ignore-radius-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-ignore-radius-computed.html
@@ -19,9 +19,9 @@ test(() => {
     assert_equals(style.borderTopRightRadius, '999px');
     assert_equals(style.borderBottomRightRadius, '999px');
     assert_equals(style.borderBottomLeftRadius, '999px');
-    assert_equals(style.cornerTopLeftShape, 'bevel');
-    assert_equals(style.cornerTopRightShape, 'bevel');
-    assert_equals(style.cornerBottomRightShape, 'bevel');
-    assert_equals(style.cornerBottomLeftShape, 'bevel');
+    assert_equals(style.cornerTopLeftShape, 'superellipse(0)');
+    assert_equals(style.cornerTopRightShape, 'superellipse(0)');
+    assert_equals(style.cornerBottomRightShape, 'superellipse(0)');
+    assert_equals(style.cornerBottomLeftShape, 'superellipse(0)');
 }, "border-radius and corner-shape are NOT reset in computed style when border-shape is specified");
 </script>


### PR DESCRIPTION
#### 0345af3f97508ed7ebcae62ab9448336a2fd77ea
<pre>
border-shape-ignore-radius-computed.html asserts keyword serialization for corner-shape computed value, but spec requires superellipse() form
<a href="https://bugs.webkit.org/show_bug.cgi?id=316787">https://bugs.webkit.org/show_bug.cgi?id=316787</a>
<a href="https://rdar.apple.com/179239806">rdar://179239806</a>

Reviewed by Tim Nguyen.

The fix updates the assertions from &apos;bevel&apos; to &apos;superellipse(0)&apos;, which is the correct canonical computed value. The test intent is unchanged — it still verifies that corner-shape is
not reset when border-shape is specified, but now checks the spec-correct serialization.

* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-ignore-radius-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/border-shape/border-shape-ignore-radius-computed.html:

Canonical link: <a href="https://commits.webkit.org/314941@main">https://commits.webkit.org/314941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1130e5f4b1d014012ab24d25e5de620b6d28de03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176665 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130409 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110926 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25398 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179205 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30013 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138806 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150087 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/105025 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25523 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26966 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40369 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39766 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5067 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->