### PR TITLE
WebModelPlayer should support setting the entityTransform while the model is unloaded (hidden)

### DIFF
--- a/LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt
+++ b/LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt
@@ -5,4 +5,5 @@ PASS <model> invalid state if usdz does not exist
 PASS <model> invalid state for incorrect usdz file
 PASS <model> reload visible model after source change
 PASS <model> stage-mode orbit survives multiple unload-reload cycles
+PASS <model> entityTransform can be set while unloaded
 

--- a/LayoutTests/model-element/model-element-lazy-loading-unloading.html
+++ b/LayoutTests/model-element/model-element-lazy-loading-unloading.html
@@ -139,6 +139,32 @@ promise_test(async t => {
 
 }, `<model> stage-mode orbit survives multiple unload-reload cycles`);
 
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/heart.usdz");
+    model.className = "model-element";
+
+    scrollElementIntoView(model);
+    await waitForModelState(model, "Loaded");
+    await model.ready;
+
+    const loadedTransform = model.entityTransform.rotate(0, 45, 0).scale(2, 2, 2);
+    model.entityTransform = loadedTransform;
+    assert_3d_matrix_equals(model.entityTransform, loadedTransform);
+
+    window.scrollTo(0, 0);
+    await waitForModelState(model, "Unloaded", 10000);
+
+    const unloadedTransform = model.entityTransform.translate(0, 0, -10).rotate(0, 30, 0).scale(0.5, 0.5, 0.5);
+    model.entityTransform = unloadedTransform;
+    assert_3d_matrix_equals(model.entityTransform, unloadedTransform);
+
+    scrollElementIntoView(model);
+    await waitForModelState(model, "Loaded");
+    await sleepForSeconds(0.1);
+
+    assert_3d_matrix_equals(model.entityTransform, unloadedTransform);
+}, `<model> entityTransform can be set while unloaded`);
+
 </script>
 </body>
 

--- a/LayoutTests/platform/visionos/model-element/model-element-graphics-layers-expected.txt
+++ b/LayoutTests/platform/visionos/model-element/model-element-graphics-layers-expected.txt
@@ -10,7 +10,6 @@
           (position 8.00 8.00)
           (bounds 300.00 150.00)
           (drawsContent 1)
-          (backgroundColor #000000)
         )
       )
     )

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -779,7 +779,11 @@ void WebModelPlayer::setEntityTransform(WebCore::TransformationMatrix matrix)
         model->setEntityTransform(static_cast<simd_float4x4>(matrix));
         notifyEntityTransformUpdated();
         startUpdateLoopIfNeeded();
+        return;
     }
+
+    if (m_cachedTransformState)
+        (*m_cachedTransformState)->setEntityTransform(matrix);
 }
 
 void WebModelPlayer::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)


### PR DESCRIPTION
#### 5c716eb329990daee1e186c6a03623609b8589f4
<pre>
WebModelPlayer should support setting the entityTransform while the model is unloaded (hidden)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316792">https://bugs.webkit.org/show_bug.cgi?id=316792</a>
&lt;<a href="https://rdar.apple.com/179114750">rdar://179114750</a>&gt;

Reviewed by Mike Wyrzykowski.

If the entityTransform was set while the model was unloaded, we would
just drop the new transform and restore the old one on reload.
Instead, update the cached transform state state so we can restore the
correct transform on reload.

Tests: model-element/model-element-lazy-loading-unloading.html

* LayoutTests/model-element/model-element-graphics-layers-expected.txt:
Re-baseline after 314750@main.
* LayoutTests/platform/visionos/model-element/model-element-graphics-layers-expected.txt: Copied from LayoutTests/model-element/model-element-graphics-layers-expected.txt.
Add a visionOS version without the background color.
* LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt:
* LayoutTests/model-element/model-element-lazy-loading-unloading.html:
Add a test covering this scenario.

* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::setEntityTransform):
Update the transform on the cached transform state.

Canonical link: <a href="https://commits.webkit.org/314951@main">https://commits.webkit.org/314951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43ac36b08880fa4c74289f53ea2cc6497a901675

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176659 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/adc9692c-dce4-47a6-a3ab-2c7afd9ab000) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130404 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f44e956-58dd-469b-a1e6-55411f8d3ff0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110921 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97ae9f3d-335f-478e-9348-6d55ec755344) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30496 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25392 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179199 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30011 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138800 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138686 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37353 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105019 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26964 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40363 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39760 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5065 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39905 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->