### PR TITLE
[JSC][Temporal] Fix double-throw crash in Temporal constructors; clean up stress tests

### DIFF
--- a/JSTests/stress/temporal-calendar.js
+++ b/JSTests/stress/temporal-calendar.js
@@ -1,6 +1,4 @@
 //@ requireOptions("--useTemporal=1")
-// FIXME: toLocaleString requires IntlDateTimeFormat Temporal support, implemented in the next patch.
-//@ skip
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/temporal-duration.js
+++ b/JSTests/stress/temporal-duration.js
@@ -1,6 +1,4 @@
 //@ requireOptions("--useTemporal=1")
-// FIXME: toLocaleString requires IntlDateTimeFormat Temporal support, implemented in the next patch.
-//@ skip
 
 function shouldBe(actual, expected) {
     if (actual !== expected)

--- a/JSTests/stress/temporal-plainyearmonth-constructor-exception-check.js
+++ b/JSTests/stress/temporal-plainyearmonth-constructor-exception-check.js
@@ -1,0 +1,11 @@
+//@ requireOptions("--useTemporal=1", "--validateExceptionChecks=1")
+
+function opt(a1) {
+    var a2 = new Temporal.PlainYearMonth(((NaN * a1 <= 0).__proto__ = "\\u{1F4A9}ba"), 1, 'chinese', 1);
+    a3 = a1;
+    let a4 = a4.withPlainTime(a3);
+    throw a1;
+}
+try { opt((function* () { }.constructor)) } catch (y) { }
+try { opt(9007199254740991) } catch (y) { }
+try { opt("\\u{10428}\\u{10000}x") } catch (y) { }

--- a/JSTests/stress/temporal-timezone.js
+++ b/JSTests/stress/temporal-timezone.js
@@ -1,6 +1,4 @@
 //@ requireOptions("--useTemporal=1")
-// FIXME: toLocaleString requires IntlDateTimeFormat Temporal support, implemented in the next patch.
-//@ skip
 
 function shouldBe(actual, expected) {
     if (actual !== expected)
@@ -23,26 +21,26 @@ function shouldThrow(func, errorType) {
 shouldThrow(() => { new Temporal.TimeZone("UTC"); }, TypeError);
 shouldThrow(() => { Temporal.TimeZone.from("UTC"); }, TypeError);
 
-// FIXME: TimeZone is accessed via timeZoneId on ZonedDateTime
-// {
-//     let zdt = Temporal.ZonedDateTime.from("2024-06-15T12:00[Asia/Tokyo]");
-//     shouldBe(zdt.timeZoneId, "Asia/Tokyo");
-//     shouldBe(zdt.offset, "+09:00");
-// }
+// TimeZone is accessed via timeZoneId on ZonedDateTime
+{
+    let zdt = Temporal.ZonedDateTime.from("2024-06-15T12:00[Asia/Tokyo]");
+    shouldBe(zdt.timeZoneId, "Asia/Tokyo");
+    shouldBe(zdt.offset, "+09:00");
+}
 
-// FIXME: UTC, fixed offset, ZonedDateTime
-// {
-//     let zdt = Temporal.ZonedDateTime.from("2024-06-15T12:00[UTC]");
-//     shouldBe(zdt.timeZoneId, "UTC");
-//     shouldBe(zdt.offset, "+00:00");
-// }
+// UTC, fixed offset, ZonedDateTime
+{
+    let zdt = Temporal.ZonedDateTime.from("2024-06-15T12:00[UTC]");
+    shouldBe(zdt.timeZoneId, "UTC");
+    shouldBe(zdt.offset, "+00:00");
+}
 
-// FIXME: Fixed UTC offset ZonedDateTime
-// {
-//     let zdt = new Temporal.ZonedDateTime(0n, "+05:30");
-//     shouldBe(zdt.timeZoneId, "+05:30");
-//     shouldBe(zdt.offset, "+05:30");
-// }
+// Fixed UTC offset ZonedDateTime
+{
+    let zdt = new Temporal.ZonedDateTime(0n, "+05:30");
+    shouldBe(zdt.timeZoneId, "+05:30");
+    shouldBe(zdt.offset, "+05:30");
+}
 
 // Temporal.Now.timeZoneId returns a string
 {

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
@@ -99,26 +99,26 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
 
     if (argumentCount > 0) {
         auto value = callFrame->uncheckedArgument(0).toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(value)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate year property must be finite"_s);
         duration.setField(TemporalUnit::Year, value);
-        RETURN_IF_EXCEPTION(scope, { });
     }
 
     if (argumentCount > 1) {
         auto value = callFrame->uncheckedArgument(1).toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(value)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate month property must be finite"_s);
         duration.setField(TemporalUnit::Month, value);
-        RETURN_IF_EXCEPTION(scope, { });
     }
 
     if (argumentCount > 2) {
         auto value = callFrame->uncheckedArgument(2).toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(value)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDate day property must be finite"_s);
         duration.setField(TemporalUnit::Day, value);
-        RETURN_IF_EXCEPTION(scope, { });
     }
 
     // Steps 5-7: if calendar undefined → "iso8601"; if not String → TypeError; CanonicalizeCalendar.

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayConstructor.cpp
@@ -98,20 +98,20 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* global
     double isoMonth = 1;
     if (argumentCount > 0) {
         auto value = callFrame->uncheckedArgument(0).toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(value)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay month property must be finite"_s);
         isoMonth = value;
-        RETURN_IF_EXCEPTION(scope, { });
     }
 
     // Step 4: d = ToIntegerWithTruncation(isoDay).
     double isoDay = 1;
     if (argumentCount > 1) {
         auto value = callFrame->uncheckedArgument(1).toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(value)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay day property must be finite"_s);
         isoDay = value;
-        RETURN_IF_EXCEPTION(scope, { });
     }
 
     if (argumentCount < 2) [[unlikely]]
@@ -135,10 +135,10 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainMonthDay, (JSGlobalObject* global
     double referenceYear = 1972;
     if (argumentCount > 3 && !callFrame->uncheckedArgument(3).isUndefined()) {
         auto value = callFrame->uncheckedArgument(3).toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(value)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainMonthDay reference year must be finite"_s);
         referenceYear = value;
-        RETURN_IF_EXCEPTION(scope, { });
     }
 
     // Steps 9-11: IsValidISODate + CreateISODateRecord + CreateTemporalMonthDay.

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthConstructor.cpp
@@ -98,20 +98,20 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainYearMonth, (JSGlobalObject* globa
     double isoYear = 0;
     if (argumentCount > 0) {
         auto value = callFrame->uncheckedArgument(0).toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(value)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainYearMonth year property must be finite"_s);
         isoYear = value;
-        RETURN_IF_EXCEPTION(scope, { });
     }
 
     // Step 4: Let m be ?ToIntegerWithTruncation(isoMonth).
     double isoMonth = 1;
     if (argumentCount > 1) {
         auto value = callFrame->uncheckedArgument(1).toIntegerWithTruncation(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
         if (!std::isfinite(value)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainYearMonth month property must be finite"_s);
         isoMonth = value;
-        RETURN_IF_EXCEPTION(scope, { });
     }
 
     if (argumentCount < 2) [[unlikely]]
@@ -142,10 +142,10 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainYearMonth, (JSGlobalObject* globa
         JSValue refArg = callFrame->uncheckedArgument(3);
         if (!refArg.isUndefined()) {
             auto value = refArg.toIntegerWithTruncation(globalObject);
+            RETURN_IF_EXCEPTION(scope, { });
             if (!std::isfinite(value)) [[unlikely]]
                 return throwVMRangeError(globalObject, scope, "Temporal.PlainYearMonth reference day must be finite"_s);
             referenceDay = value;
-            RETURN_IF_EXCEPTION(scope, { });
         }
     }
 


### PR DESCRIPTION
#### 19e18af9f08841b6921050b6d471dbc13b937977
<pre>
[JSC][Temporal] Fix double-throw crash in Temporal constructors; clean up stress tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=316793">https://bugs.webkit.org/show_bug.cgi?id=316793</a>
<a href="https://rdar.apple.com/179110003">rdar://179110003</a>

Reviewed by Yusuke Suzuki.

toIntegerWithTruncation() can throw (e.g. when an argument&apos;s valueOf
triggers JS execution) and return NaN. PlainDate, PlainYearMonth, and
PlainMonthDay constructors placed RETURN_IF_EXCEPTION after the
!isfinite() guard, so when toIntegerWithTruncation() threw and returned
NaN, the isfinite check triggered throwVMRangeError on top of a pending
exception, crashing via verifyExceptionCheckNeedIsSatisfied. Fix by
moving RETURN_IF_EXCEPTION immediately after each
toIntegerWithTruncation() call.

Also remove stale //@ skip from temporal-calendar.js,
temporal-duration.js, and temporal-timezone.js now that Temporal is
complete, and enable the previously-FIXMEd ZonedDateTime.timeZoneId
and offset tests in temporal-timezone.js.

Test: JSTests/stress/temporal-plainyearmonth-constructor-exception-check.js
Canonical link: <a href="https://commits.webkit.org/314985@main">https://commits.webkit.org/314985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05946151a5b4cfdef771a005beea30a021025fa1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125277 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a7913dc-79ad-4b89-8af1-cc1b15eb2e0b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130399 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9a7c567-530b-42cf-9d40-a97b19ec94b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110916 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e39169ce-8ab3-4d49-b7df-29649db5eadc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31797 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30495 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25386 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179193 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32239 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138796 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138682 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41853 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105013 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33938 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26957 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200273 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113611 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53813 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39754 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5058 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39899 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->