### PR TITLE
REGRESSION(314731@main): [GTK][WPE] New test failures when using js-test.js instead of waitUntilDone

### DIFF
--- a/LayoutTests/fast/events/touch/gesture/gesture-click.html
+++ b/LayoutTests/fast/events/touch/gesture/gesture-click.html
@@ -10,6 +10,7 @@
 <div id="console"></div>
 
 <script>
+window.jsTestIsAsync = true;
 var mouseEventsReceived = 0;
 var expectedEvents = [
   { type: 'mousemove', detail: 0 },
@@ -60,11 +61,14 @@ function runTest() {
 
     if (window.eventSender) {
         description("This tests basic gesture callbacks.");
-        window.jsTestIsAsync = true;
-        // A 'tap' gesture event should generate a sequence of mouse events.
-        eventSender.gestureTap(10, 12);
-        eventSender.leapForward(10);
-        eventSender.keyDown(' ');
+        if (eventSender.gestureTap) {
+            // A 'tap' gesture event should generate a sequence of mouse events.
+            eventSender.gestureTap(10, 12);
+            eventSender.leapForward(10);
+            eventSender.keyDown(' ');
+        } else {
+            endTest();
+        }
     } else {
         debug("This test requires DumpRenderTree.  Tap on the blue rect to log.")
     }

--- a/LayoutTests/fast/events/touch/gesture/gesture-dblclick-expected.txt
+++ b/LayoutTests/fast/events/touch/gesture/gesture-dblclick-expected.txt
@@ -1,4 +1,4 @@
-This tests gesture callbacks for the double tap gesture.
+This tests gesture callbacks for a double tap sequence of gestures.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 

--- a/LayoutTests/fast/events/touch/gesture/gesture-dblclick.html
+++ b/LayoutTests/fast/events/touch/gesture/gesture-dblclick.html
@@ -10,6 +10,7 @@
 <div id="console"></div>
 
 <script>
+window.jsTestIsAsync = true;
 var expectedEvents = [
   {type: 'mousemove', x: 10, y: 12, detail: 0 },
   {type: 'mousedown', x: 10, y: 12, detail: 1 },
@@ -67,12 +68,15 @@ function runTest() {
 
     if (window.eventSender) {
         description("This tests gesture callbacks for a double tap sequence of gestures.");
-        window.jsTestIsAsync = true;
-        eventSender.gestureTap(10, 12);
-        eventSender.leapForward(10);
-        eventSender.gestureTap(11, 12, 2);
-        eventSender.leapForward(50);
-        eventSender.keyDown(' ');
+        if (eventSender.gestureTap) {
+            eventSender.gestureTap(10, 12);
+            eventSender.leapForward(10);
+            eventSender.gestureTap(11, 12, 2);
+            eventSender.leapForward(50);
+            eventSender.keyDown(' ');
+        } else {
+            endTest();
+        }
     } else {
         debug("This test requires DumpRenderTree.")
     }

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4867,6 +4867,7 @@ webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-div-twice-pro
 webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-iframe-editable.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-page-not-propagated.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-page-propagated.html [ Failure ]
+webkit.org/b/278719 fast/events/touch/gesture/touch-gesture-scroll-sideways.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/multi-touch-some-without-handlers.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/ontouchstart-active-selector.html [ Failure ]
 webkit.org/b/278719 fast/events/touch/page-scaled-touch-gesture-click.html [ Timeout ]
@@ -5571,11 +5572,7 @@ webkit.org/b/316428 imported/w3c/web-platform-tests/html/semantics/popovers/popo
 media/media-visible-in-viewport-in-fullscreen.html [ Skip ]
 
 webkit.org/b/316712 fast/forms/validation-message-clone.html [ Failure ]
-webkit.org/b/316712 fast/events/touch/gesture/touch-gesture-scroll-sideways.html [ Failure Timeout ]
-webkit.org/b/316712 fast/events/touch/gesture/gesture-scroll.html [ Failure ]
-webkit.org/b/316712 fast/events/touch/gesture/gesture-dblclick.html [ Failure ]
-webkit.org/b/316712 fast/events/touch/gesture/gesture-click.html [ Failure ]
-webkit.org/b/316712 fast/dom/Window/open-window-min-size.html [ Failure ]
+webkit.org/b/292843 fast/dom/Window/open-window-min-size.html [ Failure ]
 
 webkit.org/b/316718 imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses-multiple-sessions.https.html [ Pass Failure ]
 webkit.org/b/316719 fast/images/alt-text-with-right-to-left-inline-direction-reordering.html [ Pass Crash ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -750,7 +750,6 @@ webkit.org/b/188508 fast/dom/Window/window-postmessage-clone.html [ Timeout ]
 webkit.org/b/188508 fast/dom/Window/window-postmessage-clone-frames.html [ Timeout ]
 
 webkit.org/b/188509 fast/dom/Window/new-window-opener.html [ Failure ]
-# Timeout comes from webkit.org/b/292843 in glib's expectations
 webkit.org/b/188509 fast/dom/Window/timeout-released-on-close.html [ Failure ]
 webkit.org/b/188509 fast/dom/Window/window-onFocus.html [ Failure ]
 webkit.org/b/188509 fast/dom/Window/window-resize.html [ Failure ]


### PR DESCRIPTION
#### b0711e24041921ab10da23e83926b10a61efc0fe
<pre>
REGRESSION(314731@main): [GTK][WPE] New test failures when using js-test.js instead of waitUntilDone
<a href="https://bugs.webkit.org/show_bug.cgi?id=316712">https://bugs.webkit.org/show_bug.cgi?id=316712</a>

Reviewed by Abrar Rahman Protyasha and Carlos Alberto Lopez Perez.

Make similar changes to these two tests, and update expectations to match these and 314869@main.

* LayoutTests/fast/events/touch/gesture/gesture-click.html:
* LayoutTests/fast/events/touch/gesture/gesture-dblclick.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/315221@main">https://commits.webkit.org/315221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b16538a555de904bc15c3470d9e7dbc198d122a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/168452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/42009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/177780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/42385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/171411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/111617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/26476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/180380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/30779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/42021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/139405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/42709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/150851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25651 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/34692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/41213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/40610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/5835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/40861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/40755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->