### PR TITLE
[JSC][Temporal] Fix crash in Temporal.PlainMonthDay.from with very large string input

### DIFF
--- a/JSTests/stress/temporal-plainmonthday-from-large-string.js
+++ b/JSTests/stress/temporal-plainmonthday-from-large-string.js
@@ -1,0 +1,18 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrow(func, errorType) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name} but got ${error}`);
+}
+
+shouldThrow(() => Temporal.PlainMonthDay.from("a".repeat(1 << 20)), RangeError);
+shouldThrow(() => Temporal.PlainMonthDay.from("x".repeat(1 << 16), { overflow: "constrain" }), RangeError);
+
+shouldThrow(() => Temporal.PlainMonthDay.from("not-a-month-day"), RangeError);
+shouldThrow(() => Temporal.PlainMonthDay.from(""), RangeError);

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -196,7 +196,8 @@ static TemporalPlainMonthDay* fromMonthDayString(JSGlobalObject* globalObject, W
     // Step 4: ParseISODateTime(item, {TemporalMonthDayString}).
     auto dateTime = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::MonthDay);
     if (!dateTime || (std::get<2>(dateTime.value()) && std::get<2>(dateTime.value())->m_z)) [[unlikely]] {
-        throwRangeError(globalObject, scope, makeString("Temporal.PlainMonthDay.from: invalid date string "_s, string));
+        String message = tryMakeString("Temporal.PlainMonthDay.from: invalid date string "_s, string);
+        throwRangeError(globalObject, scope, message.isNull() ? "Temporal.PlainMonthDay.from: invalid date string"_s : message);
         return { };
     }
     auto [plainDate, plainTimeOptional, timeZoneOptional, calendarOptional] = WTF::move(*dateTime);
@@ -266,7 +267,8 @@ static TemporalPlainMonthDay* fromMonthDayString(JSGlobalObject* globalObject, W
         }
     }
 
-    throwRangeError(globalObject, scope, makeString("Temporal.PlainMonthDay.from: invalid date string "_s, string));
+    String message = tryMakeString("Temporal.PlainMonthDay.from: invalid date string "_s, string);
+    throwRangeError(globalObject, scope, message.isNull() ? "Temporal.PlainMonthDay.from: invalid date string"_s : message);
     return { };
 }
 


### PR DESCRIPTION
#### 221dcc89aba86cb7846c4113ee7788c6b1ca9857
<pre>
[JSC][Temporal] Fix crash in Temporal.PlainMonthDay.from with very large string input
<a href="https://bugs.webkit.org/show_bug.cgi?id=316805">https://bugs.webkit.org/show_bug.cgi?id=316805</a>
<a href="https://rdar.apple.com/179110736">rdar://179110736</a>

Reviewed by Marcus Plutowski.

fromMonthDayString used makeString to include the user-supplied string
in the RangeError message. makeString calls WTFCrash on allocation
failure, so passing a very large string (e.g. ~2 GB) caused a crash
instead of a clean RangeError.

Fix by using tryMakeString with a static fallback message, matching the
pattern already used in fromYearMonthString.

Test: JSTests/stress/temporal-plainmonthday-from-large-string.js
Canonical link: <a href="https://commits.webkit.org/314986@main">https://commits.webkit.org/314986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e805398a936b70c759831a14d0faad5a2c22bbdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125322 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b268063e-f495-49ed-981d-44f25e93eb2f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130433 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2088762c-55e7-4c75-8678-f0ac284543d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110950 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1ec7b19-9c36-4cb8-857d-ed998cc449f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31835 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30534 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25431 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179238 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32279 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138841 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138726 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41898 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105060 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33982 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27002 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200318 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113648 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53821 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39799 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5103 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40050 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39944 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->