### PR TITLE
StabilityTracer: MobileSafari at Received an invalid message 'WebLockRegistryProxy_ClientIsGoingAway'

### DIFF
--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -340,8 +340,6 @@ void WebFrameProxy::didFailProvisionalLoad()
 void WebFrameProxy::didCommitLoad(const String& contentType, const WebCore::CertificateInfo& certificateInfo, bool containsPluginDocument, DocumentSecurityPolicy&& documentSecurityPolicy, HashSet<WebCore::SecurityOriginData>&& cspOriginsThatUpgradeInsecureNavigations)
 {
     m_frameLoadState.didCommitLoad();
-    if (RefPtr page = m_page)
-        protect(process())->didCommitLoadClientOrigin(ClientOrigin { SecurityOriginData::fromURL(page->mainFrame()->url()), SecurityOriginData::fromURL(m_frameLoadState.url()) });
 
     if (m_isShowingInitialAboutBlank && !url().isAboutBlank())
         m_isShowingInitialAboutBlank = false;
@@ -352,7 +350,14 @@ void WebFrameProxy::didCommitLoad(const String& contentType, const WebCore::Cert
     m_containsPluginDocument = containsPluginDocument;
     m_documentSecurityPolicy = WTF::move(documentSecurityPolicy);
     m_cspOriginsThatUpgradeInsecureNavigations = WTF::move(cspOriginsThatUpgradeInsecureNavigations);
-    updateDocumentSecurityOrigin(nullptr);
+
+    RefPtr creator = parentFrame() ? parentFrame() : opener();
+    updateDocumentSecurityOrigin(creator.get());
+
+    if (RefPtr page = m_page) {
+        RefPtr mainFrame = page->mainFrame();
+        protect(process())->didCommitLoadClientOrigin(ClientOrigin { mainFrame ? mainFrame->documentSecurityOriginData() : SecurityOriginData { }, documentSecurityOriginData() });
+    }
 
     RefPtr webPage = page();
     if (webPage && protect(webPage->preferences())->siteIsolationEnabled())

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm
@@ -29,6 +29,7 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestUIDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/Utilities.h"
 #import <WebKit/WKPreferencesPrivate.h>
@@ -351,6 +352,94 @@ TEST(WebLocks, CrossSiteIframeUsingLocksInServiceWorkerHostingProcess)
     // Detaching the iframe will call WebLockRegistryProxy::clientIsGoingAway.
     __block bool detachDone = false;
     [webView evaluateJavaScript:@"document.getElementById('subframe').remove(); 1" completionHandler:^(id, NSError *error) {
+        EXPECT_NULL(error);
+        detachDone = true;
+    }];
+    TestWebKitAPI::Util::run(&detachDone);
+
+    // Wait long enough for webContentProcessDidTerminate to fire.
+    TestWebKitAPI::Util::runFor(0.1_s);
+    EXPECT_FALSE(webProcessTerminated);
+}
+
+TEST(WebLocks, CrossSiteIframeUsingLocksInsideAboutBlankPopup)
+{
+    TestWebKitAPI::HTTPServer server1({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+    TestWebKitAPI::HTTPServer server2({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto iframeHTML =
+        "<script>"
+        "  navigator.locks.request('iframe-lock', () => new Promise(() => {}));"
+        "</script>"_s;
+
+    // Opener page: opens an about:blank popup (which inherits server1's origin),
+    // then injects a cross-site iframe pointing at server2 into that popup.
+    auto openerHTML = makeString(
+        "<script>"
+        "  function runTest() {"
+        "    const popup = window.open('');"
+        "    window.popupRef = popup;"
+        "    const f = popup.document.createElement('iframe');"
+        "    f.id = 'subframe';"
+        "    f.src = 'http://localhost:"_s, server2.port(), "/iframe';"
+        "    f.onload = () => webkit.messageHandlers.testHandler.postMessage('IFRAME_READY');"
+        "    popup.document.body.appendChild(f);"
+        "  }"
+        "</script>"_s);
+
+    server1.addResponse("/"_s, { openerHTML });
+    server2.addResponse("/iframe"_s, { iframeHTML });
+
+    // No process swap on navigation keeps the popup in the opener's process.
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().processSwapsOnNavigation = NO;
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().processPool = processPool.get();
+    enableWebLocksAPI(configuration.get());
+    configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    __block RetainPtr<TestWKWebView> popupWebView;
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *cfg, WKNavigationAction *, WKWindowFeatures *) {
+        popupWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:cfg]);
+        return popupWebView.get();
+    };
+    [webView setUIDelegate:uiDelegate.get()];
+
+    __block bool done = false;
+    __block bool webProcessTerminated = false;
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webProcessTerminated = true;
+        done = true;
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        if ([message isEqualToString:@"IFRAME_READY"])
+            done = true;
+    }];
+
+    [webView synchronouslyLoadRequest:server1.request()];
+    [webView evaluateJavaScript:@"runTest()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&done);
+
+    // Wait long enough for webContentProcessDidTerminate to fire.
+    TestWebKitAPI::Util::runFor(0.1_s);
+    EXPECT_FALSE(webProcessTerminated);
+
+    // If the WebProcess was terminated by requestLock's MESSAGE_CHECK, we
+    // have already failed and don't need to check clientIsGoingAway.
+    if (webProcessTerminated)
+        return;
+
+    // Detaching the iframe will call WebLockRegistryProxy::clientIsGoingAway.
+    __block bool detachDone = false;
+    [webView evaluateJavaScript:@"window.popupRef.document.getElementById('subframe').remove(); 1" completionHandler:^(id, NSError *error) {
         EXPECT_NULL(error);
         detachDone = true;
     }];


### PR DESCRIPTION
#### 1632df729caed9bbd3e75fe1332f6d2464f49781
<pre>
StabilityTracer: MobileSafari at Received an invalid message &apos;WebLockRegistryProxy_ClientIsGoingAway&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=315738">https://bugs.webkit.org/show_bug.cgi?id=315738</a>
<a href="https://rdar.apple.com/178065152">rdar://178065152</a>

Reviewed by Charlie Wolfe.

The message check added to requestLock() and clientIsGoingAway():
MESSAGE_CHECK(m_process-&gt;hasCommittedClientOrigin(clientOrigin));
may still fail after the fix in <a href="https://rdar.apple.com/177020691">rdar://177020691</a>.

The issue is that the ClientOrigins that the UI process stores in the map
may be different than the ones sent by web process to requestLock().

The ClientOrigins that the web process sends are computed in
WebLockManager::clientOriginFromContext(). In cases where the document&apos;s
topOrigin or securityOrigin is inherited from the parent or owner document,
this function will indeed use the inherited origins.

But the UI process side doesn&apos;t account for inherited security origins.
WebFrameProxy::didCommitLoad() computes the topOrigin and securityOrigin
straight from the URL. So in the case of an about:blank URL, it will
compute an opaque securityOrigin, whereas the web process will find and
send over the inherited securityOrigin.

The new test WebLocks.CrossSiteIframeUsingLocksInsideAboutBlankPopup
demonstrates such a scenario. In this case, there is a main frame hosted
on server1. It creates an about:blank popup and embeds in it an iframe that
is hosted on server2.

The UI process will store the following (topOrigin, securityOrigin):
main frame: { server1, server1 }
popup:      { opaque1, opaque2 }
iframe:     { opaque3, server2 }

The web process accounts for inherited origins and will have:
main frame: { server1, server1 }
popup:      { server1, server1 }
iframe:     { server1, server2 }

So when the iframe sends the requestLock() or clientIsGoingAway() IPCs,
its ClientOrigin isn&apos;t found in the map, and the message check kills the
web process.

We need to replicate the inheritance logic of the web process in the UI process.
This already exists in WebFrameProxy::updateDocumentSecurityOrigin(). So we fix
the issue by ensuring that we pass the creator (parent or opener if there&apos;s no
parent) to this function so that it correctly computes and sets the
documentSecurityOrigin and then using these computed securityOrigins.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didCommitLoad):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebLocks.mm:
(TestWebKitAPI::TEST(WebLocks, CrossSiteIframeUsingLocksInsideAboutBlankPopup)):

Canonical link: <a href="https://commits.webkit.org/314987@main">https://commits.webkit.org/314987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35d9135d87f161178b6aced6b346f0d6cf0b67b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125305 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48e1ebb9-7e80-4a0c-b662-e57779ede212) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130422 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2762b33-2556-418b-9523-b2203452edef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110939 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d26e1c49-ab38-4cca-a29e-600aec3fe166) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31818 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30516 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25414 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179221 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32262 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138825 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138710 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41881 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105041 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25548 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26979 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40385 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113631 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39782 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5080 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->