### PR TITLE
[JSC][Temporal] Cache ICU UCalendar per TimeZoneID in TimeZoneICUBridge

### DIFF
--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -61,7 +61,7 @@ static CString buildICULocale(StringView calendarId)
 
 // buildCalendarTemplate — internal: opens ICU UCalendar for the given CalendarID, set to UTC.
 // NOTE: For Gregory/ISO/Japanese/Buddhist/Roc: sets Gregorian change date to -infinity for proleptic Gregorian arithmetic.
-static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> buildCalendarTemplate(CalendarID calendarId)
+static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> buildCalendarTemplate(const AbstractLocker&, CalendarID calendarId)
 {
     auto str = calendarIDToString(calendarId);
     auto locale = buildICULocale(str);
@@ -85,9 +85,8 @@ static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> buildCalendarTemplate(
 }
 
 struct CalendarCacheEntry {
-    WTF::Lock useLock;
-    std::atomic<bool> initialized { false };
-    UCalendar* cal { nullptr };
+    Lock useLock;
+    std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> cal;
 };
 
 static CalendarCacheEntry& calendarCacheEntry(CalendarID calendarId)
@@ -100,27 +99,16 @@ static CalendarCacheEntry& calendarCacheEntry(CalendarID calendarId)
     return cache.get()[calendarId];
 }
 
-static void ensureCalendar(CalendarCacheEntry& entry, CalendarID calendarId)
-{
-    if (entry.initialized.load(std::memory_order_acquire))
-        return;
-    WTF::Locker locker { entry.useLock };
-    if (!entry.initialized.load(std::memory_order_relaxed)) {
-        auto owned = buildCalendarTemplate(calendarId);
-        entry.cal = owned.release();
-        entry.initialized.store(true, std::memory_order_release);
-    }
-}
-
 template<typename F>
 static auto withCalendar(CalendarID calendarId, F&& fn) -> decltype(fn(static_cast<UCalendar*>(nullptr)))
 {
     CalendarCacheEntry& entry = calendarCacheEntry(calendarId);
-    ensureCalendar(entry, calendarId);
-    WTF::Locker locker { entry.useLock };
+    Locker locker { entry.useLock };
+    if (!entry.cal)
+        entry.cal = buildCalendarTemplate(locker, calendarId);
     if (entry.cal)
-        ucal_clear(entry.cal);
-    return fn(entry.cal);
+        ucal_clear(entry.cal.get());
+    return fn(entry.cal.get());
 }
 
 // lunarCalendarExtendedYearFor1972 — probes UCAL_EXTENDED_YEAR for the given lunisolar calendar
@@ -1307,22 +1295,16 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
-        // Clone for surpassesMonths iteration.
-        UErrorCode cloneStatus = U_ZERO_ERROR;
-        auto trialCalOwned = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_clone(cal, &cloneStatus));
-        if (!trialCalOwned || U_FAILURE(cloneStatus)) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-
         for (;;) {
-            auto surpasses = surpassesMonths(trialCalOwned.get(), calendarId, sign, source.day, target.year, target.monthCode, target.ordinalMonth, target.day);
+            auto surpasses = surpassesMonths(cal, calendarId, sign, source.day, target.year, target.monthCode, target.ordinalMonth, target.day);
             if (!surpasses) [[unlikely]]
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
             if (*surpasses)
                 break;
             months = candidateMonths;
             candidateMonths += sign;
-            // trialCal already advanced by surpassesMonths — no reset needed.
-            // (Resetting to cal's fixed position would cause infinite loop since cal never moves.)
+            // cal already advanced by surpassesMonths — no reset needed here.
+            // ucal_setMillis(cal, startMs) below resets it before applying the final months count.
         }
 
         // Restore cal to (one + years), apply total months in one ucal_add (avoids undo asymmetry).
@@ -1762,33 +1744,30 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
             ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
             ucal_getMillis(cal, &status);
             if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s)); // Use a separate calendar to count months in year.
-            // Clone: need an independent copy to advance months while cal stays at its current date.
-            UErrorCode cloneStatus = U_ZERO_ERROR;
-            auto countCal = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_clone(cal, &cloneStatus));
-            if (U_FAILURE(cloneStatus)) [[unlikely]]
-                return makeUnexpected(rangeError("Failed to open counting calendar"_s));
+                return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s));
+            // Count months in year by walking cal forward, then reset to year start.
             double calMs = ucal_getMillis(cal, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
-            ucal_setMillis(countCal.get(), calMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuSetCalendarFailed));
-            int32_t savedYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
+            int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuReadCalendarFailed));
             int32_t monthsInYear = 1;
             for (int i = 0; i < 14; i++) {
-                ucal_add(countCal.get(), UCAL_MONTH, 1, &status);
+                ucal_add(cal, UCAL_MONTH, 1, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-                int32_t curYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
+                int32_t curYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuReadCalendarFailed));
                 if (curYear != savedYear)
                     break;
                 monthsInYear++;
             }
+            // Reset to year start before advancing to target month.
+            ucal_setMillis(cal, calMs, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuSetCalendarFailed));
 
             // Clamp or reject month against monthsInYear.
             uint8_t resolvedMonth = month;

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -30,26 +30,63 @@
 #include "CalendarICUBridge.h"
 #include "DateConstructor.h"
 #include "IntlObject.h"
+#include "JSCTimeZone.h"
 #include <unicode/ucal.h>
 #include <wtf/DateMath.h>
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/TinyLRUCache.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 namespace JSC {
 namespace TemporalCore {
 
-// openCalendarForTimeZone — internal: opens ICU UCalendar for a named (IANA) timezone
-static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendarForTimeZone(const TimeZone& timeZone)
+class TimeZoneCacheEntry : public ThreadSafeRefCounted<TimeZoneCacheEntry> {
+    WTF_MAKE_TZONE_ALLOCATED(TimeZoneCacheEntry);
+public:
+    Lock useLock;
+    std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> cal;
+};
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TimeZoneCacheEntry);
+
+struct TimeZoneLRUCachePolicy {
+    static bool isKeyNull(const TimeZone&) { return false; }
+    static RefPtr<TimeZoneCacheEntry> createValueForNullKey() { return nullptr; }
+    static RefPtr<TimeZoneCacheEntry> createValueForKey(const TimeZone&) { return adoptRef(*new TimeZoneCacheEntry); }
+    static TimeZone createKeyForStorage(const TimeZone& tz) { return tz; }
+};
+
+static RefPtr<TimeZoneCacheEntry> timeZoneCacheEntry(const TimeZone& timeZone)
+{
+    static Lock cacheLock;
+    static LazyNeverDestroyed<TinyLRUCache<TimeZone, RefPtr<TimeZoneCacheEntry>, 8, TimeZoneLRUCachePolicy>> cache;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        cache.construct();
+    });
+    Locker locker { cacheLock };
+    return cache.get().get(timeZone);
+}
+
+template<typename F>
+static auto withTimeZone(const TimeZone& timeZone, F&& fn) -> decltype(fn(static_cast<UCalendar*>(nullptr)))
 {
     ASSERT(timeZone.isID());
-    String tzStr = timeZone.toICUString();
-    StringView view(tzStr);
-    auto upconverted = view.upconvertedCharacters();
-    UErrorCode status = U_ZERO_ERROR;
-    auto calendar = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(
-        ucal_open(upconverted, view.length(), "", UCAL_DEFAULT, &status));
-    if (U_FAILURE(status)) [[unlikely]]
-        return nullptr;
-    return calendar;
+    auto entry = timeZoneCacheEntry(timeZone);
+    ASSERT(entry);
+    Locker locker { entry->useLock };
+    if (!entry->cal) {
+        String tzStr = timeZone.toICUString();
+        StringView view(tzStr);
+        auto upconverted = view.upconvertedCharacters();
+        UErrorCode status = U_ZERO_ERROR;
+        entry->cal = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_open(upconverted, view.length(), "", UCAL_DEFAULT, &status));
+    }
+    if (entry->cal)
+        ucal_clear(entry->cal.get());
+    return fn(entry->cal.get());
 }
 
 // getOffsetMsAtEpoch — internal: queries ICU for UTC+DST offset in ms at a given epoch
@@ -122,19 +159,16 @@ TemporalResult<int64_t> getOffsetNanosecondsFor(const TimeZone& timeZone, ISO860
 
     // 3. Return GetNamedTimeZoneOffsetNanoseconds(parseResult.[[Name]], epochNs).
     // NOTE: Implemented via ICU4C: UCAL_ZONE_OFFSET + UCAL_DST_OFFSET.
-    // FIXME: openCalendarForTimeZone (ucal_open/ucal_close) is called per getter; a TimeZoneID→UCalendar
-    //        cache on VM would eliminate this overhead for named timezones.
-    auto calendar = openCalendarForTimeZone(timeZone);
-    if (!calendar)
-        return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
-
-    double epochMs = static_cast<double>(exactTime.floorEpochMilliseconds());
-    auto offsetMs = getOffsetMsAtEpoch(calendar.get(), epochMs);
-    if (!offsetMs)
-        return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
-
-    constexpr int64_t nsPerMs = 1'000'000; // nsPerMillisecond
-    return static_cast<int64_t>(*offsetMs) * nsPerMs;
+    return withTimeZone(timeZone, [&](UCalendar* cal) -> TemporalResult<int64_t> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
+        double epochMs = static_cast<double>(exactTime.floorEpochMilliseconds());
+        auto offsetMs = getOffsetMsAtEpoch(cal, epochMs);
+        if (!offsetMs)
+            return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
+        constexpr int64_t nsPerMs = 1'000'000;
+        return static_cast<int64_t>(*offsetMs) * nsPerMs;
+    });
 }
 
 // tryPreLMTFallback — workaround for ICU4C snapping pre-first-transition dates to the wrong year.
@@ -165,136 +199,138 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
     // NOTE: Sub-ms fields are added back after ms-level computation; offset changes occur at ≥second granularity.
     Int128 subMs = static_cast<Int128>(time.microsecond()) * 1000 + static_cast<Int128>(time.nanosecond());
 
-    auto calendar = openCalendarForTimeZone(timeZone);
-    if (!calendar)
-        return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
-
     // Compute the "naive" local epoch — the local datetime treated as UTC, used for gap/fold detection.
     double localMs = isoDateTimeToLocalMs(date, time);
 
-    auto makeExactTime = [&](double epochMs) -> ISO8601::ExactTime {
-        auto base = ISO8601::ExactTime::fromEpochMilliseconds(static_cast<int64_t>(epochMs));
-        return ISO8601::ExactTime(base.epochNanoseconds() + subMs);
-    };
+    return withTimeZone(timeZone, [&](UCalendar* cal) -> TemporalResult<PossibleEpochNanoseconds> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
 
-    // Set ICU calendar to local date+time. ICU months are 0-indexed.
-    // Explicitly set UCAL_MILLISECOND to avoid retaining a stale field (ucal_setDateTime does not set ms).
-    UErrorCode status = U_ZERO_ERROR;
-    ucal_setDateTime(calendar.get(),
-        date.year(), static_cast<int32_t>(date.month()) - 1, date.day(),
-        time.hour(), time.minute(), time.second(),
-        &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
-    ucal_set(calendar.get(), UCAL_MILLISECOND, time.millisecond());
+        auto makeExactTime = [&](double epochMs) -> ISO8601::ExactTime {
+            auto base = ISO8601::ExactTime::fromEpochMilliseconds(static_cast<int64_t>(epochMs));
+            return ISO8601::ExactTime(base.epochNanoseconds() + subMs);
+        };
 
-    // ICU resolves the local time to one epoch (its "default" interpretation).
-    double icuEpochMs = ucal_getMillis(calendar.get(), &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-
-    auto icuOffsetMs = getOffsetMsAtEpoch(calendar.get(), icuEpochMs);
-    if (!icuOffsetMs)
-        return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
-
-    // If icuEpoch + offset ≠ localMs the local time is in a DST gap (spring-forward).
-    bool icuValid = (icuEpochMs + static_cast<double>(*icuOffsetMs) == localMs);
-    if (!icuValid) {
-        if (auto fallbackMs = tryPreLMTFallback(calendar.get(), localMs, icuEpochMs))
-            return PossibleEpochNanoseconds { makeExactTime(*fallbackMs) };
-
-        // Gap: store bracket offsets in GapOffsets so disambiguate needs no extra ICU calls.
-        // afterNs = post-transition offset (= the ICU-resolved offset at the gap).
-        int64_t afterNs = static_cast<int64_t>(*icuOffsetMs) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
-        // beforeNs = pre-transition offset (find via previous transition or 1-day probe fallback).
-        int64_t beforeNs = afterNs;
-        {
-            ucal_setMillis(calendar.get(), icuEpochMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
-
-            UDate transitionMs = 0;
-            auto result = ucal_getTimeZoneTransitionDate(calendar.get(), UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &status);
-            if (U_FAILURE(status)) [[unlikely]]
-                return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
-
-            if (result) {
-                auto preOffset = getOffsetMsAtEpoch(calendar.get(), transitionMs - 1.0);
-                if (preOffset)
-                    beforeNs = static_cast<int64_t>(*preOffset) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
-            }
-            if (beforeNs == afterNs) {
-                constexpr int64_t nsPerDay = 86'400'000'000'000LL; // nsPerDay
-                Int128 naiveNs = static_cast<Int128>(localMs) * ISO8601::ExactTime::nsPerMillisecond + subMs;
-                auto offsetResult = getOffsetNanosecondsFor(timeZone, ISO8601::ExactTime(naiveNs - Int128(nsPerDay)));
-                if (offsetResult)
-                    beforeNs = *offsetResult;
-            }
-        }
-        return PossibleEpochNanoseconds { GapOffsets { beforeNs, afterNs } };
-    }
-
-    auto primaryCandidate = makeExactTime(icuEpochMs);
-
-    // Check for a second candidate (DST fold) via nearest transition boundary.
-    // 25 hours covers all known IANA single-step transitions including 24-hour date-line crossings.
-    const double maxFoldWindowMs = 90'000'000.0; // 25 hours in ms
-    std::optional<ISO8601::ExactTime> secondCandidate;
-
-    auto tryFoldFromTransition = [&](UTimeZoneTransitionType transType) -> bool {
+        // Set ICU calendar to local date+time. ICU months are 0-indexed.
+        // Explicitly set UCAL_MILLISECOND to avoid retaining a stale field (ucal_setDateTime does not set ms).
         UErrorCode status = U_ZERO_ERROR;
-        ucal_setMillis(calendar.get(), icuEpochMs, &status);
+        ucal_setDateTime(cal,
+            date.year(), static_cast<int32_t>(date.month()) - 1, date.day(),
+            time.hour(), time.minute(), time.second(),
+            &status);
         if (U_FAILURE(status)) [[unlikely]]
-            return false;
-        UDate transitionMs = 0;
-        auto result = ucal_getTimeZoneTransitionDate(calendar.get(), transType, &transitionMs, &status);
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+        ucal_set(cal, UCAL_MILLISECOND, time.millisecond());
+
+        // ICU resolves the local time to one epoch (its "default" interpretation).
+        double icuEpochMs = ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
-            return false;
-        if (!result)
-            return false;
-        if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
-            return false;
-        double otherSideMs = (transType == UCAL_TZ_TRANSITION_PREVIOUS)
-            ? transitionMs - 1.0
-            : transitionMs + 1.0;
-        auto otherOffset = getOffsetMsAtEpoch(calendar.get(), otherSideMs);
-        if (!otherOffset || *otherOffset == *icuOffsetMs)
-            return false;
-        double probe = localMs - static_cast<double>(*otherOffset);
-        if (probe == icuEpochMs)
-            return false;
-        auto verifyOffset = getOffsetMsAtEpoch(calendar.get(), probe);
-        if (!verifyOffset || *verifyOffset != *otherOffset)
-            return false;
-        secondCandidate = makeExactTime(probe);
-        return true;
-    };
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
 
-    if (!tryFoldFromTransition(UCAL_TZ_TRANSITION_PREVIOUS))
-        tryFoldFromTransition(UCAL_TZ_TRANSITION_NEXT);
+        auto icuOffsetMs = getOffsetMsAtEpoch(cal, icuEpochMs);
+        if (!icuOffsetMs)
+            return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
 
-    // ICU quirk: retry from 1ms later to catch transition-boundary fold case.
-    if (!secondCandidate) {
-        auto tryFoldFromOffset = [&](double probeEpochMs) -> bool {
+        // If icuEpoch + offset ≠ localMs the local time is in a DST gap (spring-forward).
+        bool icuValid = (icuEpochMs + static_cast<double>(*icuOffsetMs) == localMs);
+        if (!icuValid) {
+            if (auto fallbackMs = tryPreLMTFallback(cal, localMs, icuEpochMs))
+                return PossibleEpochNanoseconds { makeExactTime(*fallbackMs) };
+
+            // Gap: store bracket offsets in GapOffsets so disambiguate needs no extra ICU calls.
+            // afterNs = post-transition offset (= the ICU-resolved offset at the gap).
+            int64_t afterNs = static_cast<int64_t>(*icuOffsetMs) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+            // beforeNs = pre-transition offset (find via previous transition or 1-day probe fallback).
+            int64_t beforeNs = afterNs;
+            {
+                ucal_setMillis(cal, icuEpochMs, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
+
+                UDate transitionMs = 0;
+                auto result = ucal_getTimeZoneTransitionDate(cal, UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
+
+                if (result) {
+                    auto preOffset = getOffsetMsAtEpoch(cal, transitionMs - 1.0);
+                    if (preOffset)
+                        beforeNs = static_cast<int64_t>(*preOffset) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+                }
+                if (beforeNs == afterNs) {
+                    constexpr int64_t nsPerDay = 86'400'000'000'000LL;
+                    Int128 naiveNs = static_cast<Int128>(localMs) * ISO8601::ExactTime::nsPerMillisecond + subMs;
+                    // Inline getOffsetNanosecondsFor — avoids recursive withTimeZone call which would deadlock.
+                    double probeEpochMs = static_cast<double>(static_cast<int64_t>((naiveNs - Int128(nsPerDay)) / static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond)));
+                    auto probeOffset = getOffsetMsAtEpoch(cal, probeEpochMs);
+                    if (probeOffset)
+                        beforeNs = static_cast<int64_t>(*probeOffset) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+                }
+            }
+            return PossibleEpochNanoseconds { GapOffsets { beforeNs, afterNs } };
+        }
+
+        auto primaryCandidate = makeExactTime(icuEpochMs);
+
+        // Check for a second candidate (DST fold) via nearest transition boundary.
+        // 25 hours covers all known IANA single-step transitions including 24-hour date-line crossings.
+        const double maxFoldWindowMs = 90'000'000.0; // 25 hours in ms
+        std::optional<ISO8601::ExactTime> secondCandidate;
+
+        auto tryFoldFromTransition = [&](UTimeZoneTransitionType transType) -> bool {
             UErrorCode status = U_ZERO_ERROR;
-            ucal_setMillis(calendar.get(), probeEpochMs, &status);
+            ucal_setMillis(cal, icuEpochMs, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return false;
             UDate transitionMs = 0;
-            auto result = ucal_getTimeZoneTransitionDate(calendar.get(), UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &status);
+            auto result = ucal_getTimeZoneTransitionDate(cal, transType, &transitionMs, &status);
             if (U_FAILURE(status)) [[unlikely]]
                 return false;
             if (!result)
                 return false;
             if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
                 return false;
-            auto otherOffset = getOffsetMsAtEpoch(calendar.get(), transitionMs - 1.0);
+            double otherSideMs = (transType == UCAL_TZ_TRANSITION_PREVIOUS)
+                ? transitionMs - 1.0
+                : transitionMs + 1.0;
+            auto otherOffset = getOffsetMsAtEpoch(cal, otherSideMs);
             if (!otherOffset || *otherOffset == *icuOffsetMs)
                 return false;
             double probe = localMs - static_cast<double>(*otherOffset);
             if (probe == icuEpochMs)
                 return false;
-            auto verifyOffset = getOffsetMsAtEpoch(calendar.get(), probe);
+            auto verifyOffset = getOffsetMsAtEpoch(cal, probe);
+            if (!verifyOffset || *verifyOffset != *otherOffset)
+                return false;
+            secondCandidate = makeExactTime(probe);
+            return true;
+        };
+
+        if (!tryFoldFromTransition(UCAL_TZ_TRANSITION_PREVIOUS))
+            tryFoldFromTransition(UCAL_TZ_TRANSITION_NEXT);
+
+        // ICU quirk: retry from 1ms later to catch transition-boundary fold case.
+        if (!secondCandidate) {
+            auto tryFoldFromOffset = [&](double probeEpochMs) -> bool {
+                UErrorCode status = U_ZERO_ERROR;
+                ucal_setMillis(cal, probeEpochMs, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return false;
+                UDate transitionMs = 0;
+                auto result = ucal_getTimeZoneTransitionDate(cal, UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &status);
+                if (U_FAILURE(status)) [[unlikely]]
+                    return false;
+                if (!result)
+                    return false;
+                if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
+                    return false;
+            auto otherOffset = getOffsetMsAtEpoch(cal, transitionMs - 1.0);
+            if (!otherOffset || *otherOffset == *icuOffsetMs)
+                return false;
+            double probe = localMs - static_cast<double>(*otherOffset);
+            if (probe == icuEpochMs)
+                return false;
+            auto verifyOffset = getOffsetMsAtEpoch(cal, probe);
             if (!verifyOffset || *verifyOffset != *otherOffset)
                 return false;
             secondCandidate = makeExactTime(probe);
@@ -303,14 +339,15 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
         tryFoldFromOffset(icuEpochMs + 1.0);
     }
 
-    if (!secondCandidate)
-        return PossibleEpochNanoseconds { primaryCandidate };
+        if (!secondCandidate)
+            return PossibleEpochNanoseconds { primaryCandidate };
 
-    ISO8601::ExactTime earlier = primaryCandidate;
-    ISO8601::ExactTime later = *secondCandidate;
-    if (earlier.epochNanoseconds() > later.epochNanoseconds())
-        std::swap(earlier, later);
-    return PossibleEpochNanoseconds { std::array<ISO8601::ExactTime, 2> { earlier, later } };
+        ISO8601::ExactTime earlier = primaryCandidate;
+        ISO8601::ExactTime later = *secondCandidate;
+        if (earlier.epochNanoseconds() > later.epochNanoseconds())
+            std::swap(earlier, later);
+        return PossibleEpochNanoseconds { std::array<ISO8601::ExactTime, 2> { earlier, later } };
+    }); // withTimeZone
 }
 
 // getPossibleEpochNanosecondsFor — temporal_rs: TimeZone::get_possible_epoch_ns_for (src/builtins/core/time_zone.rs)
@@ -358,18 +395,9 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
     if (timeZone.isUTCOffset())
         return std::optional<ISO8601::ExactTime> { std::nullopt };
 
-    // 2. Open ICU calendar for timeZone.
-    auto calendar = openCalendarForTimeZone(timeZone);
-    if (!calendar)
-        return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
-
-    UErrorCode status = U_ZERO_ERROR;
-    // 3. Let epochMs be floor(exactTime) for Next; ceil(exactTime) for Previous (sub-ms epochs round up per spec).
+    // 2. Compute epochMs.
     double epochMs;
     if (direction == TransitionDirection::Previous) {
-        // ceilEpochMs: ceiling of (epochNs / 1e6).
-        // C++ truncates toward zero — that is already the ceiling for negative values.
-        // For positive sub-ms remainder, truncation gave the floor, so add 1.
         Int128 epochNs = exactTime.epochNanoseconds();
         int64_t ms = static_cast<int64_t>(epochNs / static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond));
         if (epochNs % static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond) > 0)
@@ -377,59 +405,50 @@ TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const Ti
         epochMs = static_cast<double>(ms);
     } else
         epochMs = static_cast<double>(exactTime.floorEpochMilliseconds());
-    ucal_setMillis(calendar.get(), epochMs, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuSetCalendarFailed));
 
-    UTimeZoneTransitionType transType = (direction == TransitionDirection::Next) ? UCAL_TZ_TRANSITION_NEXT : UCAL_TZ_TRANSITION_PREVIOUS;
+    return withTimeZone(timeZone, [&](UCalendar* cal) -> TemporalResult<std::optional<ISO8601::ExactTime>> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenTimeZoneFailed));
 
-    // 4. Repeat (up to 20 times to skip rule-only changes):
-    // Skip ICU transitions where the UTC offset doesn't actually change (rule changes that
-    // affect DST notation but not the offset). Spec requires: offset(t) ≠ offset(t-1).
-    for (int safetyLimit = 0; safetyLimit < 20; ++safetyLimit) {
-        //    a. Let transition be the next/previous transition from epochMs in ICU.
-        UDate transitionMs = 0;
-        bool hasTransition = ucal_getTimeZoneTransitionDate(
-            calendar.get(), transType, &transitionMs, &status);
+        UErrorCode status = U_ZERO_ERROR;
+        ucal_setMillis(cal, epochMs, &status);
         if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuTransitionFailed));
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
 
-        //    b. If no transition, return null.
-        if (!hasTransition)
-            return std::optional<ISO8601::ExactTime> { std::nullopt };
+        UTimeZoneTransitionType transType = (direction == TransitionDirection::Next) ? UCAL_TZ_TRANSITION_NEXT : UCAL_TZ_TRANSITION_PREVIOUS;
 
-        auto transition = ISO8601::ExactTime::fromEpochMilliseconds(static_cast<int64_t>(transitionMs));
-        //    c. If transition is out of Temporal's valid range, return null.
-        if (!transition.isValid())
-            return std::optional<ISO8601::ExactTime> { std::nullopt };
+        // 3. Repeat (up to 20 times to skip rule-only changes).
+        for (int safetyLimit = 0; safetyLimit < 20; ++safetyLimit) {
+            UDate transitionMs = 0;
+            bool hasTransition = ucal_getTimeZoneTransitionDate(cal, transType, &transitionMs, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuTransitionFailed));
 
-        //    d. If the UTC offset actually changed at transition (offsetBefore ≠ offsetAfter), return transition.
-        // Check if offset actually changed at this transition.
-        // Compare offset just before and just after the transition.
-        double beforeMs = transitionMs - 1.0;
-        double afterMs = transitionMs;
-        UErrorCode s2 = U_ZERO_ERROR;
-        auto cal2 = openCalendarForTimeZone(timeZone);
-        if (!cal2)
-            return std::optional<ISO8601::ExactTime> { transition }; // fallback
-        ucal_setMillis(cal2.get(), beforeMs, &s2);
-        int32_t offsetBefore = ucal_get(cal2.get(), UCAL_ZONE_OFFSET, &s2) + ucal_get(cal2.get(), UCAL_DST_OFFSET, &s2);
-        ucal_setMillis(cal2.get(), afterMs, &s2);
-        int32_t offsetAfter = ucal_get(cal2.get(), UCAL_ZONE_OFFSET, &s2) + ucal_get(cal2.get(), UCAL_DST_OFFSET, &s2);
-        // NOTE: check s2 before comparing offsets — if any ucal call above failed, both
-        // offsetBefore and offsetAfter would be 0 (equal), silently skipping a real transition.
-        if (U_FAILURE(s2)) [[unlikely]]
-            return std::optional<ISO8601::ExactTime> { transition }; // fallback: treat as real transition
-        if (offsetBefore != offsetAfter)
-            return std::optional<ISO8601::ExactTime> { transition };
+            if (!hasTransition)
+                return std::optional<ISO8601::ExactTime> { std::nullopt };
 
-        //    e. Otherwise, advance past this transition and continue.
-        // Offset didn't change — skip and find the next/previous real transition.
-        ucal_setMillis(calendar.get(), direction == TransitionDirection::Previous ? beforeMs : transitionMs + 1.0, &status);
-        if (U_FAILURE(status)) [[unlikely]]
-            return makeUnexpected(rangeError(icuTransitionFailed));
-    }
-    return std::optional<ISO8601::ExactTime> { std::nullopt }; // no real transition found
+            auto transition = ISO8601::ExactTime::fromEpochMilliseconds(static_cast<int64_t>(transitionMs));
+            if (!transition.isValid())
+                return std::optional<ISO8601::ExactTime> { std::nullopt };
+
+            // Check if offset actually changed at this transition by querying before/after on cal directly.
+            double beforeMs = transitionMs - 1.0;
+            double afterMs = transitionMs;
+            ucal_setMillis(cal, beforeMs, &status);
+            int32_t offsetBefore = ucal_get(cal, UCAL_ZONE_OFFSET, &status) + ucal_get(cal, UCAL_DST_OFFSET, &status);
+            ucal_setMillis(cal, afterMs, &status);
+            int32_t offsetAfter = ucal_get(cal, UCAL_ZONE_OFFSET, &status) + ucal_get(cal, UCAL_DST_OFFSET, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return std::optional<ISO8601::ExactTime> { transition };
+            if (offsetBefore != offsetAfter)
+                return std::optional<ISO8601::ExactTime> { transition };
+
+            ucal_setMillis(cal, direction == TransitionDirection::Previous ? beforeMs : transitionMs + 1.0, &status);
+            if (U_FAILURE(status)) [[unlikely]]
+                return makeUnexpected(rangeError(icuTransitionFailed));
+        }
+        return std::optional<ISO8601::ExactTime> { std::nullopt };
+    }); // withTimeZone
 }
 
 // disambiguatePossibleEpochNanoseconds — temporal_rs: TimeZone::disambiguate_possible_epoch_nanos (src/builtins/core/time_zone.rs)


### PR DESCRIPTION
#### 7830cc6341b519edd8ffa9726c0bebc1715d52da
<pre>
[JSC][Temporal] Cache ICU UCalendar per TimeZoneID in TimeZoneICUBridge
<a href="https://bugs.webkit.org/show_bug.cgi?id=316815">https://bugs.webkit.org/show_bug.cgi?id=316815</a>
<a href="https://rdar.apple.com/179262861">rdar://179262861</a>

Reviewed by Yusuke Suzuki.

TimeZoneICUBridge: Previously every getOffsetNanosecondsFor,
getPossibleEpochNanosecondsFor, and getTimeZoneTransition call opened
and closed a UCalendar via ucal_open/ucal_close per invocation.

This patch caches one UCalendar per IANA timezone in a static per-process
TinyLRUCache&lt;TimeZone, RefPtr&lt;TimeZoneCacheEntry&gt;, 8&gt;. Using TimeZone as
the key avoids cross-thread String ownership issues and uses the
already-resolved canonical ID for comparison. TimeZoneCacheEntry is
ThreadSafeRefCounted so callers hold a RefPtr that keeps the entry alive
even if the LRU evicts it. Each entry owns its UCalendar via
unique_ptr&lt;UCalendar, ICUDeleter&lt;ucal_close&gt;&gt; so it is properly closed
when evicted and destroyed. Initialization is folded into withTimeZone
under the entry lock, no separate atomic flag needed.

getTimeZoneTransition previously cloned the calendar to query before/after
offsets at each transition. Since only ucal_setMillis + ucal_get are used
(no ucal_set field overrides), cal can be reused directly for the queries
and ucal_clone is eliminated.

getNamedTimeZoneEpochNanoseconds previously called getOffsetNanosecondsFor
recursively while holding the entry lock; that call is now inlined using
getOffsetMsAtEpoch to avoid deadlock.

CalendarICUBridge: buildCalendarTemplate now takes const AbstractLocker&amp;
to document that the caller holds the entry lock. CalendarCacheEntry::cal
is now unique_ptr&lt;UCalendar, ICUDeleter&lt;ucal_close&gt;&gt; for proper cleanup.
Initialization is folded into withCalendar under the entry lock. Two
ucal_clone calls are eliminated:
- calendarDateUntil: trialCalOwned clone removed; workCal walks the month
  loop directly since ucal_setMillis(startMs) resets it afterward.
- calendarDateFromFields: countCal clone removed; cal counts months then
  resets via ucal_setMillis(calMs) before advancing to the target month.

Canonical link: <a href="https://commits.webkit.org/315075@main">https://commits.webkit.org/315075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f14313a473ca7316daa736df775928b3380c0f52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125638 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc4dde89-db81-40d7-8277-df71c174e62a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130656 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02debcda-1370-43bf-837a-66297a7f0ea4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111173 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02e1cd0d-4e2a-448a-8a68-210bdb1af85a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32110 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25943 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160563 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179840 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29191 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32592 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139080 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138962 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42202 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105481 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25579 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34250 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27279 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200622 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113958 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53895 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40103 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5379 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->