### PR TITLE
Have VTTRegion use LoggerHelper

### DIFF
--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -63,6 +63,10 @@ VTTRegion::VTTRegion(ScriptExecutionContext& context)
     : ContextDestructionObserver(&context)
     , m_id(emptyString())
     , m_scrollTimer(*this, &VTTRegion::scrollTimerFired)
+#if !RELEASE_LOG_DISABLED
+    , m_logger(&downcast<Document>(context).logger())
+    , m_logIdentifier(uniqueLogIdentifier())
+#endif
 {
 }
 
@@ -203,7 +207,7 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
         if (WebVTTParser::parseFloatPercentageValue(input, floatWidth) && parsedEntireRun(input, valueRun))
             m_width = floatWidth;
         else
-            LOG(Media, "VTTRegion::parseSettingValue, invalid Width");
+            ERROR_LOG(LOGIDENTIFIER, "invalid Width");
         break;
     }
     case Lines: {
@@ -211,7 +215,7 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
         if (input.scanDigits(number) && parsedEntireRun(input, valueRun))
             m_lines = number;
         else
-            LOG(Media, "VTTRegion::parseSettingValue, invalid Lines");
+            ERROR_LOG(LOGIDENTIFIER, "invalid Lines");
         break;
     }
     case RegionAnchor: {
@@ -219,7 +223,7 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
         if (WebVTTParser::parseFloatPercentageValuePair(input, ',', anchor) && parsedEntireRun(input, valueRun))
             m_regionAnchor = anchor;
         else
-            LOG(Media, "VTTRegion::parseSettingValue, invalid RegionAnchor");
+            ERROR_LOG(LOGIDENTIFIER, "invalid RegionAnchor");
         break;
     }
     case ViewportAnchor: {
@@ -227,14 +231,14 @@ void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
         if (WebVTTParser::parseFloatPercentageValuePair(input, ',', anchor) && parsedEntireRun(input, valueRun))
             m_viewportAnchor = anchor;
         else
-            LOG(Media, "VTTRegion::parseSettingValue, invalid ViewportAnchor");
+            ERROR_LOG(LOGIDENTIFIER, "invalid ViewportAnchor");
         break;
     }
     case Scroll:
         if (input.scanRun(valueRun, upKeyword()))
             m_scroll = ScrollSetting::Up;
         else
-            LOG(Media, "VTTRegion::parseSettingValue, invalid Scroll");
+            ERROR_LOG(LOGIDENTIFIER, "invalid Scroll");
         break;
     case None:
         break;
@@ -296,7 +300,7 @@ void VTTRegion::displayLastTextTrackCueBox()
 
 void VTTRegion::willRemoveTextTrackCueBox(VTTCueBox* box)
 {
-    LOG(Media, "VTTRegion::willRemoveTextTrackCueBox");
+    DEBUG_LOG(LOGIDENTIFIER);
     ASSERT(m_cueContainer->contains(box));
 
     double boxHeight = box->boundingClientRect().height();
@@ -380,7 +384,7 @@ void VTTRegion::prepareRegionDisplayTree()
 
 void VTTRegion::startTimer()
 {
-    LOG(Media, "VTTRegion::startTimer");
+    DEBUG_LOG(LOGIDENTIFIER);
 
     if (m_scrollTimer.isActive())
         return;
@@ -391,7 +395,7 @@ void VTTRegion::startTimer()
 
 void VTTRegion::stopTimer()
 {
-    LOG(Media, "VTTRegion::stopTimer");
+    DEBUG_LOG(LOGIDENTIFIER);
 
     if (m_scrollTimer.isActive())
         m_scrollTimer.stop();
@@ -399,7 +403,7 @@ void VTTRegion::stopTimer()
 
 void VTTRegion::scrollTimerFired()
 {
-    LOG(Media, "VTTRegion::scrollTimerFired");
+    DEBUG_LOG(LOGIDENTIFIER);
 
     stopTimer();
     displayLastTextTrackCueBox();
@@ -409,6 +413,28 @@ Document* VTTRegion::document() const
 {
     return downcast<Document>(scriptExecutionContext());
 }
+
+#if !RELEASE_LOG_DISABLED
+ASCIILiteral VTTRegion::logClassName() const
+{
+    return "VTTRegion"_s;
+}
+
+WTFLogChannel& VTTRegion::logChannel() const
+{
+    return LogMedia;
+}
+
+const Logger& VTTRegion::logger() const
+{
+    return *m_logger;
+}
+
+uint64_t VTTRegion::logIdentifier() const
+{
+    return m_logIdentifier;
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -37,6 +37,7 @@
 #include <WebCore/FloatPoint.h>
 #include <WebCore/TextTrack.h>
 #include <WebCore/Timer.h>
+#include <wtf/LoggerHelper.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
@@ -45,7 +46,13 @@ class HTMLDivElement;
 class VTTCueBox;
 class VTTScanner;
 
-class WEBCORE_EXPORT VTTRegion final : public RefCounted<VTTRegion>, public ContextDestructionObserver {
+class WEBCORE_EXPORT VTTRegion final
+    : public RefCounted<VTTRegion>
+    , public ContextDestructionObserver
+#if !RELEASE_LOG_DISABLED
+    , private LoggerHelper
+#endif
+{
 public:
     static Ref<VTTRegion> create(ScriptExecutionContext& context)
     {
@@ -95,6 +102,13 @@ public:
     void willRemoveTextTrackCueBox(VTTCueBox*);
 
     void cueStyleChanged() { m_recalculateStyles = true; }
+
+#if !RELEASE_LOG_DISABLED
+    ASCIILiteral logClassName() const final;
+    const Logger& logger() const final;
+    uint64_t logIdentifier() const final;
+    WTFLogChannel& logChannel() const final;
+#endif
 
 private:
     VTTRegion(ScriptExecutionContext&);
@@ -151,6 +165,11 @@ private:
     Timer m_scrollTimer;
 
     bool m_recalculateStyles { true };
+
+#if !RELEASE_LOG_DISABLED
+    mutable RefPtr<Logger> m_logger;
+    mutable uint64_t m_logIdentifier { 0 };
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### a3cc41643a72dfef45cb1094a950d071f0eb0408
<pre>
Have VTTRegion use LoggerHelper
<a href="https://bugs.webkit.org/show_bug.cgi?id=316817">https://bugs.webkit.org/show_bug.cgi?id=316817</a>
<a href="https://rdar.apple.com/179263975">rdar://179263975</a>

Reviewed by Abrar Rahman Protyasha.

Have VTTRegion use ALWAYS_LOG/ERROR_LOG/DEBUG_LOG, etc. macros.

No new tests. No change in behavior.

* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::VTTRegion):
(WebCore::VTTRegion::parseSettingValue):
(WebCore::VTTRegion::willRemoveTextTrackCueBox):
(WebCore::VTTRegion::startTimer):
(WebCore::VTTRegion::stopTimer):
(WebCore::VTTRegion::scrollTimerFired):
(WebCore::VTTRegion::logClassName const):
(WebCore::VTTRegion::logChannel const):
(WebCore::VTTRegion::logger const):
(WebCore::VTTRegion::logIdentifier const):
* Source/WebCore/html/track/VTTRegion.h:

Canonical link: <a href="https://commits.webkit.org/314952@main">https://commits.webkit.org/314952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c45f05f0d654037002d2458ae536365b196a45c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176706 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02d17715-3c3d-4757-87a6-30f55c5f77ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41159 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b14125f4-1fe4-4f6a-a839-4d1a30796b9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32861 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/110956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07e8356c-6c2d-4be5-b7e1-eb9401913a18) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25439 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179246 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30051 "Found 1 new test failure: fast/webgpu/nocrash/fuzz-298315.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41218 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41906 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105068 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33987 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40410 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39807 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5105 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40058 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39952 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->