### PR TITLE
[RenderElement] Consolidate bitfields and move initializers to the header

### DIFF
--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2005-2026 Samuel Weinig (sam@webkit.org)
- * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2010-2018 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -128,9 +128,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderElement);
 
 struct SameSizeAsRenderElement : public RenderObject {
     SingleThreadPackedWeakPtr<RenderObject> firstChild;
-    unsigned bitfields1 : 12;
     SingleThreadPackedWeakPtr<RenderObject> lastChild;
-    unsigned bitfields2 : 13;
+    unsigned bitfields : 21;
     Style::ComputedStyle style;
 };
 
@@ -144,21 +143,7 @@ static_assert(sizeof(RenderElement) == sizeof(SameSizeAsRenderElement), "RenderE
 inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument, Style::ComputedStyle&& style, OptionSet<TypeFlag> flags, TypeSpecificFlags typeSpecificFlags)
     : RenderObject(type, elementOrDocument, flags, typeSpecificFlags)
     , m_firstChild(nullptr)
-    , m_hasInitializedStyle(false)
-    , m_hasPausedImageAnimations(false)
-    , m_hasCounterNodeMap(false)
-#if HAVE(SUPPORT_HDR_DISPLAY)
-    , m_hasHDRImages(false)
-#endif
-    , m_isFirstLetter(false)
-    , m_renderBlockHasMarginBeforeQuirk(false)
-    , m_renderBlockHasMarginAfterQuirk(false)
-    , m_renderBlockShouldForceRelayoutChildren(false)
-    , m_renderBlockFlowLineLayoutPath(RenderBlockFlow::UndeterminedPath)
     , m_lastChild(nullptr)
-    , m_isRegisteredForVisibleInViewportCallback(false)
-    , m_visibleInViewportState(static_cast<unsigned>(VisibleInViewportState::Unknown))
-    , m_didContributeToVisuallyNonEmptyPixelCount(false)
     , m_style(WTF::move(style))
 {
     ASSERT(RenderObject::isRenderElement());

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2010, 2012 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -454,32 +454,29 @@ private:
     template<typename> Color selectionColor() const;
 
     SingleThreadPackedWeakPtr<RenderObject> m_firstChild;
-    unsigned m_hasInitializedStyle : 1;
+    SingleThreadPackedWeakPtr<RenderObject> m_lastChild;
 
-    unsigned m_hasPausedImageAnimations : 1;
-    unsigned m_hasCounterNodeMap : 1;
+    unsigned m_hasInitializedStyle : 1 { false };
+    unsigned m_hasPausedImageAnimations : 1 { false };
+    unsigned m_hasCounterNodeMap : 1 { false };
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    unsigned m_hasHDRImages : 1;
+    unsigned m_hasHDRImages : 1 { false };
 #endif
-
-    unsigned m_isFirstLetter : 1;
-    unsigned m_renderBlockHasMarginBeforeQuirk : 1;
-    unsigned m_renderBlockHasMarginAfterQuirk : 1;
-    unsigned m_renderBlockShouldForceRelayoutChildren : 1;
+    unsigned m_isFirstLetter : 1 { false };
+    unsigned m_renderBlockHasMarginBeforeQuirk : 1 { false };
+    unsigned m_renderBlockHasMarginAfterQuirk : 1 { false };
+    unsigned m_renderBlockShouldForceRelayoutChildren : 1 { false };
     unsigned m_renderBlockHasRareData : 1 { false };
     unsigned m_renderBoxHasShapeOutsideInfo : 1 { false };
     unsigned m_hasCachedSVGResource : 1 { false };
-    unsigned m_renderBlockFlowLineLayoutPath : 3;
+    unsigned m_renderBlockFlowLineLayoutPath : 3 { 0 }; // RenderBlockFlow::UndeterminedPath
     unsigned m_mayHaveLayerInSubtree : 1 { false };
-
-    SingleThreadPackedWeakPtr<RenderObject> m_lastChild;
-
-    unsigned m_isRegisteredForVisibleInViewportCallback : 1;
-    unsigned m_visibleInViewportState : 2;
-    unsigned m_didContributeToVisuallyNonEmptyPixelCount : 1;
+    unsigned m_isRegisteredForVisibleInViewportCallback : 1 { false };
+    unsigned m_visibleInViewportState : 2 { static_cast<unsigned>(VisibleInViewportState::Unknown) };
+    unsigned m_didContributeToVisuallyNonEmptyPixelCount : 1 { false };
     unsigned m_scrollAnchoringSuppressionStyleChanged : 1 { false };
     unsigned m_isInPendingSVGTransformAttributeUpdates : 1 { false };
-    // 10 bits free.
+    // 11 bits free.
 
     Style::ComputedStyle m_style;
 };


### PR DESCRIPTION
#### 7d811938adae07a25b84d2854ddb30a3a7ba10ce
<pre>
[RenderElement] Consolidate bitfields and move initializers to the header
<a href="https://bugs.webkit.org/show_bug.cgi?id=316822">https://bugs.webkit.org/show_bug.cgi?id=316822</a> <a href="https://rdar.apple.com/179271998">rdar://179271998</a>

Reviewed by Alan Baradlay and Dan Glastonbury.

Give every RenderElement bitfield a default member initializer so defaults live
with the declarations, and drop the redundant initializers from the constructor.

Keep all single-bit flags as `unsigned` (not `bool`) so the bitfields share one
allocation unit, and move m_lastChild up next to m_firstChild so the two packed
pointers are adjacent and all the flags form a single contiguous run. Layout is
unchanged, as the SameSizeAsRenderElement static_assert confirms.

No behavior change.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement): Drop redundant member initializers.
* Source/WebCore/rendering/RenderElement.h: Consolidate bitfields, add default
member initializers, move m_lastChild adjacent to m_firstChild.

Canonical link: <a href="https://commits.webkit.org/316206@main">https://commits.webkit.org/316206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2c052c2b72feebc76285d92646de1f88f37db3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180691 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128840 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5387c61e-c74d-4989-b22e-b6eb7ee642e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133544 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52129da3-3a9d-4e8d-86c0-c7fececd65c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114004 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eccc2eb6-c0ab-4421-9ad0-dfd2395f35dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33574 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29184 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183089 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35884 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141891 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44706 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141700 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38325 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45395 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30224 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110100 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36950 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117291 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43906 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43552 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43441 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->