### PR TITLE
Add API test to check blocked URL's for Parental Controls Content Filtering

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
@@ -37,6 +37,32 @@
 
 using namespace TestWebKitAPI;
 
+TEST(ParentalControlsContentFilteringTests, BlockedURL)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    auto blockedURL = [NSURL URLWithString:@"https://example.com"];
+    __block bool mockInstalled = false;
+    [[webView configuration].websiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:@[blockedURL] completionHandler:^{
+        mockInstalled = true;
+    }];
+    Util::run(&mockInstalled);
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool didFail = false;
+
+    [navigationDelegate setDidFailProvisionalNavigation:^(WKWebView *, WKNavigation *, NSError *error) {
+        EXPECT_WK_STREQ(WebKitErrorDomain, error.domain);
+        EXPECT_EQ(kWKErrorCodeFrameLoadBlockedByContentFilter, error.code);
+        didFail = true;
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com"]]];
+
+    Util::run(&didFail);
+}
+
+
 TEST(ParentalControlsContentFilteringTests, BlockedURLAfterRedirect)
 {
     HTTPServer server({


### PR DESCRIPTION
#### dc3cc6d74576df5ab061933989f6f9846cdca29f
<pre>
Add API test to check blocked URL&apos;s for Parental Controls Content Filtering
<a href="https://bugs.webkit.org/show_bug.cgi?id=316823">https://bugs.webkit.org/show_bug.cgi?id=316823</a>
<a href="https://rdar.apple.com/179272409">rdar://179272409</a>

Reviewed by Per Arne Vollan.

Parental Controls Content Filtering API tests currently only test redirects.
We should check the basic case where a single URL is immediately blocked.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm:
(TEST(ParentalControlsContentFilteringTests, BlockedURL)):

Canonical link: <a href="https://commits.webkit.org/315502@main">https://commits.webkit.org/315502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6d0421968dda39c5ad5358f1d3108a08cc9d959

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125342 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130451 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91690 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dd63555-3759-4543-8488-5c8dfde1c81b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110968 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31854 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30553 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25451 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179258 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138852 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41230 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138737 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41918 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27017 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105088 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33998 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40422 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5118 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39819 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40070 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39964 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->