### PR TITLE
NavigationAPIMethodTracker should manage its own promise settlement

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -93,9 +93,77 @@ NavigationAPIMethodTracker::NavigationAPIMethodTracker(JSC::JSGlobalObject& glob
     , m_finishedPromise(WTF::move(finished))
     , m_identifier(Identifier::generate())
 {
+    // Because rejection is also reported via the navigateerror event, the finished promise
+    // never causes unhandled rejection reporting.
+    m_finishedPromise->markAsHandled();
 }
 
 NavigationAPIMethodTracker::~NavigationAPIMethodTracker() = default;
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#notify-about-the-committed-to-entry
+void NavigationAPIMethodTracker::commitTo(NavigationHistoryEntry& entry, NavigationNavigationType navigationType)
+{
+    // The navigation may have been aborted (settling both promises) before the commit signal arrives,
+    // for example by an intercept handler starting another navigation.
+    if (m_state == State::Settled)
+        return;
+
+    ASSERT(!m_committedToEntry);
+    m_committedToEntry = &entry;
+    if (navigationType != NavigationNavigationType::Traverse && m_serializedState)
+        entry.setState(WTF::move(m_serializedState));
+
+    protect(m_committedPromise)->resolve<IDLInterface<NavigationHistoryEntry>>(entry);
+
+    if (m_state == State::FinishedBeforeCommit) {
+        protect(m_finishedPromise)->resolve<IDLInterface<NavigationHistoryEntry>>(entry);
+        m_state = State::Settled;
+    } else
+        m_state = State::Committed;
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#resolve-the-finished-promise
+void NavigationAPIMethodTracker::resolveFinished()
+{
+    if (m_state == State::Settled)
+        return;
+
+    RefPtr committedToEntry = m_committedToEntry;
+    if (!committedToEntry) {
+        // The committed promise must resolve first; hold the finish signal until commitTo() runs.
+        m_state = State::FinishedBeforeCommit;
+        return;
+    }
+
+    ASSERT(m_state == State::Committed);
+    protect(m_finishedPromise)->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
+    m_state = State::Settled;
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#reject-the-finished-promise
+void NavigationAPIMethodTracker::rejectFinished(const Exception& exception, JSC::JSValue exceptionObject)
+{
+    if (m_state == State::Settled)
+        return;
+
+    // Only reject the committed promise if it hasn't been fulfilled yet. If the navigation was committed
+    // before being aborted, the committed promise stays fulfilled while only the finished promise rejects.
+    if (m_state != State::Committed)
+        protect(m_committedPromise)->reject(exception, RejectAsHandled::No, exceptionObject);
+    protect(m_finishedPromise)->reject(exception, RejectAsHandled::Yes, exceptionObject);
+    m_state = State::Settled;
+}
+
+void NavigationAPIMethodTracker::rejectFinished(JSC::JSValue error)
+{
+    if (m_state == State::Settled)
+        return;
+
+    if (m_state != State::Committed)
+        protect(m_committedPromise)->reject<IDLAny>(error, RejectAsHandled::No);
+    protect(m_finishedPromise)->reject<IDLAny>(error, RejectAsHandled::Yes);
+    m_state = State::Settled;
+}
 
 Navigation::Navigation(LocalDOMWindow& window)
     : LocalDOMWindowProperty(&window)
@@ -354,8 +422,6 @@ RefPtr<NavigationAPIMethodTracker> Navigation::maybeSetUpcomingNonTraversalTrack
 {
     RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), WTF::move(serializedState));
 
-    apiMethodTracker->finishedPromise().markAsHandled();
-
     // FIXME: We should be able to assert m_upcomingNonTraverseMethodTracker is empty.
     if (!hasEntriesAndEventsDisabled()) {
         Locker locker { m_apiMethodTrackersLock };
@@ -370,8 +436,6 @@ RefPtr<NavigationAPIMethodTracker> Navigation::addUpcomingTraverseAPIMethodTrack
 {
     RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), nullptr);
     apiMethodTracker->setKey(key);
-
-    apiMethodTracker->finishedPromise().markAsHandled();
 
     {
         Locker locker { m_apiMethodTrackersLock };
@@ -453,13 +517,15 @@ Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const
     frame()->loader().loadFrameRequest(WTF::move(request), nullptr, { });
 
     // If the load() call never made it to the point that NavigateEvent was emitted, thus promoteUpcomingAPIMethodTracker() called, this will be true.
-    {
+    bool loadWasAborted = [&] {
         Locker locker { m_apiMethodTrackersLock };
-        if (m_upcomingNonTraverseMethodTracker == apiMethodTracker) {
-            m_upcomingNonTraverseMethodTracker = nullptr;
-            return createErrorResult(protect(apiMethodTracker->committedPromise()), protect(apiMethodTracker->finishedPromise()), ExceptionCode::AbortError, "Navigation aborted"_s);
-        }
-    }
+        if (m_upcomingNonTraverseMethodTracker != apiMethodTracker)
+            return false;
+        m_upcomingNonTraverseMethodTracker = nullptr;
+        return true;
+    }();
+    if (loadWasAborted)
+        rejectFinishedPromise(apiMethodTracker.get());
 
     return apiMethodTrackerDerivedResult(*apiMethodTracker);
 }
@@ -494,9 +560,16 @@ Navigation::Result Navigation::performTraversal(JSC::JSGlobalObject& globalObjec
     RefPtr apiMethodTracker = addUpcomingTraverseAPIMethodTracker(globalObject, WTF::move(committed), WTF::move(finished), key, options.info);
 
     // FIXME: 11. Let sourceSnapshotParams be the result of snapshotting source snapshot params given document.
-    protect(frame->navigationScheduler())->scheduleHistoryNavigationByKey(key, [apiMethodTracker] (ScheduleHistoryNavigationResult result) {
-        if (result == ScheduleHistoryNavigationResult::Aborted)
-            createErrorResult(protect(apiMethodTracker->committedPromise()), protect(apiMethodTracker->finishedPromise()), ExceptionCode::AbortError, "Navigation aborted"_s);
+    protect(frame->navigationScheduler())->scheduleHistoryNavigationByKey(key, [weakThis = WeakPtr { this }, apiMethodTracker] (ScheduleHistoryNavigationResult result) {
+        if (result != ScheduleHistoryNavigationResult::Aborted)
+            return;
+
+        // Going through rejectFinishedPromise also removes the tracker from m_upcomingTraverseMethodTrackers;
+        // otherwise a later traversal to the same key would be deduplicated against the settled promises.
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->rejectFinishedPromise(apiMethodTracker.get());
+        else
+            apiMethodTracker->rejectFinished(Exception { ExceptionCode::AbortError, "Navigation aborted"_s }, JSC::JSValue { });
     });
 
     return apiMethodTrackerDerivedResult(*apiMethodTracker);
@@ -598,15 +671,9 @@ bool Navigation::hasEntriesAndEventsDisabled() const
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#resolve-the-finished-promise
 void Navigation::resolveFinishedPromise(NavigationAPIMethodTracker* apiMethodTracker)
 {
-    RefPtr committedToEntry = apiMethodTracker->committedToEntry();
-    if (!committedToEntry) {
-        apiMethodTracker->setFinishedBeforeCommit(true);
-        return;
-    }
-
-    protect(apiMethodTracker->committedPromise())->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
-    protect(apiMethodTracker->finishedPromise())->resolve<IDLInterface<NavigationHistoryEntry>>(*committedToEntry);
-    cleanupAPIMethodTracker(apiMethodTracker);
+    apiMethodTracker->resolveFinished();
+    if (apiMethodTracker->isSettled())
+        cleanupAPIMethodTracker(apiMethodTracker);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#reject-the-finished-promise
@@ -614,11 +681,7 @@ void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTrac
 {
     RELEASE_LOG(Navigation, "rejectFinishedPromise: rejecting promises for tracker=%p with exception='%s'", apiMethodTracker, exception.message().utf8().data());
 
-    // Only reject committed promise if it hasn't been fulfilled yet (committedToEntry is null). If the navigation was "committed" (state updated)
-    // before being aborted, the committed promise should remain fulfilled while only the finished promise gets rejected.
-    if (!apiMethodTracker->committedToEntry())
-        protect(apiMethodTracker->committedPromise())->reject(exception, RejectAsHandled::No, exceptionObject);
-    protect(apiMethodTracker->finishedPromise())->reject(exception, RejectAsHandled::Yes, exceptionObject);
+    apiMethodTracker->rejectFinished(exception, exceptionObject);
     cleanupAPIMethodTracker(apiMethodTracker);
 }
 
@@ -627,8 +690,9 @@ void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTrac
     if (!apiMethodTracker)
         return;
 
-    auto* globalObject = protect(scriptExecutionContext())->globalObject();
-    if (!globalObject && apiMethodTracker)
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
+    auto* globalObject = scriptExecutionContext ? scriptExecutionContext->globalObject() : nullptr;
+    if (!globalObject)
         globalObject = apiMethodTracker->committedPromise().globalObject();
     if (!globalObject)
         return;
@@ -643,16 +707,12 @@ void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTrac
 void Navigation::notifyCommittedToEntry(NavigationAPIMethodTracker* apiMethodTracker, NavigationHistoryEntry* entry, NavigationNavigationType navigationType)
 {
     ASSERT(entry);
-    apiMethodTracker->setCommittedToEntry(entry);
-    if (navigationType != NavigationNavigationType::Traverse) {
-        if (apiMethodTracker->serializedState())
-            protect(apiMethodTracker->committedToEntry())->setState(apiMethodTracker->takeSerializedState());
-    }
+    if (!entry)
+        return;
 
-    if (apiMethodTracker->finishedBeforeCommit())
-        resolveFinishedPromise(apiMethodTracker);
-    else
-        protect(apiMethodTracker->committedPromise())->resolve<IDLInterface<NavigationHistoryEntry>>(*entry);
+    apiMethodTracker->commitTo(*entry, navigationType);
+    if (apiMethodTracker->isSettled())
+        cleanupAPIMethodTracker(apiMethodTracker);
 }
 
 void Navigation::updateNavigationEntry(Ref<HistoryItem>&& item, ShouldCopyStateObjectFromCurrentEntry shouldCopyStateObjectFromCurrentEntry)
@@ -1121,7 +1181,7 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
 
     // For intercepted traverse navigations, notify committed after handlers have been invoked but before
     // they complete. This ensures the correct event ordering.
-    if (navigationType == NavigationNavigationType::Traverse && event.wasIntercepted() && apiMethodTracker && !apiMethodTracker->committedToEntry())
+    if (navigationType == NavigationNavigationType::Traverse && event.wasIntercepted() && apiMethodTracker && !apiMethodTracker->hasCommitted())
         notifyCommittedToEntry(apiMethodTracker, protect(currentEntry()).get(), navigationType);
 
     if (!event.wasIntercepted() && !apiMethodTracker) {
@@ -1183,8 +1243,8 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
                 protectedThis->dispatchEvent(ErrorEvent::create(*navGlobalObject, eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { navGlobalObject->vm(), result }));
 
                 if (apiMethodTracker) {
-                    protect(apiMethodTracker->finishedPromise())->reject<IDLAny>(result, RejectAsHandled::Yes);
-                    protectedThis->cleanupAPIMethodTracker(apiMethodTracker);
+                    apiMethodTracker->rejectFinished(result);
+                    protectedThis->cleanupAPIMethodTracker(apiMethodTracker.get());
                 }
 
                 if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
@@ -1224,10 +1284,10 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
     promoteUpcomingAPIMethodTracker(destination->key());
 
-    RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
+    RefPtr<NavigationAPIMethodTracker> apiMethodTracker;
     {
         Locker locker { m_apiMethodTrackersLock };
-        ongoingAPIMethodTracker = m_ongoingAPIMethodTracker;
+        apiMethodTracker = m_ongoingAPIMethodTracker;
     }
 
     // Enforce rate limiting to prevent excessive navigation requests.
@@ -1239,24 +1299,14 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
                 document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "Excessive navigation attempts blocked."_s);
         }
 
-        if (ongoingAPIMethodTracker) {
-            // Reject the promises and clean up.
-            auto exception = Exception { ExceptionCode::QuotaExceededError, "Navigation rate limit exceeded"_s };
-            protect(ongoingAPIMethodTracker->committedPromise())->reject(exception);
-            protect(ongoingAPIMethodTracker->finishedPromise())->reject(exception);
-            cleanupAPIMethodTracker(ongoingAPIMethodTracker.get());
-        }
+        if (apiMethodTracker)
+            rejectFinishedPromise(apiMethodTracker.get(), Exception { ExceptionCode::QuotaExceededError, "Navigation rate limit exceeded"_s }, JSC::JSValue { });
 
         return DispatchResult::Aborted;
     }
 
     RefPtr document = window()->document();
 
-    RefPtr<NavigationAPIMethodTracker> apiMethodTracker;
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        apiMethodTracker = m_ongoingAPIMethodTracker;
-    }
     // FIXME: this should not be needed, we should pass it into FrameLoader.
     if (apiMethodTracker && apiMethodTracker->serializedState())
         destination->setStateObject(protect(apiMethodTracker->serializedState()));

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -66,16 +66,21 @@ public:
     void setKey(const String& key) { m_key = key; }
     JSValueInWrappedObject& info() { return m_info; }
     SerializedScriptValue* serializedState() const { return m_serializedState.get(); }
-    void setSerializedState(RefPtr<SerializedScriptValue>&& state) { m_serializedState = WTF::move(state); }
-    RefPtr<SerializedScriptValue> takeSerializedState() { return WTF::move(m_serializedState); }
-    NavigationHistoryEntry* committedToEntry() const { return m_committedToEntry.get(); }
-    void setCommittedToEntry(NavigationHistoryEntry* entry) { m_committedToEntry = entry; }
     DeferredPromise& committedPromise() { return m_committedPromise; }
     const DeferredPromise& committedPromise() const { return m_committedPromise; }
     DeferredPromise& finishedPromise() { return m_finishedPromise; }
     const DeferredPromise& finishedPromise() const { return m_finishedPromise; }
-    bool finishedBeforeCommit() const { return m_finishedBeforeCommit; }
-    void setFinishedBeforeCommit(bool value) { m_finishedBeforeCommit = value; }
+
+    bool hasCommitted() const { return !!m_committedToEntry; }
+    bool isSettled() const { return m_state == State::Settled; }
+
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#notify-about-the-committed-to-entry
+    void commitTo(NavigationHistoryEntry&, NavigationNavigationType);
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#resolve-the-finished-promise
+    void resolveFinished();
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#reject-the-finished-promise
+    void rejectFinished(const Exception&, JSC::JSValue exceptionObject);
+    void rejectFinished(JSC::JSValue error);
 
 private:
     NavigationAPIMethodTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue&& info, RefPtr<SerializedScriptValue>&& serializedState);
@@ -83,7 +88,15 @@ private:
     enum class IdentifierType { };
     using Identifier = ObjectIdentifier<IdentifierType>;
 
-    bool m_finishedBeforeCommit { false };
+    // The commit and finish signals can arrive in either order; each promise settles exactly once.
+    enum class State : uint8_t {
+        Pending,
+        FinishedBeforeCommit,
+        Committed,
+        Settled,
+    };
+
+    State m_state { State::Pending };
     String m_key;
     JSValueInWrappedObject m_info;
     RefPtr<SerializedScriptValue> m_serializedState;


### PR DESCRIPTION
#### fa68546060593a1cffebe2dbc2dec3d5edc20eeb
<pre>
NavigationAPIMethodTracker should manage its own promise settlement
<a href="https://bugs.webkit.org/show_bug.cgi?id=316812">https://bugs.webkit.org/show_bug.cgi?id=316812</a>
<a href="https://rdar.apple.com/179261686">rdar://179261686</a>

Reviewed by Anne van Kesteren.

NavigationAPIMethodTracker exposed all of its state through getters and
setters, and the spec algorithms that operate on it (&quot;notify about the
committed-to entry&quot;, &quot;resolve/reject the finished promise&quot;) lived in
Navigation, probing committedToEntry() and a finishedBeforeCommit flag
from the outside. Several call sites also settled the tracker&apos;s promises
by hand, each with a slightly different recipe (the rate limiter path,
the navigate() path for loads that never reach the navigate event, the
intercept-handler failure path, and the traversal cancellation callback).

Move those algorithms into the tracker as commitTo(), resolveFinished()
and rejectFinished(), driven by an internal state enum (Pending /
FinishedBeforeCommit / Committed / Settled) that replaces the
finishedBeforeCommit bool. The tracker now guarantees its own invariants:
each promise settles at most once, a finish signal that arrives before
commit is held until commitTo() runs, and an uncommitted navigation
rejects both promises while a committed one only rejects the finished
promise. This also removes the redundant re-resolution of the committed
promise that resolveFinishedPromise used to perform, which relied on
DeferredPromise ignoring a second resolve.

Navigation&apos;s notifyCommittedToEntry / resolveFinishedPromise /
rejectFinishedPromise become thin wrappers that delegate to the tracker
and handle tracker cleanup, and all remaining settlement paths are
routed through them.

One behavior fix: when NavigationScheduler cancelled a scheduled key
traversal, the completion callback rejected the tracker&apos;s promises but
never removed the tracker from m_upcomingTraverseMethodTrackers. A later
traverseTo(), back() or forward() to the same key would then be
deduplicated against the stale tracker and receive the already-rejected
promises instead of starting a new traversal. The callback now goes
through rejectFinishedPromise, which also cleans up the upcoming map.

This is preparation for implementing NavigationInterceptOptions&apos;
precommitHandler, which adds another commit-timing state and would
otherwise have to thread more flags through Navigation.

No new tests. Covered by existing imported/w3c/web-platform-tests/
navigation-api tests, which pass in both release and debug.

* Source/WebCore/page/Navigation.h:
(WebCore::NavigationAPIMethodTracker::hasCommitted const):
(WebCore::NavigationAPIMethodTracker::isSettled const):
(WebCore::NavigationAPIMethodTracker::committedToEntry const): Deleted.
(WebCore::NavigationAPIMethodTracker::setCommittedToEntry): Deleted.
(WebCore::NavigationAPIMethodTracker::finishedBeforeCommit const): Deleted.
(WebCore::NavigationAPIMethodTracker::setFinishedBeforeCommit): Deleted.
(WebCore::NavigationAPIMethodTracker::setSerializedState): Deleted.
(WebCore::NavigationAPIMethodTracker::takeSerializedState): Deleted.
* Source/WebCore/page/Navigation.cpp:
(WebCore::NavigationAPIMethodTracker::NavigationAPIMethodTracker):
(WebCore::NavigationAPIMethodTracker::commitTo):
(WebCore::NavigationAPIMethodTracker::resolveFinished):
(WebCore::NavigationAPIMethodTracker::rejectFinished):
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker):
(WebCore::Navigation::addUpcomingTraverseAPIMethodTracker):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::notifyCommittedToEntry):
(WebCore::Navigation::resolveFinishedPromise):
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::handleSameDocumentNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/314979@main">https://commits.webkit.org/314979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e2199b4c554e3445db7a0153a7217721146b54f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34834 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176799 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0e8b8ad-26bc-438e-b42f-9a308de38c9d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41252 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/176799 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f41a39c-3e29-467d-a0a4-08eb0949dd9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170701 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/176799 "") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/802cddce-dcd4-4dbc-8ccb-09f07f6471f3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25532 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179341 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30136 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41311 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37368 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41999 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105183 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34071 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40503 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39900 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/5192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->