### PR TITLE
WebProcessProxy::waitForSharedPreferencesForWebProcessToSync ignores the requested version for the GPU process

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2603,7 +2603,10 @@ void WebProcessProxy::waitForSharedPreferencesForWebProcessToSync(uint64_t share
     ASSERT(!m_awaitedSharedPreferencesVersion);
     if (m_sharedPreferencesVersionInNetworkProcess >= sharedPreferencesVersion
 #if ENABLE(GPU_PROCESS)
-        || m_sharedPreferencesVersionInGPUProcess >= m_awaitedSharedPreferencesVersion
+        && m_sharedPreferencesVersionInGPUProcess >= sharedPreferencesVersion
+#endif
+#if ENABLE(MODEL_PROCESS)
+        && m_sharedPreferencesVersionInModelProcess >= sharedPreferencesVersion
 #endif
         )
         return completionHandler(true);


### PR DESCRIPTION
#### ee450e8742d8d330f540faba7e3e172032079ee5
<pre>
WebProcessProxy::waitForSharedPreferencesForWebProcessToSync ignores the requested version for the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=316826">https://bugs.webkit.org/show_bug.cgi?id=316826</a>
<a href="https://rdar.apple.com/179274782">rdar://179274782</a>

Reviewed by Rupin Mittal.

The early-out had two bugs. The GPU clause compared against m_awaitedSharedPreferencesVersion, which
is still 0 here, so it was always true; compare against the sharedPreferencesVersion parameter
instead. And the clauses were combined with || and omitted the Model process, so it could complete
after a single process caught up; use &amp;&amp; and add the Model clause so it fires only once every
process has synced.

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::waitForSharedPreferencesForWebProcessToSync):

Canonical link: <a href="https://commits.webkit.org/315720@main">https://commits.webkit.org/315720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd88090c5fdcc166a165791d2882fc3695c9877d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126928 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bb99dd4-7455-42b7-ad3c-b2b48a063a71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42764 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132326 "Found 3 new test failures: http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-but-access-from-wrong-frame.https.html http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92745 "8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d926d45f-f155-473a-a1e2-19527c5b9f8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112300 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94172819-1c72-436a-8eee-33948e5ca2f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33592 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31939 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27272 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143582 "Found 1 new API test failure: TestWebKitAPI.SafeBrowsing.PhishingInFrame (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181172 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36108 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140776 "Found 3 new test failures: http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-but-access-from-wrong-frame.https.html http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42794 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140090 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43483 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28452 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107403 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35359 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115248 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41993 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6540 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41386 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41641 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41529 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->