### PR TITLE
[JSC] Reland global liveness MovHint removal

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp
@@ -28,8 +28,7 @@
 
 #if ENABLE(DFG_JIT)
 
-#include "DFGEpoch.h"
-#include "DFGForAllKills.h"
+#include "DFGBlockMapInlines.h"
 #include "DFGGraph.h"
 #include "DFGInsertionSet.h"
 #include "DFGMayExit.h"
@@ -50,7 +49,6 @@ public:
     MovHintRemovalPhase(Graph& graph)
         : Phase(graph, "MovHint removal"_s)
         , m_insertionSet(graph)
-        , m_state(OperandsLike, graph.block(0)->variablesAtHead)
         , m_changed(false)
     {
     }
@@ -59,8 +57,70 @@ public:
     {
         dataLogIf(DFGMovHintRemovalPhaseInternal::verbose, "Graph before MovHint removal:\n", m_graph);
 
+        // First figure out where various locals are live across the whole
+        // graph. This is a backward "bytecode liveness restricted to OSR exit
+        // sites" analysis:
+        //   Use:  any node which may exit. The locals that are live in
+        //         bytecode at the node's exit origin are use-d here. For
+        //         exception-only exits we use the matching catch handler's
+        //         origin.
+        //         Additionally, the bytecode-live set at every block's
+        //         terminal is treated as a use even when the terminal
+        //         itself doesn't exit. MovHints anchor phantom allocations
+        //         to bytecode locals in the OSR availability map; the
+        //         availability map is used by FTL's exit emission and
+        //         ObjectAllocationSinking, both walk from bytecode-live locals
+        //         through the heap closure to pick up heap promotions for sunk
+        //         allocations. If we kill a MovHint that anchors a phantom to
+        //         a bytecode-live local just because the next FTL-exit-OK node
+        //         has it bytecode-dead, the closure can no longer reach the
+        //         phantom, and the heap promotion (e.g. StructurePLoc) is
+        //         pruned at the use site.
+        //   Def:  MovHint kills its destination local.
+        BlockMap<Operands<bool>> liveAtHead(m_graph);
+        BlockMap<Operands<bool>> liveAtTail(m_graph);
+
+        for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
+            liveAtHead[block] = Operands<bool>(OperandsLike, block->variablesAtHead, false);
+            liveAtTail[block] = Operands<bool>(OperandsLike, block->variablesAtHead, false);
+        }
+
+        bool changed;
+        do {
+            changed = false;
+            for (BlockIndex blockIndex = m_graph.numBlocks(); blockIndex--;) {
+                BasicBlock* block = m_graph.block(blockIndex);
+                if (!block)
+                    continue;
+
+                Operands<bool> live = liveAtTail[block];
+                m_graph.forAllLiveInBytecode(
+                    block->terminal()->origin.forExit,
+                    [&](Operand operand) {
+                        live.operand(operand) = true;
+                    });
+                for (unsigned nodeIndex = block->size(); nodeIndex--;) {
+                    Node* node = block->at(nodeIndex);
+                    if (node->op() == MovHint)
+                        live.operand(node->unlinkedOperand()) = false;
+                    defineLiveOperands(node, live);
+                }
+
+                if (live == liveAtHead[block])
+                    continue;
+
+                liveAtHead[block] = live;
+                changed = true;
+
+                for (BasicBlock* predecessor : block->predecessors) {
+                    for (size_t i = live.size(); i--;)
+                        liveAtTail[predecessor][i] |= live[i];
+                }
+            }
+        } while (changed);
+
         for (BasicBlock* block : m_graph.blocksInNaturalOrder())
-            handleBlock(block);
+            handleBlock(block, liveAtTail[block]);
 
         m_insertionSet.execute(m_graph.block(0));
 
@@ -68,80 +128,62 @@ public:
     }
 
 private:
-    void handleBlock(BasicBlock* block)
+    void defineLiveOperands(Node* node, Operands<bool>& live)
+    {
+        switch (mayExit(m_graph, node)) {
+        case DoesNotExit:
+            return;
+
+        case Exits: {
+            m_graph.forAllLiveInBytecode(
+                node->origin.forExit,
+                [&](Operand operand) {
+                    live.operand(operand) = true;
+                });
+            return;
+        }
+
+        case ExitsForExceptions: {
+            // Exception-only exits divert to the matching catch handler;
+            // the locals that need to remain available are those the
+            // handler will read, not those at the throwing site's exit
+            // origin. If there's no handler in this machine frame, the
+            // exception unwinds out and no local needs to stay alive on
+            // this exit edge.
+            CodeOrigin catchOrigin;
+            HandlerInfo* handler = nullptr;
+            if (m_graph.willCatchExceptionInMachineFrame(node->origin.forExit, catchOrigin, handler)) {
+                m_graph.forAllLiveInBytecode(
+                    catchOrigin,
+                    [&](Operand operand) {
+                        live.operand(operand) = true;
+                    });
+            }
+            return;
+        }
+        }
+    }
+
+    void handleBlock(BasicBlock* block, const Operands<bool>& liveAtTail)
     {
         dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "Handing block ", pointerDump(block));
 
-        // A MovHint is unnecessary if the local dies before it is used. We answer this question by
-        // maintaining the current exit epoch, and associating an epoch with each local. When a
-        // local dies, it gets the current exit epoch. If a MovHint occurs in the same epoch as its
-        // local, then it means there was no exit between the local's death and the MovHint - i.e.
-        // the MovHint is unnecessary.
+        Operands<bool> live = liveAtTail;
+        m_graph.forAllLiveInBytecode(
+            block->terminal()->origin.forExit,
+            [&](Operand operand) {
+                live.operand(operand) = true;
+            });
 
-        Epoch currentEpoch = Epoch::first();
-
-        m_state.fill(Epoch());
-
-        // This is a heuristic. We found cases that BB ends with Jump, and successor no longer have liveness for locals.
-        // However, at the end of the current BB, it is alive and we failed to kill that MovHint while we do not have exits.
-        // This is a work-around for that case, we chase only one successor and collect a bit more precise liveness information.
-        if (block->terminal()->isJump()) {
-            auto* successor = block->successor(0);
-
-            m_graph.forAllLiveInBytecode(
-                successor->terminal()->origin.forExit,
-                [&] (Operand reg) {
-                    m_state.operand(reg) = currentEpoch;
-                });
-
-            // Assume that blocks after we exit.
-            currentEpoch.bump();
-
-            for (unsigned nodeIndex = successor->size(); nodeIndex--;) {
-                Node* node = successor->at(nodeIndex);
-
-                if (node->op() == MovHint)
-                    m_state.operand(node->unlinkedOperand()) = Epoch();
-
-                if (mayExit(m_graph, node) != DoesNotExit)
-                    currentEpoch.bump();
-
-                Node* before = block->terminal();
-                if (nodeIndex)
-                    before = successor->at(nodeIndex - 1);
-
-                forAllKilledOperands(
-                    m_graph, before, node,
-                    [&] (Operand operand) {
-                        // This function is a bit sloppy - it might claim to kill a local even if
-                        // it's still live after. We need to protect against that.
-                        if (!!m_state.operand(operand))
-                            return;
-
-                        dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    Killed operand at ", node, ": ", operand);
-                        m_state.operand(operand) = currentEpoch;
-                    });
-            }
-        } else {
-            m_graph.forAllLiveInBytecode(
-                block->terminal()->origin.forExit,
-                [&] (Operand reg) {
-                    m_state.operand(reg) = currentEpoch;
-                });
-
-            // Assume that blocks after we exit.
-            currentEpoch.bump();
-        }
-
-        dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    Locals at ", block->terminal()->origin.forExit, ": ", m_state);
+        dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    Locals at ", block->terminal()->origin.forExit, ": ", live);
 
         for (unsigned nodeIndex = block->size(); nodeIndex--;) {
             Node* node = block->at(nodeIndex);
 
             if (node->op() == MovHint) {
-                Epoch localEpoch = m_state.operand(node->unlinkedOperand());
-                dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    At ", node, " (", node->unlinkedOperand(), "): current = ", currentEpoch, ", local = ", localEpoch);
-                if (!localEpoch || localEpoch == currentEpoch) {
+                bool isAlive = live.operand(node->unlinkedOperand());
+                dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    At ", node, " (", node->unlinkedOperand(), "): live: ", isAlive);
+                if (!isAlive) {
                     // Now, MovHint will put bottom value to dead locals. This means that if you insert a new DFG node which introduce
                     // a new OSR exit, then it gets confused with the already-determined-dead locals. So this phase runs at very end of
                     // DFG pipeline, and we do not insert a node having a new OSR exit (if it is existing OSR exit, or if it does not exit,
@@ -154,31 +196,14 @@ private:
                     node->child1() = Edge(constant, useKind);
                     m_changed = true;
                 }
-                m_state.operand(node->unlinkedOperand()) = Epoch();
+                live.operand(node->unlinkedOperand()) = false;
             }
-
-            if (mayExit(m_graph, node) != DoesNotExit)
-                currentEpoch.bump();
-
-            if (nodeIndex) {
-                forAllKilledOperands(
-                    m_graph, block->at(nodeIndex - 1), node,
-                    [&] (Operand operand) {
-                        // This function is a bit sloppy - it might claim to kill a local even if
-                        // it's still live after. We need to protect against that.
-                        if (!!m_state.operand(operand))
-                            return;
-
-                        dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    Killed operand at ", node, ": ", operand);
-                        m_state.operand(operand) = currentEpoch;
-                    });
-            }
+            defineLiveOperands(node, live);
         }
     }
 
     InsertionSet m_insertionSet;
     UncheckedKeyHashMap<std::underlying_type_t<UseKind>, Node*, WTF::IntHash<std::underlying_type_t<UseKind>>, WTF::UnsignedWithZeroKeyHashTraits<std::underlying_type_t<UseKind>>> m_constants;
-    Operands<Epoch> m_state;
     bool m_changed;
 };
 


### PR DESCRIPTION
#### 4401bf8b0133fd4f34e2f8f7004daf92fc9ff6db
<pre>
[JSC] Reland global liveness MovHint removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=316804">https://bugs.webkit.org/show_bug.cgi?id=316804</a>
<a href="https://rdar.apple.com/179252499">rdar://179252499</a>

Reviewed by Yijia Huang.

The previous attempt at this (295369@main) was reverted because removing
pruneByLiveness from the OSR availability iteration loop caused a bug,
stale heap entries (whose base nodes have a valid stack flush via PutStackSinking,
so they no longer need materialization) would accumulate in availabilityAtHead
and reach FTLs buildExitArguments, where they crash the &quot;Could not find
materialization&quot; assertion. That fix needs more work and is left for a
separate change.

This patch only relands the MovHint removal improvement. The phase now
performs a global backward liveness analysis instead of the prior
single-successor-walk heuristic.

* Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp:

Canonical link: <a href="https://commits.webkit.org/315151@main">https://commits.webkit.org/315151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27c17e734e7f8bb6e99503528ffb30b9de64bb74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168055 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125748 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/311f139b-dc17-462f-9acd-25a893525c65) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130755 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c4bed3e-9f56-4fcb-a2ac-16d10e5ada9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33227 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111272 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8335da21-acb9-4847-a07b-357fa7226802) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32208 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30915 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26053 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160673 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179950 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29301 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139180 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139060 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42312 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105622 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25613 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34348 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27382 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200733 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114068 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53923 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40213 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5481 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40464 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40358 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->