### PR TITLE
[perf.webkit.org] Update sync-commits.py to support Canonical-link

### DIFF
--- a/Websites/perf.webkit.org/tools/sync-commits.py
+++ b/Websites/perf.webkit.org/tools/sync-commits.py
@@ -19,7 +19,7 @@ from urllib.request import urlopen
 
 # There are some buggy commit messages:
 # Canonical link: https://commits.webkit.org/https://commits.webkit.org/232477@main
-REVISION_IDENTIFIER_IN_MSG_RE = re.compile(r'^Canonical link: (https\://commits\.webkit\.org/)+(?P<revision_identifier>\d+\.?\d*@(?P<branch_name>[\w\.\-]+))\n', flags=re.MULTILINE)
+REVISION_IDENTIFIER_IN_MSG_RE = re.compile(r'^Canonical-link: (https\://commits\.webkit\.org/)+(?P<revision_identifier>\d+\.?\d*@(?P<branch_name>[\w\.\-]+))\n', flags=re.MULTILINE)
 REVISION_IN_MSG_RE = re.compile(r'^git-svn-id: https://svn\.webkit\.org/repository/webkit/[\w\W]+@(?P<revision>\d+) [\w\d\-]+\n', flags=re.MULTILINE)
 HASH_RE = re.compile(r'^[a-f0-9A-F]+$')
 REVISION_RE = re.compile(r'^[Rr]?(?P<revision>\d+)$')
@@ -266,7 +266,16 @@ class GitRepository(Repository):
 
         revision_identifier = None
         if self._report_revision_identifier_in_commit_msg:
-            for revision_identifier_match in REVISION_IDENTIFIER_IN_MSG_RE.finditer(message):
+            trailer_output = subprocess.check_output(
+                ['git', '-C', self._git_checkout,
+                 '-c', 'trailer.Canonical-link.key=Canonical-link',
+                 '-c', 'trailer.Identifier.key=Identifier',
+                 '-c', 'trailer.git-svn-id.key=git-svn-id',
+                 'interpret-trailers', '--parse', '--no-divider'],
+                input=message.replace('\nCanonical link:', '\nCanonical-link:'),
+                encoding='utf-8',
+            )
+            for revision_identifier_match in REVISION_IDENTIFIER_IN_MSG_RE.finditer(trailer_output):
                 if self._git_branch and revision_identifier_match.group('branch_name') != self._git_branch:
                     continue
                 revision_identifier = revision_identifier_match.group('revision_identifier')


### PR DESCRIPTION
#### bc80ea5383e3e5e759386744a2a5b5eec88d18b9
<pre>
[perf.webkit.org] Update sync-commits.py to support Canonical-link
<a href="https://bugs.webkit.org/show_bug.cgi?id=316832">https://bugs.webkit.org/show_bug.cgi?id=316832</a>
<a href="https://rdar.apple.com/179276740">rdar://179276740</a>

Reviewed by Dewei Zhu.

This follows the same pattern we&apos;re using elsewhere: convert to
hyphened form, and then parse with parse-trailers.

* Websites/perf.webkit.org/tools/sync-commits.py:
(GitRepository._revision_from_tokens):

Canonical link: <a href="https://commits.webkit.org/320067@main">https://commits.webkit.org/320067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ca485bd341d95cf4021a82c5ce88f02d03e47ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125355 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130460 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91695 "1 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110977 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31867 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30565 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30076 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179271 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41243 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138861 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41931 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27029 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138746 "") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34012 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105105 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40435 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5131 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39832 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40083 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39977 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->