### PR TITLE
Fix visionOS build of TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2230,20 +2230,36 @@
 			isa = PBXShellScriptBuildPhase;
 			inputPaths = (
 				"$(PLATFORM_DIR)/Developer/Library/Frameworks/Testing.framework",
+				"$(PLATFORM_DIR)/Developer/Library/Frameworks/_Testing_AppKit.framework",
+				"$(PLATFORM_DIR)/Developer/Library/Frameworks/_Testing_CoreGraphics.framework",
+				"$(PLATFORM_DIR)/Developer/Library/Frameworks/_Testing_CoreImage.framework",
+				"$(PLATFORM_DIR)/Developer/Library/Frameworks/_Testing_CoreTransferable.framework",
+				"$(PLATFORM_DIR)/Developer/Library/Frameworks/_Testing_Foundation.framework",
+				"$(PLATFORM_DIR)/Developer/Library/Frameworks/_Testing_UIKit.framework",
 				"$(PLATFORM_DIR)/Developer/usr/lib/lib_TestingInterop.dylib",
 			);
 			name = "Embed Testing.framework";
 			outputPaths = (
 				"$(BUILT_PRODUCTS_DIR)/Testing.framework",
+				"$(BUILT_PRODUCTS_DIR)/_Testing_AppKit.framework",
+				"$(BUILT_PRODUCTS_DIR)/_Testing_CoreGraphics.framework",
+				"$(BUILT_PRODUCTS_DIR)/_Testing_CoreImage.framework",
+				"$(BUILT_PRODUCTS_DIR)/_Testing_CoreTransferable.framework",
+				"$(BUILT_PRODUCTS_DIR)/_Testing_Foundation.framework",
+				"$(BUILT_PRODUCTS_DIR)/_Testing_UIKit.framework",
 				"$(BUILT_PRODUCTS_DIR)/lib_TestingInterop.dylib",
 			);
 			shellPath = /bin/sh;
 			shellScript = (
-				"ditto \"${PLATFORM_DIR}/Developer/Library/Frameworks/Testing.framework\" \"${BUILT_PRODUCTS_DIR}/Testing.framework\"",
-				"",
-				"if [ -e \"${PLATFORM_DIR}/Developer/usr/lib/lib_TestingInterop.dylib\" ]; then",
-				"    ditto \"${PLATFORM_DIR}/Developer/usr/lib/lib_TestingInterop.dylib\" \"${BUILT_PRODUCTS_DIR}/lib_TestingInterop.dylib\"",
-				"fi",
+				"# The Swift explicit-modules dep scanner resolves cross-import overlays relative to the",
+				"# parent module's location, so the _Testing_* overlays must live next to the dittoed",
+				"# Testing.framework, not just in PLATFORM_DIR.",
+				"for (( i=0 ; $i < $SCRIPT_INPUT_FILE_COUNT ; i++ )); do",
+				"    eval input=\"\\${SCRIPT_INPUT_FILE_$i}\"",
+				"    if [ -e \"$input\" ]; then",
+				"        ditto \"$input\" \"${BUILT_PRODUCTS_DIR}/$(basename \"$input\")\"",
+				"    fi",
+				"done",
 				"",
 			);
 		};


### PR DESCRIPTION
#### 37efec2a17bc6b82734047af378d58ea0b21ce53
<pre>
Fix visionOS build of TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=316845">https://bugs.webkit.org/show_bug.cgi?id=316845</a>
<a href="https://rdar.apple.com/179283028">rdar://179283028</a>

Reviewed by Elliott Williams.

This fixes build failures like this:

error: Clang dependency scanning failure:  (in target &apos;TestWebKitAPI&apos; from project &apos;TestWebKitAPI&apos;)
error: Unable to resolve module dependency: &apos;_Testing_CoreTransferable&apos; (in target &apos;TestWebKitAPI&apos; from project &apos;TestWebKitAPI&apos;)
  note: A dependency of main module &apos;_TestWebKitAPI-CrossImportOverlays&apos;
  note: A dependency of main module &apos;_TestWebKitAPI-CrossImportOverlays&apos; (in target &apos;TestWebKitAPI&apos; from project &apos;TestWebKitAPI&apos;)

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/315261@main">https://commits.webkit.org/315261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95587519adf823bb8a457f2a85b69cfcb1145ce2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126146 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4eef6383-5752-4cf9-8555-71ce9f885306) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131103 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92199 "2 flakes 4 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b5eed62-133f-43ec-9c22-48eb21eb4ea1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111614 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d4fad96-4255-48c3-a2e4-d4785b60786c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32552 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31254 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26469 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142538 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180373 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139539 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139402 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42702 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106346 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25668 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27749 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41206 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40603 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5834 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40854 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40748 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->