### PR TITLE
_archiveWithConfiguration occasionally fails with "Invalid file path" on pages with <link rel="icon">

### DIFF
--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -807,8 +807,24 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createInternal(const String& markupSt
         RefPtr documentLoader = frame.loader().documentLoader();
         ASSERT(documentLoader);
         for (auto& icon : documentLoader->linkIcons()) {
-            if (auto resource = documentLoader->subresource(icon.url))
-                subresources.append(resource.releaseNonNull());
+            if (uniqueSubresources.contains(icon.url.string()))
+                continue;
+
+            auto resource = documentLoader->subresource(icon.url);
+            if (!resource)
+                continue;
+
+            auto addResult = uniqueSubresources.add(icon.url.string(), emptyString());
+
+            if (!subresourcesDirectoryName.isNull()) {
+                String subresourceFileName = generateValidFileName(icon.url, uniqueFileNames);
+                uniqueFileNames.add(subresourceFileName);
+                String subresourceFilePath = FileSystem::pathByAppendingComponent(subresourcesDirectoryName, subresourceFileName);
+                resource->setRelativeFilePath(subresourceFilePath);
+                addResult.iterator->value = frame.isMainFrame() ? subresourceFilePath : subresourceFileName;
+            }
+
+            subresources.append(resource.releaseNonNull());
         }
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm
@@ -2255,6 +2255,53 @@ TEST(WebArchive, SaveResourcesWithUTF8Encoding)
     Util::run(&saved);
 }
 
+TEST(WebArchive, ArchiveWithConfigurationLinkIcon)
+{
+    RetainPtr<NSURL> directoryURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"ArchiveWithConfigurationLinkIconTest"] isDirectory:YES];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager removeItemAtURL:directoryURL.get() error:nil];
+
+    HTTPServer server({
+        { "/main.html"_s, { "<head>"
+            "<link rel=\"icon\" href=\"/favicon.ico\">"
+            "<link rel=\"stylesheet\" href=\"/favicon.ico\">"
+            "</head>"
+            "<script>window.onload = () => window.webkit.messageHandlers.testHandler.postMessage('done');</script>"_s } },
+        { "/favicon.ico"_s, { { { "Content-Type"_s, "text/css"_s } }, "/* */"_s } },
+    });
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    static bool messageReceived = false;
+    [webView performAfterReceivingMessage:@"done" action:[&] {
+        messageReceived = true;
+    }];
+    [webView loadRequest:server.request("/main.html"_s)];
+    Util::run(&messageReceived);
+
+    static bool saved = false;
+    RetainPtr<_WKArchiveConfiguration> archiveConfiguration = adoptNS([[_WKArchiveConfiguration alloc] init]);
+    archiveConfiguration.get().directory = directoryURL.get();
+    archiveConfiguration.get().suggestedFileName = @"host";
+    [webView _archiveWithConfiguration:archiveConfiguration.get() completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
+
+        NSString *mainResourcePath = [directoryURL URLByAppendingPathComponent:@"host.html"].path;
+        EXPECT_TRUE([fileManager fileExistsAtPath:mainResourcePath]);
+
+        NSString *resourceDirectoryPath = [directoryURL URLByAppendingPathComponent:@"host_files"].path;
+        NSArray *resourceFileNames = [fileManager contentsOfDirectoryAtPath:resourceDirectoryPath error:nil];
+        EXPECT_EQ(resourceFileNames.count, 2u);
+
+        for (NSString *fileName in resourceFileNames)
+            EXPECT_TRUE([fileName containsString:@"favicon"]);
+
+        saved = true;
+    }];
+    Util::run(&saved);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC) || PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### b9b0329aab4d4832c70e831244a9ec7e0b82ab26
<pre>
_archiveWithConfiguration occasionally fails with &quot;Invalid file path&quot; on pages with &lt;link rel=&quot;icon&quot;&gt;
<a href="https://rdar.apple.com/179262267">rdar://179262267</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316813">https://bugs.webkit.org/show_bug.cgi?id=316813</a>

Reviewed by Sihui Liu.

This patch addresses occasional &quot;Invalid file path&quot; errors when using _archiveWithConfiguration.
LegacyWebArchive::createInternal collects subresources in two passes. The second loop
reads from DocumentLoader::linkIcons() to pick up favicons and appends whatever DocumentLoader::subresource()
returns. Consequently, we might get a brand-new ArchiveResource with empty m_relativeFilePath,
which causes ArchiveResource::saveToDisk to hit the empty-path check and cause the failure.

This change makes the second loop more closely mirror the first loop.
We skip URLs already in uniqueSubresources, so favicons that are also referenced don&apos;t produce this
duplicate ArchiveResource. Also, for URLs unique to the icon loop, generate a valid filename and
path to avoid this empty relative filepath issue.

The new test reproduces the buggy condition by serving a page by referencing the same URL
in &lt;link rel=&quot;icon&quot;&gt; and &lt;link rel=&quot;stylesheet&quot;&gt;. Without the fix, the old implementation fails with
_archiveWithConfiguration: fails with WKErrorDomain Code=1 (&quot;Invalid file&quot;) and with the fix,
the test passes.

* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createInternal):

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CreateWebArchive.mm:
(TestWebKitAPI::(WebArchive, ArchiveWithConfigurationLinkIcon)):
The test produces 2 files because it gets added once in the first loop.
Since the the favicon is referenced as a stylesheet,
addSubresourcesForCSSStyleSheetsIfNecessary removes it from uniqueSubresources and added again.
This means favicon is processed again and appended giving a count of 2.

Canonical link: <a href="https://commits.webkit.org/315547@main">https://commits.webkit.org/315547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77cc80a6407c6feb320dc24fad55f7a6d8658b15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131861 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112365 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181248 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140318 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/168692 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42870 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140156 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43559 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28581 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107499 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35426 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115324 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42069 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6671 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->