### PR TITLE
CSP 'self' does not match in opaque-origin http(s) documents

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-after-redirect.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-after-redirect.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Expecting logs: ["PASS script-src self after redirect"]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-after-redirect.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-after-redirect.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS script-src self after redirect"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+</head>
+
+<body>
+    <script>
+        window.onmessage = function(e) {
+            log(e.data);
+        }
+    </script>
+
+    <iframe sandbox="allow-scripts" src="/common/redirect.py?location=http://{{hosts[alt][]}}:{{ports[http][0]}}/content-security-policy/sandbox/support/csp-self-redirect-target.html"></iframe>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-all-directives.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-all-directives.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Expecting logs: ["PASS script-src self", "PASS img-src self", "PASS style-src self", "PASS frame-src self"]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-all-directives.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-all-directives.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS script-src self", "PASS img-src self", "PASS style-src self", "PASS frame-src self"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+</head>
+
+<body>
+    <script>
+        window.onmessage = function(e) {
+            log(e.data);
+        }
+    </script>
+
+    <iframe sandbox="allow-scripts" src="support/csp-multi-directive.sub.html"></iframe>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-allows-same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-allows-same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Expecting logs: ["PASS script-src self sandboxed iframe"]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-allows-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-allows-same-origin.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS script-src self sandboxed iframe"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+</head>
+
+<body>
+    <script>
+        window.onmessage = function(e) {
+            log(e.data);
+        }
+    </script>
+
+    <iframe sandbox="allow-scripts" src="support/csp-self.html"></iframe>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-blocks-cross-origin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-blocks-cross-origin.sub-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Expecting logs: ["PASS same-origin script allowed in sandboxed iframe", "PASS cross-origin script blocked in sandboxed iframe"]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-blocks-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-blocks-cross-origin.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS same-origin script allowed in sandboxed iframe", "PASS cross-origin script blocked in sandboxed iframe"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+</head>
+
+<body>
+    <script>
+        window.onmessage = function(e) {
+            log(e.data);
+        }
+    </script>
+
+    <iframe sandbox="allow-scripts" src="support/csp-self-and-cross-origin.sub.html"></iframe>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-via-header-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-via-header-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Expecting logs: ["PASS script-src self sandboxed iframe (header-delivered)"]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-via-header.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-via-header.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS script-src self sandboxed iframe (header-delivered)"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+</head>
+
+<body>
+    <script>
+        window.onmessage = function(e) {
+            log(e.data);
+        }
+    </script>
+
+    <iframe sandbox="allow-scripts" src="support/iframe-with-csp-header-self.html"></iframe>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-multi-directive.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-multi-directive.sub.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'; img-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self'">
+    <link rel="stylesheet" href="iframe-self-style.css" id="styleLink">
+</head>
+<body>
+    <script>window.__scriptLoaded = false;</script>
+    <script src="iframe-self-pass.js"></script>
+    <script>
+        function postPass(label) { window.parent.postMessage("PASS " + label, "*"); }
+        function postFail(label) { window.parent.postMessage("FAIL " + label, "*"); }
+
+        if (window.__scriptLoaded)
+            postPass("script-src self");
+        else
+            postFail("script-src self");
+
+        var img = new Image();
+        img.onload = function() { postPass("img-src self"); };
+        img.onerror = function() { postFail("img-src self"); };
+        img.src = "/content-security-policy/support/pass.png";
+
+        var styleLink = document.getElementById("styleLink");
+        function reportStyle() {
+            if (styleLink.sheet)
+                postPass("style-src self");
+            else
+                postFail("style-src self");
+        }
+        if (styleLink.sheet)
+            reportStyle();
+        else {
+            styleLink.addEventListener("load", reportStyle);
+            styleLink.addEventListener("error", function() { postFail("style-src self"); });
+        }
+
+        var frame = document.createElement("iframe");
+        frame.onload = function() { postPass("frame-src self"); };
+        frame.onerror = function() { postFail("frame-src self"); };
+        frame.src = "empty.html";
+        document.body.appendChild(frame);
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self-and-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self-and-cross-origin.sub.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'">
+</head>
+<body>
+    <script>
+        window.__scriptLoaded = false;
+        window.__crossOriginScriptLoaded = false;
+    </script>
+    <script src="iframe-self-pass.js"></script>
+    <script src="http://{{hosts[alt][]}}:{{ports[http][0]}}/content-security-policy/sandbox/support/iframe-cross-pass.js"></script>
+    <script>
+        var sameOriginMsg = window.__scriptLoaded
+            ? "PASS same-origin script allowed in sandboxed iframe"
+            : "FAIL same-origin script blocked in sandboxed iframe";
+        var crossOriginMsg = window.__crossOriginScriptLoaded
+            ? "FAIL cross-origin script not blocked in sandboxed iframe"
+            : "PASS cross-origin script blocked in sandboxed iframe";
+        window.parent.postMessage(sameOriginMsg, "*");
+        window.parent.postMessage(crossOriginMsg, "*");
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self-redirect-target.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self-redirect-target.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'">
+</head>
+<body>
+    <script>self.__scriptLoaded = false;</script>
+    <script src="iframe-self-pass.js"></script>
+    <script>
+        var msg = self.__scriptLoaded
+            ? "PASS script-src self after redirect"
+            : "FAIL script blocked after redirect";
+        window.parent.postMessage(msg, "*");
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'">
+</head>
+<body>
+    <script>window.__scriptLoaded = false;</script>
+    <script src="iframe-self-pass.js"></script>
+    <script>
+        var msg = window.__scriptLoaded
+            ? "PASS script-src self sandboxed iframe"
+            : "FAIL script blocked in sandboxed iframe";
+        window.parent.postMessage(msg, "*");
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-cross-pass.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-cross-pass.js
@@ -1,0 +1,1 @@
+window.__crossOriginScriptLoaded = true;

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-self-pass.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-self-pass.js
@@ -1,0 +1,1 @@
+self.__scriptLoaded = true;

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-self-style.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-self-style.css
@@ -1,0 +1,1 @@
+.iframe-self-style-marker { color: rgb(1, 2, 3); }

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-with-csp-header-self.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-with-csp-header-self.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script>window.__scriptLoaded = false;</script>
+    <script src="iframe-self-pass.js"></script>
+    <script>
+        var msg = window.__scriptLoaded
+            ? "PASS script-src self sandboxed iframe (header-delivered)"
+            : "FAIL script blocked in sandboxed iframe (header-delivered)";
+        window.parent.postMessage(msg, "*");
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-with-csp-header-self.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-with-csp-header-self.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: script-src 'self' 'unsafe-inline'

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -123,7 +123,13 @@ ContentSecurityPolicy::ContentSecurityPolicy(URL&& protectedURL, ScriptExecution
     , m_protectedURL { WTF::move(protectedURL) }
 {
     ASSERT(scriptExecutionContext.securityOrigin());
-    updateSourceSelf(*protect(scriptExecutionContext.securityOrigin()));
+    // CSP3 2.2.2: a policy's self-origin is the response URL's origin. Apply when the runtime
+    // origin is opaque and the URL is http(s); local schemes inherit via Document::initSecurityContext.
+    bool hasOpaqueOriginWithResponseURL = scriptExecutionContext.securityOrigin()->isOpaque() && m_protectedURL.protocolIsInHTTPFamily();
+    if (hasOpaqueOriginWithResponseURL)
+        updateSourceSelf(SecurityOrigin::create(m_protectedURL).get());
+    else
+        updateSourceSelf(*protect(scriptExecutionContext.securityOrigin()));
     // FIXME: handle the non-document case.
     if (auto* document = dynamicDowncast<Document>(scriptExecutionContext)) {
         if (auto* page = document->page())


### PR DESCRIPTION
#### 01c89d15c3f8e75934784f53bf7816bc6c6fb636
<pre>
CSP &apos;self&apos; does not match in opaque-origin http(s) documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=316847">https://bugs.webkit.org/show_bug.cgi?id=316847</a>
<a href="https://rdar.apple.com/178638597">rdar://178638597</a>

Reviewed by Ryan Reno.

314912@main introduced a regression where &apos;self&apos; no longer matches anything in the CSP of
an http(s) document with an opaque origin (such as one inside an &lt;iframe sandbox&gt; without
allow-same-origin). Same-origin scripts, styles, images, and nested iframes all get
refused. WebKit resolves &apos;self&apos; against the opaque origin (which has no host), when
per CSP3 2.2.2 it should be using the response URL&apos;s origin.

Fix by adding a check in the CSP constructor that when the runtime origin is opaque and the
URL is http(s) we derive &apos;self&apos; from m_protectedURL. Non-opaque documents keep resolving
&apos;self&apos; through their own origin, so opaque local-scheme documents (about:blank, srcdoc,
blob:, etc.) keep inheriting &apos;self&apos; from the parent via Document::initSecurityContext.

Tests: imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-after-redirect.sub.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-all-directives.sub.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-allows-same-origin.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-blocks-cross-origin.sub.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-via-header.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-multi-directive.sub.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self-and-cross-origin.sub.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self-redirect-target.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self.html
       imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-with-csp-header-self.html

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-after-redirect.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-after-redirect.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-all-directives.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-all-directives.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-allows-same-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-allows-same-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-blocks-cross-origin.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-blocks-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-via-header-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/iframe-self-via-header.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-multi-directive.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self-and-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self-redirect-target.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/csp-self.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-cross-pass.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-self-pass.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-self-style.css: Added.
(.iframe-self-style-marker):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-with-csp-header-self.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/support/iframe-with-csp-header-self.html.headers: Added.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:

Canonical link: <a href="https://commits.webkit.org/315247@main">https://commits.webkit.org/315247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c00a841dd4ed23f9c853e69d2073c5795febe814

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126139 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/380100b3-ebed-4d31-95ff-e359bc17aced) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131096 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92191 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8ae8b78-117e-4ab8-bee0-47e551ce43ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111607 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22f990aa-58f9-4521-9be1-25a6881f02b3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32544 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31248 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26462 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142530 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180366 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139531 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42007 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35410 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139395 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37544 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150844 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106331 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34684 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27743 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114455 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40596 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5827 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40847 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40741 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->