### PR TITLE
[cmake] Allow WEBKIT_* environment variables to override feature option defaults

### DIFF
--- a/Source/cmake/WebKitFeatures.cmake
+++ b/Source/cmake/WebKitFeatures.cmake
@@ -430,10 +430,16 @@ macro(WEBKIT_OPTION_END)
 
     list(SORT _WEBKIT_AVAILABLE_OPTIONS)
     set(_MAX_FEATURE_LENGTH 0)
+    set(_ENV_OVERRIDDEN_OPTIONS "")
     foreach (_name ${_WEBKIT_AVAILABLE_OPTIONS})
         string(LENGTH ${_name} _name_length)
         if (_name_length GREATER _MAX_FEATURE_LENGTH)
             set(_MAX_FEATURE_LENGTH ${_name_length})
+        endif ()
+
+        if (DEFINED ENV{WEBKIT_${_name}})
+            set(_WEBKIT_AVAILABLE_OPTIONS_INITIAL_VALUE_${_name} $ENV{WEBKIT_${_name}})
+            list(APPEND _ENV_OVERRIDDEN_OPTIONS "${_name}=$ENV{WEBKIT_${_name}}")
         endif ()
 
         option(${_name} "${_WEBKIT_AVAILABLE_OPTIONS_DESCRIPTION_${_name}}" ${_WEBKIT_AVAILABLE_OPTIONS_INITIAL_VALUE_${_name}})
@@ -441,6 +447,11 @@ macro(WEBKIT_OPTION_END)
             mark_as_advanced(FORCE ${_name})
         endif ()
     endforeach ()
+
+    if (_ENV_OVERRIDDEN_OPTIONS)
+        list(JOIN _ENV_OVERRIDDEN_OPTIONS ", " _joined)
+        message(STATUS "Port defaults overridden by WEBKIT_* environment: ${_joined}")
+    endif ()
 
     if (ENABLE_LAYOUT_TESTS AND NOT DEVELOPER_MODE)
         set(ENABLE_LAYOUT_TESTS OFF)


### PR DESCRIPTION
#### 07b00e3a26a83f5ffc0ca8302db3ea7f771cffcf
<pre>
[cmake] Allow WEBKIT_* environment variables to override feature option defaults
<a href="https://bugs.webkit.org/show_bug.cgi?id=316848">https://bugs.webkit.org/show_bug.cgi?id=316848</a>
<a href="https://rdar.apple.com/179284019">rdar://179284019</a>

Reviewed by NOBODY (OOPS!).

WebKit&apos;s CMake build had no environment-variable hook for overriding feature
toggles (the ENABLE_*, USE_* options registered via WEBKIT_OPTION_DEFINE).
The only override paths were -D on the cmake command line and --cmakeargs in
build-webkit, which is awkward when the same toggle wants to be carried
across many builds and many checkouts.

i.e)
export WEBKIT_ENABLE_BACK_FORWARD_LIST_SWIFT=OFF

Add a generic hook in WEBKIT_OPTION_END(): for every registered option &lt;NAME&gt;,
an environment variable WEBKIT_&lt;NAME&gt; (for example
WEBKIT_ENABLE_BACK_FORWARD_LIST_SWIFT=OFF) replaces the port default before
option() is called.

Precedence (high to low):
  1. -D NAME=... on the cmake command line
  2. existing cache value (carried over from a prior configure)
  3. WEBKIT_&lt;NAME&gt; environment variable  &lt;- new
  4. WEBKIT_OPTION_DEFAULT_PORT_VALUE (port default)
  5. WEBKIT_OPTION_DEFINE (global default)

Known limitation, documented in the comment: once a value is in CMakeCache.txt,
subsequent env-var changes do not take effect until the cache is reset
(cmake --fresh, or remove CMakeCache.txt). This matches the common &quot;set in
shell profile, fresh configure picks it up&quot; workflow and avoids racing the
explicit -D path that users rely on for one-off overrides.

A STATUS line is emitted at configure time listing every option whose default
the environment overrode, so it is obvious from build logs what is in effect.

The WEBKIT_ prefix avoids collisions with unrelated env vars in the user&apos;s
shell (for example ENABLE_DEBUG used by other tooling) and matches the
existing convention of WEBKIT_NINJA_LINK_MAX, WEBKIT_LIBRARIES,
WEBKIT_IGNORE_PATH, etc.

No new tests (build configuration only).

* Source/cmake/WebKitFeatures.cmake:
(WEBKIT_OPTION_END):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07b00e3a26a83f5ffc0ca8302db3ea7f771cffcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125418 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/902982f7-a23a-472e-82ce-8c6fe2f6d766) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130508 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe101c1b-650e-40c3-8606-30c21e242624) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111025 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/087762aa-5a1b-4c89-932a-01c1d5df2747) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31922 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30621 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25527 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141910 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179336 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138909 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138794 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41994 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105178 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34066 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27086 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200414 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40498 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53844 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39895 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5189 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40146 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->