### PR TITLE
WebModelPlayer should restore stageMode when reloaded

### DIFF
--- a/LayoutTests/model-element/gpup/stagemode-orbit-resumes-after-reload-expected.txt
+++ b/LayoutTests/model-element/gpup/stagemode-orbit-resumes-after-reload-expected.txt
@@ -1,0 +1,3 @@
+
+PASS <model> stagemode=orbit resumes from the restored pose after an unload/reload cycle
+

--- a/LayoutTests/model-element/gpup/stagemode-orbit-resumes-after-reload.html
+++ b/LayoutTests/model-element/gpup/stagemode-orbit-resumes-after-reload.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ] -->
+<meta charset="utf-8">
+<title>&lt;model> stagemode=orbit resumes from the restored pose after reload</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/model-element-test-utils.js"></script>
+<script src="../resources/model-utils.js"></script>
+<style>
+.spacer {
+    height: 200vh;
+}
+.model-element {
+    width: 300px;
+    height: 300px;
+}
+</style>
+<body>
+<div class="spacer"></div>
+<script>
+'use strict';
+
+function modelCenter(model) {
+    const rect = model.getBoundingClientRect();
+    return { x: Math.round(rect.left + rect.width / 2), y: Math.round(rect.top + rect.height / 2) };
+}
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "../resources/heart.usdz");
+    model.className = "model-element";
+    model.stageMode = "orbit";
+
+    scrollElementIntoView(model);
+    await waitForModelState(model, "Loaded");
+    const initialTransform = await waitForEntityTransform(model);
+
+    const center = modelCenter(model);
+    eventSender.mouseMoveTo(center.x, center.y);
+    eventSender.mouseDown();
+    await sleepForSeconds(0.1);
+    eventSender.mouseMoveTo(center.x - 100, center.y);
+    await sleepForSeconds(0.1);
+    eventSender.mouseMoveTo(center.x - 100, center.y);
+    await sleepForSeconds(0.1);
+    eventSender.mouseUp();
+    await sleepForSeconds(0.1);
+
+    const orbitedTransform = model.entityTransform;
+    // The gesture did rotate the model.
+    assert_3d_matrix_not_equals(orbitedTransform, initialTransform);
+
+    window.scrollTo(0, 0);
+    await waitForModelState(model, "Unloaded", 10000);
+    scrollElementIntoView(model);
+    await waitForModelState(model, "Loaded");
+    const reloadedTransform = await waitForEntityTransform(model);
+    // The model keeps its rotation during reload.
+    assert_3d_matrix_approx_equals(reloadedTransform, orbitedTransform);
+
+    const reloadedCenter = modelCenter(model);
+    eventSender.mouseMoveTo(reloadedCenter.x, reloadedCenter.y);
+    eventSender.mouseDown();
+    await sleepForSeconds(0.1);
+    eventSender.mouseMoveTo(reloadedCenter.x, reloadedCenter.y);
+    await sleepForSeconds(0.1);
+    const transformAfterPress = model.entityTransform;
+    eventSender.mouseUp();
+
+    // The "no move" gesture did not reset the model rotation.
+    assert_3d_matrix_approx_equals(transformAfterPress, reloadedTransform);
+
+    eventSender.mouseMoveTo(reloadedCenter.x, reloadedCenter.y);
+    eventSender.mouseDown();
+    await sleepForSeconds(0.1);
+    eventSender.mouseMoveTo(reloadedCenter.x - 100, reloadedCenter.y);
+    await sleepForSeconds(0.1);
+    const transformAfterDrag = model.entityTransform;
+    eventSender.mouseUp();
+
+    // The gesture still rotates the model.
+    assert_3d_matrix_not_equals(transformAfterDrag, reloadedTransform);
+}, `<model> stagemode=orbit resumes from the restored pose after an unload/reload cycle`);
+
+</script>
+</body>

--- a/Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.h
+++ b/Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.h
@@ -36,6 +36,7 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 - (void)gestureDidUpdateWithDeltaX:(float)dx deltaY:(float)dy;
 - (void)gestureDidEnd;
 - (BOOL)stepWithElapsedTime:(float)dt;
+- (void)setCurrentYaw:(float)yaw pitch:(float)pitch;
 
 @end
 

--- a/Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.swift
+++ b/Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.swift
@@ -70,6 +70,11 @@ extension WKStageModeOrbitSimulator {
         previousDeltaX = dx
     }
 
+    func setCurrentYaw(_ yaw: Float, pitch: Float) {
+        self.yaw = yaw
+        self.pitch = pitch
+    }
+
     func gestureDidEnd() {
         isDecelerating = true
         isPitchSettling = true
@@ -112,6 +117,7 @@ extension WKStageModeOrbitSimulator {
     func gestureDidUpdate(withDeltaX dx: Float, deltaY dy: Float) {}
     func gestureDidEnd() {}
     func step(withElapsedTime dt: Float) -> Bool { false }
+    func setCurrentYaw(_ yaw: Float, pitch: Float) {}
 }
 
 #endif

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -380,8 +380,17 @@ void WebModelPlayer::enterFullscreen()
 void WebModelPlayer::handleMouseDown(const WebCore::LayoutPoint& startingPoint, MonotonicTime)
 {
     m_initialPoint = startingPoint;
-    if (!m_orbitSimulator)
+    if (!m_orbitSimulator) {
         m_orbitSimulator = adoptNS([[WKStageModeOrbitSimulator alloc] init]);
+        // Seed from the current pose so a gesture after reload doesn't snap to default.
+        if (auto transform = entityTransform()) {
+            auto matrix = static_cast<simd_float4x4>(*transform);
+            simd_float3 c0 = simd_normalize(simd_make_float3(matrix.columns[0]));
+            simd_float3 c1 = simd_normalize(simd_make_float3(matrix.columns[1]));
+            simd_float3 c2 = simd_normalize(simd_make_float3(matrix.columns[2]));
+            [m_orbitSimulator setCurrentYaw:std::atan2(-c2.x, c0.x) pitch:std::atan2(-c1.z, c1.y)];
+        }
+    }
     [m_orbitSimulator gestureDidBegin];
     startUpdateLoopIfNeeded();
 }
@@ -850,6 +859,7 @@ void WebModelPlayer::reload(WebCore::Model& modelSource, WebCore::LayoutSize siz
     load(modelSource, size);
     m_cachedAnimationState = animationState;
     if (transformState) {
+        setStageMode(transformState->stageMode());
         if (auto entityTransform = transformState->entityTransform())
             setEntityTransform(*entityTransform);
     }


### PR DESCRIPTION
#### 9b9a6b01499fb3a138593c7a476744d421e3952b
<pre>
WebModelPlayer should restore stageMode when reloaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=316851">https://bugs.webkit.org/show_bug.cgi?id=316851</a>
&lt;<a href="https://rdar.apple.com/179249565">rdar://179249565</a>&gt;

Reviewed by Mike Wyrzykowski.

Update `WebModelPlayer::reload` to restore the stageMode value too.

Test: model-element/gpup/stagemode-orbit-resumes-after-reload.html

* LayoutTests/model-element/gpup/stagemode-orbit-resumes-after-reload-expected.txt: Added.
* LayoutTests/model-element/gpup/stagemode-orbit-resumes-after-reload.html: Added.
Introduce a new test covering this change. It&apos;s specific to the GPUP
implementation.

* Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.h:
* Source/WebKit/Shared/Model/WKStageModeOrbitSimulator.swift:
(WKStageModeOrbitSimulator.setCurrentYaw(_:pitch:)):
Introduce a method to seed the WKStageModeOrbitSimulator with restored
pitch / yaw values.

* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::handleMouseDown):
(WebKit::WebModelPlayer::reload):
Seed the `WKStageModeOrbitSimulator` with pitch / yaw values to avoid
jumps when orbiting a reloaded model.

Canonical link: <a href="https://commits.webkit.org/315026@main">https://commits.webkit.org/315026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5255f7f3bf1179f6fbb23dd718e17b7a6599c16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125398 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130493 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111010 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31905 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30604 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25507 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179314 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32364 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138899 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138784 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37406 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105151 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34051 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27196 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113729 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39875 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5170 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40126 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->