### PR TITLE
[Site Isolation] Storage access isn't revoked when an iframe navigates itself cross-origin

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -61,7 +61,6 @@ http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html [ 
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture-ephemeral.https.html [ Failure ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture.https.html [ Failure ]
 http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html [ Failure ]
-http/tests/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html [ Failure ]
 http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html [ Failure ]
 http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Failure ]

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1077,9 +1077,15 @@ WebCore::AllowsContentJavaScript WebLocalFrameLoaderClient::allowsContentJavaScr
 void WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse,
     FormState* formState, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<WebCore::HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, FramePolicyFunction&& function)
 {
-    if (auto requestor = navigationAction.requester()) {
-        if (requestor->frameID && *requestor->frameID != m_frame->frameID() && Site(requestor->url) != Site(m_frame->url()))
+    if (auto requestor = navigationAction.requester(); requestor && requestor->frameID) {
+        // another frame initiated navigation
+        if (*requestor->frameID != m_frame->frameID() && Site(requestor->url) != Site(m_frame->url()))
             removeStorageAccess();
+        // this frame navigated itself
+        else if (*requestor->frameID == m_frame->frameID()) {
+            if (redirectResponse.isNull() && !SecurityOrigin::create(m_frame->url())->isSameOriginAs(SecurityOrigin::create(request.url())))
+                removeStorageAccess();
+        }
     }
 
     WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(navigationAction, request, redirectResponse, formState, clientRedirectSourceForHistory, navigationID, WTF::move(hitTestResult), hasOpener, navigationUpgradeToHTTPSBehavior, sandboxFlags, policyDecisionMode, WTF::move(function));


### PR DESCRIPTION
#### 874b11286861f277dc660f09801778933052228a
<pre>
[Site Isolation] Storage access isn&apos;t revoked when an iframe navigates itself cross-origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=316853">https://bugs.webkit.org/show_bug.cgi?id=316853</a>
<a href="https://rdar.apple.com/179286611">rdar://179286611</a>

Reviewed by Matthew Finkel.

When an iframe wants to access storage APIs it needs to be granted &quot;storage access&quot;.
This can be granted via something like a user gesture.

Importantly for this bug, storage access should be revoked when an iframe navigates itself
to a cross-origin site.

The iframe&apos;s &quot;storage access&quot; is normally revoked after a cross-origin check in
WebLocalFrameLoaderClient::dispatchWillChangeDocument.

However, with site isolation, a cross-origin navigation ends up committing the load
in a new process and calling WebLocalFrameLoaderClient::dispatchWillChangeDocument.
It performs the origin check and calls removeStorageAccess as expected, however
this new process never held storage access to begin with.

The issue arises when the navigation involves a redirect. Take for example when
a localhost iframe navigates to 127.0.0.1 which gets redirected back to localhost:
1. Navigate localhost -&gt; 127.0.0.1
    - localhost process has storage access.
    - This cross-origin navigation spawns up a new process for 127.0.0.1
    - WebLocalFrameLoaderClient::dispatchWillChangeDocument tries to
        remove storage access in the 127.0.0.1 process since it fails
        the cross-origin check
    - !! The 127.0.0.1 process never had storage access so nothing changes
2. Redirect 127.0.0.1 -&gt; localhost
    - The navigation re-uses the localhost process
    - WebLocalFrameLoaderClient::dispatchWillChangeDocument performs the
        cross-origin check and sees that the the document&apos;s current URL
        is the same as the new URL and it will NOT removeStorageAccess
3. The result is that storage access survives after an iframe
    undergoes a cross-origin navigation

This patch introduces a fix which removes storage access for cross-origin navigations
right at the source process, when the navigation starts.
In WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction, when an iframe
is navigating itself to a cross-origin site, we sever the storage access right there.
This way storage access is gone regardless of wherever the redirect ends up.

This is what the Storage Access API spec mentions (<a href="https://privacycg.github.io/storage-access/)">https://privacycg.github.io/storage-access/)</a>
    &quot;we limit the impact of a &apos;storage-access&apos; permission grant to only give access to
    unpartitioned data to the nested Document that called requestStorageAccess() and only
    until the nested Document navigates across an origin boundary.&quot;

This fixes http/tests/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html
with site isolation enabled.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/315222@main">https://commits.webkit.org/315222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb8b53f4957bbc8d2d348417da248088908419d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125469 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7357940b-b800-407f-88b8-332962b500b9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130542 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91752 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2cc140e6-7eaa-4711-bcd2-4450c59571cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111059 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/780cec13-ab74-4f65-b55f-dab6dcc0b4ee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31975 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30671 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25578 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179387 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138961 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138845 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42045 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25652 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34115 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27446 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113800 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39946 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5542 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40197 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40091 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->