### PR TITLE
AX: VoiceOver does not expose aria-actions custom actions when the action target is accessibility-ignored

### DIFF
--- a/LayoutTests/accessibility/aria-actions-ignored-target-expected.txt
+++ b/LayoutTests/accessibility/aria-actions-ignored-target-expected.txt
@@ -1,0 +1,24 @@
+This test verifies that aria-actions targets which are themselves accessibility-ignored (here, role=button elements inside a listbox option) are still exposed with an accessible name, and thus as invokable custom actions.
+
+The action targets are resolved in DOM order:
+PASS: deleteAction.domIdentifier === 'delete-action'
+PASS: favoriteAction.domIdentifier === 'favorite-action'
+
+The action targets are accessibility-ignored (they are buttons inside a listbox option):
+PASS: deleteAction.isIgnored === true
+PASS: favoriteAction.isIgnored === true
+
+Even though they are ignored, the action targets expose their accessible name:
+PASS: platformValueForW3CName(deleteAction) === 'Delete'
+PASS: platformValueForW3CName(favoriteAction) === 'Favorite'
+
+The custom actions are exposed on the option and can be invoked:
+PASS: option.invokeCustomActionAtIndex(0) === true
+PASS: option.invokeCustomActionAtIndex(1) === true
+PASS: clickedActions[0] === 'delete-action'
+PASS: clickedActions[1] === 'favorite-action'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Delete Favorite

--- a/LayoutTests/accessibility/aria-actions-ignored-target.html
+++ b/LayoutTests/accessibility/aria-actions-ignored-target.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ ARIAActionsSupportEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<ul role="listbox">
+<li id="option" role="option" tabindex="0" aria-label="Artichokes" aria-actions="delete-action favorite-action">
+    <span role="button" id="delete-action" aria-label="Delete">Delete</span>
+    <span role="button" id="favorite-action" aria-label="Favorite">Favorite</span>
+</li>
+</ul>
+
+<script>
+var output = "This test verifies that aria-actions targets which are themselves accessibility-ignored (here, role=button elements inside a listbox option) are still exposed with an accessible name, and thus as invokable custom actions.\n\n";
+
+if (window.accessibilityController) {
+    var clickedActions = [];
+    document.getElementById("delete-action").addEventListener("click", () => clickedActions.push("delete-action"));
+    document.getElementById("favorite-action").addEventListener("click", () => clickedActions.push("favorite-action"));
+
+    var option = accessibilityController.accessibleElementById("option");
+    var deleteAction = option.ariaActionsElementAtIndex(0);
+    var favoriteAction = option.ariaActionsElementAtIndex(1);
+
+    output += "The action targets are resolved in DOM order:\n";
+    output += expect("deleteAction.domIdentifier", "'delete-action'");
+    output += expect("favoriteAction.domIdentifier", "'favorite-action'");
+    output += "\n";
+
+    output += "The action targets are accessibility-ignored (they are buttons inside a listbox option):\n";
+    output += expect("deleteAction.isIgnored", "true");
+    output += expect("favoriteAction.isIgnored", "true");
+    output += "\n";
+
+    output += "Even though they are ignored, the action targets expose their accessible name:\n";
+    output += expect("platformValueForW3CName(deleteAction)", "'Delete'");
+    output += expect("platformValueForW3CName(favoriteAction)", "'Favorite'");
+    output += "\n";
+
+    output += "The custom actions are exposed on the option and can be invoked:\n";
+    output += expect("option.invokeCustomActionAtIndex(0)", "true");
+    output += expect("option.invokeCustomActionAtIndex(1)", "true");
+    output += expect("clickedActions[0]", "'delete-action'");
+    output += expect("clickedActions[1]", "'favorite-action'");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1001,6 +1001,7 @@ accessibility/dynamic-speak-as.html [ Failure ]
 
 # Missing AccessibilityUIElement::{ariaActionsElementAtIndex, invokeCustomActionAtIndex} implementations.
 accessibility/aria-actions.html [ Skip ]
+accessibility/aria-actions-ignored-target.html [ Skip ]
 
 # Missing AccessibilityUIElement::showMenu implementation.
 accessibility/show-menu-fires-contextmenu-event.html [ Skip ]

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -399,6 +399,10 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     }
     AXLOG(makeString("AXIsolatedTree::addUnconnectedNode creating isolated object from live object ID "_s, objectID.loggingString()));
 
+    // Mark this as an unconnected node before creating its isolated data below, as
+    // createIsolatedObjectData() gates caching of the full property set on isUnconnectedNode().
+    m_unconnectedNodes.add(objectID);
+
     // Because we are queuing a change for an object not intended to be connected to the rest of the tree,
     // we don't need to update m_nodeMap or m_pendingChanges.childrenUpdates for this object or its parent as is
     // done in AXIsolatedTree::nodeChangeForObject and AXIsolatedTree::queueChange.
@@ -409,7 +413,6 @@ void AXIsolatedTree::addUnconnectedNode(Ref<AccessibilityObject> axObject)
     NodeChange nodeChange { createIsolatedObjectData(axObject, *this), axObject->wrapper() };
     Locker locker { m_changeLogLock };
     mutablePendingChanges()->appends.append(WTF::move(nodeChange));
-    m_unconnectedNodes.add(objectID);
 }
 
 void AXIsolatedTree::queueRemovals(Vector<NodeAndParentID>&& subtreeRemovals)


### PR DESCRIPTION
#### 5a62df176e3b50f969cef1d86afff9c007a0f2f1
<pre>
AX: VoiceOver does not expose aria-actions custom actions when the action target is accessibility-ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=316854">https://bugs.webkit.org/show_bug.cgi?id=316854</a>
<a href="https://rdar.apple.com/179286650">rdar://179286650</a>

Reviewed by Dominic Mazzoni.

When an element with aria-actions points at action targets that are themselves
accessibility-ignored, VoiceOver exposed no custom actions for the source element,
even though the relation itself was built and synced correctly.

This happened whenever the action target was ignored. As an optimization, we cache
only a limited set of properties for nodes that are ignored, unless they are
&quot;unconnected&quot; nodes (not in the exposed tree) that are part of a relation.

However, we failed to add the ignored object into AXIsolatedTree::m_unconnectedNodes
until after the oject had already been created, defeating the behavior of caching all
properties for objects in relations. Because we didn&apos;t cache all properties for these
objects, they computed an empty accname, and thus were not allowed to be exposed as actions.

This fix is simple: add to m_unconnectedNodes before creating the isolated object.

* LayoutTests/accessibility/aria-actions-ignored-target-expected.txt: Added.
* LayoutTests/accessibility/aria-actions-ignored-target.html: Added.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::addUnconnectedNode):

Canonical link: <a href="https://commits.webkit.org/315097@main">https://commits.webkit.org/315097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc4d14c280ef4dc0f6f5b667e068bba1db108352

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125733 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90b1c1c7-ef16-4956-93b7-87045957dd68) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130741 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fefbdae-1521-4f46-adaf-f93d45c1fa44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111258 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a8f0cbe-a968-4ae2-9b8a-7301928536af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30901 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26038 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179935 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32687 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139166 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139046 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37453 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105596 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27372 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40198 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5471 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40449 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40343 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->