### PR TITLE
Don't generate unused Objective C++ source code

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -99,6 +99,7 @@ private:
 
 } // namespace WebKit
 
+#if PLATFORM(COCOA)
 #define WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(ImplClass, ScriptClass, PropertyName) \
 public: \
     template<typename... Args> \
@@ -135,6 +136,10 @@ private: \
     JSClassRef wrapperClass() const final { return JS##ImplClass::ScriptClass##ClassSingleton(); } \
 \
     using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+#else
+// FIXME: Remove this when CodeGeneratorExtensions.pm is able to generate C++ instead of Objective C++.
+#define WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(ImplClass, ScriptClass, PropertyName)
+#endif
 
 // End of macro.
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrappable.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrappable.h
@@ -42,9 +42,17 @@ public:
 
 } // namespace WebKit
 
+#if PLATFORM(COCOA)
 #define SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(ImplClass, ScriptClass) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::ImplClass) \
 static bool isType(const WebKit::JSWebExtensionWrappable& wrappable) { return wrappable.wrapperClass() == WebKit::JS##ImplClass::ScriptClass##ClassSingleton(); } \
 SPECIALIZE_TYPE_TRAITS_END()
+#else
+// FIXME: Remove this when CodeGeneratorExtensions.pm is able to generate C++ instead of Objective C++.
+#define SPECIALIZE_TYPE_TRAITS_WEB_EXTENSION(ImplClass, ScriptClass) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::ImplClass) \
+static bool isType(const WebKit::JSWebExtensionWrappable& wrappable) { return false; } \
+SPECIALIZE_TYPE_TRAITS_END()
+#endif
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -190,6 +190,7 @@ using namespace WTF;
 class ${implementationClassName};
 
 class ${className} : public ${parentClassName} {
+#if PLATFORM(COCOA)
 public:
     static JSClassRef @{[$self->_classRefGetter($idlType)]}();
     static JSClassRef @{[$self->_classRefGetter($idlType, "GlobalObjectClass")]}();
@@ -256,10 +257,13 @@ EOF
         push(@contents, "    static JSValueRef getProperty(JSContextRef, JSObjectRef, JSStringRef, JSValueRef*);\n");
     }
 
+    push(@contents, "#endif // PLATFORM(COCOA)\n");
     push(@contents, <<EOF);
 };
 
+#if PLATFORM(COCOA)
 ${implementationClassName}* to${implementationClassName}(JSContextRef, JSValueRef);
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -199,6 +199,8 @@ void WebExtensionContextProxy::setContentScriptWorld(WebCore::DOMWrapperWorld& w
 
 void WebExtensionContextProxy::enumerateFramesAndNamespaceObjects(NOESCAPE const Function<void(WebFrame&, WebExtensionAPINamespace&)>& function, Ref<DOMWrapperWorld>&& world)
 {
+    // FIXME: Remove the PLATFORM(COCOA) guard when CodeGeneratorExtensions.pm is able to generate C++ instead of Objective C++.
+#if PLATFORM(COCOA)
     m_extensionContentFrames.forEach([&](auto& frame) {
         RefPtr page = frame.page() ? frame.page()->corePage() : nullptr;
         if (!page)
@@ -227,10 +229,13 @@ void WebExtensionContextProxy::enumerateFramesAndNamespaceObjects(NOESCAPE const
 
         function(frame, *namespaceObjectImpl);
     });
+#endif
 }
 
 void WebExtensionContextProxy::enumerateFramesAndWebPageNamespaceObjects(NOESCAPE const Function<void(WebFrame&, WebExtensionAPIWebPageNamespace&)>& function)
 {
+    // FIXME: Remove the PLATFORM(COCOA) guard when CodeGeneratorExtensions.pm is able to generate C++ instead of Objective C++.
+#if PLATFORM(COCOA)
     m_extensionContentFrames.forEach([&](auto& frame) {
         auto context = frame.jsContextForWorld(mainWorldSingleton());
         auto globalObject = JSContextGetGlobalObject(context);
@@ -245,6 +250,7 @@ void WebExtensionContextProxy::enumerateFramesAndWebPageNamespaceObjects(NOESCAP
 
         function(frame, *namespaceObjectImpl);
     });
+#endif
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 7db58d007507464b34d33df56e7be1a822de7c18
<pre>
Don&apos;t generate unused Objective C++ source code
<a href="https://bugs.webkit.org/show_bug.cgi?id=315765">https://bugs.webkit.org/show_bug.cgi?id=315765</a>

Reviewed by NOBODY (OOPS!).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7db58d007507464b34d33df56e7be1a822de7c18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125687 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130700 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91856 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30858 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25992 "Hash 7db58d00 for PR 66930 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142141 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179889 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139125 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139006 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42251 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105531 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27326 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114007 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40152 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5426 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->