### PR TITLE
Avoid full subtree walk for non-scaling-stroke when no scaling exists in the SVG tree

### DIFF
--- a/LayoutTests/svg/custom/non-scaling-stroke-nested-scaling-ancestor-expected.svg
+++ b/LayoutTests/svg/custom/non-scaling-stroke-nested-scaling-ancestor-expected.svg
@@ -1,0 +1,5 @@
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+  <title>Reference: rect at the same viewport coords with default 3px stroke</title>
+  <rect x="40" y="40" width="100" height="60"
+        fill="lightblue" stroke="red" stroke-width="3"/>
+</svg>

--- a/LayoutTests/svg/custom/non-scaling-stroke-nested-scaling-ancestor.svg
+++ b/LayoutTests/svg/custom/non-scaling-stroke-nested-scaling-ancestor.svg
@@ -1,0 +1,13 @@
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+  <title>NSS shape with a non-immediate scaling ancestor renders with correct stroke and bbox</title>
+  <!-- A few pixels at the rectangle's mitered corners differ between the
+       NSS render path and the default-stroke render path. -->
+  <meta name="fuzzy" content="maxDifference=0-128; totalPixels=0-40" />
+  <g transform="scale(2)">
+    <g class="inner">
+      <rect x="20" y="20" width="50" height="30"
+            fill="lightblue" stroke="red" stroke-width="3"
+            vector-effect="non-scaling-stroke"/>
+    </g>
+  </g>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -590,6 +590,16 @@ void SVGRenderSupport::updateAncestorNonScalingStrokeCounts(RenderElement& rende
     }
 }
 
+bool SVGRenderSupport::computeHasScalingAncestor(const RenderElement& renderer)
+{
+    auto* parent = renderer.parent();
+    if (auto* svgModelObject = dynamicDowncast<LegacyRenderSVGModelObject>(parent))
+        return svgModelObject->hasScalingAncestor() || !svgModelObject->localToParentTransform().isIdentityOrTranslation();
+    if (auto* root = dynamicDowncast<LegacyRenderSVGRoot>(parent))
+        return !root->localToBorderBoxTransform().isIdentityOrTranslation();
+    return false;
+}
+
 void SVGRenderSupport::elementInsertedIntoTree(RenderElement& renderer)
 {
     if (renderer.style().vectorEffect() == VectorEffect::NonScalingStroke)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -97,6 +97,8 @@ public:
 
     static void NODELETE updateAncestorNonScalingStrokeCounts(RenderElement&, int delta);
 
+    static bool computeHasScalingAncestor(const RenderElement&);
+
     static void NODELETE elementInsertedIntoTree(RenderElement&);
     static void NODELETE elementWillBeRemovedFromTree(RenderElement&);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -90,6 +90,8 @@ void LegacyRenderSVGContainer::layout()
     // Allow LegacyRenderSVGTransformableContainer to update its transform.
     bool updatedTransform = calculateLocalTransform();
 
+    setHasScalingAncestor(SVGRenderSupport::computeHasScalingAncestor(*this));
+
     // LegacyRenderSVGViewportContainer needs to set the 'layout size changed' flag.
     determineIfLayoutSizeChanged();
 
@@ -210,6 +212,9 @@ FloatRect LegacyRenderSVGContainer::strokeBoundingBox() const
 FloatRect LegacyRenderSVGContainer::repaintRectInLocalCoordinates(RepaintRectCalculation repaintRectCalculation) const
 {
     if (hasNonScalingStrokeDescendant()) {
+        if (!hasScalingAncestor() && localToParentTransform().isIdentityOrTranslation())
+            return m_repaintBoundingBox;
+
         auto boundingBoxes = SVGRenderSupport::computeContainerBoundingBoxes(*this, repaintRectCalculation);
         FloatRect repaintBoundingBox = boundingBoxes.repaintBoundingBox;
         SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox, repaintRectCalculation);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -70,6 +70,9 @@ public:
 
     virtual void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = nullptr) const;
 
+    bool hasScalingAncestor() const { return m_hasScalingAncestor; }
+    void setHasScalingAncestor(bool value) { m_hasScalingAncestor = value; }
+
 protected:
     LegacyRenderSVGModelObject(Type, SVGElement&, Style::ComputedStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
@@ -80,6 +83,8 @@ private:
     // This method should never be called, SVG uses a different nodeAtPoint method
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
     void absoluteFocusRingQuads(Vector<FloatQuad>&) final;
+
+    bool m_hasScalingAncestor : 1 { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -530,6 +530,9 @@ FloatRect LegacyRenderSVGRoot::strokeBoundingBox() const
 FloatRect LegacyRenderSVGRoot::repaintRectInLocalCoordinates(RepaintRectCalculation repaintRectCalculation) const
 {
     if (hasNonScalingStrokeDescendant()) {
+        if (m_localToBorderBoxTransform.isIdentityOrTranslation())
+            return m_repaintBoundingBox;
+
         auto boundingBoxes = SVGRenderSupport::computeContainerBoundingBoxes(*this, repaintRectCalculation);
         FloatRect repaintBoundingBox = boundingBoxes.repaintBoundingBox;
         SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox, repaintRectCalculation);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -161,6 +161,8 @@ void LegacyRenderSVGShape::layout()
         updateCachedBoundariesInParents = true;
     }
 
+    setHasScalingAncestor(SVGRenderSupport::computeHasScalingAncestor(*this));
+
     // Invalidate all resources of this client if our layout changed.
     if (everHadLayout() && selfNeedsLayout())
         SVGResourcesCache::clientLayoutChanged(*this);
@@ -491,6 +493,9 @@ FloatRect LegacyRenderSVGShape::repaintRectInLocalCoordinates(RepaintRectCalcula
 {
     // During initial layout the path may not exist yet, so check path before calculating.
     if (hasNonScalingStroke() && hasPath()) {
+        if (!hasScalingAncestor() && m_localTransform.isIdentityOrTranslation())
+            return m_repaintBoundingBox;
+
         FloatRect repaintBoundingBox = SVGRenderSupport::calculateApproximateStrokeBoundingBox(*this);
         SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox, repaintRectCalculation);
         return repaintBoundingBox;


### PR DESCRIPTION
#### c52f78ad2c4d402d423f696158ae8413d0bfef5f
<pre>
Avoid full subtree walk for non-scaling-stroke when no scaling exists in the SVG tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=316857">https://bugs.webkit.org/show_bug.cgi?id=316857</a>
<a href="https://rdar.apple.com/179288836">rdar://179288836</a>

Reviewed by Simon Fraser.

In legacy SVG, repaintRectInLocalCoordinates() bypasses its cache for
non-scaling-stroke (NSS) subtrees. For trees with thousands of NSS
shapes that bypass is a hot loop: every repaint walks the entire subtree
and each leaf climbs the DOM to compute its CTM.

But NSS only changes the bounding box when the CTM has a scale, skew, or
rotate component. If a renderer&apos;s ancestor chain and its own transform
are all identity-or-translation, NSS is a no-op and the cached repaint
bounding box is already correct.

This fixes a real-world perf issue. On content with thousands of nested
NSS paths and no scaling, computeContainerBoundingBoxes was the single
hottest function at ~8.5% of total time; with the cache hit it drops to
~0.3%

* LayoutTests/svg/custom/non-scaling-stroke-nested-scaling-ancestor-expected.svg: Added.
* LayoutTests/svg/custom/non-scaling-stroke-nested-scaling-ancestor.svg: Added.

* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::updateAncestorScalingTransformCounts):
(WebCore::SVGRenderSupport::elementWillBeRemovedFromTree):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
(WebCore::LegacyRenderSVGContainer::hasScalingTransformDescendant const):
(WebCore::LegacyRenderSVGContainer::adjustScalingTransformDescendantCount):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h:
(WebCore::LegacyRenderSVGModelObject::isCountedAsScalingTransformDescendant const):
(WebCore::LegacyRenderSVGModelObject::setIsCountedAsScalingTransformDescendant):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::layout):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::calculateLocalTransform):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp:
(WebCore::LegacyRenderSVGViewportContainer::calculateLocalTransform):

Canonical link: <a href="https://commits.webkit.org/316651@main">https://commits.webkit.org/316651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fb55c275bf0ea123d623d5e14fd0af9bf4a4d56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130354 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b938952b-834c-4889-9b41-7bf14c7b2f63) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134391 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94865 "22 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b85f6306-40aa-4e1c-9a41-13c5c6ee343f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114862 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e14d72f4-9350-4a32-b670-62615250e114) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34750 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30855 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184789 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143188 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143065 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38679 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47066 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31285 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112052 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38065 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118818 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45583 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9396 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44983 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->