### PR TITLE
Importing modules from a document with no base URL causes null deref

### DIFF
--- a/LayoutTests/js/dom/modules/import-from-javascript-url-new-window-expected.txt
+++ b/LayoutTests/js/dom/modules/import-from-javascript-url-new-window-expected.txt
@@ -1,0 +1,2 @@
+This test passes if import() in the null-URL initial document of a new top-level window rejects with a TypeError instead of crashing the WebContent process.
+PASS

--- a/LayoutTests/js/dom/modules/import-from-javascript-url-new-window.html
+++ b/LayoutTests/js/dom/modules/import-from-javascript-url-new-window.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body onload="test()">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+var w;
+
+function test() {
+    w = window.open("javascript:import('x').then(() => opener.concludeTest('resolved', false), e => opener.concludeTest(String(e), e instanceof TypeError));void 0");
+}
+
+// Called from the opened window once import() settles.
+function concludeTest(result, isTypeError) {
+    var pass = isTypeError && result === "TypeError: Cannot import a module from a document with no base URL.";
+    document.getElementById("console").textContent = pass ? "PASS" : ("FAIL: " + result);
+
+    if (w)
+        w.close();
+
+    setTimeout(doneHandler, 1);
+
+    function doneHandler() {
+        if (!w || w.closed) {
+            if (window.testRunner)
+                testRunner.notifyDone();
+            return;
+        }
+        setTimeout(doneHandler, 1);
+    }
+}
+</script>
+This test passes if import() in the null-URL initial document of a new top-level window rejects with a TypeError instead of crashing the WebContent process.
+<div id="console">FAIL, test did not run</div>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -401,7 +401,12 @@ JSC::JSPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* jsGlobalOb
                 scriptFetcher = WorkerScriptFetcher::create(*parameters, FetchOptions::Credentials::SameOrigin, destination, ReferrerPolicy::EmptyString);
         }
     }
-    ASSERT(baseURL.isValid());
+
+    if (!baseURL.isValid()) {
+        scope.release();
+        return rejectPromise(*m_context, globalObject, ExceptionCode::TypeError, "Cannot import a module from a document with no base URL."_s);
+    }
+
     ASSERT(scriptFetcher);
     ASSERT(parameters);
 


### PR DESCRIPTION
#### 6cc340adc68dbe2b5baa0f77d638731fc577746a
<pre>
Importing modules from a document with no base URL causes null deref
<a href="https://bugs.webkit.org/show_bug.cgi?id=316862">https://bugs.webkit.org/show_bug.cgi?id=316862</a>
<a href="https://rdar.apple.com/179143870">rdar://179143870</a>

Reviewed by Yusuke Suzuki.

This replaces an assertion that the base URL is valid when dynamically importing a module
from ScriptModuleLoader with an actual validation.

Test: js/dom/modules/import-from-javascript-url-new-window.html

* LayoutTests/js/dom/modules/import-from-javascript-url-new-window-expected.txt: Added.
* LayoutTests/js/dom/modules/import-from-javascript-url-new-window.html: Added.
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::importModule):

Canonical link: <a href="https://commits.webkit.org/315109@main">https://commits.webkit.org/315109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9668288d00c24b2e0118fe749244d820bff17b54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177173 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125571 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9887ae13-b4dc-4460-81bc-eb8ebbf9e486) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130615 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91809 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/007bbee2-cbf5-491f-aced-1537198722c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111132 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d19528d-6510-41f4-b368-8c3d22849a4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32051 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30755 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.DataTaskIdentifierCollision (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25875 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160496 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29124 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32525 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139036 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37463 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105411 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27225 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200555 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113891 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40036 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5327 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40287 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->