### PR TITLE
[SVG] text-orientation does not affect glyph orientation in SVG <text>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt
@@ -30,23 +30,23 @@ PASS 'text-orientation: sideways' - horizontal-tb
 FAIL Rotation attribute - horizontal-tb assert_equals: c expected 0 but got 360
 FAIL <textPath> - horizontal-tb assert_equals: r expected 70 but got 45
 PASS 'text-orientation: mixed' - vertical-rl
-FAIL 'text-orientation: upright' - vertical-rl assert_equals: T expected 0 but got 90
-FAIL 'text-orientation: sideways' - vertical-rl assert_equals: 水 expected 90 but got 0
+PASS 'text-orientation: upright' - vertical-rl
+PASS 'text-orientation: sideways' - vertical-rl
 PASS Rotation attribute - vertical-rl
 FAIL <textPath> - vertical-rl assert_equals: r expected 70 but got 45
 PASS 'text-orientation: mixed' - vertical-lr
-FAIL 'text-orientation: upright' - vertical-lr assert_equals: T expected 0 but got 90
-FAIL 'text-orientation: sideways' - vertical-lr assert_equals: 水 expected 90 but got 0
+PASS 'text-orientation: upright' - vertical-lr
+PASS 'text-orientation: sideways' - vertical-lr
 PASS Rotation attribute - vertical-lr
 FAIL <textPath> - vertical-lr assert_equals: r expected 70 but got 45
-FAIL 'text-orientation: mixed' - sideways-rl assert_equals: 月 expected 90 but got 0
-FAIL 'text-orientation: upright' - sideways-rl assert_equals: 火 expected 90 but got 0
-FAIL 'text-orientation: sideways' - sideways-rl assert_equals: 水 expected 90 but got 0
-FAIL Rotation attribute - sideways-rl assert_equals: 木 expected 270.5 but got 180.5
-FAIL <textPath> - sideways-rl assert_equals: 金 expected 45 but got 315
-FAIL 'text-orientation: mixed' - sideways-lr assert_equals: M expected -90 but got 90
-FAIL 'text-orientation: upright' - sideways-lr assert_equals: T expected -90 but got 90
-FAIL 'text-orientation: sideways' - sideways-lr assert_equals: W expected -90 but got 90
-FAIL Rotation attribute - sideways-lr assert_equals: t expected 270 but got 90
-FAIL <textPath> - sideways-lr assert_equals: F expected 225 but got 45
+PASS 'text-orientation: mixed' - sideways-rl
+PASS 'text-orientation: upright' - sideways-rl
+PASS 'text-orientation: sideways' - sideways-rl
+PASS Rotation attribute - sideways-rl
+FAIL <textPath> - sideways-rl assert_equals: r expected 70 but got 45
+PASS 'text-orientation: mixed' - sideways-lr
+PASS 'text-orientation: upright' - sideways-lr
+PASS 'text-orientation: sideways' - sideways-lr
+PASS Rotation attribute - sideways-lr
+FAIL <textPath> - sideways-lr assert_equals: r expected 250 but got 225
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt
@@ -7,6 +7,6 @@ ABC
 FAIL vertical-rl assert_equals: expected 113 but got 103
 FAIL vertical-lr assert_equals: expected 113 but got 103
 FAIL sideways-rl assert_equals: expected 113 but got 103
-FAIL sideways-lr assert_equals: expected 93 but got 103
+FAIL sideways-lr assert_equals: expected 97 but got 107
 PASS tspan
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -148,26 +148,50 @@ float SVGTextLayoutEngineBaseline::calculateAlignmentBaselineShift(bool isVertic
 
 float SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle(bool isVerticalText, const Style::ComputedStyle& style, const char32_t& character) const
 {
-    if (isVerticalText) {
-        return Style::valueRepresentation(style.glyphOrientationVertical(),
-            [&](const CSS::Keyword::Auto&) {
-                auto verticalOrientation = static_cast<UVerticalOrientation>(u_getIntPropertyValue(character, UCHAR_VERTICAL_ORIENTATION));
-                switch (verticalOrientation) {
-                case U_VO_UPRIGHT:
-                case U_VO_TRANSFORMED_UPRIGHT:
-                    return 0.0f;
-                case U_VO_ROTATED:
-                case U_VO_TRANSFORMED_ROTATED:
-                    return 90.0f;
-                }
-                RELEASE_ASSERT_NOT_REACHED();
-            },
-            [](const Style::Angle<>& angle) {
-                return Style::evaluate<float>(angle);
-            }
-        );
-    } else
+    if (!isVerticalText)
         return 0.0f;
+
+    auto writingMode = style.writingMode();
+
+    // In the sideways-* writing modes every glyph is typeset rotated a quarter
+    // turn toward the block direction, independent of 'text-orientation' and the
+    // character's intrinsic vertical orientation. sideways-rl rotates clockwise
+    // (90deg); sideways-lr rotates counter-clockwise (reported as -90deg).
+    if (!writingMode.isVerticalTypographic())
+        return writingMode.isBlockFlipped() ? 90.0f : 270.0f;
+
+    // In the vertical typographic modes (vertical-rl / vertical-lr) the CSS
+    // 'text-orientation' property (SVG2 / CSS Writing Modes 3) determines the
+    // glyph orientation, superseding the deprecated 'glyph-orientation-vertical'.
+    // The initial 'mixed' value falls back to 'glyph-orientation-vertical' so the
+    // legacy property keeps working when 'text-orientation' is unset.
+    // https://drafts.csswg.org/css-writing-modes-3/#text-orientation
+    switch (writingMode.computedTextOrientation()) {
+    case TextOrientation::Upright:
+        return 0.0f;
+    case TextOrientation::Sideways:
+        return 90.0f;
+    case TextOrientation::Mixed:
+        break;
+    }
+
+    return Style::valueRepresentation(style.glyphOrientationVertical(),
+        [&](const CSS::Keyword::Auto&) {
+            auto verticalOrientation = static_cast<UVerticalOrientation>(u_getIntPropertyValue(character, UCHAR_VERTICAL_ORIENTATION));
+            switch (verticalOrientation) {
+            case U_VO_UPRIGHT:
+            case U_VO_TRANSFORMED_UPRIGHT:
+                return 0.0f;
+            case U_VO_ROTATED:
+            case U_VO_TRANSFORMED_ROTATED:
+                return 90.0f;
+            }
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [](const Style::Angle<>& angle) {
+            return Style::evaluate<float>(angle);
+        }
+    );
 }
 
 static inline bool glyphOrientationIsMultiplyOf180Degrees(float orientationAngle)


### PR DESCRIPTION
#### 7c4cdd40963bfc1179b43e178a58277afbfb9be0
<pre>
[SVG] text-orientation does not affect glyph orientation in SVG &lt;text&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=315190">https://bugs.webkit.org/show_bug.cgi?id=315190</a>
<a href="https://rdar.apple.com/178044217">rdar://178044217</a>

Reviewed by Nikolas Zimmermann.

SVG &lt;text&gt; ignored the CSS &apos;text-orientation&apos; property when computing the
per-glyph rotation in vertical writing modes. The value is parsed, computed
and inherited like any other property, but SVGTextLayoutEngineBaseline only
ever consulted the deprecated &apos;glyph-orientation-vertical&apos; property, so
&apos;mixed&apos; / &apos;upright&apos; / &apos;sideways&apos; had no effect on the rendered glyphs or on
SVGTextContentElement.getRotationOfChar().

In addition, the sideways-rl / sideways-lr writing modes did not typeset
glyphs sideways: they fell through to the per-character UAX#50 path instead
of rotating every glyph a quarter turn toward the block direction.

This patch makes calculateGlyphOrientationAngle() honor the writing mode and
&apos;text-orientation&apos; per SVG2 / CSS Writing Modes 3:

- sideways-rl / sideways-lr: every glyph is rotated a quarter turn
  (clockwise for sideways-rl, counter-clockwise for sideways-lr),
  independent of &apos;text-orientation&apos; and the character&apos;s intrinsic vertical
  orientation. The counter-clockwise case returns 270deg so the existing
  advance/orientation-shift handling applies; getRotationOfChar() reports it
  as -90 via the atan2-based extraction.
- vertical-rl / vertical-lr: &apos;text-orientation&apos; determines the orientation
  (upright -&gt; 0deg, sideways -&gt; 90deg). The initial &apos;mixed&apos; value falls back
  to &apos;glyph-orientation-vertical&apos;, preserving the legacy property when
  &apos;text-orientation&apos; is unset.

* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt: Rebaseline
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::calculateGlyphOrientationAngle const):

Canonical link: <a href="https://commits.webkit.org/315080@main">https://commits.webkit.org/315080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9907bc2b2bfa406c89d493abe66dbc7162f8c73e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125426 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130515 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91726 "4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111032 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31930 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30629 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25535 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179344 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32392 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138921 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138806 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37441 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42002 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105186 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34074 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27096 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113757 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39903 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5199 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40048 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->