### PR TITLE
[JSC] `String#replace`, `String#replaceAll` and `String#split` RegExp paths miss observable side effects

### DIFF
--- a/JSTests/stress/dfg-string-split-regexp-no-split-fallback-evaluation-order.js
+++ b/JSTests/stress/dfg-string-split-regexp-no-split-fallback-evaluation-order.js
@@ -1,0 +1,34 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function doSplit(string, separator, limit) {
+    return string.split(separator, limit);
+}
+noInline(doSplit);
+
+// Train with an object limit so the DFG does not speculate the limit argument
+// as Int32 and OSR-exit before reaching operationStringSplitRegExp.
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(JSON.stringify(doSplit("a,b,c", /,/, { valueOf() { return 4; } })), '["a","b","c"]');
+
+// A separator with an own undefined @@split keeps the primordial watchpoints
+// intact but routes operationStringSplitRegExp to its no-@@split fallback,
+// which must evaluate ToUint32(limit) before ToString(separator).
+let order = [];
+let re = /,/;
+re[Symbol.split] = undefined;
+re.toString = function() {
+    order.push("separator");
+    return ",";
+};
+let limit = {
+    valueOf() {
+        order.push("limit");
+        return 4;
+    }
+};
+let result = doSplit("a,b,c", re, limit);
+shouldBe(JSON.stringify(order), '["limit","separator"]');
+shouldBe(JSON.stringify(result), '["a","b","c"]');

--- a/JSTests/stress/string-replace-regexp-fast-path-tostring-side-effects.js
+++ b/JSTests/stress/string-replace-regexp-fast-path-tostring-side-effects.js
@@ -1,0 +1,36 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+// Overriding RegExp.prototype.exec fires the primordial RegExp watchpoint, so
+// the recheck after ToString(this) must reject the fast path from then on.
+{
+    let execCalled = false;
+    let re = /,/g;
+    let obj = {
+        toString() {
+            RegExp.prototype.exec = function() {
+                execCalled = true;
+                return null;
+            };
+            return "a,b,c";
+        }
+    };
+    let result = String.prototype.replace.call(obj, re, "X");
+    shouldBe(execCalled, true);
+    shouldBe(result, "a,b,c");
+}
+
+// After the watchpoint has fired, the generic @@replace path must also honor
+// the overridden exec.
+{
+    let execCalled = false;
+    RegExp.prototype.exec = function() {
+        execCalled = true;
+        return null;
+    };
+    let result = "a,b,c".replace(/,/, "X");
+    shouldBe(execCalled, true);
+    shouldBe(result, "a,b,c");
+}

--- a/JSTests/stress/string-replaceall-regexp-fast-path-tostring-side-effects.js
+++ b/JSTests/stress/string-replaceall-regexp-fast-path-tostring-side-effects.js
@@ -1,0 +1,38 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+// RegExp.prototype.compile does not fire any watchpoint. Dropping the "g" flag
+// during ToString(this) must result in a single replacement, matching the
+// generic @@replace which rereads the flags after ToString.
+{
+    let re = /,/g;
+    let obj = {
+        toString() {
+            re.compile(",");
+            return "a,b,c";
+        }
+    };
+    let result = String.prototype.replaceAll.call(obj, re, "X");
+    shouldBe(result, "aXb,c");
+}
+
+// Overriding RegExp.prototype.exec fires the primordial RegExp watchpoint, so
+// this must stay the last case in this file.
+{
+    let execCalled = false;
+    let re = /,/g;
+    let obj = {
+        toString() {
+            RegExp.prototype.exec = function() {
+                execCalled = true;
+                return null;
+            };
+            return "a,b,c";
+        }
+    };
+    let result = String.prototype.replaceAll.call(obj, re, "X");
+    shouldBe(execCalled, true);
+    shouldBe(result, "a,b,c");
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4104,13 +4104,13 @@ JSC_DEFINE_JIT_OPERATION(operationStringSplitRegExp, EncodedJSValue, (JSGlobalOb
         OPERATION_RETURN(scope, JSValue::encode(result));
     }
     // No @@split — ToString the separator and use the string-separator engine.
-    JSString* separatorString = separator->toString(globalObject);
-    OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
     unsigned limit = 0xFFFFFFFFu;
     if (!limitValue.isUndefined()) {
         limit = limitValue.toUInt32(globalObject);
         OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
+    JSString* separatorString = separator->toString(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
     OPERATION_RETURN(scope, JSValue::encode(stringSplitFast(globalObject, thisString, separatorString, limit)));
 }
 

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -1074,24 +1074,11 @@ static inline String getSubstitution(JSGlobalObject* globalObject, const String&
     return result.toString();
 }
 
-// 22.2.6.11 RegExp.prototype [ %Symbol.replace% ] ( string, replaceValue )
-// https://tc39.es/ecma262/#sec-regexp.prototype-%25symbol.replace%25
-JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncReplace, (JSGlobalObject* globalObject, CallFrame* callFrame))
+JSValue regExpReplaceGeneric(JSGlobalObject* globalObject, JSObject* thisObject, JSString* string, JSValue replaceValue)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // 1. Let rx be the this value.
-    JSValue thisValue = callFrame->thisValue();
-
-    // 2. If Type(rx) is not Object, throw a TypeError exception.
-    if (!thisValue.isObject()) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "RegExp.prototype.@@replace requires that |this| be an Object"_s);
-    JSObject* thisObject = asObject(thisValue);
-
-    // 3. Let S be ? ToString(string).
-    JSString* string = callFrame->argument(0).toString(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
     String str = string->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -1099,7 +1086,6 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncReplace, (JSGlobalObject* globalObject, 
 
     // 4. Let lengthS be the number of code unit elements in S.
     // 5. Let functionalReplace be IsCallable(replaceValue).
-    JSValue replaceValue = callFrame->argument(1);
     auto callData = JSC::getCallData(replaceValue);
     bool functionalReplace = callData.type != CallData::Type::None;
 
@@ -1138,7 +1124,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncReplace, (JSGlobalObject* globalObject, 
     // 12. Repeat, while done is false,
     while (true) {
         // a. Let result be ? RegExpExec(rx, S).
-        JSValue result = regExpExec(globalObject, thisValue, string);
+        JSValue result = regExpExec(globalObject, thisObject, string);
         RETURN_IF_EXCEPTION(scope, { });
 
         // b. If result is null, then
@@ -1318,7 +1304,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncReplace, (JSGlobalObject* globalObject, 
             throwOutOfMemoryError(globalObject, scope);
             return { };
         }
-        return JSValue::encode(jsString(vm, accumulatedResult.toString()));
+        return jsString(vm, accumulatedResult.toString());
     }
 
     // 17. Return the string-concatenation of accumulatedResult and the substring of S from nextSourcePosition.
@@ -1327,7 +1313,25 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncReplace, (JSGlobalObject* globalObject, 
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
-    return JSValue::encode(jsString(vm, accumulatedResult.toString()));
+    return jsString(vm, accumulatedResult.toString());
+}
+
+// 22.2.6.11 RegExp.prototype [ %Symbol.replace% ] ( string, replaceValue )
+// https://tc39.es/ecma262/#sec-regexp.prototype-%25symbol.replace%25
+JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncReplace, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "RegExp.prototype.@@replace requires that |this| be an Object"_s);
+    JSObject* thisObject = asObject(thisValue);
+
+    JSString* string = callFrame->argument(0).toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(regExpReplaceGeneric(globalObject, thisObject, string, callFrame->argument(1))));
 }
 
 // https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.matchall%

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.h
@@ -59,6 +59,7 @@ class RegExpObject;
 class JSString;
 
 JSValue regExpMatchFast(JSGlobalObject*, RegExpObject*, JSString* inputString);
+JSValue regExpReplaceGeneric(JSGlobalObject*, JSObject* thisObject, JSString* inputString, JSValue replaceValue);
 JSValue regExpSearchFast(JSGlobalObject*, RegExpObject*, JSString* inputString);
 JSValue regExpSearchGeneric(JSGlobalObject*, JSObject* thisObject, JSString* inputString);
 JSCell* regExpSplitFast(JSGlobalObject*, RegExpObject*, JSString* inputString, unsigned limit);

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -615,7 +615,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncReplace, (JSGlobalObject* globalObject, 
         if (regExpObject && regExpObject->isSymbolReplaceFastAndNonObservable()) [[likely]] {
             JSString* string = thisValue.toString(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
-            RELEASE_AND_RETURN(scope, JSValue::encode(replaceUsingRegExpSearch(vm, globalObject, string, regExpObject, callFrame->argument(1))));
+            if (regExpObject->isSymbolReplaceFastAndNonObservable()) [[likely]]
+                RELEASE_AND_RETURN(scope, JSValue::encode(replaceUsingRegExpSearch(vm, globalObject, string, regExpObject, callFrame->argument(1))));
+            RELEASE_AND_RETURN(scope, JSValue::encode(regExpReplaceGeneric(globalObject, regExpObject, string, callFrame->argument(1))));
         }
 
         JSObject* searchObject = asObject(searchValue);
@@ -676,7 +678,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncReplaceAll, (JSGlobalObject* globalObjec
                 return throwVMTypeError(globalObject, scope, "String.prototype.replaceAll argument must not be a non-global regular expression"_s);
             JSString* string = thisValue.toString(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
-            RELEASE_AND_RETURN(scope, JSValue::encode(replaceUsingRegExpSearch(vm, globalObject, string, regExpObject, callFrame->argument(1))));
+            if (regExpObject->isSymbolReplaceFastAndNonObservable()) [[likely]]
+                RELEASE_AND_RETURN(scope, JSValue::encode(replaceUsingRegExpSearch(vm, globalObject, string, regExpObject, callFrame->argument(1))));
+            RELEASE_AND_RETURN(scope, JSValue::encode(regExpReplaceGeneric(globalObject, regExpObject, string, callFrame->argument(1))));
         }
 
         bool searchValueIsRegExp = isRegExp(vm, globalObject, searchValue);


### PR DESCRIPTION
#### eff90f74db57d243c062b7ced375361f06da78c0
<pre>
[JSC] `String#replace`, `String#replaceAll` and `String#split` RegExp paths miss observable side effects
<a href="https://bugs.webkit.org/show_bug.cgi?id=316627">https://bugs.webkit.org/show_bug.cgi?id=316627</a>

Reviewed by Yusuke Suzuki.

This fixes three problems:

1. stringProtoFuncReplace never rechecked isSymbolReplaceFastAndNonObservable()
   after ToString(this), so its side effects (e.g. overriding
   RegExp.prototype.exec) were ignored. Recheck, the same way String#search
   does, via regExpReplaceGeneric extracted from regExpProtoFuncReplace.

2. stringProtoFuncReplaceAll had the same problem. Apply the same fix.

3. The no-@@split fallback in operationStringSplitRegExp evaluated
   ToString(separator) before ToUint32(limit). The spec evaluates the limit
   first.

Tests: JSTests/stress/dfg-string-split-regexp-no-split-fallback-evaluation-order.js
       JSTests/stress/string-replace-regexp-fast-path-tostring-side-effects.js
       JSTests/stress/string-replaceall-regexp-fast-path-tostring-side-effects.js

* JSTests/stress/dfg-string-split-regexp-no-split-fallback-evaluation-order.js: Added.
(shouldBe):
(valueOf):
(re.toString):
(let.limit.valueOf):
* JSTests/stress/string-replace-regexp-fast-path-tostring-side-effects.js: Added.
(shouldBe):
(throw.new.Error.let.obj.toString.RegExp.prototype.exec):
(throw.new.Error):
(shouldBe.RegExp.prototype.exec):
* JSTests/stress/string-replaceall-regexp-fast-path-tostring-side-effects.js: Added.
(shouldBe):
(throw.new.Error):
(shouldBe.let.obj.toString.RegExp.prototype.exec):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/315169@main">https://commits.webkit.org/315169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cad0e00f05a674f3d43214baadbf1f49193aeaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125430 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130516 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91728 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111033 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31936 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30632 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25539 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160366 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141924 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179348 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28995 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32396 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138923 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138808 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37498 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42006 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105190 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34079 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27100 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200426 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40510 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113761 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53850 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39907 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5203 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->