### PR TITLE
Propagate null custom element registry to descendants during parsing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-initialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-initialize-expected.txt
@@ -11,5 +11,5 @@ PASS initialize sets element.customElementRegistry permantently
 PASS initialize is no-op on a subtree with a non-null registry
 PASS initialize works on Document
 PASS initialize works on DocumentFragment
-FAIL initialize sets registry on shadow root descendants with no registry assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS initialize sets registry on shadow root descendants with no registry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/ShadowRoot-init-declarative-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Custom element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry assert_equals: expected object "[object CustomElementRegistry]" but got null
+PASS Custom element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry
 PASS Built-in element inside 'shadowrootcustomelementregistry' declarative shadow root should use document's registry as attachShadow default registry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/element-mutation-expected.txt
@@ -1,17 +1,17 @@
 
 PASS An element with global registry should not change its registry when run append into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run append out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run append into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run append out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run append into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after append into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run append between scoped shadow roots.
 PASS An element with global registry should not change its registry when run appendChild into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run appendChild out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run appendChild into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run appendChild out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run appendChild into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after appendChild into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run appendChild between scoped shadow roots.
 PASS An element with global registry should not change its registry when run prepend into a shadow tree with scoped registry.
-FAIL An element with scoped registry should not change its registry when run prepend out of the shadow tree. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
-FAIL An element with scoped registry should not change its registry when run prepend into another shadow tree with different scoped registry. assert_equals: expected object "[object CustomElementRegistry]" but got object "[object CustomElementRegistry]"
+PASS An element with scoped registry should not change its registry when run prepend out of the shadow tree.
+PASS An element with scoped registry should not change its registry when run prepend into another shadow tree with different scoped registry.
 PASS A freshly created element should preserve global registry after prepend into and removal from a scoped shadow root.
 PASS A freshly created element should preserve global registry when run prepend between scoped shadow roots.
 PASS Declarative shadow DOM with shadowrootcustomelementregistry attribute without registry initialized should remain null registry after adoption.

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-expected.txt
@@ -8,18 +8,18 @@ PASS Cloning a custom element candidate with null regsitry should create an elem
 PASS HTML parser should create a custom element with null registry if customelementregistry is set
 PASS Setting customelementregistry content attribute after a custom element had finishsed parsing should not set null registry
 PASS Cloning a custom element with null regsitry should create an element with null registry
-FAIL Descendants of an element with customelementregistry should use null registry assert_equals: expected null but got object "[object CustomElementRegistry]"
+PASS Descendants of an element with customelementregistry should use null registry
 PASS Setting customelementregistry content attribute during constructor should not make it use null registry
-FAIL Body with customelementregistry attribute during initial parse should have null registry and propagate to children assert_equals: div child of body with customelementregistry should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Custom element candidate child of body with customelementregistry should have null registry during initial parse assert_equals: custom element candidate child of body with customelementregistry should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Descendants of body with customelementregistry should all have null registry during initial parse assert_equals: div child should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Body with customelementregistry in a complete document structure should have null registry assert_equals: div child should have null registry expected null but got object "[object CustomElementRegistry]"
+PASS Body with customelementregistry attribute during initial parse should have null registry and propagate to children
+PASS Custom element candidate child of body with customelementregistry should have null registry during initial parse
+PASS Descendants of body with customelementregistry should all have null registry during initial parse
+PASS Body with customelementregistry in a complete document structure should have null registry
 PASS Initial parse: built-in element with customelementregistry has null registry
 PASS Initial parse: custom element candidate with customelementregistry has null registry
 PASS Initial parse: built-in element without customelementregistry uses global registry
 PASS Initial parse: custom element candidate without customelementregistry uses global registry
-FAIL Initial parse: child of element with customelementregistry inherits null registry assert_equals: Child of element with customelementregistry should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Initial parse: custom element candidate child inherits null registry from parent assert_equals: Custom element candidate child of element with customelementregistry should have null registry expected null but got object "[object CustomElementRegistry]"
-FAIL Initial parse: deeply nested descendant inherits null registry assert_equals: Deeply nested custom element candidate should have null registry expected null but got object "[object CustomElementRegistry]"
+PASS Initial parse: child of element with customelementregistry inherits null registry
+PASS Initial parse: custom element candidate child inherits null registry from parent
+PASS Initial parse: deeply nested descendant inherits null registry
 PASS Initial parse: global registry define only upgrades elements without customelementregistry
 

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -91,6 +91,11 @@ public:
         return treeScope.customElementRegistry();
     }
 
+    static CustomElementRegistry* registryForNode(const Node& node)
+    {
+        return registryForNodeOrTreeScope(node, node.treeScope());
+    }
+
     static void addToScopedCustomElementRegistryMap(Element&, CustomElementRegistry&);
     static void removeFromScopedCustomElementRegistryMap(Element&);
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3462,7 +3462,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init, std::
     }
     auto scopedRegistry = ShadowRootScopedCustomElementRegistry::No;
     if (!registryKind)
-        registryKind = !registry && usesNullCustomElementRegistry() ? CustomElementRegistryKind::Null : CustomElementRegistryKind::Window;
+        registryKind = CustomElementRegistryKind::Window;
     if (registryKind == CustomElementRegistryKind::Null) {
         ASSERT(!registry);
         scopedRegistry = ShadowRootScopedCustomElementRegistry::Yes;
@@ -4428,15 +4428,18 @@ void Element::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventIn
     });
 }
 
+ContainerNode& Element::templateContentOrSelf()
+{
+    if (auto* templateElement = dynamicDowncast<HTMLTemplateElement>(*this))
+        return templateElement->fragmentForInsertion();
+    return *this;
+}
+
 ExceptionOr<void> Element::replaceChildrenWithMarkup(const String& markup, OptionSet<ParserContentPolicy> parserContentPolicy)
 {
     auto policy = OptionSet<ParserContentPolicy> { ParserContentPolicy::AllowScriptingContent } | parserContentPolicy;
 
-    Ref container = [this]() -> Ref<ContainerNode> {
-        if (auto* templateElement = dynamicDowncast<HTMLTemplateElement>(*this))
-            return templateElement->content();
-        return *this;
-    }();
+    Ref container = templateContentOrSelf();
 
     // Parsing empty string creates additional elements only inside <html> container
     // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhtml
@@ -4446,7 +4449,7 @@ ExceptionOr<void> Element::replaceChildrenWithMarkup(const String& markup, Optio
         return { };
     }
 
-    auto fragment = createFragmentForInnerOuterHTML(*this, markup, policy, CustomElementRegistry::registryForNodeOrTreeScope(container, container->treeScope()));
+    auto fragment = createFragmentForInnerOuterHTML(*this, markup, policy, CustomElementRegistry::registryForNode(container));
     if (fragment.hasException())
         return fragment.releaseException();
 
@@ -6131,7 +6134,7 @@ ExceptionOr<Element*> Element::insertAdjacentElement(const String& where, Elemen
     return downcast<Element>(result.releaseReturnValue());
 }
 
-// Step 1 of https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml.
+// Step 3 of https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-insertadjacenthtml
 static ExceptionOr<ContainerNode&> contextNodeForInsertion(const String& where, Element& element)
 {
     if (equalLettersIgnoringASCIICase(where, "beforebegin"_s) || equalLettersIgnoringASCIICase(where, "afterend"_s)) {
@@ -6145,29 +6148,21 @@ static ExceptionOr<ContainerNode&> contextNodeForInsertion(const String& where, 
     return Exception { ExceptionCode::SyntaxError };
 }
 
-// Step 2 of https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml.
-static ExceptionOr<Ref<Element>> contextElementForInsertion(const String& where, Element& element)
-{
-    auto contextNodeResult = contextNodeForInsertion(where, element);
-    if (contextNodeResult.hasException())
-        return contextNodeResult.releaseException();
-    CheckedRef contextNode = contextNodeResult.releaseReturnValue();
-    RefPtr contextElement = dynamicDowncast<Element>(contextNode.get());
-    if (!contextElement || (contextNode->document().isHTMLDocument() && is<HTMLHtmlElement>(contextNode.get())))
-        return Ref<Element> { HTMLBodyElement::create(protect(contextNode->document())) };
-    return contextElement.releaseNonNull();
-}
-
-// https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-insertadjacenthtml
 ExceptionOr<void> Element::insertAdjacentHTML(const String& where, const String& markup, NodeVector* addedNodes)
 {
-    // Steps 1 and 2.
-    auto contextElement = contextElementForInsertion(where, *this);
-    if (contextElement.hasException())
-        return contextElement.releaseException();
-    // Step 3.
-    RefPtr registry = CustomElementRegistry::registryForElement(contextElement.returnValue());
-    auto fragment = createFragmentForInnerOuterHTML(contextElement.releaseReturnValue(), markup, { ParserContentPolicy::AllowScriptingContent }, registry.get());
+    // Steps 3 and 4.
+    auto contextNodeResult = contextNodeForInsertion(where, *this);
+    if (contextNodeResult.hasException())
+        return contextNodeResult.releaseException();
+    Ref contextNode = contextNodeResult.releaseReturnValue();
+    // Step 5.
+    RefPtr registry = CustomElementRegistry::registryForNode(contextNode);
+    RefPtr maybeContextElement = dynamicDowncast<Element>(contextNode);
+    Ref contextElement = (maybeContextElement && !(contextNode->document().isHTMLDocument() && is<HTMLHtmlElement>(contextNode)))
+        ? maybeContextElement.releaseNonNull()
+        : Ref<Element> { HTMLBodyElement::create(protect(contextNode->document())) };
+    auto fragment = createFragmentForInnerOuterHTML(contextElement, markup, { ParserContentPolicy::AllowScriptingContent }, registry);
     if (fragment.hasException())
         return fragment.releaseException();
 
@@ -6177,7 +6172,7 @@ ExceptionOr<void> Element::insertAdjacentHTML(const String& where, const String&
         collectChildNodes(fragment.returnValue(), *addedNodes);
     }
 
-    // Step 4.
+    // Step 6.
     auto result = insertAdjacent(where, fragment.releaseReturnValue());
     if (result.hasException())
         return result.releaseException();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -403,6 +403,8 @@ public:
     Ref<Element> cloneElementWithChildren(Document&, CustomElementRegistry*) const;
     Ref<Element> cloneElementWithoutChildren(Document&, CustomElementRegistry*) const;
 
+    ContainerNode& templateContentOrSelf();
+
     void normalizeAttributes();
 
     // For exposing to DOM only.

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -802,7 +802,7 @@ ExceptionOr<void> Node::normalize()
 Ref<Node> Node::cloneNode(bool deep) const
 {
     ASSERT(!isShadowRoot());
-    RefPtr registry = CustomElementRegistry::registryForNodeOrTreeScope(*this, treeScope());
+    RefPtr registry = CustomElementRegistry::registryForNode(*this);
     return cloneNodeInternal(document(), deep ? CloningOperation::Everything : CloningOperation::SelfOnly, registry.get());
 }
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1541,6 +1541,10 @@ static ALWAYS_INLINE ExceptionOr<Ref<DocumentFragment>> createFragmentForMarkup(
     Ref document = contextElement.hasTagName(templateTag) ? contextElement.document().ensureTemplateDocument() : contextElement.document();
     auto fragment = mode == DocumentFragmentMode::New ? DocumentFragment::create(document.get()) : document->documentFragmentForInnerOuterHTML();
     ASSERT(!fragment->hasChildNodes());
+    if (!registry && contextElement.usesNullCustomElementRegistry())
+        fragment->setUsesNullCustomElementRegistry();
+    else if (fragment->usesNullCustomElementRegistry() && !document->usesNullCustomElementRegistry())
+        fragment->clearUsesNullCustomElementRegistry();
     if (document->isHTMLDocument() || parserContentPolicy.contains(ParserContentPolicy::AlwaysParseAsHTML)) {
         fragment->parseHTML(markup, contextElement, parserContentPolicy, registry);
         return fragment;
@@ -1623,7 +1627,7 @@ static void removeElementFromFragmentPreservingChildren(DocumentFragment& fragme
 
 ExceptionOr<Ref<DocumentFragment>> createContextualFragment(Element& element, const String& markup, OptionSet<ParserContentPolicy> parserContentPolicy)
 {
-    auto result = createFragmentForMarkup(element, markup, DocumentFragmentMode::New, parserContentPolicy, CustomElementRegistry::registryForElement(element));
+    auto result = createFragmentForMarkup(element, markup, DocumentFragmentMode::New, parserContentPolicy, CustomElementRegistry::registryForNode(element.templateContentOrSelf()));
     if (result.hasException())
         return result.releaseException();
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -859,10 +859,15 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
             } else
                 element = HTMLUnknownElement::create(qualifiedName, ownerDocument);
         }
-        if (!registry && treeScope->rootNode().usesNullCustomElementRegistry())
-            element->setUsesNullCustomElementRegistry();
     }
     ASSERT(element);
+    auto parentOptsOutOfCustomElementRegistry = [&] {
+        if (RefPtr parent = dynamicDowncast<Element>(currentNode()))
+            return parent->templateContentOrSelf().usesNullCustomElementRegistry();
+        return currentNode().usesNullCustomElementRegistry();
+    };
+    if (!registry && (treeScope->rootNode().usesNullCustomElementRegistry() || parentOptsOutOfCustomElementRegistry()))
+        element->setUsesNullCustomElementRegistry();
     if (registry && registry->isScoped() && registry != treeScope->customElementRegistry()) [[unlikely]]
         CustomElementRegistry::addToScopedCustomElementRegistryMap(*element, *registry);
 


### PR DESCRIPTION
#### cc7f392565fc90fc11405ac6f7d02d62d971028c
<pre>
Propagate null custom element registry to descendants during parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=316865">https://bugs.webkit.org/show_bug.cgi?id=316865</a>

Reviewed by NOBODY (OOPS!).

During parsing an explicit null custom element registry needs to be
&quot;inherited&quot;. The previous parser code only handled tree-scope-root
opt-out, and only for unknown HTML names.

Also fixes two related issues exposed by this change: attachShadow()
now defaults to the document&apos;s global registry and insertAdjacentHTML()
derives its registry from the context node rather than the body element
fallback.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc7f392565fc90fc11405ac6f7d02d62d971028c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125431 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41260 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130519 "Found 1 new test failure: imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91729 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111036 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31945 "Found 1 new test failure: imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30635 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25540 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179349 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32397 "Found 1 new failure in dom/CustomElementRegistry.h") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30159 "Found 1 new test failure: imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138950 "Found 1 new test failure: imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138820 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42007 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150233 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105191 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34084 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27112 "Found 1 new test failure: imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40511 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113762 "Found 1 new failure in dom/CustomElementRegistry.h") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39908 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5215 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40053 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->