### PR TITLE
[SVG] getRotationOfChar() returns ~360 instead of 0 for a full-turn rotate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt
@@ -27,7 +27,7 @@ F金r
 PASS 'text-orientation: mixed' - horizontal-tb
 PASS 'text-orientation: upright' - horizontal-tb
 PASS 'text-orientation: sideways' - horizontal-tb
-FAIL Rotation attribute - horizontal-tb assert_equals: c expected 0 but got 360
+PASS Rotation attribute - horizontal-tb
 FAIL <textPath> - horizontal-tb assert_equals: r expected 70 but got 45
 PASS 'text-orientation: mixed' - vertical-rl
 PASS 'text-orientation: upright' - vertical-rl

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -523,7 +523,12 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
                 m_lineLayoutChunkStarts.add(makeKey(*textBox));
         }
 
-        float angle = SVGTextLayoutAttributes::isEmptyValue(data.rotate) ? 0 : data.rotate;
+        // Reduce the supplemental rotation modulo a full turn so an exact
+        // multiple of 360 (e.g. rotate="360") collapses to the identity. A
+        // rotate(360) builds its matrix from sin(2*pi), which evaluates to a
+        // tiny non-zero value (~1e-16, machine-epsilon rounding error) rather
+        // than 0, and getRotationOfChar() then rounds that back up to ~360.
+        float angle = SVGTextLayoutAttributes::isEmptyValue(data.rotate) ? 0 : fmodf(data.rotate, 360);
 
         // Calculate glyph orientation angle.
         auto remainingCharacters = characters.subspan(m_visualCharacterOffset);


### PR DESCRIPTION
#### cffc7df0742cbdcd6c2c3a816f8f4c8392feb2d2
<pre>
[SVG] getRotationOfChar() returns ~360 instead of 0 for a full-turn rotate
<a href="https://bugs.webkit.org/show_bug.cgi?id=315193">https://bugs.webkit.org/show_bug.cgi?id=315193</a>
<a href="https://rdar.apple.com/178044934">rdar://178044934</a>

Reviewed by Simon Fraser.

A per-character rotation that is an exact multiple of a full turn (e.g.
rotate=&quot;360&quot;) was applied verbatim when building the glyph fragment
transform. rotate(360) builds its matrix from sin(2*pi), which evaluates to
a machine-epsilon-sized non-zero value (~-2.4e-16) rather than 0, so the
angle extracted by SVGTextQuery::rotationOfCharacter() via atan2() came back
as a tiny negative number instead of 0. SVGTextContentElement.getRotationOfChar()
therefore reported essentially 0-but-just-below, which normalizes to ~360.

Reduce the supplemental rotation modulo a full turn so an exact multiple of
360 collapses to the identity transform, yielding exactly 0. Values that are
not multiples of 360 (e.g. 365, -10, 180.5) are numerically unchanged.

* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt: Progression
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):

Canonical link: <a href="https://commits.webkit.org/315293@main">https://commits.webkit.org/315293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/297b339993cb055ee1828e4b5a65e4e05279fb52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125436 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130534 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91732 "5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111051 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31939 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30637 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25545 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179354 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32402 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138928 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138813 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37578 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42012 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105196 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34083 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27101 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113767 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39913 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5204 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40058 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->