### PR TITLE
Tap does not extend to full grammar range.

### DIFF
--- a/LayoutTests/editing/selection/ios/select-word-for-replacement-extends-grammar-marker-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-word-for-replacement-extends-grammar-marker-expected.txt
@@ -1,0 +1,11 @@
+Verifies that selectWordForReplacement extends to a multi-word grammar marker. This test requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.hasGrammarMarker(3, 9) is true
+PASS getSelection().toString() is "are going"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/select-word-for-replacement-extends-grammar-marker.html
+++ b/LayoutTests/editing/selection/ios/select-word-for-replacement-extends-grammar-marker.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<head>
+<style>
+div[contenteditable] {
+    font-family: monospace;
+    font-size: 24px;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that selectWordForReplacement extends to a multi-word grammar marker. This test requires WebKitTestRunner.");
+
+    if (!window.testRunner)
+        return;
+
+    const editor = document.querySelector("div[contenteditable]");
+    const rect = editor.getBoundingClientRect();
+
+    await UIHelper.activateAndWaitForInputSessionAt(rect.left + 10, rect.top + rect.height / 2);
+    await UIHelper.typeCharacters("He are going home");
+
+    // Add a grammar marker spanning "are going" (offset 3, length 9) within
+    // the inserted text node.
+    internals.setMarkerFor("grammar", 3, 9, "");
+    shouldBeTrue("internals.hasGrammarMarker(3, 9)");
+
+    // Place the caret inside the grammar marker, between "ar" and "e" of "are".
+    getSelection().collapse(editor.firstChild, 5);
+    await UIHelper.ensurePresentationUpdate();
+
+    await UIHelper.selectWordForReplacement();
+    await UIHelper.ensurePresentationUpdate();
+
+    shouldBeEqualToString("getSelection().toString()", "are going");
+
+    editor.textContent = "";
+    editor.blur();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div contenteditable></div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1722,7 +1722,7 @@ void WebPage::extendSelectionForReplacement(CompletionHandler<void()>&& completi
     if (!container)
         return;
 
-    auto markerRanges = protect(document->markers())->markersFor(*container, { DocumentMarkerType::DictationAlternatives, DocumentMarkerType::CorrectionIndicator }).map([&](auto& marker) {
+    auto markerRanges = protect(document->markers())->markersFor(*container, { DocumentMarkerType::DictationAlternatives, DocumentMarkerType::CorrectionIndicator, DocumentMarkerType::Grammar }).map([&](auto& marker) {
         return makeSimpleRange(*container, *marker);
     });
 


### PR DESCRIPTION
#### 6c2d1f6c2130b49309309bc874924b31cc9dd674
<pre>
Tap does not extend to full grammar range.
<a href="https://bugs.webkit.org/show_bug.cgi?id=316866">https://bugs.webkit.org/show_bug.cgi?id=316866</a>
<a href="https://rdar.apple.com/178998221">rdar://178998221</a>

Reviewed by Aditya Keerthi and Alex Christensen.

Test: editing/selection/ios/select-word-for-replacement-extends-grammar-marker.html

When tapping in an editable region on iOS, extendSelectionForReplacement
extends the caret to cover any DictationAlternatives or CorrectionIndicator
marker that contains the caret. Grammar markers were not included, so
tapping inside a multi-word grammar suggestion only selected the word
under the caret rather than the entire suggestion range.

Add DocumentMarkerType::Grammar to the set of marker types searched, so
the full grammar range is selected on tap.

* LayoutTests/editing/selection/ios/select-word-for-replacement-extends-grammar-marker-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-word-for-replacement-extends-grammar-marker.html: Added.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::extendSelectionForReplacement):

Canonical link: <a href="https://commits.webkit.org/315029@main">https://commits.webkit.org/315029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8b4ce2fc11e005cd5547aa7afeb2568f2499b29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41257 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34852 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176817 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125441 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f10bc010-e1a4-4c94-a22b-ed18672d5a16) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130526 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2a825af-efe5-4559-a266-32155c7f07bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111043 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a897371-b693-4403-a7cd-985f7107f866) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31944 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30644 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25550 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141932 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179359 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138931 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37408 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150227 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105201 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34088 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27106 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40521 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113772 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39918 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5209 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40169 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->