### PR TITLE
[Site Isolation] Notify parent frame via checkCompleted() when child async back/forward navigation is cancelled

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4773,6 +4773,16 @@ void FrameLoader::setPendingAsyncBackForwardNavigation()
     m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::Pending;
 }
 
+void FrameLoader::clearAsyncBackForwardNavigationState()
+{
+    if (m_asyncBackForwardNavigationState == AsyncBackForwardNavigationState::None)
+        return;
+    m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::None;
+    Ref frame = m_frame.get();
+    if (RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent()))
+        parentFrame->loader().checkCompleted();
+}
+
 void FrameLoader::cancelPendingAsyncBackForwardNavigation()
 {
     if (m_asyncBackForwardNavigationState != AsyncBackForwardNavigationState::Pending)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -365,7 +365,7 @@ public:
     WEBCORE_EXPORT void NODELETE setPendingAsyncBackForwardNavigation();
     WEBCORE_EXPORT void cancelPendingAsyncBackForwardNavigation();
     bool asyncBackForwardNavigationWasCancelled() const { return m_asyncBackForwardNavigationState == AsyncBackForwardNavigationState::Cancelled; }
-    void clearAsyncBackForwardNavigationState() { m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::None; }
+    WEBCORE_EXPORT void clearAsyncBackForwardNavigationState();
     bool isWaitingForAsyncBackForwardNavigation() const { return m_asyncBackForwardNavigationState != AsyncBackForwardNavigationState::None; }
 
     void setRequiredCookiesVersion(uint64_t version) { m_requiredCookiesVersion = version; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1238,9 +1238,9 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationActi
                 return;
 
             if (action == PolicyAction::Ignore) {
-                // Reset the pending async state and re-check completeness
-                // on the parent since this child won't be loading.
-                localFrame->loader().cancelPendingAsyncBackForwardNavigation();
+                // The async back/forward navigation won't proceed; clear the wait state
+                // so the parent can run checkCompleted() without being blocked by this child.
+                localFrame->loader().clearAsyncBackForwardNavigationState();
                 return;
             }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2677,10 +2677,9 @@ void WebPage::goToBackForwardItem(GoToBackForwardItemParameters&& parameters)
         targetFrame = historyItemFrame.releaseNonNull();
 
     if (RefPtr targetLocalFrame = targetFrame->provisionalFrame() ? targetFrame->provisionalFrame() : targetFrame->coreLocalFrame()) {
-        bool wasCancelled = targetLocalFrame->loader().asyncBackForwardNavigationWasCancelled();
-        targetLocalFrame->loader().clearAsyncBackForwardNavigationState();
-        if (wasCancelled) {
+        if (targetLocalFrame->loader().asyncBackForwardNavigationWasCancelled()) {
             WEBPAGE_RELEASE_LOG(Loading, "goToBackForwardItem: Skipping because pending async back/forward traversal was cancelled");
+            targetLocalFrame->loader().clearAsyncBackForwardNavigationState();
             return;
         }
         protect(corePage())->goToItem(*targetLocalFrame, *item, parameters.backForwardType, parameters.shouldTreatAsContinuingLoad, parameters.shouldRestoreFromBackForwardCache);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -4196,6 +4196,53 @@ TEST(SiteIsolation, NavigateIframeCrossOriginBackForwardAfterSessionRestoreToNew
     testNavigateIframeBackForward(@"https://apple.com/destination", SessionRestoreMethod::NewWebView);
 }
 
+TEST(SiteIsolation, CancelledChildAsyncBackForwardNotifiesParent)
+{
+    HTTPServer server({
+        { "/page0"_s, { "<p>page0</p><iframe src='https://example.com/child0'></iframe><script>window.onload=()=>alert('page0-loaded')</script>"_s } },
+        { "/page1"_s, { "<p>page1</p><iframe src='https://example.com/child1'></iframe><script>window.onload=()=>alert('page1-loaded')</script>"_s } },
+        { "/child0"_s, { "<p>child0</p>"_s } },
+        { "/child1"_s, { "<p>child1</p>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    // Disabling BFCache so going back will perform a fresh load of page0.
+    processPoolConfiguration.get().pageCacheEnabled = NO;
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [configuration setProcessPool:processPool.get()];
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration.get());
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page0"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "page0-loaded");
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page1"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "page1-loaded");
+
+    __block bool interceptedChildPolicy = false;
+    RetainPtr capturedWebView = webView;
+    [navigationDelegate setDecidePolicyForNavigationAction:^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        if (!action.targetFrame.isMainFrame && action.navigationType == WKNavigationTypeBackForward && !interceptedChildPolicy) {
+            interceptedChildPolicy = true;
+            // Inject a cross-document navigation while the child is Pending.
+            [capturedWebView evaluateJavaScript:@"frames[0].location = 'https://example.com/injected'" completionHandler:^(id, NSError *) {
+                decisionHandler(WKNavigationActionPolicyAllow);
+            }];
+            return;
+        }
+        // Deny the injected navigation so it never commits. This prevents didBeginDocument()
+        // from accidentally unblocking the parent.
+        if (!action.targetFrame.isMainFrame && interceptedChildPolicy) {
+            decisionHandler(WKNavigationActionPolicyCancel);
+            return;
+        }
+        decisionHandler(WKNavigationActionPolicyAllow);
+    }];
+
+    [webView goBack];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "page0-loaded");
+}
+
 TEST(SiteIsolation, ValidateSessionRestoreWithoutNavigating)
 {
     HTTPServer server({


### PR DESCRIPTION
#### dd8f85cb43ada51ab9a34ec35816be6667b9c5d7
<pre>
[Site Isolation] Notify parent frame via checkCompleted() when child async back/forward navigation is cancelled
<a href="https://bugs.webkit.org/show_bug.cgi?id=316873">https://bugs.webkit.org/show_bug.cgi?id=316873</a>
<a href="https://rdar.apple.com/179296676">rdar://179296676</a>

Reviewed by Basuke Suzuki.

When UseUIProcessForBackForwardItemLoading is on and a cross-document navigation starts in a child frame that has an
async back/forward navigation pending, loadWithDocumentLoader() calls stopCheck() =&gt; invalidatePolicyListeners(), which
fires the pending BF policy callback with PolicyAction::Ignore. The Ignore handler (and the wasCancelled path) was
clearing the async-wait state on the child but never calling checkCompleted() on the parent. This left the parent
blocked, so its window.onload never fired.

This patch fixes the issue by moving the parent checkCompleted() call into clearAsyncBackForwardNavigationState()
itself, so every cancellation site automatically unblocks the parent. An early-return guard (state == None) ensures
there is no behavioral change for non-SI code paths where the async-wait state is never set.
WebPage::goToBackForwardItem() is also restructured to call clearAsyncBackForwardNavigationState() only on the cancelled
path, not before the normal goToItem() call; this is safer since the Pending state keeps the parent correctly blocked
until didBeginDocument() clears it once the new load starts.

Test: SiteIsolation.CancelledChildAsyncBackForwardNotifiesParent

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::clearAsyncBackForwardNavigationState):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::goToBackForwardItem):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, CancelledChildAsyncBackForwardNotifiesParent)):

Canonical link: <a href="https://commits.webkit.org/315480@main">https://commits.webkit.org/315480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1c132cf8f0d78071d1ae7ad55866d288e6c1f3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41742 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35313 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125887 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3773d93c-f9aa-43ca-8879-84494348b7e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130876 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91995 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/709c5ee9-16d5-48a1-881a-e03ad03bca05) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171145 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33343 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 5 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111388 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92d7e488-628b-465b-b9c9-86c18e321c6b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32329 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31034 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26210 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180114 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139313 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41755 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37683 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42443 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105817 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34463 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114203 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40947 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5606 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40344 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40595 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->