### PR TITLE
[MSE][Cocoa] imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html is a permanent failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-remove-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-remove-expected.txt
@@ -11,8 +11,8 @@ PASS Test remove while update pending.
 PASS Test aborting a remove operation.
 PASS Test remove with a start at the duration.
 PASS Test remove transitioning readyState from 'ended' to 'open'.
-FAIL Test removing all appended data. assert_equals: Initial buffered range. expected "{ [0.095, 6.548) }" but got "{ [0.000, 6.548) }"
-FAIL Test removing beginning of appended data. assert_equals: Initial buffered range. expected "{ [0.095, 6.548) }" but got "{ [0.000, 6.548) }"
-FAIL Test removing the middle of appended data. assert_equals: Initial buffered range. expected "{ [0.095, 6.548) }" but got "{ [0.000, 6.548) }"
-FAIL Test removing the end of appended data. assert_equals: Initial buffered range. expected "{ [0.095, 6.548) }" but got "{ [0.000, 6.548) }"
+PASS Test removing all appended data.
+PASS Test removing beginning of appended data.
+PASS Test removing the middle of appended data.
+PASS Test removing the end of appended data.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html
@@ -48,7 +48,8 @@
                                               expectedTimestampOffset, expectedBufferedRangeStartTime,
                                               expectedBufferedRangeMaxEndTimeBeforeEOS,
                                               expectedBufferedRangeEndTimeAfterEOS,
-                                              callback) {
+                                              callback,
+                                              expectedBufferedRangesAfterEOS) {
               assert_approx_equals(sourceBuffer.timestampOffset,
                                    expectedTimestampOffset,
                                    0.001,
@@ -71,7 +72,7 @@
               test.waitForExpectedEvents(function()
               {
                   assertBufferedEquals(sourceBuffer,
-                                       "{ [" + expectedBufferedRangeStartTime.toFixed(3) + ", " + expectedBufferedRangeEndTimeAfterEOS.toFixed(3) + ") }",
+                                       expectedBufferedRangesAfterEOS || ("{ [" + expectedBufferedRangeStartTime.toFixed(3) + ", " + expectedBufferedRangeEndTimeAfterEOS.toFixed(3) + ") }"),
                                        "sourceBuffer.buffered after EOS");
                   callback();
               });
@@ -122,13 +123,25 @@
                       var expectedStart = Math.max(segmentInfo.media[1].timev, segmentInfo.media[1].timea) - firstOffset;
                       var expectedEnd = Math.min(segmentInfo.media[0].endtimev, segmentInfo.media[0].endtimea) + secondOffset;
                       var expectedEndEOS = Math.max(segmentInfo.media[0].endtimev, segmentInfo.media[0].endtimea) + secondOffset;
+
+                      // If media[0]'s two tracks have different first PTS, sequence mode aligns
+                      // the earlier one to the previous segment's end, leaving a gap of that delta
+                      // before the later track.
+                      var media0PerTrackHeadDelta =
+                          Math.abs(segmentInfo.media[0].timev - segmentInfo.media[0].timea);
+                      var expectedBufferedRangesAfterEOS = (media0PerTrackHeadDelta > 0)
+                          ? "{ [" + expectedStart.toFixed(3) + ", " + secondOffset.toFixed(3) + ")"
+                            + " [" + (secondOffset + media0PerTrackHeadDelta).toFixed(3) + ", " + expectedEndEOS.toFixed(3) + ") }"
+                          : "{ [" + expectedStart.toFixed(3) + ", " + expectedEndEOS.toFixed(3) + ") }";
+
                       // Current timestampOffset should reflect offset required to put media[0]
                       // immediately after media[1]'s highest frame end timestamp (as was adjusted
                       // by an earlier timestampOffset).
                       verify_offset_and_buffered(test, mediaSource, sourceBuffer,
                                                  secondOffset, expectedStart,
                                                  expectedEnd, expectedEndEOS,
-                                                 test.done);
+                                                 test.done,
+                                                 expectedBufferedRangesAfterEOS);
                   })
               });
           }, "Test sequence AppendMode appendBuffer(second media segment, then first media segment)");

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4364,6 +4364,7 @@ webkit.org/b/211940 fast/text/multiple-codeunit-vertical-upright.html [ ImageOnl
 
 webkit.org/b/167108 imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html [ Failure ]
 webkit.org/b/197711 imported/w3c/web-platform-tests/media-source/mediasource-correct-frames.html [ Failure ]
+webkit.org/b/316964 imported/w3c/web-platform-tests/media-source/mediasource-remove.html [ Failure ]
 
 webkit.org/b/207978 imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing.sub.https.html [ Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -799,7 +799,6 @@ webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/URL-createObjec
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-append-buffer.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-errors.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-is-type-supported.html [ Skip ]
-webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html [ Skip ]
 webkit.org/b/161725 imported/w3c/web-platform-tests/media-source/mediasource-sourcebuffer-mode.html [ Skip ]
 webkit.org/b/214166 imported/w3c/web-platform-tests/media-source/idlharness.window.html [ Skip ]
 
@@ -1477,6 +1476,7 @@ webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/backgrou
 webkit.org/b/206604 animations/animation-welcome-safari.html [ Pass Failure ]
 
 webkit.org/b/207062 imported/w3c/web-platform-tests/media-source/mediasource-replay.html [ Pass Failure ]
+webkit.org/b/316898 imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality.html [ Pass Failure ]
 
 webkit.org/b/206484 imported/w3c/web-platform-tests/websockets/cookies/007.html?default [ Pass Failure ]
 

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -468,6 +468,7 @@ platform/graphics/cocoa/IOSurface.mm @nonARC
 platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
 platform/graphics/cocoa/IOSurfacePoolCocoa.mm @nonARC
 platform/graphics/cocoa/ISOBMFFPreParser.cpp
+platform/graphics/cocoa/ISOBMFFTrackInfoParser.cpp
 platform/graphics/cocoa/IconCocoa.mm @nonARC
 platform/graphics/cocoa/IntRectCocoa.mm @nonARC
 platform/graphics/cocoa/ImageAdapterCocoa.mm @nonARC

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3654,6 +3654,7 @@
 		8D8AB55246EA6D3E46D7E2EF /* UnifiedSource38-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCFF63713748594F7E1BE330 /* UnifiedSource38-header-RenderStyleGetters.cpp */; };
 		8E4C96DD1AD4483500365A50 /* JSFetchResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E4C96D91AD4483500365A50 /* JSFetchResponse.h */; };
 		8E595FF95A93134A1B3ADBB4 /* ISOBMFFPreParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B588D917E3A23CFD5275BDE9 /* ISOBMFFPreParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8E595FFA5A93134A1B3ADBB5 /* ISOBMFFTrackInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B588D930E3A23CFD5275BDE9 /* ISOBMFFTrackInfoParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8F9B85867BCC1EE38784EE83 /* UnifiedSource71-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB591C358F2E176568F6C0AA /* UnifiedSource71-header-RenderStyleGetters.cpp */; };
 		9001774112E0347800648462 /* OESStandardDerivatives.h in Headers */ = {isa = PBXBuildFile; fileRef = 9001773E12E0347800648462 /* OESStandardDerivatives.h */; };
 		9001788112E0370700648462 /* JSOESStandardDerivatives.h in Headers */ = {isa = PBXBuildFile; fileRef = 9001787F12E0370700648462 /* JSOESStandardDerivatives.h */; };
@@ -18928,6 +18929,8 @@
 		B56579B41824D12A00E79F23 /* RenderChildIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderChildIterator.h; sourceTree = "<group>"; };
 		B588D917E3A23CFD5275BDE9 /* ISOBMFFPreParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ISOBMFFPreParser.h; sourceTree = "<group>"; };
 		B588D918E3A23CFD5275BDE9 /* ISOBMFFPreParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ISOBMFFPreParser.cpp; sourceTree = "<group>"; };
+		B588D930E3A23CFD5275BDE9 /* ISOBMFFTrackInfoParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ISOBMFFTrackInfoParser.h; sourceTree = "<group>"; };
+		B588D931E3A23CFD5275BDE9 /* ISOBMFFTrackInfoParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ISOBMFFTrackInfoParser.cpp; sourceTree = "<group>"; };
 		B595FF461824CEE300FF51CD /* RenderIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderIterator.h; sourceTree = "<group>"; };
 		B59CA59AF170D8FAA5B8C9AD /* MathMLScriptsElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MathMLScriptsElement.cpp; sourceTree = "<group>"; };
 		B59CA59AF170D8FAA5B8CABE /* MathMLPaddedElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MathMLPaddedElement.cpp; sourceTree = "<group>"; };
@@ -37123,6 +37126,8 @@
 				AD9FF6E01908391D003B61E0 /* IOSurfacePoolCocoa.mm */,
 				B588D918E3A23CFD5275BDE9 /* ISOBMFFPreParser.cpp */,
 				B588D917E3A23CFD5275BDE9 /* ISOBMFFPreParser.h */,
+				B588D931E3A23CFD5275BDE9 /* ISOBMFFTrackInfoParser.cpp */,
+				B588D930E3A23CFD5275BDE9 /* ISOBMFFTrackInfoParser.h */,
 				A1DD618F2B7EBD8200075A92 /* MediaPlayerCocoa.mm */,
 				CD3578AC2A28F5AA0059D97D /* MediaPlayerEnumsCocoa.h */,
 				CD3578AD2A28F5AA0059D97D /* MediaPlayerEnumsCocoa.mm */,
@@ -46121,6 +46126,7 @@
 				E86097D52D84403B00A4E526 /* ISO18013ElementInfo.h in Headers */,
 				E86097D32D84403B00A4E526 /* ISO18013PresentmentRequest.h in Headers */,
 				8E595FF95A93134A1B3ADBB4 /* ISOBMFFPreParser.h in Headers */,
+				8E595FFA5A93134A1B3ADBB5 /* ISOBMFFTrackInfoParser.h in Headers */,
 				CD5FF4992162E2BE004BD86F /* ISOBox.h in Headers */,
 				CD720B4F2268B51300047FDE /* ISOFairPlayStreamingPsshBox.h in Headers */,
 				CD5FF49E2162E4E8004BD86F /* ISOOriginalFormatBox.h in Headers */,

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1079,6 +1079,106 @@ Ref<MediaPromise> SourceBufferPrivate::append(Ref<SharedBuffer>&& buffer)
     return m_currentSourceBufferOperation.get();
 }
 
+auto SourceBufferPrivate::findPrioritySample(const SamplesVector& samples) const -> PrioritySample
+{
+    assertIsCurrent(m_dispatcher.get());
+
+    // In sequence mode, the spec's coded frame processing algorithm step 1.3
+    // sets timestampOffset = group_start_timestamp − presentation_timestamp
+    // on the first sample to enter the loop. Across multiple tracks the
+    // right "first" sample is the one carrying the smallest presentation
+    // timestamp in the segment, so all of the segment's coded frames land
+    // at or after group_start_timestamp. Step 1.3 fires both on the initial
+    // batch (m_groupStartTimestamp valid here) and after a discontinuity in
+    // step 1.6 retries it on the regressing sample, so the priority sample
+    // must be at position 0 in either case. The look-ahead per track is
+    // bounded by the H.264 / H.265 max reorder window (16); non-video
+    // tracks have no reordering, so 1 arrival suffices. Samples whose
+    // trackID is not in m_trackBufferMap (text / metadata) are dropped by
+    // isMediaSampleAllowed before step 1.3 and don't influence the choice.
+    if (m_appendMode != SourceBufferAppendMode::Sequence
+        || samples.size() <= 1
+        || m_trackBufferMap.size() <= 1)
+        return { };
+
+    static constexpr unsigned maxVideoReorderWindow = 16;
+    StdUnorderedMap<TrackID, std::pair<MediaTime, size_t>> minPresentationTimePerTrack;
+    StdUnorderedMap<TrackID, unsigned> scannedPerTrack;
+    unsigned saturatedTracks = 0;
+    for (size_t i = 0; i < samples.size(); ++i) {
+        if (saturatedTracks == m_trackBufferMap.size())
+            break;
+        Ref sample = samples[i];
+        auto trackID = sample->trackID();
+        auto trackBufferIter = m_trackBufferMap.find(trackID);
+        if (trackBufferIter == m_trackBufferMap.end())
+            continue;
+        auto description = trackBufferIter->second->description();
+        unsigned trackCap = (description && description->isVideo()) ? maxVideoReorderWindow : 1u;
+        auto& scanned = scannedPerTrack[trackID];
+        if (scanned >= trackCap)
+            continue;
+        if (++scanned == trackCap)
+            ++saturatedTracks;
+        auto pts = sample->presentationTime();
+        auto [iter, inserted] = minPresentationTimePerTrack.try_emplace(trackID, std::make_pair(pts, i));
+        if (!inserted && pts < iter->second.first)
+            iter->second = std::make_pair(pts, i);
+    }
+
+    if (minPresentationTimePerTrack.size() <= 1)
+        return { };
+
+    PrioritySample priority;
+    MediaTime priorityPresentationTime = MediaTime::positiveInfiniteTime();
+    for (auto& [trackID, ptsAndIndex] : minPresentationTimePerTrack) {
+        if (ptsAndIndex.first < priorityPresentationTime) {
+            priorityPresentationTime = ptsAndIndex.first;
+            priority.trackID = trackID;
+            priority.index = ptsAndIndex.second;
+        }
+    }
+    return priority;
+}
+
+Ref<MediaPromise> SourceBufferPrivate::processNewMediaSamples(SamplesVector&& samples, PresentationTailMap&& presentationTailPerTrack)
+{
+    assertIsCurrent(m_dispatcher.get());
+
+    RefPtr client = this->client();
+    if (!client)
+        return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
+
+    auto [priorityTrackID, priorityIndex] = findPrioritySample(samples);
+
+    // Drain the priority-track samples in [0, priorityIndex] first so step 1.3
+    // fires on the cross-track-min-PTS sample (parser arrival order need not put
+    // it at position 0).
+    if (priorityIndex) {
+        ASSERT(priorityIndex < samples.size());
+        for (size_t i = 0; i <= priorityIndex; ++i) {
+            Ref sample = samples[i];
+            if (sample->trackID() != priorityTrackID)
+                continue;
+            auto it = presentationTailPerTrack.find(sample->trackID());
+            bool isPresentationTail = it != presentationTailPerTrack.end() && sample.ptr() == it->second;
+            if (!processMediaSample(*client, WTF::move(sample), isPresentationTail))
+                return MediaPromise::createAndReject(PlatformMediaError::ParsingError);
+        }
+    }
+
+    for (size_t i = 0; i < samples.size(); ++i) {
+        Ref sample = samples[i];
+        if (priorityIndex && i <= priorityIndex && sample->trackID() == priorityTrackID)
+            continue;
+        auto it = presentationTailPerTrack.find(sample->trackID());
+        bool isPresentationTail = it != presentationTailPerTrack.end() && sample.ptr() == it->second;
+        if (!processMediaSample(*client, WTF::move(sample), isPresentationTail))
+            return MediaPromise::createAndReject(PlatformMediaError::ParsingError);
+    }
+    return MediaPromise::createAndResolve();
+}
+
 void SourceBufferPrivate::processPendingMediaSamples()
 {
     assertIsCurrent(m_dispatcher.get());
@@ -1093,18 +1193,7 @@ void SourceBufferPrivate::processPendingMediaSamples()
             return MediaPromise::createAndReject(!result ? result.error() : PlatformMediaError::BufferRemoved);
         if (abortCount != protectedThis->m_abortCount)
             return MediaPromise::createAndResolve();
-
-        RefPtr client = protectedThis->client();
-        if (!client)
-            return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);
-
-        for (auto& sample : samples) {
-            auto it = presentationTailPerTrack.find(sample->trackID());
-            bool isPresentationTail = it != presentationTailPerTrack.end() && sample.ptr() == it->second;
-            if (!protectedThis->processMediaSample(*client, WTF::move(sample), isPresentationTail))
-                return MediaPromise::createAndReject(PlatformMediaError::ParsingError);
-        }
-        return MediaPromise::createAndResolve();
+        return protectedThis->processNewMediaSamples(WTF::move(samples), WTF::move(presentationTailPerTrack));
     });
 }
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -292,6 +292,23 @@ private:
     void computeEvictionData(ComputeEvictionDataRule = ComputeEvictionDataRule::Default);
 
     using SamplesVector = Vector<Ref<MediaSample>>;
+
+    // In sequence mode with multiple tracks, finds the sample carrying the
+    // smallest presentation timestamp across tracks, using a bounded per-track
+    // look-ahead. Its index in the batch selects which sample step 1.3 of coded
+    // frame processing fires on. Returns { 0, 0 } when no reordering is needed.
+    struct PrioritySample {
+        TrackID trackID { 0 };
+        size_t index { 0 };
+    };
+    PrioritySample findPrioritySample(const SamplesVector&) const;
+
+    // Runs coded frame processing over a settled append batch: fetches the
+    // client, orders the batch around the priority sample, and feeds each
+    // sample to processMediaSample.
+    using PresentationTailMap = StdUnorderedMap<TrackID, MediaSample*>;
+    Ref<MediaPromise> processNewMediaSamples(SamplesVector&&, PresentationTailMap&&);
+
     SamplesVector m_pendingSamples WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());
     // Per video track, the pending sample with the highest presentationEndTime. Maintained
     // incrementally in didReceiveSample and drained in lockstep with m_pendingSamples so

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h
@@ -27,11 +27,14 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
+#include "ISOBMFFTrackInfoParser.h"
 #include "Logging.h"
 #include "MediaSourceConfiguration.h"
 #include "SourceBufferParser.h"
 #include <wtf/Box.h>
+#include <wtf/HashMap.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/MediaTime.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -76,6 +79,8 @@ public:
     void didProvideContentKeyRequestInitializationDataForTrackID(NSData*, uint64_t trackID);
     void didProvideContentKeyRequestSpecifierForTrackID(NSData*, uint64_t trackID);
 
+    void setEmptyEditOffsetsFromInitSegment(Vector<ISOBMFFTrackInfoParser::TrackEditInfo>&&);
+
 private:
 #if !RELEASE_LOG_DISABLED
     const Logger* loggerPtr() const { return m_logger.get(); }
@@ -89,6 +94,7 @@ private:
     RetainPtr<WebAVStreamDataParserListener> m_delegate;
     const MediaSourceConfiguration m_configuration;
     const std::unique_ptr<ISOBMFFPreParser> m_preParser;
+    HashMap<uint64_t, MediaTime, WTF::IntHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_emptyEditOffsetForTrackID;
     bool m_parserStateWasReset { false };
     std::optional<int> m_lastErrorCode;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -213,24 +213,29 @@ MediaPlayerEnums::SupportsType SourceBufferParserAVFObjC::isContentTypeSupported
     return AVStreamDataParserMIMETypeCache::singleton().canDecodeType(extendedType);
 }
 
-static std::unique_ptr<ISOBMFFPreParser> makePreParserIfNeeded(const ContentType& contentType, AVStreamDataParser* parser)
+static std::unique_ptr<ISOBMFFPreParser> makePreParserIfNeeded(const ContentType& contentType, AVStreamDataParser* parser, SourceBufferParserAVFObjC& parserOwner)
 {
     auto containerType = contentType.containerType();
     if (!equalLettersIgnoringASCIICase(containerType, "video/mp4"_s) && !equalLettersIgnoringASCIICase(containerType, "audio/mp4"_s))
         return nullptr;
-    return makeUnique<ISOBMFFPreParser>([parser = RetainPtr { parser }](Ref<const SharedBuffer>&& buffer, SourceBufferParser::AppendFlags flags) {
-        RetainPtr nsData = buffer->createNSData();
-        if (flags == SourceBufferParser::AppendFlags::Discontinuity)
-            [parser appendStreamData:nsData.get() withFlags:AVStreamDataParserStreamDataDiscontinuity];
-        else
-            [parser appendStreamData:nsData.get()];
-    });
+    return makeUnique<ISOBMFFPreParser>(
+        [parser = RetainPtr { parser }](Ref<const SharedBuffer>&& buffer, SourceBufferParser::AppendFlags flags) {
+            RetainPtr nsData = buffer->createNSData();
+            if (flags == SourceBufferParser::AppendFlags::Discontinuity)
+                [parser appendStreamData:nsData.get() withFlags:AVStreamDataParserStreamDataDiscontinuity];
+            else
+                [parser appendStreamData:nsData.get()];
+        },
+        [weakParser = ThreadSafeWeakPtr { parserOwner }](auto&& edits) {
+            if (RefPtr protectedParser = weakParser.get())
+                protectedParser->setEmptyEditOffsetsFromInitSegment(WTF::move(edits));
+        });
 }
 
 SourceBufferParserAVFObjC::SourceBufferParserAVFObjC(const ContentType& contentType, const MediaSourceConfiguration& configuration)
     : m_parser(adoptNS([PAL::allocAVStreamDataParserInstance() init]))
     , m_configuration(configuration)
-    , m_preParser(makePreParserIfNeeded(contentType, m_parser.get()))
+    , m_preParser(makePreParserIfNeeded(contentType, m_parser.get(), *this))
 {
     m_delegate = adoptNS([[WebAVStreamDataParserWithKeySpecifierListener alloc] initWithParser:m_parser.get() parent:this]);
 
@@ -284,6 +289,7 @@ void SourceBufferParserAVFObjC::resetParserState()
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_parserStateWasReset = true;
+    m_emptyEditOffsetForTrackID.clear();
     if (m_preParser)
         m_preParser->reset();
 }
@@ -363,11 +369,19 @@ void SourceBufferParserAVFObjC::didProvideMediaDataForTrackID(TrackID trackID, C
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "trackID = ", trackID, ", mediaType = ", mediaType);
     UNUSED_PARAM(flags);
-    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, sampleBuffer = retainPtr(sampleBuffer), trackID, mediaType = mediaType] {
+
+    MediaTime emptyEditOffset;
+    if (auto it = m_emptyEditOffsetForTrackID.find(trackID); it != m_emptyEditOffsetForTrackID.end())
+        emptyEditOffset = it->value;
+
+    m_callOnClientThreadCallback([this, protectedThis = Ref { *this }, sampleBuffer = retainPtr(sampleBuffer), trackID, mediaType = mediaType, emptyEditOffset] {
         if (!m_didProvideMediaDataCallback)
             return;
 
         auto mediaSample = MediaSampleAVFObjC::create(sampleBuffer.get(), trackID);
+
+        if (emptyEditOffset.isValid() && emptyEditOffset > MediaTime::zeroTime())
+            mediaSample->offsetTimestampsBy(emptyEditOffset);
 
         if (mediaSample->isHomogeneous()) {
             m_didProvideMediaDataCallback(WTF::move(mediaSample), trackID, mediaType);
@@ -377,6 +391,17 @@ void SourceBufferParserAVFObjC::didProvideMediaDataForTrackID(TrackID trackID, C
         for (auto& sample : mediaSample->divideIntoHomogeneousSamples())
             m_didProvideMediaDataCallback(WTF::move(sample), trackID, mediaType);
     });
+}
+
+void SourceBufferParserAVFObjC::setEmptyEditOffsetsFromInitSegment(Vector<ISOBMFFTrackInfoParser::TrackEditInfo>&& edits)
+{
+    m_emptyEditOffsetForTrackID.clear();
+    for (auto& edit : edits) {
+        if (!edit.emptyEditOffset.isValid() || edit.emptyEditOffset <= MediaTime::zeroTime())
+            continue;
+        ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "applying empty-edit shift, trackID = ", edit.trackID, ", offset = ", edit.emptyEditOffset);
+        m_emptyEditOffsetForTrackID.set(edit.trackID, edit.emptyEditOffset);
+    }
 }
 
 void SourceBufferParserAVFObjC::willProvideContentKeyRequestInitializationDataForTrackID(uint64_t trackID)

--- a/Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.cpp
@@ -40,8 +40,13 @@ static constexpr auto moovBox = FourCC(std::span { "moov" });
 static constexpr auto stypBox = FourCC(std::span { "styp" });
 static constexpr auto moofBox = FourCC(std::span { "moof" });
 
-ISOBMFFPreParser::ISOBMFFPreParser(ForwardDataCallback&& callback)
-    : m_forwardDataCallback(WTF::move(callback))
+// Sanity cap for buffered moov-body capture. Past this we abandon capture
+// for the current init segment; ingestion proceeds normally.
+static constexpr size_t maxMoovBodyCaptureBytes = 8 * 1024 * 1024;
+
+ISOBMFFPreParser::ISOBMFFPreParser(ForwardDataCallback&& forwardCallback, TrackInfoCallback&& trackInfoCallback)
+    : m_forwardDataCallback(WTF::move(forwardCallback))
+    , m_trackInfoCallback(WTF::move(trackInfoCallback))
 {
 }
 
@@ -95,6 +100,8 @@ void ISOBMFFPreParser::reset()
     m_state = State::WaitingForSegment;
     m_pendingHeaderBytes.clear();
     m_remainingBytesInCurrentBox = 0;
+    m_moovBuffer.clear();
+    m_capturingMoovBody = false;
 }
 
 void ISOBMFFPreParser::setPendingInitializationSegmentForChangeType()
@@ -165,6 +172,24 @@ Expected<void, PlatformMediaError> ISOBMFFPreParser::appendData(
             m_pendingHeaderBytes.append(inputSpan.subspan(offset - pendingSize));
     };
 
+    // Append the conceptual range [start, end) to m_moovBuffer, splicing across
+    // the pending/segment boundary the same way `forward` does.
+    auto captureMoovRange = [&](size_t start, size_t end) {
+        if (start >= end)
+            return;
+        if (start >= pendingSize) {
+            m_moovBuffer.append(inputSpan.subspan(start - pendingSize, end - start));
+            return;
+        }
+        if (end <= pendingSize) {
+            m_moovBuffer.append(pendingBytes.subspan(start, end - start));
+            return;
+        }
+        auto pendingPart = pendingSize - start;
+        m_moovBuffer.append(pendingBytes.subspan(start, pendingPart));
+        m_moovBuffer.append(inputSpan.first(end - pendingSize));
+    };
+
     AppendFlags nextChunkFlags = callerFlags;
     size_t offset = 0;
     size_t forwardStart = 0;
@@ -172,8 +197,21 @@ Expected<void, PlatformMediaError> ISOBMFFPreParser::appendData(
     while (offset < totalSize) {
         if (m_remainingBytesInCurrentBox > 0) {
             auto toConsume = std::min<uint64_t>(totalSize - offset, m_remainingBytesInCurrentBox);
+            if (m_capturingMoovBody) {
+                if (m_moovBuffer.size() + toConsume > maxMoovBodyCaptureBytes) {
+                    m_moovBuffer.clear();
+                    m_capturingMoovBody = false;
+                } else
+                    captureMoovRange(offset, offset + static_cast<size_t>(toConsume));
+            }
             m_remainingBytesInCurrentBox -= toConsume;
             offset += static_cast<size_t>(toConsume);
+            if (m_capturingMoovBody && !m_remainingBytesInCurrentBox) {
+                if (m_trackInfoCallback)
+                    m_trackInfoCallback(ISOBMFFTrackInfoParser::parseMoovBody(m_moovBuffer.span()));
+                m_moovBuffer.clear();
+                m_capturingMoovBody = false;
+            }
             continue;
         }
 
@@ -218,6 +256,8 @@ Expected<void, PlatformMediaError> ISOBMFFPreParser::appendData(
                 }
                 forwardStart = offset;
                 m_state = State::ParsingInitSegment;
+                m_moovBuffer.clear();
+                m_capturingMoovBody = false;
                 break;
             }
             if (isMediaSegmentStartBox(boxType)) {
@@ -232,6 +272,11 @@ Expected<void, PlatformMediaError> ISOBMFFPreParser::appendData(
                 m_firstInitializationSegmentReceived = true;
                 m_pendingInitializationSegmentForChangeType = false;
                 m_state = State::WaitingForSegment;
+                if (m_trackInfoCallback && boxBodySize > 0) {
+                    m_capturingMoovBody = true;
+                    m_moovBuffer.clear();
+                    m_moovBuffer.reserveCapacity(std::min<uint64_t>(boxBodySize, maxMoovBodyCaptureBytes));
+                }
                 break;
             }
             if (isMediaSegmentStartBox(boxType))

--- a/Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.h
@@ -28,6 +28,7 @@
 #if ENABLE(MEDIA_SOURCE)
 
 #include <WebCore/FourCC.h>
+#include <WebCore/ISOBMFFTrackInfoParser.h>
 #include <WebCore/PlatformMediaError.h>
 #include <WebCore/SourceBufferParser.h>
 #include <optional>
@@ -55,8 +56,9 @@ class ISOBMFFPreParser {
 public:
     using AppendFlags = SourceBufferParser::AppendFlags;
     using ForwardDataCallback = Function<void(Ref<const SharedBuffer>&&, AppendFlags)>;
+    using TrackInfoCallback = Function<void(Vector<ISOBMFFTrackInfoParser::TrackEditInfo>&&)>;
 
-    explicit ISOBMFFPreParser(ForwardDataCallback&&);
+    explicit ISOBMFFPreParser(ForwardDataCallback&&, TrackInfoCallback&& = { });
 
     Expected<void, PlatformMediaError> appendData(Ref<const SharedBuffer>&&, AppendFlags = AppendFlags::None);
 
@@ -85,11 +87,14 @@ private:
     static bool isMediaSegmentStartBox(FourCC);
 
     ForwardDataCallback m_forwardDataCallback;
+    TrackInfoCallback m_trackInfoCallback;
     State m_state { State::WaitingForSegment };
     bool m_firstInitializationSegmentReceived { false };
     bool m_pendingInitializationSegmentForChangeType { false };
+    bool m_capturingMoovBody { false };
     Vector<uint8_t, 16> m_pendingHeaderBytes;
     uint64_t m_remainingBytesInCurrentBox { 0 };
+    Vector<uint8_t> m_moovBuffer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/ISOBMFFTrackInfoParser.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ISOBMFFTrackInfoParser.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ISOBMFFTrackInfoParser.h"
+
+#if ENABLE(MEDIA_SOURCE)
+
+#include "BitReader.h"
+#include "FourCC.h"
+
+namespace WebCore {
+
+static constexpr auto mvhdBox = FourCC(std::span { "mvhd" });
+static constexpr auto trakBox = FourCC(std::span { "trak" });
+static constexpr auto tkhdBox = FourCC(std::span { "tkhd" });
+static constexpr auto edtsBox = FourCC(std::span { "edts" });
+static constexpr auto elstBox = FourCC(std::span { "elst" });
+
+struct ChildBox {
+    FourCC type;
+    std::span<const uint8_t> body;
+};
+
+// Reads the next box header from `data` starting at offset 0 and returns the
+// child's type and body span (following the 8 or 16 byte header). On success,
+// `consumed` is set to the total box size (header + body). Bound-checked.
+static std::optional<ChildBox> readNextChildBox(std::span<const uint8_t> data, size_t& consumed)
+{
+    if (data.size() < 8)
+        return std::nullopt;
+
+    BitReader reader(data);
+    auto sizeValue = reader.read<uint32_t>();
+    auto typeValue = reader.read<uint32_t>();
+    if (!sizeValue || !typeValue)
+        return std::nullopt;
+
+    uint64_t totalSize = *sizeValue;
+    size_t headerSize = 8;
+    if (*sizeValue == 1) {
+        if (data.size() < 16)
+            return std::nullopt;
+        auto extendedSize = reader.read<uint64_t>();
+        if (!extendedSize)
+            return std::nullopt;
+        totalSize = *extendedSize;
+        headerSize = 16;
+    } else if (!*sizeValue) {
+        // size == 0 means "extends to end of file"; in a buffered moov body
+        // we treat this as "rest of container".
+        totalSize = data.size();
+    }
+
+    if (totalSize < headerSize || totalSize > data.size())
+        return std::nullopt;
+
+    consumed = static_cast<size_t>(totalSize);
+    return ChildBox { FourCC(*typeValue), data.subspan(headerSize, totalSize - headerSize) };
+}
+
+// Iterate every direct child box of `containerBody`, calling `fn(child)` for each.
+// Stops on malformation.
+template <typename F>
+static void forEachChildBox(std::span<const uint8_t> containerBody, F&& fn)
+{
+    size_t offset = 0;
+    while (offset < containerBody.size()) {
+        size_t consumed = 0;
+        auto child = readNextChildBox(containerBody.subspan(offset), consumed);
+        if (!child || !consumed)
+            return;
+        fn(*child);
+        offset += consumed;
+    }
+}
+
+// FullBox: u8 version + u24 flags. Returns version on success, empty on truncation.
+static std::optional<uint8_t> readFullBoxVersion(std::span<const uint8_t> body)
+{
+    if (body.size() < 4)
+        return std::nullopt;
+    return body[0];
+}
+
+// mvhd (FullBox): timescale at body offset 12 (v0) or 20 (v1), uint32 big-endian.
+static std::optional<uint32_t> readMvhdTimescale(std::span<const uint8_t> body)
+{
+    auto version = readFullBoxVersion(body);
+    if (!version)
+        return std::nullopt;
+    size_t timescaleOffset = (*version == 1) ? 20 : 12;
+    if (body.size() < timescaleOffset + 4)
+        return std::nullopt;
+    BitReader reader(body.subspan(timescaleOffset));
+    return reader.read<uint32_t>();
+}
+
+// tkhd (FullBox): track_ID at body offset 12 (v0) or 20 (v1), uint32 big-endian.
+static std::optional<uint32_t> readTkhdTrackID(std::span<const uint8_t> body)
+{
+    auto version = readFullBoxVersion(body);
+    if (!version)
+        return std::nullopt;
+    size_t trackIDOffset = (*version == 1) ? 20 : 12;
+    if (body.size() < trackIDOffset + 4)
+        return std::nullopt;
+    BitReader reader(body.subspan(trackIDOffset));
+    return reader.read<uint32_t>();
+}
+
+// elst (FullBox): looks at entry 0 only. If it's an empty edit
+// (media_time == -1), returns segment_duration; otherwise empty.
+static std::optional<uint64_t> readElstEntry0EmptyEditDuration(std::span<const uint8_t> body)
+{
+    auto version = readFullBoxVersion(body);
+    if (!version)
+        return std::nullopt;
+
+    if (body.size() < 8)
+        return std::nullopt;
+
+    BitReader reader(body.subspan(4));
+    auto entryCount = reader.read<uint32_t>();
+    if (!entryCount || !*entryCount)
+        return std::nullopt;
+
+    if (*version == 1) {
+        if (body.size() < 8 + 16)
+            return std::nullopt;
+        auto segmentDuration = reader.read<uint64_t>();
+        auto mediaTime = reader.read<uint64_t>();
+        if (!segmentDuration || !mediaTime)
+            return std::nullopt;
+        if (static_cast<int64_t>(*mediaTime) != -1)
+            return std::nullopt;
+        return *segmentDuration;
+    }
+
+    if (body.size() < 8 + 8)
+        return std::nullopt;
+    auto segmentDuration = reader.read<uint32_t>();
+    auto mediaTime = reader.read<uint32_t>();
+    if (!segmentDuration || !mediaTime)
+        return std::nullopt;
+    if (static_cast<int32_t>(*mediaTime) != -1)
+        return std::nullopt;
+    return static_cast<uint64_t>(*segmentDuration);
+}
+
+static std::optional<uint64_t> findEmptyEditDurationInEdts(std::span<const uint8_t> edtsBody)
+{
+    std::optional<uint64_t> result;
+    forEachChildBox(edtsBody, [&](const ChildBox& child) {
+        if (child.type == elstBox && !result)
+            result = readElstEntry0EmptyEditDuration(child.body);
+    });
+    return result;
+}
+
+static std::optional<ISOBMFFTrackInfoParser::TrackEditInfo> parseTrak(std::span<const uint8_t> trakBody, uint32_t movieTimescale)
+{
+    std::optional<uint32_t> trackID;
+    std::optional<uint64_t> emptyEditDuration;
+
+    forEachChildBox(trakBody, [&](const ChildBox& child) {
+        if (child.type == tkhdBox)
+            trackID = readTkhdTrackID(child.body);
+        else if (child.type == edtsBox)
+            emptyEditDuration = findEmptyEditDurationInEdts(child.body);
+    });
+
+    if (!trackID || !*trackID || !emptyEditDuration)
+        return std::nullopt;
+
+    if (*emptyEditDuration > INT64_MAX)
+        return std::nullopt;
+
+    return ISOBMFFTrackInfoParser::TrackEditInfo {
+        *trackID,
+        MediaTime(static_cast<int64_t>(*emptyEditDuration), movieTimescale),
+    };
+}
+
+Vector<ISOBMFFTrackInfoParser::TrackEditInfo> ISOBMFFTrackInfoParser::parseMoovBody(std::span<const uint8_t> moovBody)
+{
+    uint32_t movieTimescale = 0;
+    Vector<TrackEditInfo> result;
+
+    // First pass: locate mvhd to learn the movie timescale.
+    forEachChildBox(moovBody, [&](const ChildBox& child) {
+        if (child.type == mvhdBox && !movieTimescale) {
+            if (auto timescale = readMvhdTimescale(child.body); timescale && *timescale)
+                movieTimescale = *timescale;
+        }
+    });
+
+    if (!movieTimescale)
+        return result;
+
+    // Second pass: collect per-trak empty edits in movie timescale.
+    forEachChildBox(moovBody, [&](const ChildBox& child) {
+        if (child.type != trakBox)
+            return;
+        if (auto info = parseTrak(child.body, movieTimescale))
+            result.append(*info);
+    });
+
+    return result;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/cocoa/ISOBMFFTrackInfoParser.h
+++ b/Source/WebCore/platform/graphics/cocoa/ISOBMFFTrackInfoParser.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_SOURCE)
+
+#include <span>
+#include <wtf/MediaTime.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// Lightweight ISO-BMFF moov-content walker. Reads enough of the moov box
+// to identify per-track empty edits (elst entry 0 with media_time = -1)
+// and report each track's empty-edit duration as a MediaTime in the
+// movie timescale.
+class ISOBMFFTrackInfoParser {
+public:
+    struct TrackEditInfo {
+        uint64_t trackID { 0 };
+        MediaTime emptyEditOffset; // invalid MediaTime if no empty edit on this track
+    };
+
+    // Walks a complete moov box body (the bytes after its 8/16-byte box header).
+    // Returns one TrackEditInfo per trak whose elst entry 0 is an empty edit.
+    // On any malformation, returns whatever was parsed up to the failure point.
+    static WEBCORE_EXPORT Vector<TrackEditInfo> parseMoovBody(std::span<const uint8_t>);
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -705,6 +705,7 @@
 				WebCore/cocoa/H264UtilitiesCocoaTests.mm,
 				WebCore/cocoa/ImageRotationSessionVT.cpp,
 				WebCore/cocoa/IOSurfaceTests.mm,
+				WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp,
 				WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm,
 				WebCore/cocoa/PrivateClickMeasurementCocoa.mm,
 				WebCore/cocoa/ResourceMonitor.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if PLATFORM(COCOA) && ENABLE(MEDIA_SOURCE)
+
+#include "Test.h"
+#include <WebCore/ISOBMFFTrackInfoParser.h>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+using WebCore::ISOBMFFTrackInfoParser;
+
+// Minimal big-endian ISO-BMFF box builders, just enough to exercise the moov
+// walker. Every box is: u32 size (header + body) followed by 4 type bytes.
+
+static void appendBE32(Vector<uint8_t>& out, uint32_t value)
+{
+    out.append(static_cast<uint8_t>(value >> 24));
+    out.append(static_cast<uint8_t>(value >> 16));
+    out.append(static_cast<uint8_t>(value >> 8));
+    out.append(static_cast<uint8_t>(value));
+}
+
+static void appendBE64(Vector<uint8_t>& out, uint64_t value)
+{
+    appendBE32(out, static_cast<uint32_t>(value >> 32));
+    appendBE32(out, static_cast<uint32_t>(value));
+}
+
+static Vector<uint8_t> makeBox(const char (&type)[5], const Vector<uint8_t>& body)
+{
+    Vector<uint8_t> out;
+    appendBE32(out, static_cast<uint32_t>(8 + body.size()));
+    out.append(static_cast<uint8_t>(type[0]));
+    out.append(static_cast<uint8_t>(type[1]));
+    out.append(static_cast<uint8_t>(type[2]));
+    out.append(static_cast<uint8_t>(type[3]));
+    out.appendVector(body);
+    return out;
+}
+
+// mvhd (v0): FullBox(4) + creation(4) + modification(4) + timescale(4).
+static Vector<uint8_t> makeMvhd(uint32_t timescale)
+{
+    Vector<uint8_t> body;
+    appendBE32(body, 0); // version 0, flags 0
+    appendBE32(body, 0); // creation_time
+    appendBE32(body, 0); // modification_time
+    appendBE32(body, timescale);
+    return makeBox("mvhd", body);
+}
+
+// tkhd (v0): FullBox(4) + creation(4) + modification(4) + track_ID(4).
+static Vector<uint8_t> makeTkhd(uint32_t trackID)
+{
+    Vector<uint8_t> body;
+    appendBE32(body, 0); // version 0, flags 0
+    appendBE32(body, 0); // creation_time
+    appendBE32(body, 0); // modification_time
+    appendBE32(body, trackID);
+    return makeBox("tkhd", body);
+}
+
+// elst (v0): FullBox(4) + entry_count(4) + segment_duration(4) + media_time(4) + media_rate(4).
+static Vector<uint8_t> makeElstV0(uint32_t segmentDuration, int32_t mediaTime)
+{
+    Vector<uint8_t> body;
+    appendBE32(body, 0); // version 0, flags 0
+    appendBE32(body, 1); // entry_count
+    appendBE32(body, segmentDuration);
+    appendBE32(body, static_cast<uint32_t>(mediaTime));
+    appendBE32(body, 0x00010000); // media_rate (unread, present for realism)
+    return makeBox("elst", body);
+}
+
+// elst (v1): FullBox(4) + entry_count(4) + segment_duration(8) + media_time(8) + media_rate(4).
+static Vector<uint8_t> makeElstV1(uint64_t segmentDuration, int64_t mediaTime)
+{
+    Vector<uint8_t> body;
+    appendBE32(body, 0x01000000); // version 1, flags 0
+    appendBE32(body, 1); // entry_count
+    appendBE64(body, segmentDuration);
+    appendBE64(body, static_cast<uint64_t>(mediaTime));
+    appendBE32(body, 0x00010000); // media_rate
+    return makeBox("elst", body);
+}
+
+static Vector<uint8_t> makeEdts(const Vector<uint8_t>& elst)
+{
+    return makeBox("edts", elst);
+}
+
+// trak with a tkhd and an optional edts.
+static Vector<uint8_t> makeTrak(uint32_t trackID, const Vector<uint8_t>* edts)
+{
+    Vector<uint8_t> body;
+    body.appendVector(makeTkhd(trackID));
+    if (edts)
+        body.appendVector(*edts);
+    return makeBox("trak", body);
+}
+
+TEST(ISOBMFFTrackInfoParser, EmptyInputReturnsNothing)
+{
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody({ });
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(ISOBMFFTrackInfoParser, SingleTrackEmptyEditVersion0)
+{
+    Vector<uint8_t> moov;
+    moov.appendVector(makeMvhd(600));
+    auto edts = makeEdts(makeElstV0(300, -1));
+    moov.appendVector(makeTrak(1, &edts));
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    ASSERT_EQ(1U, result.size());
+    EXPECT_EQ(1U, result[0].trackID);
+    EXPECT_TRUE(result[0].emptyEditOffset.isValid());
+    EXPECT_EQ(MediaTime(300, 600), result[0].emptyEditOffset);
+}
+
+TEST(ISOBMFFTrackInfoParser, SingleTrackEmptyEditVersion1)
+{
+    Vector<uint8_t> moov;
+    moov.appendVector(makeMvhd(48000));
+    auto edts = makeEdts(makeElstV1(24000, -1));
+    moov.appendVector(makeTrak(7, &edts));
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    ASSERT_EQ(1U, result.size());
+    EXPECT_EQ(7U, result[0].trackID);
+    EXPECT_EQ(MediaTime(24000, 48000), result[0].emptyEditOffset);
+}
+
+TEST(ISOBMFFTrackInfoParser, NonEmptyEditIsIgnored)
+{
+    // media_time != -1 is a real (non-empty) edit; the track is omitted entirely.
+    Vector<uint8_t> moov;
+    moov.appendVector(makeMvhd(600));
+    auto edts = makeEdts(makeElstV0(300, 0));
+    moov.appendVector(makeTrak(1, &edts));
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(ISOBMFFTrackInfoParser, TrackWithoutEditListIsOmitted)
+{
+    // Only the track carrying an empty edit is reported; a track with no edts
+    // never appears in the results.
+    Vector<uint8_t> moov;
+    moov.appendVector(makeMvhd(600));
+    auto edts = makeEdts(makeElstV0(150, -1));
+    moov.appendVector(makeTrak(1, &edts));
+    moov.appendVector(makeTrak(2, nullptr));
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    ASSERT_EQ(1U, result.size());
+    EXPECT_EQ(1U, result[0].trackID);
+    EXPECT_EQ(MediaTime(150, 600), result[0].emptyEditOffset);
+}
+
+TEST(ISOBMFFTrackInfoParser, TrackIDZeroIsRejected)
+{
+    Vector<uint8_t> moov;
+    moov.appendVector(makeMvhd(600));
+    auto edts = makeEdts(makeElstV0(300, -1));
+    moov.appendVector(makeTrak(0, &edts));
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(ISOBMFFTrackInfoParser, MissingMvhdReturnsNothing)
+{
+    // Without a movie timescale there is nothing to express the offset in.
+    Vector<uint8_t> moov;
+    auto edts = makeEdts(makeElstV0(300, -1));
+    moov.appendVector(makeTrak(1, &edts));
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(ISOBMFFTrackInfoParser, OversizedEmptyEditDurationIsRejected)
+{
+    // segment_duration greater than INT64_MAX cannot be represented as a
+    // signed MediaTime time value and must be dropped rather than wrapped.
+    Vector<uint8_t> moov;
+    moov.appendVector(makeMvhd(600));
+    auto edts = makeEdts(makeElstV1(0x8000000000000000ULL, -1));
+    moov.appendVector(makeTrak(1, &edts));
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(ISOBMFFTrackInfoParser, TruncatedChildBoxDoesNotCrash)
+{
+    // A well-formed mvhd followed by a box whose declared size overruns the
+    // buffer: the walker must stop cleanly instead of reading out of bounds.
+    Vector<uint8_t> moov;
+    moov.appendVector(makeMvhd(600));
+    appendBE32(moov, 0xFFFFFFFF); // size claims far more than is present
+    moov.append('t');
+    moov.append('r');
+    moov.append('a');
+    moov.append('k');
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(ISOBMFFTrackInfoParser, MultipleEmptyEditTracks)
+{
+    Vector<uint8_t> moov;
+    moov.appendVector(makeMvhd(1000));
+    auto edtsA = makeEdts(makeElstV0(100, -1));
+    auto edtsB = makeEdts(makeElstV0(250, -1));
+    moov.appendVector(makeTrak(1, &edtsA));
+    moov.appendVector(makeTrak(2, &edtsB));
+
+    auto result = ISOBMFFTrackInfoParser::parseMoovBody(moov.span());
+    ASSERT_EQ(2U, result.size());
+    EXPECT_EQ(1U, result[0].trackID);
+    EXPECT_EQ(MediaTime(100, 1000), result[0].emptyEditOffset);
+    EXPECT_EQ(2U, result[1].trackID);
+    EXPECT_EQ(MediaTime(250, 1000), result[1].emptyEditOffset);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(COCOA) && ENABLE(MEDIA_SOURCE)


### PR DESCRIPTION
#### cc6a6a6dd0da3f3c3f7c96cc77a6ffe859a1a178
<pre>
[MSE][Cocoa] imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=316870">https://bugs.webkit.org/show_bug.cgi?id=316870</a>
<a href="https://rdar.apple.com/179296547">rdar://179296547</a>

Reviewed by Youenn Fablet.

The WPT mediasource-sequencemode-append-buffer.html test exercises three
SourceBuffer.mode = &quot;sequence&quot; scenarios using an asset whose video track
carries an empty edit list. Three independent issues — two engine bugs and
one test-side bug — combined to make all three subtests fail on AVFoundation
baswe MSE ; this commit addresses each.

Problems
--------

1. Empty fMP4 edit list not applied to video PTS.

    The asset&apos;s video track has an `edts/elst` whose first entry is an
    empty edit (media_time = -1, segment_duration = 0.095 s in movie
    timescale). AVStreamDataParser does not honour empty edits in fMP4, so
    the CMSampleBuffers it emits have PTS = raw mdat PTS, missing the
    elst-prescribed 0.095s presentation shift. The test&apos;s segmentInfo
    bakes in the post-shift timestamps, so the engine and the test data
    disagreed by exactly that amount.

2. Frames submitted to coded-frame processing in parser-arrival order.

    MSE Coded Frame Processing step 1.3 sets `timestampOffset =
    group_start_timestamp - presentation_timestamp` on the first sample to
    enter the loop. For multi-track segments the only spec-coherent choice
    for that &quot;first&quot; sample is the cross-track minimum-PTS sample — any
    other choice makes samples of one track land before
    group_start_timestamp. SourceBufferPrivate was iterating
    m_pendingSamples in parser-arrival order, so step 1.3 fired on
    whichever track AVStreamDataParser happened to emit first. Once
    problem 1 was fixed, that mismatch became visible: for media[1] step
    1.3 fired on video (PTS 0.896666) when audio (PTS 0.882358) should
    have driven it. The same problem reappeared on sequence-mode
    discontinuity (step 1.6 retries step 1.3 on the discontinuity-
    triggering sample) when chaining a second segment.
    A similar workaround is implemented by Firefox.

3. Third subtest&apos;s expected post-EOS buffered range was unsatisfiable.

    The third subtest appends media[1] then media[0] in sequence mode and
    asserted the post-EOS buffered range to be a single contiguous range.
    With a single per-segment `timestampOffset` (per spec) and media[0]&apos;s
    tracks not aligned at the same start (`timev` = 0.095, `timea` = 0 for
    this asset), placing media[0] adjacent to media[1] inevitably
    introduces a per-track gap inside the unified buffered range of width
    `media[0].timev − media[0].timea`. Firefox and Chrome both fail this
    subtest too — Firefox with the identical two-range output WebKit
    produces, Chrome with a different `timestampOffset` value — so no
    production engine satisfies the expected single-range output for this
    asset shape.

Solutions
---------

1. A new ISOBMFFTrackInfoParser walks the moov bytes (captured by the
    existing ISOBMFFPreParser before they are forwarded to
    AVStreamDataParser) and extracts any per-track empty edit.
    SourceBufferParserAVFObjC then offsets each emitted sample&apos;s PTS and
    DTS by that duration via MediaSampleAVFObjC::offsetTimestampsBy()
    before delivering the sample to the client.

2. Before iterating samples in processPendingMediaSamples, do a bounded
    look-ahead per track (16 frames for video — the H.264/H.265 max
    reorder window — 1 for non-video tracks) to identify the cross-track-
    min-PTS sample and its position in the batch. When that sample isn&apos;t
    already at position 0, drain priority-track samples in
    [0, priorityIndex] in a first pass; a second pass then iterates the
    remaining samples in arrival order, skipping the entries pass 1
    already processed. The samples vector itself is not mutated.

3. In the imported WPT test, compute the expected post-EOS buffered
    string from segmentInfo, accounting for media[0]&apos;s per-track head
    delta when it is non-zero (giving a two-range expected) and falling
    back to the original single-range string when it is zero. To be
    upstreamed to WPT.

Add API tests, covered by existing tests.

* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-remove-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-sequencemode-append-buffer.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac/TestExpectations: Remove the
mediasource-sequencemode-append-buffer.html Skip entry.
Mark mediasource-getvideoplaybackquality.html as Failing due to bug 316898.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
Register the new ISOBMFFTrackInfoParser source files.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::findPrioritySample const):
(WebCore::SourceBufferPrivate::processNewMediaSamples):
(WebCore::SourceBufferPrivate::processPendingMediaSamples):
Bounded per-track look-ahead identifies the cross-track-min-PTS
priority sample; a two-pass iteration drains priority-track samples
first, then the rest, without mutating m_pendingSamples.
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::makePreParserIfNeeded):
(WebCore::SourceBufferParserAVFObjC::SourceBufferParserAVFObjC):
(WebCore::SourceBufferParserAVFObjC::resetParserState): Clear the map.
(WebCore::SourceBufferParserAVFObjC::didProvideMediaDataForTrackID):
Apply the offset to each sample before delivering it.

(WebCore::SourceBufferParserAVFObjC::setEmptyEditOffsetsFromInitSegment):
Receive per-track empty-edit offsets from the pre-parser callback and
stash them in a per-track map.
* Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.cpp:
(WebCore::ISOBMFFPreParser::ISOBMFFPreParser):
(WebCore::ISOBMFFPreParser::reset):
(WebCore::ISOBMFFPreParser::appendData):
Take an optional TrackInfoCallback; buffer moov body bytes during the
segment scan and run the walker once the body is complete.

* Source/WebCore/platform/graphics/cocoa/ISOBMFFPreParser.h:
(WebCore::ISOBMFFPreParser::ISOBMFFPreParser):
* Source/WebCore/platform/graphics/cocoa/ISOBMFFTrackInfoParser.cpp:
(WebCore::FourCC):
(WebCore::readNextChildBox):
(WebCore::forEachChildBox):
(WebCore::readFullBoxVersion):
(WebCore::readMvhdTimescale):
(WebCore::readTkhdTrackID):
(WebCore::readElstEntry0EmptyEditDuration):
(WebCore::findEmptyEditDurationInEdts):
(WebCore::parseTrak):
(WebCore::ISOBMFFTrackInfoParser::parseMoovBody):
New BitReader-based walker returning each track&apos;s empty-edit duration.

* Source/WebCore/platform/graphics/cocoa/ISOBMFFTrackInfoParser.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp: Added.
(TestWebKitAPI::appendBE32):
(TestWebKitAPI::appendBE64):
(TestWebKitAPI::makeBox):
(TestWebKitAPI::makeMvhd):
(TestWebKitAPI::makeTkhd):
(TestWebKitAPI::makeElstV0):
(TestWebKitAPI::makeElstV1):
(TestWebKitAPI::makeEdts):
(TestWebKitAPI::makeTrak):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, EmptyInputReturnsNothing)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, SingleTrackEmptyEditVersion0)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, SingleTrackEmptyEditVersion1)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, NonEmptyEditIsIgnored)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, TrackWithoutEditListIsOmitted)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, TrackIDZeroIsRejected)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, MissingMvhdReturnsNothing)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, OversizedEmptyEditDurationIsRejected)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, TruncatedChildBoxDoesNotCrash)):
(TestWebKitAPI::TEST(ISOBMFFTrackInfoParser, MultipleEmptyEditTracks)):

Canonical link: <a href="https://commits.webkit.org/316626@main">https://commits.webkit.org/316626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9daccaee97a5335a9c774b08f6ba744c521d19bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130570 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134569 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115038 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36604 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31072 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185009 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37788 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143376 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38660 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47282 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112323 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38231 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119042 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45799 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9581 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45201 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45432 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->