### PR TITLE
[Margin][Legend] Positive margin on fieldset legends should shift the fieldset down.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -905,7 +905,6 @@ imported/w3c/web-platform-tests/html/browsers/windows/iframe-cross-origin-print.
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/fieldset-transform-translatez.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/fieldset-vertical.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-block-margins-2.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-block-margins.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-display-rendering.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-position-relative-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-tall.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/fast/block/basic/fieldset-stretch-to-legend-expected.txt
+++ b/LayoutTests/platform/glib/fast/block/basic/fieldset-stretch-to-legend-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x898
+layer at (0,0) size 785x918
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x898
-  RenderBlock {HTML} at (0,0) size 785x898
-    RenderBody {BODY} at (8,8) size 769x880
+layer at (0,0) size 785x918
+  RenderBlock {HTML} at (0,0) size 785x918
+    RenderBody {BODY} at (8,8) size 769x900
       RenderFieldSet {FIELDSET} at (2,0) size 140x36 [border: (8px double #000000)]
         RenderBlock {LEGEND} at (20,0) size 54x12 [bgcolor=#0080004D]
       RenderFieldSet {FIELDSET} at (2,45) size 140x37 [border: (8px double #000000)]
@@ -27,34 +27,34 @@ layer at (0,0) size 785x898
         RenderBlock {LEGEND} at (140,0) size 54x12 [bgcolor=#0080004D]
       RenderFieldSet {FIELDSET} at (2,501) size 184x31 [border: (2px groove #C0C0C0)]
         RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-      RenderFieldSet {FIELDSET} at (2,541) size 184x60 [border: (2px groove #C0C0C0)]
+      RenderFieldSet {FIELDSET} at (2,561) size 184x60 [border: (2px groove #C0C0C0)]
         RenderBlock {LEGEND} at (44,0) size 96x12 [border: (1px solid #0000FF)]
-      RenderBlock (anonymous) at (0,810) size 769x41
+      RenderBlock (anonymous) at (0,830) size 769x41
         RenderFieldSet {FIELDSET} at (2,0) size 184x30 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
         RenderText {#text} at (0,0) size 0x0
-      RenderFieldSet {FIELDSET} at (2,850) size 128x30 [border: (2px groove #C0C0C0)]
+      RenderFieldSet {FIELDSET} at (2,870) size 128x30 [border: (2px groove #C0C0C0)]
         RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,619) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,610) size 100x41
+layer at (8,639) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,630) size 100x41
     RenderFieldSet {FIELDSET} at (2,0) size 184x30 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,659) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,650) size 300x41
+layer at (8,679) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,670) size 300x41
     RenderFieldSet {FIELDSET} at (58,0) size 184x30 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,699) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,690) size 100x41
-layer at (10,699) size 184x30
+layer at (8,719) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,710) size 100x41
+layer at (10,719) size 184x30
   RenderFieldSet {FIELDSET} at (2,0) size 184x30 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,739) size 769x40
-  RenderBlock (relative positioned) {DIV} at (0,730) size 769x41
-layer at (10,739) size 184x30
+layer at (8,759) size 769x40
+  RenderBlock (relative positioned) {DIV} at (0,750) size 769x41
+layer at (10,759) size 184x30
   RenderFieldSet {FIELDSET} at (2,0) size 184x30 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,779) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,770) size 300x41
-layer at (110,779) size 184x30
+layer at (8,799) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,790) size 300x41
+layer at (110,799) size 184x30
   RenderFieldSet {FIELDSET} at (102,0) size 184x30 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/glib/fast/borders/fieldsetBorderRadius-expected.txt
+++ b/LayoutTests/platform/glib/fast/borders/fieldsetBorderRadius-expected.txt
@@ -31,37 +31,37 @@ layer at (0,0) size 800x600
           RenderBlock {LEGEND} at (135,0) size 54x12 [bgcolor=#0080004D]
         RenderFieldSet {FIELDSET} at (2,307) size 140x53 [border: (8px double #000000)]
           RenderBlock {LEGEND} at (140,0) size 54x12 [bgcolor=#0080004D]
-      RenderBlock {DIV} at (450,0) size 334x389
+      RenderBlock {DIV} at (450,0) size 334x409
         RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-        RenderFieldSet {FIELDSET} at (2,49) size 184x41 [border: (2px groove #C0C0C0)]
+        RenderFieldSet {FIELDSET} at (2,69) size 184x41 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (44,0) size 96x12 [border: (1px solid #0000FF)]
-        RenderBlock (anonymous) at (0,299) size 334x50
+        RenderBlock (anonymous) at (0,319) size 334x50
           RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
             RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
           RenderText {#text} at (0,0) size 0x0
-        RenderFieldSet {FIELDSET} at (2,348) size 128x41 [border: (2px groove #C0C0C0)]
+        RenderFieldSet {FIELDSET} at (2,368) size 128x41 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,107) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,99) size 100x41
+layer at (458,127) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,119) size 100x41
     RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,147) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,139) size 300x41
+layer at (458,167) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,159) size 300x41
     RenderFieldSet {FIELDSET} at (58,0) size 184x40 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,187) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,179) size 100x41
-layer at (460,187) size 184x40
+layer at (458,207) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,199) size 100x41
+layer at (460,207) size 184x40
   RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,227) size 334x40
-  RenderBlock (relative positioned) {DIV} at (0,219) size 334x41
-layer at (460,227) size 184x40
+layer at (458,247) size 334x40
+  RenderBlock (relative positioned) {DIV} at (0,239) size 334x41
+layer at (460,247) size 184x40
   RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,267) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,259) size 300x41
-layer at (560,267) size 184x40
+layer at (458,287) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,279) size 300x41
+layer at (560,287) size 184x40
   RenderFieldSet {FIELDSET} at (102,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/ios/fast/borders/fieldsetBorderRadius-expected.txt
+++ b/LayoutTests/platform/ios/fast/borders/fieldsetBorderRadius-expected.txt
@@ -31,37 +31,37 @@ layer at (0,0) size 800x600
           RenderBlock {LEGEND} at (135,0) size 54x12 [bgcolor=#0080004D]
         RenderFieldSet {FIELDSET} at (2,307) size 140x53 [border: (8px double #000000)]
           RenderBlock {LEGEND} at (140,0) size 54x12 [bgcolor=#0080004D]
-      RenderBlock {DIV} at (450,0) size 334x389
+      RenderBlock {DIV} at (450,0) size 334x409
         RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-        RenderFieldSet {FIELDSET} at (2,49) size 184x41 [border: (2px groove #C0C0C0)]
+        RenderFieldSet {FIELDSET} at (2,69) size 184x41 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (44,0) size 96x12 [border: (1px solid #0000FF)]
-        RenderBlock (anonymous) at (0,299) size 334x50
+        RenderBlock (anonymous) at (0,319) size 334x50
           RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
             RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
           RenderText {#text} at (0,0) size 0x0
-        RenderFieldSet {FIELDSET} at (2,348) size 128x41 [border: (2px groove #C0C0C0)]
+        RenderFieldSet {FIELDSET} at (2,368) size 128x41 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,107) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,99) size 100x41
+layer at (458,127) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,119) size 100x41
     RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,147) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,139) size 300x41
+layer at (458,167) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,159) size 300x41
     RenderFieldSet {FIELDSET} at (58,0) size 184x40 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,187) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,179) size 100x41
-layer at (460,187) size 184x40
+layer at (458,207) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,199) size 100x41
+layer at (460,207) size 184x40
   RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,227) size 334x40
-  RenderBlock (relative positioned) {DIV} at (0,219) size 334x41
-layer at (460,227) size 184x40
+layer at (458,247) size 334x40
+  RenderBlock (relative positioned) {DIV} at (0,239) size 334x41
+layer at (460,247) size 184x40
   RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,267) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,259) size 300x41
-layer at (560,267) size 184x40
+layer at (458,287) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,279) size 300x41
+layer at (560,287) size 184x40
   RenderFieldSet {FIELDSET} at (102,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/block/basic/fieldset-stretch-to-legend-expected.txt
+++ b/LayoutTests/platform/mac/fast/block/basic/fieldset-stretch-to-legend-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x898
+layer at (0,0) size 785x918
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x898
-  RenderBlock {HTML} at (0,0) size 785x898
-    RenderBody {BODY} at (8,8) size 769x880
+layer at (0,0) size 785x918
+  RenderBlock {HTML} at (0,0) size 785x918
+    RenderBody {BODY} at (8,8) size 769x900
       RenderFieldSet {FIELDSET} at (2,0) size 140x36 [border: (8px double #000000)]
         RenderBlock {LEGEND} at (20,0) size 54x12 [bgcolor=#0080004D]
       RenderFieldSet {FIELDSET} at (2,45) size 140x37 [border: (8px double #000000)]
@@ -27,34 +27,34 @@ layer at (0,0) size 785x898
         RenderBlock {LEGEND} at (140,0) size 54x12 [bgcolor=#0080004D]
       RenderFieldSet {FIELDSET} at (2,501) size 184x31 [border: (2px groove #C0C0C0)]
         RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-      RenderFieldSet {FIELDSET} at (2,541) size 184x60 [border: (2px groove #C0C0C0)]
+      RenderFieldSet {FIELDSET} at (2,561) size 184x60 [border: (2px groove #C0C0C0)]
         RenderBlock {LEGEND} at (44,0) size 96x12 [border: (1px solid #0000FF)]
-      RenderBlock (anonymous) at (0,810) size 769x41
+      RenderBlock (anonymous) at (0,830) size 769x41
         RenderFieldSet {FIELDSET} at (2,0) size 184x30 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
         RenderText {#text} at (0,0) size 0x0
-      RenderFieldSet {FIELDSET} at (2,850) size 128x30 [border: (2px groove #C0C0C0)]
+      RenderFieldSet {FIELDSET} at (2,870) size 128x30 [border: (2px groove #C0C0C0)]
         RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,619) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,610) size 100x41
+layer at (8,639) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,630) size 100x41
     RenderFieldSet {FIELDSET} at (2,0) size 184x30 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,659) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,650) size 300x41
+layer at (8,679) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,670) size 300x41
     RenderFieldSet {FIELDSET} at (58,0) size 184x30 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,699) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,690) size 100x41
-layer at (10,699) size 184x30
+layer at (8,719) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,710) size 100x41
+layer at (10,719) size 184x30
   RenderFieldSet {FIELDSET} at (2,0) size 184x30 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,739) size 769x40
-  RenderBlock (relative positioned) {DIV} at (0,730) size 769x41
-layer at (10,739) size 184x30
+layer at (8,759) size 769x40
+  RenderBlock (relative positioned) {DIV} at (0,750) size 769x41
+layer at (10,759) size 184x30
   RenderFieldSet {FIELDSET} at (2,0) size 184x30 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (8,779) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,770) size 300x41
-layer at (110,779) size 184x30
+layer at (8,799) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,790) size 300x41
+layer at (110,799) size 184x30
   RenderFieldSet {FIELDSET} at (102,0) size 184x30 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/borders/fieldsetBorderRadius-expected.txt
+++ b/LayoutTests/platform/mac/fast/borders/fieldsetBorderRadius-expected.txt
@@ -31,37 +31,37 @@ layer at (0,0) size 800x600
           RenderBlock {LEGEND} at (135,0) size 54x12 [bgcolor=#0080004D]
         RenderFieldSet {FIELDSET} at (2,307) size 140x53 [border: (8px double #000000)]
           RenderBlock {LEGEND} at (140,0) size 54x12 [bgcolor=#0080004D]
-      RenderBlock {DIV} at (450,0) size 334x389
+      RenderBlock {DIV} at (450,0) size 334x409
         RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-        RenderFieldSet {FIELDSET} at (2,49) size 184x41 [border: (2px groove #C0C0C0)]
+        RenderFieldSet {FIELDSET} at (2,69) size 184x41 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (44,0) size 96x12 [border: (1px solid #0000FF)]
-        RenderBlock (anonymous) at (0,299) size 334x50
+        RenderBlock (anonymous) at (0,319) size 334x50
           RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
             RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
           RenderText {#text} at (0,0) size 0x0
-        RenderFieldSet {FIELDSET} at (2,348) size 128x41 [border: (2px groove #C0C0C0)]
+        RenderFieldSet {FIELDSET} at (2,368) size 128x41 [border: (2px groove #C0C0C0)]
           RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,107) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,99) size 100x41
+layer at (458,127) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,119) size 100x41
     RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,147) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,139) size 300x41
+layer at (458,167) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,159) size 300x41
     RenderFieldSet {FIELDSET} at (58,0) size 184x40 [border: (2px groove #C0C0C0)]
       RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,187) size 100x40
-  RenderBlock (relative positioned) {DIV} at (0,179) size 100x41
-layer at (460,187) size 184x40
+layer at (458,207) size 100x40
+  RenderBlock (relative positioned) {DIV} at (0,199) size 100x41
+layer at (460,207) size 184x40
   RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,227) size 334x40
-  RenderBlock (relative positioned) {DIV} at (0,219) size 334x41
-layer at (460,227) size 184x40
+layer at (458,247) size 334x40
+  RenderBlock (relative positioned) {DIV} at (0,239) size 334x41
+layer at (460,247) size 184x40
   RenderFieldSet {FIELDSET} at (2,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]
-layer at (458,267) size 300x40
-  RenderBlock (relative positioned) {DIV} at (0,259) size 300x41
-layer at (560,267) size 184x40
+layer at (458,287) size 300x40
+  RenderBlock (relative positioned) {DIV} at (0,279) size 300x41
+layer at (560,287) size 184x40
   RenderFieldSet {FIELDSET} at (102,0) size 184x40 [border: (2px groove #C0C0C0)]
     RenderBlock {LEGEND} at (14,0) size 156x12 [border: (1px solid #0000FF)]

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -267,6 +267,7 @@ public:
     LayoutUnit m_paginationStrut;
     LayoutUnit m_pageLogicalOffset;
     LayoutUnit m_intrinsicBorderForFieldset;
+    LayoutUnit m_intrinsicMarginBeforeForFieldset;
     
     std::optional<SingleThreadWeakPtr<RenderFragmentedFlow>> m_enclosingFragmentedFlow;
 };
@@ -3171,6 +3172,7 @@ void RenderBlock::layoutExcludedChildren(RelayoutChildren relayoutChildren)
         return;
 
     setIntrinsicBorderForFieldset(0);
+    setIntrinsicMarginBeforeForFieldset(0);
 
     RenderBox* box = findFieldsetLegend();
     if (!box)
@@ -3223,6 +3225,7 @@ void RenderBlock::layoutExcludedChildren(RelayoutChildren relayoutChildren)
     
     LayoutUnit fieldsetBorderBefore = borderBefore();
     LayoutUnit legendLogicalHeight = logicalHeightForChild(legend);
+    LayoutUnit legendBeforeMargin = marginBeforeForChild(legend);
     LayoutUnit legendAfterMargin = marginAfterForChild(legend);
     LayoutUnit topPositionForLegend = std::max(0_lu, (fieldsetBorderBefore - legendLogicalHeight) / 2);
     LayoutUnit bottomPositionForLegend = topPositionForLegend + legendLogicalHeight + legendAfterMargin;
@@ -3232,11 +3235,13 @@ void RenderBlock::layoutExcludedChildren(RelayoutChildren relayoutChildren)
 
     // If the bottom of the legend (including its after margin) is below the fieldset border,
     // then we need to add in sufficient intrinsic border to account for this gap.
-    // FIXME: Should we support the before margin of the legend? Not entirely clear.
     // FIXME: Consider dropping support for the after margin of the legend. Not sure other
     // browsers support that anyway.
     if (bottomPositionForLegend > fieldsetBorderBefore)
         setIntrinsicBorderForFieldset(bottomPositionForLegend - fieldsetBorderBefore);
+
+    if (legendBeforeMargin > 0)
+        setIntrinsicMarginBeforeForFieldset(legendBeforeMargin);
     
     // Now that the legend is included in the border extent, we can set our logical height
     // to the borderBefore (which includes the legend and its after margin if they were bigger
@@ -3334,6 +3339,23 @@ void RenderBlock::setIntrinsicBorderForFieldset(LayoutUnit padding)
     rareData->m_intrinsicBorderForFieldset = padding;
 }
 
+LayoutUnit RenderBlock::intrinsicMarginBeforeForFieldset() const
+{
+    auto* rareData = blockRareData();
+    return rareData ? rareData->m_intrinsicMarginBeforeForFieldset : 0_lu;
+}
+
+void RenderBlock::setIntrinsicMarginBeforeForFieldset(LayoutUnit margin)
+{
+    auto* rareData = blockRareData();
+    if (!rareData) {
+        if (!margin)
+            return;
+        rareData = &ensureBlockRareData();
+    }
+    rareData->m_intrinsicMarginBeforeForFieldset = margin;
+}
+
 RectEdges<LayoutUnit> RenderBlock::borderWidths() const
 {
     if (!intrinsicBorderForFieldset())
@@ -3378,6 +3400,11 @@ LayoutUnit RenderBlock::borderRight() const
 LayoutUnit RenderBlock::borderBefore() const
 {
     return RenderBox::borderBefore() + intrinsicBorderForFieldset();
+}
+
+LayoutUnit RenderBlock::marginBefore(const WritingMode writingMode) const
+{
+    return RenderBox::marginBefore(writingMode) + intrinsicMarginBeforeForFieldset();
 }
 
 std::pair<LayoutUnit, LayoutUnit> RenderBlock::computeIntrinsicLogicalWidthsForFieldsetLegend() const

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -166,6 +166,11 @@ public:
     LayoutUnit NODELETE intrinsicBorderForFieldset() const;
     void setIntrinsicBorderForFieldset(LayoutUnit);
 
+    // Fieldset legends with a block-start margin shift the whole fieldset down rather than moving
+    // the legend within the border, by adding that margin onto the fieldset's own margin-before.
+    LayoutUnit NODELETE intrinsicMarginBeforeForFieldset() const;
+    void setIntrinsicMarginBeforeForFieldset(LayoutUnit);
+
     RectEdges<LayoutUnit> borderWidths() const override;
     LayoutUnit borderTop() const override;
     LayoutUnit borderBottom() const override;
@@ -173,6 +178,10 @@ public:
     LayoutUnit borderRight() const override;
 
     LayoutUnit borderBefore() const override;
+
+    LayoutUnit marginBefore(WritingMode) const override;
+    LayoutUnit marginBefore() const { return marginBefore(writingMode()); }
+
     LayoutUnit adjustBorderBoxLogicalHeightForBoxSizing(LayoutUnit height) const override;
     LayoutUnit adjustContentBoxLogicalHeightForBoxSizing(std::optional<LayoutUnit> height) const override;
     LayoutUnit adjustIntrinsicLogicalHeightForBoxSizing(LayoutUnit height) const override;


### PR DESCRIPTION
#### 47d8491450fb6c0c91c123bd0c0e322f0eaa8b22
<pre>
[Margin][Legend] Positive margin on fieldset legends should shift the fieldset down.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284441">https://bugs.webkit.org/show_bug.cgi?id=284441</a>
<a href="https://rdar.apple.com/141267953">rdar://141267953</a>

Reviewed by Alan Baradlay.

Webkit and Blink currently ignore block-start margin on a fieldset&apos;s
&lt;legend&gt;. The HTML spec for fieldset/legend says:

&quot;The space allocated for the element&apos;s border on the block-start side is expected to be the
element&apos;s &apos;border-block-start-width&apos; or the rendered legend&apos;s margin box size in the
fieldset&apos;s block-flow direction, whichever is greater.&quot;

<a href="https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements">https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements</a>

Our current implementation only handles border-block-start-width via
fieldsetBorderBefore() but never handles the legend&apos;s before margin.

Ths PR adds intrinsicMarginBeforeForFieldset() to add the legend&apos;s margin
onto the fieldset&apos;s marginBefore(), shifting the fieldset down with the legend.

This change fixes the WPT &quot;legend-block-margins.html&quot;

We also need to rebaseline:

basic/fieldset-stretch-to-legend-expected
fieldsetBorderRadius-expected

As we are now handling:

  &lt;legend style=&quot;width: 90px; margin: 30px;&quot;&gt;&lt;/legend&gt;

* LayoutTests/TestExpectations:
* LayoutTests/platform/glib/fast/block/basic/fieldset-stretch-to-legend-expected.txt:
* LayoutTests/platform/glib/fast/borders/fieldsetBorderRadius-expected.txt:
* LayoutTests/platform/ios/fast/borders/fieldsetBorderRadius-expected.txt:
* LayoutTests/platform/mac/fast/block/basic/fieldset-stretch-to-legend-expected.txt:
* LayoutTests/platform/mac/fast/borders/fieldsetBorderRadius-expected.txt:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::layoutExcludedChildren):
(WebCore::RenderBlock::intrinsicMarginBeforeForFieldset const):
(WebCore::RenderBlock::setIntrinsicMarginBeforeForFieldset):
(WebCore::RenderBlock::marginBefore const):
* Source/WebCore/rendering/RenderBlock.h:
(WebCore::RenderBlock::marginBefore const):

Canonical link: <a href="https://commits.webkit.org/315391@main">https://commits.webkit.org/315391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac129f23f988590202a58d05deef9d859cb46cf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126493 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b806b58a-d1af-4334-b81c-be5925aa80d1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131424 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c73e3935-eb1e-42fe-9d1d-f9eb182fef5e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111928 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ea4dd2a-56de-4ca1-b226-87fddfdbdae6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32866 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31579 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26812 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180718 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139871 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139715 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37637 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43046 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28071 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106793 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34998 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114813 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41549 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6159 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40946 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41200 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41091 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->