### PR TITLE
StabilityTracer: com.apple.WebKit.WebContent at com.apple.WebCore: WebCore::dispatchEventsOnWindowAndFocusedElement

### DIFF
--- a/LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash-expected.txt
+++ b/LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests that the WebContent process does not crash when window deactivation fires a change event on a focused form control whose onchange handler removes focus from that control.
+
+
+PASS - did not crash

--- a/LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash.html
+++ b/LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p id="description">
+This tests that the WebContent process does not crash when window deactivation
+fires a change event on a focused form control whose onchange handler removes
+focus from that control.
+</p>
+<input id="input" autofocus onchange="this.blur()">
+<div id="result"></div>
+<script>
+if (!window.testRunner || !window.eventSender)
+    document.getElementById("result").textContent = "This test requires testRunner and eventSender.";
+else {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const input = document.getElementById("input");
+    input.focus();
+
+    // Simulated keystroke marks the input as dirty.
+    eventSender.keyDown("a");
+
+    // Triggers FocusController::setActiveInternal(false) which
+    // leads to dispatchEventsOnWindowAndFocusedElement().
+    testRunner.setWindowIsKey(false);
+
+    setTimeout(() => {
+        document.getElementById("result").textContent = "PASS - did not crash";
+        testRunner.notifyDone();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -432,7 +432,8 @@ static inline void dispatchEventsOnWindowAndFocusedElement(Document* document, b
                 formControlElement->dispatchFormControlChangeEvent();
         }
 
-        document->focusedElement()->dispatchBlurEvent(nullptr);
+        if (RefPtr focusedElement = document->focusedElement())
+            focusedElement->dispatchBlurEvent(nullptr);
     }
 
     document->dispatchWindowEvent(Event::create(focused ? eventNames().focusEvent : eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));


### PR DESCRIPTION
#### ab52a089ca027eae9a1ead8b83f806417b2b268e
<pre>
StabilityTracer: com.apple.WebKit.WebContent at com.apple.WebCore: WebCore::dispatchEventsOnWindowAndFocusedElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=316860">https://bugs.webkit.org/show_bug.cgi?id=316860</a>
<a href="https://rdar.apple.com/179182828">rdar://179182828</a>

Reviewed by Abrar Rahman Protyasha and Chris Dumez.

On this line in dispatchEventsOnWindowAndFocusedElement, the focusedElement()
may be nullptr, resulting a null dereference:

document-&gt;focusedElement()-&gt;dispatchBlurEvent(nullptr);

We can reproduce the crash in this scenario: There is an input element on the
page which is focused and has an onchange handler that blurs it. We type a
character in it, and then when we CMD+TAB to open and move to a new tab, the
crash happens.

When we move away from the this page, dispatchEventsOnWindowAndFocusedElement()
is called, and since there is a HTMLFormControlElement on it, we call
dispatchFormControlChangeEvent() on it. This calls Element::blur(), which sets
Document::m_focusedElement to nullptr. Then we unconditionally dereference
document-&gt;focusedElement() in the next line (the line shown above) and crash.
This call to dispatchEventsOnWindowAndFocusedElement() was added in 308203@main.

We fix this by null checking focusedElement before using it. We add a test that
mirrors this scenario.

Credit to Abrar Protyasha for finding the repro case.

* LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash-expected.txt: Added.
* LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash.html: Added.
* Source/WebCore/page/FocusController.cpp:
(WebCore::dispatchEventsOnWindowAndFocusedElement):

Canonical link: <a href="https://commits.webkit.org/315028@main">https://commits.webkit.org/315028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c339af4ada3ee642dfac299c924ae9ce69cb053d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125455 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130533 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111050 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31960 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30657 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179373 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32421 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138945 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138830 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150245 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105215 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27124 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40535 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113786 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39932 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5227 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->