### PR TITLE
Remove unnecessary `std::optional` initialization in WebCore

### DIFF
--- a/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
@@ -66,7 +66,7 @@ ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawReques
             DigitalCredentialsRawRequests { WTF::move(rawRequestStrings) });
     });
 
-    std::optional<ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawRequests>>> firstException = std::nullopt;
+    std::optional<ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawRequests>>> firstException;
     for (auto result : results) {
         // return the first matching result without exception
         if (!result.hasException())

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -137,7 +137,7 @@ static bool isValidEncoderConfig(const WebCodecsAudioEncoderConfig& config)
 
 static ExceptionOr<AudioEncoder::Config> createAudioEncoderConfig(const WebCodecsAudioEncoderConfig& config)
 {
-    std::optional<AudioEncoder::OpusConfig> opusConfig = std::nullopt;
+    std::optional<AudioEncoder::OpusConfig> opusConfig;
     if (config.opus) {
         opusConfig = {
             .isOggBitStream = config.opus->format == OpusBitstreamFormat::Ogg,
@@ -149,11 +149,11 @@ static ExceptionOr<AudioEncoder::Config> createAudioEncoderConfig(const WebCodec
         };
     }
 
-    std::optional<bool> isAacADTS = std::nullopt;
+    std::optional<bool> isAacADTS;
     if (config.aac)
         isAacADTS = config.aac->format == AacBitstreamFormat::Adts;
 
-    std::optional<AudioEncoder::FlacConfig> flacConfig = std::nullopt;
+    std::optional<AudioEncoder::FlacConfig> flacConfig;
     if (config.flac)
         flacConfig = { config.flac->blockSize, config.flac->compressLevel };
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -767,7 +767,7 @@ void WebAnimation::setEffectiveFrameRate(std::optional<FramesPerSecond> effectiv
     if (m_effectiveFrameRate == effectiveFrameRate)
         return;
 
-    std::optional<FramesPerSecond> maximumFrameRate = std::nullopt;
+    std::optional<FramesPerSecond> maximumFrameRate;
     if (RefPtr timeline = dynamicDowncast<DocumentTimeline>(m_timeline))
         maximumFrameRate = timeline->maximumFrameRate();
 

--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -269,7 +269,7 @@ unsigned CachedMatchFinder::countMatches(const std::optional<SimpleRange>& searc
 
 unsigned CachedMatchFinder::bufferOffsetForBoundaryPoint(StringView buffer, const Vector<TextRun>& runs, const BoundaryPoint& point, FindOptions options)
 {
-    std::optional<unsigned> lastChunkEnd = std::nullopt;
+    std::optional<unsigned> lastChunkEnd;
     for (auto [i, run] : indexedRange(runs)) {
         if (&run.range.start.container.get() != &point.container.get())
             continue;

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -183,7 +183,7 @@ static UniqueRef<CaretAnimator> createCaretAnimator(FrameSelection* frameSelecti
 {
 #if PLATFORM(MAC) && HAVE(REDESIGNED_TEXT_CURSOR)
     if (redesignedTextCursorEnabled()) {
-        std::optional<LayoutRect> existingExpansionRect = std::nullopt;
+        std::optional<LayoutRect> existingExpansionRect;
         if (optionalCaretType)
             existingExpansionRect = frameSelection->caretAnimator().caretRepaintRectForLocalRect(LayoutRect());
 

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -547,7 +547,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(const Render
     auto rect = bounds;
     float cornerRadius = 0;
     OptionSet<InteractionRegion::CornerMask> maskedCorners { };
-    std::optional<Path> clipPath = std::nullopt;
+    std::optional<Path> clipPath;
 
     CheckedRef style = regionRenderer.style();
     CheckedPtr<const RenderBox> regionRendererBox;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -758,7 +758,7 @@ void Navigation::recursivelyDisposeOfForwardEntriesInParents(BackForwardItemIden
     if (frame() == navigatedFrame)
         return;
 
-    std::optional<size_t> index = std::nullopt;
+    std::optional<size_t> index;
     for (size_t i = 0; i < m_entries.size(); i++) {
         if (m_entries[i]->associatedHistoryItem().itemID() == itemID) {
             index = i;

--- a/Source/WebCore/platform/AbortableTaskQueue.h
+++ b/Source/WebCore/platform/AbortableTaskQueue.h
@@ -148,7 +148,7 @@ public:
         if (m_aborting)
             return std::nullopt;
 
-        std::optional<R> response = std::nullopt;
+        std::optional<R> response;
         postTask([this, &response, &mainThreadTaskHandler]() {
             R responseValue = mainThreadTaskHandler();
             Locker locker { m_lock };


### PR DESCRIPTION
#### d47ec7b52d86dd2cf411943f382cab0ba1f72d2d
<pre>
Remove unnecessary `std::optional` initialization in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=316739">https://bugs.webkit.org/show_bug.cgi?id=316739</a>
<a href="https://rdar.apple.com/179180921">rdar://179180921</a>

Reviewed by Chris Dumez.

ISO C++ Standard explicitly guarantees that a default-initialized std::optional
does not contain a value. So, initializing one with std::nullopt is redundant.

* Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp:
(WebCore::DigitalCredentialsRequestDataBuilder::build):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::createAudioEncoderConfig):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setEffectiveFrameRate):
* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::CachedMatchFinder::bufferOffsetForBoundaryPoint):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::createCaretAnimator):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::recursivelyDisposeOfForwardEntriesInParents):
* Source/WebCore/platform/AbortableTaskQueue.h:

Canonical link: <a href="https://commits.webkit.org/315046@main">https://commits.webkit.org/315046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6cb4825b3110b7532f7b443c5164345a3bd1988

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125459 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130536 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31963 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179377 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138948 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138833 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37420 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42035 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105223 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27127 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113790 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39936 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5230 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->