### PR TITLE
Remove extraneous smart pointer get() calls from DocumentWriter.cpp and ScrollLatchingController.cpp

### DIFF
--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -208,8 +208,8 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     frameLoader->setOutgoingReferrer(url);
     frame->setDocument(document.copyRef());
 
-    if (RefPtr decoder = m_decoder)
-        document->setDecoder(decoder.get());
+    if (m_decoder)
+        document->setDecoder(m_decoder.copyRef());
     if (ownerDocument) {
         // |document| is the result of evaluating a JavaScript URL.
         document->setCookieURL(ownerDocument->cookieURL());
@@ -252,7 +252,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     if (existingDocument && existingDocument->contentSecurityPolicy() && document->contentSecurityPolicy())
         document->contentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(existingDocument->contentSecurityPolicy()->takeNavigationRequestsToUpgrade());
 
-    frameLoader->didBeginDocument(dispatch, previousWindow.get());
+    frameLoader->didBeginDocument(dispatch, previousWindow);
 
     document->implicitOpen();
 
@@ -284,10 +284,10 @@ TextResourceDecoder& DocumentWriter::decoder()
         // an attack vector.
         // FIXME: This might be too cautious for non-7bit-encodings and
         // we may consider relaxing this later after testing.
-        if (canReferToParentFrameEncoding(frame.ptr(), parentFrame.get()))
+        if (canReferToParentFrameEncoding(frame.ptr(), parentFrame))
             decoder->setHintEncoding(parentFrame->document()->decoder());
         if (m_encoding.isEmpty()) {
-            if (canReferToParentFrameEncoding(frame.ptr(), parentFrame.get()))
+            if (canReferToParentFrameEncoding(frame.ptr(), parentFrame))
                 decoder->setEncoding(parentFrame->document()->textEncoding(), TextResourceDecoder::EncodingFromParentFrame);
         } else {
             decoder->setEncoding(m_encoding,

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
@@ -136,7 +136,7 @@ void ScrollLatchingController::updateAndFetchLatchingStateForFrame(LocalFrame& f
             FrameState state;
             state.frame = &frame;
             state.wheelEventElement = latchedElement;
-            if (shouldLatchToScrollableArea(frame, scrollableArea.get(), m_cumulativeEventDelta))
+            if (shouldLatchToScrollableArea(frame, scrollableArea, m_cumulativeEventDelta))
                 state.scrollableArea = scrollableArea;
             state.isOverWidget = isOverWidget;
 
@@ -152,7 +152,7 @@ void ScrollLatchingController::updateAndFetchLatchingStateForFrame(LocalFrame& f
             return;
 
         // We may not have latched at gesture start because of small deltas. Re-evaluate latching based on accumulated delta.
-        if (!state->scrollableArea && shouldLatchToScrollableArea(frame, scrollableArea.get(), m_cumulativeEventDelta))
+        if (!state->scrollableArea && shouldLatchToScrollableArea(frame, scrollableArea, m_cumulativeEventDelta))
             state->scrollableArea = scrollableArea;
     }
 


### PR DESCRIPTION
#### c109337e2ca86a978f86c478ed215cc4889ca127
<pre>
Remove extraneous smart pointer get() calls from DocumentWriter.cpp and ScrollLatchingController.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=316877">https://bugs.webkit.org/show_bug.cgi?id=316877</a>
<a href="https://rdar.apple.com/179302972">rdar://179302972</a>

Reviewed by Basuke Suzuki.

The smart pointer implicitly converts to the raw resource at the call site so these
get() calls are extraneous. Let&apos;s cleans up call sites in DocumentWriter and ScrollLatchingController.cpp

No new tests needed.

* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
(WebCore::DocumentWriter::decoder):
* Source/WebCore/page/scrolling/ScrollLatchingController.cpp:
(WebCore::ScrollLatchingController::updateAndFetchLatchingStateForFrame):

Canonical link: <a href="https://commits.webkit.org/315012@main">https://commits.webkit.org/315012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dee12dae00e84b0d7d052314160cc7d26ba06003

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125460 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5328be72-25f6-4037-8522-c6a068bcc4b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130537 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ffab95e4-293d-42bb-85d6-85ac16b08fb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111054 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81314e78-6182-4d99-9062-02e6d70edc6f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25569 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179378 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138949 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138834 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42036 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105224 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25552 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27128 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113791 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39937 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5231 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40188 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40082 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->