### PR TITLE
Crash in WebCore::MediaPlayerPrivateWebM::reenqueueMediaForTime

### DIFF
--- a/LayoutTests/media/video-webm-seek-multi-audio-tracks-expected.txt
+++ b/LayoutTests/media/video-webm-seek-multi-audio-tracks-expected.txt
@@ -1,0 +1,17 @@
+Test that seeking does not crash when a multi-audio-track WebM has more TrackBuffers than enabled track identifiers.
+
+
+EXPECTED (video.videoTracks.length == '1') OK
+EXPECTED (video.audioTracks.length == '2') OK
+EXPECTED (video.audioTracks[0].enabled == 'true') OK
+EXPECTED (video.audioTracks[1].enabled == 'false') OK
+EVENT(canplay)
+EVENT(seeking)
+EVENT(seeked)
+EVENT(seeking)
+EVENT(seeked)
+EVENT(seeking)
+EVENT(seeked)
+PASS: seek with extra unselected audio track did not crash
+END OF TEST
+

--- a/LayoutTests/media/video-webm-seek-multi-audio-tracks.html
+++ b/LayoutTests/media/video-webm-seek-multi-audio-tracks.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <script src="video-test.js"></script>
+        <script>
+            async function start()
+            {
+                findMediaElement();
+
+                waitForEvent('canplay');
+                waitForEvent('seeking');
+                waitForEvent('seeked');
+                waitForEvent('error', failTest);
+
+                video.src = 'content/vp9-opus-good-3tracks.webm';
+                await waitFor(video, "loadedmetadata", true);
+
+                // The asset has 1 video + 2 audio tracks. WebKit auto-selects/enables
+                // only the first of each kind.
+                testExpected('video.videoTracks.length', 1);
+                testExpected('video.audioTracks.length', 2);
+                testExpected('video.audioTracks[0].enabled', true);
+                testExpected('video.audioTracks[1].enabled', false);
+
+                await waitFor(video, "canplay", true);
+
+                video.currentTime = 1;
+                await waitFor(video, "seeked", true);
+
+                video.currentTime = 0;
+                await waitFor(video, "seeked", true);
+
+                video.currentTime = 0.5;
+                await waitFor(video, "seeked", true);
+
+                consoleWrite("PASS: seek with extra unselected audio track did not crash");
+                endTest();
+            }
+        </script>
+    </head>
+
+    <body onload="start()">
+        <p>Test that seeking does not crash when a multi-audio-track WebM has more TrackBuffers than enabled track identifiers.</p>
+        <video controls></video>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1252,8 +1252,13 @@ void MediaPlayerPrivateWebM::reenqueueMediaForTime(const MediaTime& time)
 void MediaPlayerPrivateWebM::reenqueueMediaForTime(TrackBuffer& trackBuffer, TrackID trackId, const MediaTime& time, NeedsFlush needsFlush)
 {
     assertIsCurrent(runningQueue());
+
+    auto trackIdentifier = maybeTrackIdentifierFor(trackId);
+    if (!trackIdentifier)
+        return; // Track not selected.
+
     if (needsFlush == NeedsFlush::Yes)
-        m_renderer->flushTrack(trackIdentifierFor(trackId));
+        m_renderer->flushTrack(*trackIdentifier);
 
     if (trackBuffer.reenqueueMediaForTime(time, timeFudgeFactor(), m_loadFinished))
         provideMediaData(trackBuffer, trackId);
@@ -1433,7 +1438,11 @@ void MediaPlayerPrivateWebM::trackDidChangeEnabled(AudioTrackPrivate& track, boo
         return;
     }
 
-    m_renderer->removeTrack(trackIdentifierFor(trackId));
+    auto trackIdentifier = maybeTrackIdentifierFor(trackId);
+    if (!trackIdentifier)
+        return;
+
+    m_renderer->removeTrack(*trackIdentifier);
     m_trackIdentifiers.erase(trackId);
     m_readyForMoreSamplesMap.erase(trackId);
 }


### PR DESCRIPTION
#### 4ae3b23da26b52582ba246d300fc25acdc0e6816
<pre>
Crash in WebCore::MediaPlayerPrivateWebM::reenqueueMediaForTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=316880">https://bugs.webkit.org/show_bug.cgi?id=316880</a>
<a href="https://rdar.apple.com/179182491">rdar://179182491</a>

Reviewed by Eric Carlson.

Should a track become disabled while seeking, the renderer&apos;s track would
get destroyed and removed from the m_trackIdentifiers. The code assumed
that if the trackIdentifier was in m_trackBufferMap , then it would be enabled.

We now guard against this by first checking if the trackIdentifier is in the
map and abort.

Added tests.

* LayoutTests/media/video-webm-seek-multi-audio-tracks-expected.txt: Added.
* LayoutTests/media/video-webm-seek-multi-audio-tracks.html: Added.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::reenqueueMediaForTime):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeEnabled): Pre-emptive correctness. Just in case as it&apos;s a similar pattern as the above.

Canonical link: <a href="https://commits.webkit.org/314993@main">https://commits.webkit.org/314993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e86c2fc087ace8f3fec26057ee2436726ec56eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34878 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176844 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41296 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/176844 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170745 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/176844 "") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25576 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179385 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30181 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37383 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105238 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34114 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40547 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39944 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5237 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40195 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->