### PR TITLE
ScreenTime data removal uses an unanchored host suffix match, deleting unrelated sites' data

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
@@ -68,6 +68,15 @@ void getScreenTimeURLs(std::optional<WTF::UUID> identifier, CompletionHandler<vo
     }).get()];
 }
 
+static bool hostIsInDomain(NSString *host, NSString *domain)
+{
+    if (![host hasSuffix:domain])
+        return false;
+
+    NSUInteger suffixOffset = host.length - domain.length;
+    return !suffixOffset || [host characterAtIndex:suffixOffset - 1] == '.';
+}
+
 void removeScreenTimeData(const HashSet<URL>& websitesToRemove, const WebsiteDataStoreConfiguration& configuration, CompletionHandler<void()>&& completionHandler)
 {
     RetainPtr<NSString> profileIdentifier;
@@ -77,16 +86,19 @@ void removeScreenTimeData(const HashSet<URL>& websitesToRemove, const WebsiteDat
     RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
 
     RetainPtr<NSMutableSet<NSString *>> websitesToRemoveDomains = [NSMutableSet set];
-    for (auto& url : websitesToRemove)
-        if (RetainPtr host = url.host().createNSString())
+    for (auto& url : websitesToRemove) {
+        if (RetainPtr host = url.host().createNSString(); host && [host length])
             [websitesToRemoveDomains addObject:host.get()];
+    }
 
     [webHistory fetchAllHistoryWithCompletionHandler:makeBlockPtr([webHistory, websitesToRemoveDomains, completionHandler = WTF::move(completionHandler)](NSSet<NSURL *> *urls, NSError *error) mutable {
         if (!error) {
             for (NSURL *url in urls) {
                 for (NSString *domainString in websitesToRemoveDomains.get()) {
-                    if ([[url host] hasSuffix:domainString])
+                    if (hostIsInDomain([url host], domainString)) {
                         [webHistory deleteHistoryForURL:url];
+                        break;
+                    }
                 }
             }
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenTime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenTime.mm
@@ -784,6 +784,76 @@ TEST(ScreenTime, RemoveData)
         EXPECT_TRUE([deletedURLs containsObject:url]);
 }
 
+TEST(ScreenTime, RemoveDataDoesNotMatchUnanchoredHostSuffix)
+{
+    __block bool childRestrictionsDone = false;
+
+    RetainPtr exactMatchURL = adoptNS([[NSURL alloc] initWithString:@"https://github.com/WebKit/WebKit"]);
+    RetainPtr subdomainURL = adoptNS([[NSURL alloc] initWithString:@"https://www.github.com/apple"]);
+    RetainPtr unrelatedSuffixURL = adoptNS([[NSURL alloc] initWithString:@"https://notgithub.com/"]);
+
+    __block RetainPtr<NSSet<NSURL *>> fetchedURLs = adoptNS([[NSSet alloc] initWithArray:@[
+        exactMatchURL.get(),
+        subdomainURL.get(),
+        unrelatedSuffixURL.get()
+    ]]);
+
+    InstanceMethodSwizzler fetchHistorySwizzler {
+        PAL::getSTWebHistoryClassSingleton(),
+        @selector(fetchAllHistoryWithCompletionHandler:),
+        imp_implementationWithBlock(^(id object, void (^completionHandler)(NSSet<NSURL *> *urls, NSError *error)) {
+            completionHandler(fetchedURLs.get(), nil);
+        })
+    };
+
+    __block RetainPtr<NSMutableSet<NSURL *>> deletedURLs = adoptNS([[NSMutableSet alloc] init]);
+    InstanceMethodSwizzler deleteHistorySwizzler {
+        PAL::getSTWebHistoryClassSingleton(),
+        @selector(deleteHistoryForURL:),
+        imp_implementationWithBlock(^(id object, NSURL *url) {
+            [deletedURLs addObject:url];
+        })
+    };
+
+    RetainPtr dataTypeScreenTime = adoptNS([[NSSet alloc] initWithArray:@[ WKWebsiteDataTypeScreenTime ]]);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    RetainPtr websiteDataStore = [WKWebsiteDataStore defaultDataStore];
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+
+    RetainPtr webView = webViewForScreenTimeTests(configuration.get());
+
+    RetainPtr request = [NSURLRequest requestWithURL:exactMatchURL.get()];
+    auto swizzle = swizzleEnforcesChildRestrictions(childRestrictionsDone);
+    [webView synchronouslyLoadSimulatedRequest:request.get() responseHTMLString:@""];
+    TestWebKitAPI::Util::run(&childRestrictionsDone);
+
+    __block bool done = false;
+    [websiteDataStore fetchDataRecordsOfTypes:dataTypeScreenTime.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
+        // Remove data only for "github.com". The unrelated "notgithub.com" record is left in place;
+        // it must not be deleted just because its host ends with the literal "github.com".
+        RetainPtr<NSMutableArray<WKWebsiteDataRecord *>> recordsToRemove = adoptNS([[NSMutableArray alloc] init]);
+        for (WKWebsiteDataRecord *record in dataRecords) {
+            if ([record.displayName isEqualToString:@"github.com"])
+                [recordsToRemove addObject:record];
+        }
+
+        [websiteDataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] forDataRecords:recordsToRemove.get() completionHandler:^{
+            done = true;
+        }];
+    }];
+
+    TestWebKitAPI::Util::run(&done);
+
+    // "github.com" and its subdomain "www.github.com" should be deleted, but "notgithub.com"
+    // must survive: a bare hasSuffix: check would have incorrectly matched and deleted it.
+    EXPECT_EQ([deletedURLs count], 2u);
+    EXPECT_TRUE([deletedURLs containsObject:exactMatchURL.get()]);
+    EXPECT_TRUE([deletedURLs containsObject:subdomainURL.get()]);
+    EXPECT_FALSE([deletedURLs containsObject:unrelatedSuffixURL.get()]);
+}
+
 TEST(ScreenTime, OffscreenSystemScreenTimeBlockingView)
 {
     __block bool childRestrictionsDone = false;


### PR DESCRIPTION
#### 3919bd62ec83c09518a8000ff29870a613d22e5b
<pre>
ScreenTime data removal uses an unanchored host suffix match, deleting unrelated sites&apos; data
<a href="https://bugs.webkit.org/show_bug.cgi?id=316884">https://bugs.webkit.org/show_bug.cgi?id=316884</a>

Reviewed by Abrar Rahman Protyasha.

ScreenTimeWebsiteDataSupport::removeScreenTimeData() built a set of host
strings from the origins to remove, then for every URL in the ScreenTime
history deleted it when [[url host] hasSuffix:domainString]. A bare
hasSuffix: check has no label boundary, so removing ScreenTime data for
&quot;apple.com&quot; also matched and deleted history for &quot;notapple.com&quot;,
&quot;myapple.com&quot;, &quot;evilapple.com&quot;, etc. — any host that happens to end with
the literal suffix.

WebsiteDataRecord::hostIsInDomain() already implements the correct
semantics: a suffix match additionally requires either an exact match or
that the character preceding the suffix is &apos;.&apos;. Add an NSString-based
equivalent and use it in place of the bare hasSuffix: check, so that
&quot;apple.com&quot; matches &quot;apple.com&quot; and &quot;www.apple.com&quot; but not &quot;notapple.com&quot;.

The comparison is kept in NSString space because the
fetchAllHistoryWithCompletionHandler completion block may run off the
main thread, where WTF::String ref-counting is not thread-safe. Also
 break out of the inner loop once a URL matches (avoiding a redundant
deleteHistoryForURL: for the same URL), and skip empty hosts when
building the match set.

Test: ScreenTime.RemoveDataDoesNotMatchUnanchoredHostSuffix

* Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm:
(WebKit::ScreenTimeWebsiteDataSupport::hostIsInDomain):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeData):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenTime.mm:
(TEST(ScreenTime, RemoveDataDoesNotMatchUnanchoredHostSuffix)):

Canonical link: <a href="https://commits.webkit.org/315087@main">https://commits.webkit.org/315087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3e97691083df188356f06f6b5683ac38442c73c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125732 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f905e652-1695-4773-b9bb-7b8e2f4ece63) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130740 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e98f0426-d2d7-4469-9b7b-778ace9b82d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111257 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c62158f2-8e4f-4c90-a956-dbe062bae934) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32191 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30899 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26037 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179934 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139165 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139045 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42296 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105595 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25585 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34332 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27369 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114052 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40197 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5468 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40448 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40342 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->