### PR TITLE
EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain continues after a failed query and reads the wrong row

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
@@ -281,7 +281,7 @@ void EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain(WebCore::R
 
     if (!selectSiteStatement
         || selectSiteStatement->bindText(1, site.string()) != SQLITE_OK)
-        reportSQLError(__FUNCTION__, "Failed to query specific site"_s);
+        return reportSQLError(__FUNCTION__, "Failed to query specific site"_s);
 
     if (selectSiteStatement->step() == SQLITE_ROW) {
         if (static_cast<EnhancedSecurity>(selectSiteStatement->columnInt(0)) == EnhancedSecurity::Disabled)


### PR DESCRIPTION
#### 9abd5581eeb8cdf9595c8807e8ec4ad4fd61495c
<pre>
EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain continues after a failed query and reads the wrong row
<a href="https://bugs.webkit.org/show_bug.cgi?id=316886">https://bugs.webkit.org/show_bug.cgi?id=316886</a>

Reviewed by Rupin Mittal.

trackEnhancedSecurityForDomain() called reportSQLError() when the SelectSite
statement was null or its bindText() failed, but did not return afterwards.
Control fell through to selectSiteStatement-&gt;step(), so on a bind failure
(e.g. under memory pressure) the SELECT ran against a statement whose
parameter was never bound, evaluating the cached/auto-reset statement
against a stale or NULL site. The subsequent EnhancedSecurity::Disabled
check then read the wrong row, which could skip the INSERT OR REPLACE and
silently re-enable a site the user had explicitly disabled (or, in the
unreachable null-statement case, dereference a null CheckedPtr).

reportSQLError() only logs; it is meant to be a terminal error path here.
Return on the error, matching the existing idiom in this file (e.g.
deleteAllSites() and enhancedSecurityOnlyDomains()).

* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp:
(WebKit::EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain):

Canonical link: <a href="https://commits.webkit.org/315071@main">https://commits.webkit.org/315071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bb54293de2198b92231ef54a19639328279c21b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125477 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130545 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111062 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bcb6097-c54f-4aa4-87c2-734f716a6dc6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31982 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30679 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25586 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141970 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179395 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138967 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34836 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138851 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37437 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42053 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105258 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27146 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40557 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113808 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39954 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5249 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40205 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40099 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->