### PR TITLE
REGRESSION(235201@main): WKProcessAssertionBackgroundTaskManager can never cancel its pending release task

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -35,6 +35,7 @@
 #import "RunningBoardServicesSPI.h"
 #import "WebProcessPool.h"
 #import <wtf/HashMap.h>
+#import <wtf/OSObjectPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/ThreadSafeWeakHashSet.h>
@@ -88,7 +89,7 @@ static bool processHasActiveRunTimeLimitation()
     RetainPtr<RBSAssertion> _backgroundTask;
     std::atomic<bool> _backgroundTaskWasInvalidated;
     ThreadSafeWeakHashSet<ProcessAndUIAssertion> _assertionsNeedingBackgroundTask;
-    dispatch_block_t _pendingTaskReleaseTask;
+    OSObjectPtr<dispatch_block_t> _pendingTaskReleaseTask;
     RefPtr<WebKit::ProcessStateMonitor> m_processStateMonitor;
 }
 
@@ -163,10 +164,11 @@ static bool processHasActiveRunTimeLimitation()
         return;
 
     RELEASE_LOG(ProcessSuspension, "%p - WKProcessAssertionBackgroundTaskManager: _scheduleReleaseTask because the expiration handler has been called", self);
-    WorkQueue::mainSingleton().dispatchAfter(releaseBackgroundTaskAfterExpirationDelay, [self, retainedSelf = retainPtr(self)] {
-        _pendingTaskReleaseTask = nil;
+    SUPPRESS_RETAINPTR_CTOR_ADOPT _pendingTaskReleaseTask = adoptOSObject(dispatch_block_create(static_cast<dispatch_block_flags_t>(0), ^{
+        _pendingTaskReleaseTask = nullptr;
         [self _releaseBackgroundTask];
-    });
+    }));
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, releaseBackgroundTaskAfterExpirationDelay.nanosecondsAs<int64_t>()), mainDispatchQueueSingleton(), _pendingTaskReleaseTask.get());
 }
 
 - (void)_cancelPendingReleaseTask
@@ -175,8 +177,8 @@ static bool processHasActiveRunTimeLimitation()
         return;
 
     RELEASE_LOG(ProcessSuspension, "%p - WKProcessAssertionBackgroundTaskManager: _cancelPendingReleaseTask because the application is foreground again", self);
-    dispatch_block_cancel(_pendingTaskReleaseTask);
-    _pendingTaskReleaseTask = nil;
+    dispatch_block_cancel(_pendingTaskReleaseTask.get());
+    _pendingTaskReleaseTask = nullptr;
 }
 
 - (BOOL)_hasBackgroundTask


### PR DESCRIPTION
#### 693452d7e8af6e04dd3f6bd3719d91755f1de9a3
<pre>
REGRESSION(235201@main): WKProcessAssertionBackgroundTaskManager can never cancel its pending release task
<a href="https://bugs.webkit.org/show_bug.cgi?id=316889">https://bugs.webkit.org/show_bug.cgi?id=316889</a>

Reviewed by Per Arne Vollan.

-[WKProcessAssertionBackgroundTaskManager _scheduleReleaseTask] schedules a task
that releases the background assertion 2 seconds after the UI assertion&apos;s
expiration handler fires. This task is meant to be cancelled by
_cancelPendingReleaseTask when the application returns to the foreground.

235201@main (&quot;Introduce WorkQueue::main() to get the main thread&apos;s work queue&quot;)
rewrote _scheduleReleaseTask to dispatch the work via
WorkQueue::main().dispatchAfter() instead of dispatch_block_create() +
dispatch_after(). In doing so it dropped the assignment to the
_pendingTaskReleaseTask ivar. As a result _pendingTaskReleaseTask stayed null,
so _cancelPendingReleaseTask always took its early
`if (!_pendingTaskReleaseTask) return;` path and the dispatch_block_cancel() was
never reached. The background assertion was then released ~2 seconds later even
though the app had already come back to the foreground, leaving the Web
processes unable to take foreground activities.

Restore the cancellable task by creating it with dispatch_block_create() (which
dispatch_block_cancel() requires) and storing it in _pendingTaskReleaseTask so it
can actually be cancelled. The block is held in an OSObjectPtr&lt;dispatch_block_t&gt;
that adopts the +1 returned by dispatch_block_create(), so the manual
Block_release() dance the original code needed is no longer necessary.

* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(-[WKProcessAssertionBackgroundTaskManager _scheduleReleaseTask]):
(-[WKProcessAssertionBackgroundTaskManager _cancelPendingReleaseTask]):

Canonical link: <a href="https://commits.webkit.org/315178@main">https://commits.webkit.org/315178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7628b79ce15da5d54d567eb21eac310ac369d9aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125533 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ae018e6-e34f-406f-9150-ba6feedc4911) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130594 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91787 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a15ab694-00ce-45ca-84a0-a8a5cac370fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111111 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f79478aa-b451-4330-946e-df7c62927b0a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32027 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30730 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25642 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142017 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179452 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32499 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139013 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37502 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42109 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105353 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34169 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27198 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40613 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113865 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40010 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5300 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40155 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->