### PR TITLE
CoreIPCCGColorSpace::toCF() crashes dereferencing null Box<> when decoding IndexedColorSpace

### DIFF
--- a/LayoutTests/ipc/coreipc.js
+++ b/LayoutTests/ipc/coreipc.js
@@ -545,6 +545,7 @@ export class ArgumentSerializer {
         if (argumentType.includes("<")) {
             const [ templateType, innerType ] = ArgumentSerializer.parseTemplate(argumentType);
             switch (templateType) {
+                case 'Box':
                 case 'RefPtr':
                 case 'std::unique_ptr':
                 case 'RetainPtr':
@@ -1048,6 +1049,7 @@ export class ArgumentParser {
         if (argumentType.includes("<")) {
             const [ templateType, innerType ] = ArgumentSerializer.parseTemplate(argumentType);
             switch (templateType) {
+                case 'Box':
                 case 'RefPtr':
                 case 'std::unique_ptr':
                 case 'RetainPtr':

--- a/LayoutTests/ipc/indexed-colorspace-null-inner-crash-expected.txt
+++ b/LayoutTests/ipc/indexed-colorspace-null-inner-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/indexed-colorspace-null-inner-crash.html
+++ b/LayoutTests/ipc/indexed-colorspace-null-inner-crash.html
@@ -1,0 +1,62 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+
+  window.setTimeout(async () => {
+    if (!window.IPC)
+      return window.testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const renderingBackendIdentifier = Math.floor(Math.random() * 0x1000000);
+    const streamConnection = CoreIPC.newStreamConnection();
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+      renderingBackendIdentifier: renderingBackendIdentifier,
+      connectionHandle: streamConnection
+    });
+    const remoteBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    // Send CreateImageBuffer with an IndexedColorSpace whose inner colorSpace Box is null.
+    // Without the fix, toCF() dereferences the null Box and the GPU process crashes.
+    remoteBackend.CreateImageBuffer({
+      logicalSize: { width: 1, height: 1 },
+      renderingMode: 1,
+      renderingPurpose: 2,
+      resolutionScale: 1,
+      colorSpace: {
+        serializableColorSpace: {
+          alias: {
+            optionalValue: {
+              m_cgColorSpace: {
+                alias: {
+                  variantType: 'WebKit::IndexedColorSpace',
+                  variant: {
+                    index: 1,
+                    table: [0, 0, 0, 255, 255, 255],
+                    colorSpace: {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      bufferFormat: { pixelFormat: 0, useLosslessCompression: 0 },
+      identifier: Math.floor(Math.random() * 0x1000000),
+      contextIdentifier: Math.floor(Math.random() * 0x1000000)
+    });
+
+    streamConnection.connection.invalidate();
+
+    // Allow time for the GPU process to receive and process the message before
+    // declaring the test done, so a crash is detected as a test failure.
+    setTimeout(() => {
+      window.testRunner?.notifyDone();
+    }, 500);
+  }, 20);
+</script>
+
+This test passes if WebKit does not crash.

--- a/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.mm
@@ -106,6 +106,8 @@ RetainPtr<CGColorSpaceRef> CoreIPCCGColorSpace::toCF() const
         return adoptCF(CGColorSpaceCreateWithPropertyList(propertyList.get()));
     },
     [](const IndexedColorSpace& colorSpace) -> RetainPtr<CGColorSpaceRef> {
+        if (!colorSpace.colorSpace)
+            return nullptr;
         RetainPtr innerColorSpace = colorSpace.colorSpace->toCF();
         RetainPtr innerPropertyList = adoptCF(CGColorSpaceCopyPropertyList(innerColorSpace.get()));
         RetainPtr lastIndex = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt8Type, &colorSpace.index));


### PR DESCRIPTION
#### 6807acd8362be9bcaa4010dfd1dab6112735923b
<pre>
CoreIPCCGColorSpace::toCF() crashes dereferencing null Box&lt;&gt; when decoding IndexedColorSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=316892">https://bugs.webkit.org/show_bug.cgi?id=316892</a>
<a href="https://rdar.apple.com/178983712">rdar://178983712</a>

Reviewed by Pascoe.

toCF() unconditionally dereferences the inner colorSpace Box via operator-&gt;, which has a RELEASE_ASSERT(isValid()) that fires when the Box is null. A null Box is a valid decoded state since ArgumentCoder&lt;Box&lt;T&gt;&gt; accepts a false-encoded bool to
represent null. Adding the null check causes toCF() to return nullptr instead, which propagates up through the existing null guard and the DestinationColorSpace validator, cleanly rejecting the malformed message without crashing.

Test: ipc/indexed-colorspace-null-inner-crash.html

* LayoutTests/ipc/coreipc.js:
(export.ArgumentSerializer):
* LayoutTests/ipc/indexed-colorspace-null-inner-crash-expected.txt: Added.
* LayoutTests/ipc/indexed-colorspace-null-inner-crash.html: Added.
* Source/WebKit/Shared/cf/CoreIPCCGColorSpace.mm:
(WebKit::CoreIPCCGColorSpace::toCF const):

Canonical link: <a href="https://commits.webkit.org/315048@main">https://commits.webkit.org/315048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90ed35f6f2e88a2830165258204fd7a6ce50cda1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177208 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b28ab438-fe75-45ed-b44a-054dead2fa9e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41423 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94c3ee9b-d8e3-404c-9b0a-83d4bfd71ed6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111153 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebead697-7ed1-4d28-980a-362c06901545) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25911 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179808 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30299 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34942 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/138940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37416 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150373 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/105449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34222 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113926 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40071 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5355 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40322 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40216 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->