### PR TITLE
CloseWatcherManager::remove() mutates m_groups while iterating it

### DIFF
--- a/LayoutTests/fast/dom/CloseWatcher/close-watcher-manager-remove-crash-expected.txt
+++ b/LayoutTests/fast/dom/CloseWatcher/close-watcher-manager-remove-crash-expected.txt
@@ -1,0 +1,5 @@
+Test for a crash in CloseWatcherManager::remove() caused by mutating m_groups while range-iterating over it.
+
+remove() iterates m_groups with a range-for and, when a group becomes empty, calls m_groups.removeFirst(group) inside the loop. WTF::Vector::removeAt shifts the surviving groups down in place and shrinks the size; the range-for's end iterator (captured before the shrink) then points past the live size, so the following iterations read out-of-bounds slots of the m_groups buffer (flagged as a contiguous-container overflow under ASAN). We build many groups and remove the watcher in the first one so the loop walks the maximal shifted range.
+
+PASS: did not crash.

--- a/LayoutTests/fast/dom/CloseWatcher/close-watcher-manager-remove-crash.html
+++ b/LayoutTests/fast/dom/CloseWatcher/close-watcher-manager-remove-crash.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test for a crash in CloseWatcherManager::remove() caused by mutating m_groups
+while range-iterating over it.</p>
+<p>remove() iterates m_groups with a range-for and, when a group becomes empty,
+calls m_groups.removeFirst(group) inside the loop. WTF::Vector::removeAt shifts
+the surviving groups down in place and shrinks the size; the range-for's end
+iterator (captured before the shrink) then points past the live size, so the
+following iterations read out-of-bounds slots of the m_groups buffer (flagged as
+a contiguous-container overflow under ASAN). We build many groups and remove the
+watcher in the first one so the loop walks the maximal shifted range.</p>
+<p id="result">FAIL: did not run to completion.</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const numberOfGroups = 16;
+const watchers = [];
+
+// Build `numberOfGroups` separate entries in CloseWatcherManager::m_groups.
+// A new group is only created when m_groups.size() < m_allowedNumberOfGroups,
+// and that limit is raised by one each time notifyAboutUserActivation() observes
+// a fresh user activation. So we interleave: create a watcher, then deliver a
+// trusted activation so the next watcher is allowed to start its own group.
+// (We keep references to every watcher so none is garbage-collected, which would
+// otherwise call remove() and mutate m_groups before we are ready.)
+for (let i = 0; i < numberOfGroups; ++i) {
+    watchers.push(new CloseWatcher());
+    if (window.eventSender) {
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
+}
+// m_groups == [[w0], [w1], ..., [w15]]
+
+// Destroy the watcher in the FIRST (non-last) group. remove() empties group 0
+// and calls m_groups.removeFirst(group) during the range-for over m_groups,
+// shifting every remaining group down by one. The loop's end iterator, captured
+// before the shrink, now points past the live size, so the following iterations
+// read out-of-bounds (poisoned, under ASAN) slots of the m_groups buffer.
+watchers[0].destroy();
+
+// Clean up the surviving watchers.
+for (let i = 1; i < watchers.length; ++i)
+    watchers[i].destroy();
+
+document.getElementById("result").textContent = "PASS: did not crash.";
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
@@ -56,9 +56,11 @@ void CloseWatcherManager::remove(CloseWatcher& watcher)
         group.removeFirstMatching([&watcher] (const Ref<CloseWatcher>& current) {
             return current.ptr() == &watcher;
         });
-        if (group.isEmpty())
-            m_groups.removeFirst(group);
     }
+
+    m_groups.removeAllMatching([] (const Vector<Ref<CloseWatcher>>& group) {
+        return group.isEmpty();
+    });
 }
 
 void CloseWatcherManager::notifyAboutUserActivation()


### PR DESCRIPTION
#### 914243151f5f88c9d205dda0d5771c9ee83d6524
<pre>
CloseWatcherManager::remove() mutates m_groups while iterating it
<a href="https://bugs.webkit.org/show_bug.cgi?id=316895">https://bugs.webkit.org/show_bug.cgi?id=316895</a>

Reviewed by Anne van Kesteren.

While iterating over m_groups, the code would sometimes call `removeFirst()`
on m_groups, thus modifying the container it is iterating on. It is not
safe to do this so I&apos;m fixing it.

Test: fast/dom/CloseWatcher/close-watcher-manager-remove-crash.html

* LayoutTests/fast/dom/CloseWatcher/close-watcher-manager-remove-crash-expected.txt: Added.
* LayoutTests/fast/dom/CloseWatcher/close-watcher-manager-remove-crash.html: Added.
* Source/WebCore/html/closewatcher/CloseWatcherManager.cpp:
(WebCore::CloseWatcherManager::remove):

Canonical link: <a href="https://commits.webkit.org/315063@main">https://commits.webkit.org/315063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1fe243659ed014bb8946da0a56c2abfb6352df3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177294 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/800784e6-0b74-4b77-93d1-23930cee3a93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41510 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c982ca4a-3e05-4580-ac31-c5737c26fc30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170957 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111223 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c117d60e-ff51-4145-92e5-fc11f72b5949) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25996 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179893 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30373 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41567 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37430 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150447 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105535 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34294 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40759 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40156 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5429 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40407 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->