### PR TITLE
decompose4() computes the wrong quaternion y component

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate3d-180deg-near-x-axis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate3d-180deg-near-x-axis-expected.txt
@@ -1,0 +1,3 @@
+
+PASS decompose4() recovers the correct quaternion y component near a 180deg rotation about the X axis
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate3d-180deg-near-x-axis.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate3d-180deg-near-x-axis.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Transform interpolation: decomposing a 180deg rotation whose largest axis component is X</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#interpolation-of-3d-matrices">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#recomposing-to-a-3d-matrix">
+<meta name="assert" content="Interpolating between rotations about different axes decomposes each matrix into a quaternion. Decomposing rotate3d(2, 1, 1, 180deg), a ~180deg rotation whose largest axis component is X, must recover the correct quaternion y component.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<div id="box"></div>
+<script>
+test(() => {
+    const box = document.getElementById("box");
+    const animation = box.animate(
+        [{ transform: "rotate3d(2, 1, 1, 180deg)" }, { transform: "rotate3d(0, 0, 1, 30deg)" }],
+        { duration: 1, fill: "both" });
+    animation.pause();
+    animation.currentTime = 0;
+
+    const m12 = new DOMMatrix(getComputedStyle(box).transform).m12;
+    assert_approx_equals(m12, 2 / 3, 1e-4);
+}, "decompose4() recovers the correct quaternion y component near a 180deg rotation about the X axis");
+</script>
+</body>

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -646,7 +646,7 @@ static bool decompose4(const TransformationMatrix::Matrix4& mat, TransformationM
         r = std::sqrt(1.0 + column[0][0] - column[1][1] - column[2][2]);
         s = 0.5 / r;
         x = 0.5 * r;
-        y = (column[1][0] - column[0][1]) * s;
+        y = (column[1][0] + column[0][1]) * s;
         z = (column[2][0] + column[0][2]) * s;
         w = (column[1][2] - column[2][1]) * s;
     } else if (column[1][1] > column[2][2]) {


### PR DESCRIPTION
#### f9b924f3b1181c07bab2e627ef738777efa791e0
<pre>
decompose4() computes the wrong quaternion y component
<a href="https://bugs.webkit.org/show_bug.cgi?id=316896">https://bugs.webkit.org/show_bug.cgi?id=316896</a>
<a href="https://rdar.apple.com/179334309">rdar://179334309</a>

Reviewed by Simon Fraser.

When the matrix&apos;s X diagonal element is largest, decompose4() knows x and uses s = 1 / (4 * x) to
recover the other quaternion components.

CSS Transforms Level 2 defines the relevant rotation matrix entries as
2 * (x * y - z * w) and 2 * (x * y + z * w):
<a href="https://www.w3.org/TR/css-transforms-2/#recomposing-to-a-3d-matrix">https://www.w3.org/TR/css-transforms-2/#recomposing-to-a-3d-matrix</a>

These entries must be added to recover y, since their sum is 4 * x * y. Subtracting them cancels the
xy term and yields the wrong rotation axis for matrices near a 180° rotation whose largest axis
component is X.

Test: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate3d-180deg-near-x-axis.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate3d-180deg-near-x-axis-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate3d-180deg-near-x-axis.html: Added.
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::decompose4):

Canonical link: <a href="https://commits.webkit.org/315288@main">https://commits.webkit.org/315288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09cc080e4e7dd84aa7c84d7c1b5c7b5f22180ca6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126214 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bc14749-1543-45eb-99d4-cec9efd0f884) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131167 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92249 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93dc2351-c9ad-4bdf-9056-c0d80c1d4b91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111678 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e838657f-5d75-4e8f-8760-3a999b1c6282) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32621 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31315 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26538 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142607 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180442 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33165 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139607 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139466 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106431 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25681 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27809 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114530 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40671 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5892 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->