### PR TITLE
[LBSE] Extend non-layered 2D local transform handling to RenderSVGText

### DIFF
--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -704,18 +704,35 @@ void RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange
 
     updateHasSVGTransformFlags();
 
-    // Refresh the layer transform, returning the (previous, current) pair. Shared by the text
-    // fast-path and the non-text layered branch. Forces a stacking context on an identity to
-    // non-identity transition (the batched flush skips RenderLayer::styleChanged), then marks the
-    // layer subtree for a position update.
-    auto refreshLayerTransform = [&]() -> std::pair<AffineTransform, AffineTransform> {
-        auto previousTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
-        updateLayerTransform();
-        auto currentTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
-        if (previousTransform.isIdentity() && !currentTransform.isIdentity())
-            layer()->forceStackingContextIfNeeded();
-        layer()->setSelfAndDescendantsNeedPositionUpdate();
-        return { previousTransform, currentTransform };
+    // A layer is neither created nor destroyed below, so probe it once up front.
+    const bool isLayered = hasLayer();
+
+    // Refresh the transform, returning the (previous, current) pair. For layered renderers this
+    // forces a stacking context on an identity-to-non-identity transition (the batched flush skips
+    // RenderLayer::styleChanged) and marks the layer subtree for a position update. A non-layered
+    // RenderSVGModelObject updates its cached m_localTransform in place, while a non-layered
+    // RenderSVGText is only probed (see the branch below).
+    auto refreshTransform = [&]() -> std::pair<AffineTransform, AffineTransform> {
+        if (isLayered) {
+            auto previousTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
+            updateLayerTransform();
+            auto currentTransform = layerTransform() ? layerTransform()->toAffineTransform() : identity;
+            if (previousTransform.isIdentity() && !currentTransform.isIdentity())
+                layer()->forceStackingContextIfNeeded();
+            layer()->setSelfAndDescendantsNeedPositionUpdate();
+            return { previousTransform, currentTransform };
+        }
+        if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(this)) {
+            auto previousTransform = svgModel->localTransform();
+            svgModel->updateLocalTransform();
+            return { previousTransform, svgModel->localTransform() };
+        }
+        // RenderSVGText is probed, not cached: writing m_localTransform before layout would feed
+        // updateScaledFont() a reference box that is only final after layout. The caller writes it
+        // once the scale is known unchanged, or leaves it for layout on a scale change.
+        if (auto* text = dynamicDowncast<RenderSVGText>(this))
+            return { text->localTransform(), text->computeLocalTransform() };
+        return { identity, identity };
     };
 
     // A re-layout is only necessary when the effective x/y scale changes: the next RenderSVGText
@@ -726,63 +743,48 @@ void RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange
                 || !WTF::areEssentiallyEqual(previousTransform.yScale(), currentTransform.yScale()));
     };
 
-    // RenderSVGText fast-path: do not refresh the cached repaint rect between the transform
-    // write and the text relayout. Composing the new transform with pre-relayout text metrics
-    // would cache an intermediate-state rect and cause a spurious repaint - the post-layout
-    // walk diffs the pre-mutation rect against the post-relayout rect instead.
-    if (is<RenderSVGText>(*this)) {
-        AffineTransform previousTransform;
-        AffineTransform currentTransform;
-        if (hasLayer())
-            std::tie(previousTransform, currentTransform) = refreshLayerTransform();
+    auto [previousTransform, currentTransform] = refreshTransform();
 
-        if (scaleChangedBetween(previousTransform, currentTransform)) {
-            auto& text = downcast<RenderSVGText>(*this);
+    // A scale change re-measures the text at the new on-screen font size (SVG sizes glyphs by the
+    // transform scale). Mark the affected text - this renderer when the transform is on a <text>,
+    // otherwise the transformed container's text descendants - and let layout recompute its metrics,
+    // refresh its cached transform and repaint. setNeedsLayout() also defers the flush's position
+    // update, which would otherwise run with the new transform but pre-relayout metrics.
+    if (scaleChangedBetween(previousTransform, currentTransform)) {
+        auto markTextForRelayout = [](RenderSVGText& text) {
             text.setNeedsTextMetricsUpdate();
-            // Dirty layout so the flush's deferToLayoutPass guard fires, otherwise the early
-            // position walk caches an intermediate-state rect against pre-relayout metrics.
             text.setNeedsLayout();
+        };
+        if (auto* text = dynamicDowncast<RenderSVGText>(this)) {
+            markTextForRelayout(*text);
+            repaintClientsOfReferencedSVGResources();
             return;
         }
-
-        repaintClientsOfReferencedSVGResources();
-        return;
-    }
-
-    // Non-text path: dirty the position-update bit and let the batched flush emit the delta
-    // repaints, in place of per-element computeRepaintRectsIncludingDescendants() + repaint().
-    AffineTransform previousTransform;
-    AffineTransform currentTransform;
-
-    bool isLayered = hasLayer();
-    if (isLayered) {
-        // Non-layered old-position repaint runs in the Pass 1 loop of the batched flush.
-        std::tie(previousTransform, currentTransform) = refreshLayerTransform();
-    } else if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(this)) {
-        previousTransform = svgModel->localTransform();
-        svgModel->updateLocalTransform();
-        currentTransform = svgModel->localTransform();
-    }
-
-    if (scaleChangedBetween(previousTransform, currentTransform)) {
         bool markedAny = false;
-        for (auto& textDescendantAffectedByTransformChange : descendantsOfType<RenderSVGText>(*this)) {
-            textDescendantAffectedByTransformChange.setNeedsTextMetricsUpdate();
-            // Dirty layout so the flush's deferToLayoutPass guard fires, otherwise the early
-            // position walk caches an intermediate-state rect (new container transform composed
-            // with pre-relayout text metrics).
-            textDescendantAffectedByTransformChange.setNeedsLayout();
+        for (auto& text : descendantsOfType<RenderSVGText>(*this)) {
+            markTextForRelayout(text);
             markedAny = true;
         }
-
-        if (markedAny)
+        if (markedAny) {
+            repaintClientsOfReferencedSVGResources();
             return;
+        }
     }
 
-    // New-position repaint: layered renderers ride the batched flush. Non-layered renderers
-    // either issue a full repaint here, or - when the caller has snapshotted a pre-mutation
-    // rect - defer to repaintAfterLayoutIfNeeded() for a corner/edge-strip delta repaint.
-    if (!isLayered && repaintMode == SVGAttributeChangeRepaintMode::Issue)
+    // Scale unchanged, so no relayout is needed - just repaint the move. For a non-layered renderer
+    // the batched transform flush repaints the moved region by comparing the renderer's repaint rect
+    // from before and after the change, but it skips RenderSVGText because a text rect depends on
+    // metrics the flush does not recompute. So non-layered text caches its transform here
+    // (refreshTransform() only probed it) and compares its own before and after rects. Other
+    // non-layered renderers were already cached by refreshTransform() and repainted by the flush.
+    // Layered renderers repaint through their layer position update.
+    if (auto* text = dynamicDowncast<RenderSVGText>(this); text && !isLayered) {
+        auto repaintContainer = containerForRepaint().renderer;
+        auto oldRects = rectsForRepaintingAfterLayout(repaintContainer.get(), RepaintOutlineBounds::Yes);
+        text->updateLocalTransform();
+        auto newRects = rectsForRepaintingAfterLayout(repaintContainer.get(), RepaintOutlineBounds::Yes);
+        repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderLayerModelObject> { repaintContainer.get() }, RequiresFullRepaint::No, oldRects, newRects);
+    } else if (!isLayered && repaintMode == SVGAttributeChangeRepaintMode::Issue)
         repaint();
 
     // Renderers inside <clipPath>/<mask>/<pattern>/etc. don't paint directly - a transform

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -91,6 +91,7 @@
 #include "SelectionGeometry.h"
 #include "Settings.h"
 #include "StyleResolver.h"
+#include "StyleTransformResolver.h"
 #include "TransformState.h"
 #include "ViewTransition.h"
 #include <algorithm>
@@ -1541,12 +1542,11 @@ void RenderObject::getTransformFromContainer(const LayoutSize& offsetInContainer
     CheckedPtr<RenderLayer> layer;
     if (hasLayer() && (layer = downcast<RenderLayerModelObject>(*this).layer()) && layer->transform())
         transform.multiply(layer->currentTransform());
-    else if (document().settings().layerBasedSVGEngineEnabled()) {
-        // Non-layered SVG elements: use the renderer's cached local SVG transform.
-        if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(*this)) {
-            if (auto svgTransform = svgModel->localTransform(); !svgTransform.isIdentity())
-                transform.multiply(TransformationMatrix(svgTransform));
-        }
+    else if (document().settings().layerBasedSVGEngineEnabled() && isSVGLayerAwareRenderer()) {
+        // Non-layered SVG elements: use the cached local transform. localTransform() is virtual,
+        // returning m_localTransform for RenderSVGModelObject and RenderSVGText, identity otherwise.
+        if (auto svgTransform = localTransform(); !svgTransform.isIdentity())
+            transform.multiply(TransformationMatrix(svgTransform));
     }
 
     CheckedPtr perspectiveObject = parent();

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -74,6 +74,8 @@ void RenderSVGModelObject::updateFromStyle()
 {
     RenderLayerModelObject::updateFromStyle();
     updateHasSVGTransformFlags();
+    if (!hasLayer())
+        updateLocalTransform();
 }
 
 void RenderSVGModelObject::updateLocalTransform()

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -303,6 +303,19 @@ static inline void updateFontInAllDescendants(RenderSVGText& text)
     }
 }
 
+AffineTransform RenderSVGText::computeLocalTransform() const
+{
+    ASSERT(document().settings().layerBasedSVGEngineEnabled());
+    TransformationMatrix transform;
+    applyTransform(transform, style(), transformReferenceBoxRect(style()), Style::TransformResolver::allTransformOperations);
+    return transform.toAffineTransform();
+}
+
+void RenderSVGText::updateLocalTransform()
+{
+    m_localTransform = computeLocalTransform();
+}
+
 void RenderSVGText::layout()
 {
     auto isLayerBasedSVGEngineEnabled = [&]() {
@@ -409,6 +422,11 @@ void RenderSVGText::layout()
 
     if (isLayerBasedSVGEngineEnabled()) {
         updateLayerTransform();
+        // Non-layered text caches its transform in m_localTransform (read via localTransform()
+        // by getCTM()/getScreenCTM(), hit-testing and the transform-recursion paint path),
+        // mirroring RenderSVGModelObject::updateLocalTransform(). Layered text uses its RenderLayer.
+        if (!hasLayer())
+            updateLocalTransform();
         updateCachedBoundariesInParents = false; // No longer needed for LBSE.
         layoutChanged = false; // No longer needed for LBSE.
     } else {

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -86,6 +86,10 @@ public:
 
     SVGRootInlineBox* legacyRootBox() const;
 
+    void updateLocalTransform();
+    AffineTransform computeLocalTransform() const;
+    AffineTransform localTransform() const override { return m_localTransform; }
+
 private:
     void graphicsElement() const = delete;
 
@@ -116,7 +120,6 @@ private:
     // FIXME: [LBSE] Begin code only needed for legacy SVG engine.
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
     const AffineTransform& localToParentTransform() const LIFETIME_BOUND override { return m_localTransform; }
-    AffineTransform localTransform() const override { return m_localTransform; }
     // FIXME: [LBSE] End code only needed for legacy SVG engine.
 
     bool NODELETE shouldHandleSubtreeMutations() const;

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -40,6 +40,7 @@
 #include "SVGTextPathElement.h"
 #include "Settings.h"
 #include "StyleTransformResolver.h"
+#include "TransformationMatrix.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {


### PR DESCRIPTION
#### f654a53b02aa9440e7e32aaf51465a57b134c1ec
<pre>
[LBSE] Extend non-layered 2D local transform handling to RenderSVGText
<a href="https://bugs.webkit.org/show_bug.cgi?id=316903">https://bugs.webkit.org/show_bug.cgi?id=316903</a>

Reviewed by Rob Buis.

Foundation for conditional layer creation: once an SVG renderer can lack a
RenderLayer, its plain 2D transform must be cached on the renderer and read
back while painting, hit-testing and computing CTMs, instead of living on the
layer&apos;s transformation matrix.

RenderSVGText gains its own updateLocalTransform(), similar to the legacy
engine, and layout() now calls updateLocalTransform() once glyph metrics are
stable for non-layered text.

RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange()
combines its layered and non-layered transform refresh into one refreshTransform()
helper: it updates the RenderLayer transform when layered, and the cached
m_localTransform when the renderer is a non-layered RenderSVGModelObject.

Non-layered RenderSVGText is handled separately, because its transform depends
on glyph metrics that are only final after layout: it probes the new transform
with computeLocalTransform(), a non-caching variant of updateLocalTransform().
A changed scale schedules a relayout, so layout() recomputes the transform from
fresh metrics - an unchanged scale refreshes m_localTransform in place and
issues a delta repaint, with no relayout.

These paths stay dormant until requiresLayer() becomes conditional.

* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::getTransformFromContainer const):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::updateFromStyle):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::computeLocalTransform const):
(WebCore::RenderSVGText::updateLocalTransform):
(WebCore::RenderSVGText::layout):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:

Canonical link: <a href="https://commits.webkit.org/315025@main">https://commits.webkit.org/315025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93e1786b0bcc22637d90690be06e85c75ff844af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130599 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111116 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25647 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179457 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32504 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139018 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138902 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37407 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42114 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105363 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34174 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27201 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113870 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40015 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5303 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->