### PR TITLE
Remove constructorNeedsFormElement

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1725,7 +1725,7 @@ Ref<Element> Document::createElement(const QualifiedName& name, bool createdByPa
 
     // FIXME: Use registered namespaces and look up in a hash to find the right factory.
     if (name.namespaceURI() == xhtmlNamespaceURI) {
-        element = HTMLElementFactory::createKnownElement(name, *this, nullptr, createdByParser);
+        element = HTMLElementFactory::createKnownElement(name, *this, createdByParser);
         if (!element) [[unlikely]]
             element = createFallbackHTMLElement(*this, registry, name);
     } else if (name.namespaceURI() == SVGNames::svgNamespaceURI)
@@ -1959,7 +1959,7 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
 
     auto opportunisticallyMatchedBuiltinElement = ([&]() -> RefPtr<Element> {
         if (namespaceURI == xhtmlNamespaceURI)
-            return HTMLElementFactory::createKnownElement(qualifiedName, document, nullptr, /* createdByParser */ false);
+            return HTMLElementFactory::createKnownElement(qualifiedName, document, /* createdByParser */ false);
         if (namespaceURI == SVGNames::svgNamespaceURI)
             return SVGElementFactory::createKnownElement(qualifiedName, document, /* createdByParser */ false);
 #if ENABLE(MATHML)

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -120,7 +120,7 @@ void createImageControls(HTMLElement& element)
     style->setTextContent(String { shadowStyle });
     shadowRoot->appendChild(WTF::move(style));
     
-    Ref button = HTMLButtonElement::create(HTMLNames::buttonTag, protect(element.document()), nullptr);
+    Ref button = HTMLButtonElement::create(HTMLNames::buttonTag, protect(element.document()));
     button->setIdAttribute(imageControlsButtonIdentifier());
     controlLayer->appendChild(button);
     controlLayer->setUserAgentPart(UserAgentParts::appleAttachmentControlsContainer());

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -250,7 +250,6 @@ sub defaultElementPropertyHash
         parsedTagName => lc $localName,
         parsedTagEnumValue => $requiresAdjustment ? lc($identifier) . "CaseUnadjusted" : $tagEnumValue,
         constructorNeedsCreatedByParser => 0,
-        constructorNeedsFormElement => 0,
         noConstructor => 0,
         interfaceName => defaultInterfaceName($identifier),
         # By default, the JSInterfaceName is the same as the interfaceName.
@@ -477,10 +476,6 @@ sub printConstructorSignature
     my ($F, $elementKey, $constructorName, $constructorTagName) = @_;
 
     print F "static Ref<$parameters{namespace}Element> ${constructorName}Constructor(const QualifiedName& $constructorTagName, Document& document";
-    if ($parameters{namespace} eq "HTML") {
-        print F ", HTMLFormElement*";
-        print F " formElement" if $allElements{$elementKey}{constructorNeedsFormElement};
-    }
     print F ", bool";
     print F " createdByParser" if $allElements{$elementKey}{constructorNeedsCreatedByParser};
     print F ")\n{\n";
@@ -541,7 +536,6 @@ END
 
     # Call the constructor with the right parameters.
     print F "    return ${interfaceName}::create($constructorTagName, document";
-    print F ", formElement" if $allElements{$elementKey}{constructorNeedsFormElement};
     print F ", createdByParser" if $allElements{$elementKey}{constructorNeedsCreatedByParser};
     print F ");\n}\n";
 }
@@ -610,13 +604,7 @@ sub printTagNameCases
     my ($F, $tagConstructorMap, $usePassedName) = @_;
     my %tagConstructorMap = %$tagConstructorMap;
 
-    my $argumentList;
-
-    if ($parameters{namespace} eq "HTML") {
-        $argumentList = "document, formElement, createdByParser";
-    } else {
-        $argumentList = "document, createdByParser";
-    }
+    my $argumentList = "document, createdByParser";
 
     for my $elementKey (sort keys %tagConstructorMap) {
         next if $allElements{$elementKey}{noConstructor};
@@ -1718,11 +1706,6 @@ sub printFactoryCppFile
     my $F;
     open F, ">$cppPath";
 
-    my $formElementArgumentForDeclaration = "";
-    my $formElementArgumentForDefinition = "";
-    $formElementArgumentForDeclaration = ", HTMLFormElement*" if $parameters{namespace} eq "HTML";
-    $formElementArgumentForDefinition = ", HTMLFormElement* formElement" if $parameters{namespace} eq "HTML";
-
     printLicenseHeader($F);
 
     print F <<END;
@@ -1754,13 +1737,7 @@ namespace WebCore {
 END
 
     my %tagConstructorMap = buildConstructorMap();
-    my $argumentList;
-
-    if ($parameters{namespace} eq "HTML") {
-        $argumentList = "document, formElement, createdByParser";
-    } else {
-        $argumentList = "document, createdByParser";
-    }
+    my $argumentList = "document, createdByParser";
 
     my $lowercaseNamespacePrefix = lc($parameters{namespacePrefix});
 
@@ -1774,7 +1751,7 @@ END
 
     print F <<END;
 
-RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElement(TagName tagName, Document& document$formElementArgumentForDefinition, bool createdByParser)
+RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElement(TagName tagName, Document& document, bool createdByParser)
 {
     switch (tagName) {
 END
@@ -1787,7 +1764,7 @@ END
     }
 }
 
-RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElementWithName(TagName tagName, const QualifiedName& name, Document& document$formElementArgumentForDefinition, bool createdByParser)
+RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElementWithName(TagName tagName, const QualifiedName& name, Document& document, bool createdByParser)
 {
     switch (tagName) {
 END
@@ -1800,17 +1777,17 @@ END
     }
 }
 
-RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElement(const AtomString& localName, Document& document$formElementArgumentForDefinition, bool createdByParser)
+RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElement(const AtomString& localName, Document& document, bool createdByParser)
 {
     return createKnownElement(tagNameForElementName(find$parameters{namespace}ElementName(localName)), $argumentList);
 }
 
-RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElement(const QualifiedName& name, Document& document$formElementArgumentForDefinition, bool createdByParser)
+RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElement(const QualifiedName& name, Document& document, bool createdByParser)
 {
     return createKnownElementWithName(tagNameForElementName(name.nodeName()), name, $argumentList);
 }
 
-Ref<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createElement(const AtomString& localName, Document& document$formElementArgumentForDefinition, bool createdByParser)
+Ref<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createElement(const AtomString& localName, Document& document, bool createdByParser)
 {
     auto elementName = find$parameters{namespace}ElementName(localName);
     if (elementName != ElementName::Unknown)
@@ -1818,7 +1795,7 @@ Ref<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createE
     return $parameters{fallbackInterfaceName}::create(QualifiedName(nullAtom(), localName, $parameters{namespace}Names::${lowercaseNamespacePrefix}NamespaceURI), document);
 }
 
-Ref<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createElement(const QualifiedName& name, Document& document$formElementArgumentForDefinition, bool createdByParser)
+Ref<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createElement(const QualifiedName& name, Document& document, bool createdByParser)
 {
     auto elementName = name.nodeName();
     if (elementName != ElementName::Unknown) {
@@ -1853,7 +1830,6 @@ sub printFactoryHeaderFile
 namespace WebCore {
 
 class Document;
-class HTMLFormElement;
 class QualifiedName;
 
 class $parameters{namespace}Element;
@@ -1864,29 +1840,12 @@ class $parameters{namespace}ElementFactory {
 public:
 END
 
-print F "    static RefPtr<$parameters{namespace}Element> createKnownElement(const AtomString&, Document&";
-print F ", HTMLFormElement* = nullptr" if $parameters{namespace} eq "HTML";
-print F ", bool createdByParser = false);\n";
-
-print F "    static RefPtr<$parameters{namespace}Element> createKnownElement(const QualifiedName&, Document&";
-print F ", HTMLFormElement* = nullptr" if $parameters{namespace} eq "HTML";
-print F ", bool createdByParser = false);\n";
-
-print F "    static RefPtr<$parameters{namespace}Element> createKnownElement(TagName, Document&";
-print F ", HTMLFormElement* = nullptr" if $parameters{namespace} eq "HTML";
-print F ", bool createdByParser = false);\n";
-
-print F "    static RefPtr<$parameters{namespace}Element> createKnownElementWithName(TagName, const QualifiedName&, Document&";
-print F ", HTMLFormElement* = nullptr" if $parameters{namespace} eq "HTML";
-print F ", bool createdByParser = false);\n";
-
-print F "    static Ref<$parameters{namespace}Element> createElement(const AtomString&, Document&";
-print F ", HTMLFormElement* = nullptr" if $parameters{namespace} eq "HTML";
-print F ", bool createdByParser = false);\n";
-
-print F "    static Ref<$parameters{namespace}Element> createElement(const QualifiedName&, Document&";
-print F ", HTMLFormElement* = nullptr" if $parameters{namespace} eq "HTML";
-print F ", bool createdByParser = false);\n";
+print F "    static RefPtr<$parameters{namespace}Element> createKnownElement(const AtomString&, Document&, bool createdByParser = false);\n";
+print F "    static RefPtr<$parameters{namespace}Element> createKnownElement(const QualifiedName&, Document&, bool createdByParser = false);\n";
+print F "    static RefPtr<$parameters{namespace}Element> createKnownElement(TagName, Document&, bool createdByParser = false);\n";
+print F "    static RefPtr<$parameters{namespace}Element> createKnownElementWithName(TagName, const QualifiedName&, Document&, bool createdByParser = false);\n";
+print F "    static Ref<$parameters{namespace}Element> createElement(const AtomString&, Document&, bool createdByParser = false);\n";
+print F "    static Ref<$parameters{namespace}Element> createElement(const QualifiedName&, Document&, bool createdByParser = false);\n";
 
 printf F <<END;
 };

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -230,7 +230,7 @@ void FileInputType::createShadowSubtree()
     ASSERT(element()->shadowRoot());
 
     Ref element = *this->element();
-    Ref button = HTMLInputElement::create(inputTag, protect(element->document()), nullptr, false);
+    Ref button = HTMLInputElement::create(inputTag, protect(element->document()), false);
     {
         ScriptDisallowedScope::EventAllowedScope eventAllowedScopeBeforeAppend { button };
         button->setAttributeWithoutSynchronization(typeAttr, InputTypeNames::button());

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -44,8 +44,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FormAssociatedCustomElement);
 using namespace HTMLNames;
 
 FormAssociatedCustomElement::FormAssociatedCustomElement(HTMLMaybeFormAssociatedCustomElement& element)
-    : ValidatedFormListedElement { nullptr }
-    , m_element { element }
+    : m_element { element }
 {
 }
 

--- a/Source/WebCore/html/FormAssociatedElement.cpp
+++ b/Source/WebCore/html/FormAssociatedElement.cpp
@@ -30,11 +30,6 @@
 
 namespace WebCore {
 
-FormAssociatedElement::FormAssociatedElement(HTMLFormElement* form)
-    : m_formSetByParser(form)
-{
-}
-
 RefPtr<HTMLFormElement> FormAssociatedElement::formForBindings() const
 {
     // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -41,13 +41,14 @@ public:
     virtual RefPtr<HTMLFormElement> formForBindings() const;
 
     void setForm(RefPtr<HTMLFormElement>&&);
+    void setFormSetByParser(HTMLFormElement* form) { ASSERT(!m_formSetByParser); m_formSetByParser = form; }
     virtual void elementInsertedIntoAncestor(Element&, Node::InsertionType);
     virtual void elementRemovedFromAncestor(Element&, Node::RemovalType);
 
     virtual FormAssociatedElement* NODELETE asFormAssociatedElement() = 0;
 
 protected:
-    explicit FormAssociatedElement(HTMLFormElement*);
+    FormAssociatedElement() = default;
 
     virtual void resetFormOwner() = 0;
     virtual void setFormInternal(RefPtr<HTMLFormElement>&&);

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -60,10 +60,7 @@ private:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FormAttributeTargetObserver);
 
-FormListedElement::FormListedElement(HTMLFormElement* form)
-    : FormAssociatedElement(form)
-{
-}
+FormListedElement::FormListedElement() = default;
 
 FormListedElement::~FormListedElement() = default;
 

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -90,7 +90,7 @@ public:
     virtual ValidatedFormListedElement* asValidatedFormListedElement() = 0;
 
 protected:
-    explicit FormListedElement(HTMLFormElement*);
+    FormListedElement();
 
     void clearForm() { setForm(nullptr); }
 

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -56,22 +56,22 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLButtonElement);
 
 using namespace HTMLNames;
 
-inline HTMLButtonElement::HTMLButtonElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+inline HTMLButtonElement::HTMLButtonElement(const QualifiedName& tagName, Document& document)
+    : HTMLFormControlElement(tagName, document)
     , m_type(Type::Submit)
     , m_isActivatedSubmit(false)
 {
     ASSERT(hasTagName(buttonTag));
 }
 
-Ref<HTMLButtonElement> HTMLButtonElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLButtonElement> HTMLButtonElement::create(const QualifiedName& tagName, Document& document)
 {
-    return adoptRef(*new HTMLButtonElement(tagName, document, form));
+    return adoptRef(*new HTMLButtonElement(tagName, document));
 }
 
 Ref<HTMLButtonElement> HTMLButtonElement::create(Document& document)
 {
-    return adoptRef(*new HTMLButtonElement(buttonTag, document, nullptr));
+    return adoptRef(*new HTMLButtonElement(buttonTag, document));
 }
 
 Node::NeedsPostConnectionSteps HTMLButtonElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -33,7 +33,7 @@ class HTMLButtonElement final : public HTMLFormControlElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLButtonElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLButtonElement);
 public:
-    static Ref<HTMLButtonElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLButtonElement> create(const QualifiedName&, Document&);
     static Ref<HTMLButtonElement> create(Document&);
     
     const AtomString& NODELETE value() const;
@@ -51,7 +51,7 @@ public:
     bool isDevolvableWidget() const override { return true; }
 
 private:
-    HTMLButtonElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
+    HTMLButtonElement(const QualifiedName& tagName, Document&);
 
     enum class Type : uint8_t { Submit, Reset, Button };
 

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -45,8 +45,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLFieldSetElement);
 
 using namespace HTMLNames;
 
-inline HTMLFieldSetElement::HTMLFieldSetElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+inline HTMLFieldSetElement::HTMLFieldSetElement(const QualifiedName& tagName, Document& document)
+    : HTMLFormControlElement(tagName, document)
 {
     ASSERT(hasTagName(fieldsetTag));
 }
@@ -57,9 +57,9 @@ HTMLFieldSetElement::~HTMLFieldSetElement()
         document().removeDisabledFieldsetElement();
 }
 
-Ref<HTMLFieldSetElement> HTMLFieldSetElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLFieldSetElement> HTMLFieldSetElement::create(const QualifiedName& tagName, Document& document)
 {
-    return adoptRef(*new HTMLFieldSetElement(tagName, document, form));
+    return adoptRef(*new HTMLFieldSetElement(tagName, document));
 }
 
 bool HTMLFieldSetElement::isDisabledFormControl() const

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -32,7 +32,7 @@ class HTMLFieldSetElement final : public HTMLFormControlElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLFieldSetElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFieldSetElement);
 public:
-    static Ref<HTMLFieldSetElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLFieldSetElement> create(const QualifiedName&, Document&);
 
     HTMLLegendElement* NODELETE legend() const;
 
@@ -42,7 +42,7 @@ public:
     void removeInvalidDescendant(const HTMLElement&);
 
 private:
-    HTMLFieldSetElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLFieldSetElement(const QualifiedName&, Document&);
     ~HTMLFieldSetElement();
 
     bool isDisabledFormControl() const final;

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -61,9 +61,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLFormControlElement);
 
 using namespace HTMLNames;
 
-HTMLFormControlElement::HTMLFormControlElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+HTMLFormControlElement::HTMLFormControlElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document, { TypeFlag::IsShadowRootOrFormControlElement, TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument } )
-    , ValidatedFormListedElement(form)
     , m_isRequired(false)
     , m_valueMatchesRenderer(false)
     , m_wasChangedSinceLastFormControlChangeEvent(false)

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -107,7 +107,7 @@ public:
     using Node::deref;
 
 protected:
-    HTMLFormControlElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
+    HTMLFormControlElement(const QualifiedName& tagName, Document&);
 
     NeedsPostConnectionSteps insertionSteps(InsertionType, ContainerNode&) override;
     void postConnectionSteps() override;

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -87,9 +87,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLImageElement);
 
 using namespace HTMLNames;
 
-HTMLImageElement::HTMLImageElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+HTMLImageElement::HTMLImageElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document, { TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument })
-    , FormAssociatedElement(form)
     , ActiveDOMObject(document)
     , m_imageLoader(makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this))
     , m_imageDevicePixelRatio(1.0f)
@@ -99,14 +98,14 @@ HTMLImageElement::HTMLImageElement(const QualifiedName& tagName, Document& docum
 
 Ref<HTMLImageElement> HTMLImageElement::create(Document& document)
 {
-    auto image = adoptRef(*new HTMLImageElement(imgTag, document));
+    Ref image = adoptRef(*new HTMLImageElement(imgTag, document));
     image->suspendIfNeeded();
     return image;
 }
 
-Ref<HTMLImageElement> HTMLImageElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLImageElement> HTMLImageElement::create(const QualifiedName& tagName, Document& document)
 {
-    auto image = adoptRef(*new HTMLImageElement(tagName, document, form));
+    Ref image = adoptRef(*new HTMLImageElement(tagName, document));
     image->suspendIfNeeded();
     return image;
 }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -61,7 +61,7 @@ class HTMLImageElement
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLImageElement);
 public:
     static Ref<HTMLImageElement> create(Document&);
-    static Ref<HTMLImageElement> create(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
+    static Ref<HTMLImageElement> create(const QualifiedName&, Document&);
     static Ref<HTMLImageElement> createForLegacyFactoryFunction(Document&, std::optional<unsigned> width, std::optional<unsigned> height);
 
     virtual ~HTMLImageElement();
@@ -178,7 +178,7 @@ public:
     Image* image() const;
 
 protected:
-    HTMLImageElement(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
+    HTMLImageElement(const QualifiedName&, Document&);
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -118,8 +118,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ListAttributeTargetObserver);
 
 static constexpr int maxSavedResults = 256;
 
-HTMLInputElement::HTMLInputElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form, CreationType creationType)
-    : HTMLTextFormControlElement(tagName, document, form)
+HTMLInputElement::HTMLInputElement(const QualifiedName& tagName, Document& document, CreationType creationType)
+    : HTMLTextFormControlElement(tagName, document)
     , m_parsingInProgress(creationType == CreationType::ByParser)
     // m_inputType is lazily created when constructed by the parser to avoid constructing unnecessarily a text inputType,
     // just to destroy them when the |type| attribute gets set by the parser to something else than 'text'.
@@ -128,14 +128,14 @@ HTMLInputElement::HTMLInputElement(const QualifiedName& tagName, Document& docum
     ASSERT(hasTagName(inputTag));
 }
 
-Ref<HTMLInputElement> HTMLInputElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form, bool createdByParser)
+Ref<HTMLInputElement> HTMLInputElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
 {
-    return adoptRef(*new HTMLInputElement(tagName, document, form, createdByParser ? CreationType::ByParser : CreationType::Normal));
+    return adoptRef(*new HTMLInputElement(tagName, document, createdByParser ? CreationType::ByParser : CreationType::Normal));
 }
 
 Ref<Element> HTMLInputElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*) const
 {
-    return adoptRef(*new HTMLInputElement(tagQName(), document, nullptr, CreationType::ByCloning));
+    return adoptRef(*new HTMLInputElement(tagQName(), document, CreationType::ByCloning));
 }
 
 HTMLImageLoader& HTMLInputElement::ensureImageLoader()

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -66,7 +66,7 @@ class HTMLInputElement final : public HTMLTextFormControlElement {
 public:
     USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
-    static Ref<HTMLInputElement> create(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
+    static Ref<HTMLInputElement> create(const QualifiedName&, Document&, bool createdByParser);
     virtual ~HTMLInputElement();
 
     WEBCORE_EXPORT bool NODELETE alpha();
@@ -363,7 +363,7 @@ public:
 
 private:
     enum class CreationType : uint8_t { Normal, ByParser, ByCloning };
-    HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, CreationType);
+    HTMLInputElement(const QualifiedName&, Document&, CreationType);
 
     void defaultEventHandler(Event&) final;
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -64,16 +64,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLObjectElement);
 
 using namespace HTMLNames;
 
-inline HTMLObjectElement::HTMLObjectElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+inline HTMLObjectElement::HTMLObjectElement(const QualifiedName& tagName, Document& document)
     : HTMLPlugInElement(tagName, document)
-    , FormListedElement(form)
 {
     ASSERT(hasTagName(objectTag));
 }
 
-Ref<HTMLObjectElement> HTMLObjectElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLObjectElement> HTMLObjectElement::create(const QualifiedName& tagName, Document& document)
 {
-    return adoptRef(*new HTMLObjectElement(tagName, document, form));
+    return adoptRef(*new HTMLObjectElement(tagName, document));
 }
 
 HTMLObjectElement::~HTMLObjectElement()

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -35,7 +35,7 @@ class HTMLObjectElement final : public HTMLPlugInElement, public FormListedEleme
 public:
     USING_CAN_MAKE_WEAKPTR(HTMLPlugInElement);
 
-    static Ref<HTMLObjectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLObjectElement> create(const QualifiedName&, Document&);
 
     bool isExposed() const;
 
@@ -54,7 +54,7 @@ public:
     using HTMLPlugInElement::deref;
 
 private:
-    HTMLObjectElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLObjectElement(const QualifiedName&, Document&);
     ~HTMLObjectElement();
 
     int defaultTabIndex() const final;

--- a/Source/WebCore/html/HTMLOutputElement.cpp
+++ b/Source/WebCore/html/HTMLOutputElement.cpp
@@ -44,21 +44,21 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLOutputElement);
 
-inline HTMLOutputElement::HTMLOutputElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+inline HTMLOutputElement::HTMLOutputElement(const QualifiedName& tagName, Document& document)
+    : HTMLFormControlElement(tagName, document)
 {
 }
 
 HTMLOutputElement::~HTMLOutputElement() = default;
 
-Ref<HTMLOutputElement> HTMLOutputElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLOutputElement> HTMLOutputElement::create(const QualifiedName& tagName, Document& document)
 {
-    return adoptRef(*new HTMLOutputElement(tagName, document, form));
+    return adoptRef(*new HTMLOutputElement(tagName, document));
 }
 
 Ref<HTMLOutputElement> HTMLOutputElement::create(Document& document)
 {
-    return create(HTMLNames::outputTag, document, nullptr);
+    return create(HTMLNames::outputTag, document);
 }
 
 const AtomString& HTMLOutputElement::formControlType() const

--- a/Source/WebCore/html/HTMLOutputElement.h
+++ b/Source/WebCore/html/HTMLOutputElement.h
@@ -41,7 +41,7 @@ class HTMLOutputElement final : public HTMLFormControlElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLOutputElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOutputElement);
 public:
-    static Ref<HTMLOutputElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLOutputElement> create(const QualifiedName&, Document&);
     static Ref<HTMLOutputElement> create(Document&);
     ~HTMLOutputElement();
 
@@ -52,7 +52,7 @@ public:
     DOMTokenList& htmlFor();
     
 private:
-    HTMLOutputElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLOutputElement(const QualifiedName&, Document&);
 
     bool canContainRangeEndPoint() const final { return false; }
     bool computeWillValidate() const final { return false; }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -134,8 +134,8 @@ SUPPRESS_NODELETE const AtomString& SelectSlotAssignment::slotNameForHostChild(c
 // https://html.spec.whatwg.org/#dom-htmloptionscollection-length
 static constexpr unsigned maxSelectItems = 100000;
 
-HTMLSelectElement::HTMLSelectElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+HTMLSelectElement::HTMLSelectElement(const QualifiedName& tagName, Document& document)
+    : HTMLFormControlElement(tagName, document)
     , m_typeAhead(this)
     , m_size(0)
     , m_lastOnChangeIndex(-1)
@@ -150,17 +150,17 @@ HTMLSelectElement::HTMLSelectElement(const QualifiedName& tagName, Document& doc
     ASSERT(hasTagName(selectTag));
 }
 
-Ref<HTMLSelectElement> HTMLSelectElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLSelectElement> HTMLSelectElement::create(const QualifiedName& tagName, Document& document)
 {
     ASSERT(tagName.matches(selectTag));
-    Ref select = adoptRef(*new HTMLSelectElement(tagName, document, form));
+    Ref select = adoptRef(*new HTMLSelectElement(tagName, document));
     select->addShadowRoot(ShadowRoot::create(document, makeUnique<SelectSlotAssignment>()));
     return select;
 }
 
 Ref<HTMLSelectElement> HTMLSelectElement::create(Document& document)
 {
-    return HTMLSelectElement::create(selectTag, document, nullptr);
+    return HTMLSelectElement::create(selectTag, document);
 }
 
 HTMLSelectElement::~HTMLSelectElement() = default;

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -58,7 +58,7 @@ public:
     void ref() const final { HTMLFormControlElement::ref(); }
     void deref() const final { HTMLFormControlElement::deref(); }
 
-    static Ref<HTMLSelectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLSelectElement> create(const QualifiedName&, Document&);
     static Ref<HTMLSelectElement> create(Document&);
     ~HTMLSelectElement();
 
@@ -213,7 +213,7 @@ public:
     int typeAheadMatchIndex(KeyboardEvent&);
 
 protected:
-    HTMLSelectElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLSelectElement(const QualifiedName&, Document&);
 
 private:
     const AtomString& formControlType() const final;

--- a/Source/WebCore/html/HTMLTagNames.in
+++ b/Source/WebCore/html/HTMLTagNames.in
@@ -24,7 +24,7 @@ big interfaceName=HTMLElement
 blockquote interfaceName=HTMLQuoteElement
 body
 br interfaceName=HTMLBRElement
-button constructorNeedsFormElement
+button
 canvas customTypeHelper
 caption interfaceName=HTMLTableCaptionElement
 center interfaceName=HTMLElement
@@ -45,7 +45,7 @@ dl interfaceName=HTMLDListElement
 dt interfaceName=HTMLElement
 em interfaceName=HTMLElement
 embed settingsConditional=embedElementEnabled
-fieldset interfaceName=HTMLFieldSetElement, constructorNeedsFormElement
+fieldset interfaceName=HTMLFieldSetElement
 figcaption interfaceName=HTMLElement
 figure interfaceName=HTMLElement
 font
@@ -67,8 +67,8 @@ html
 i interfaceName=HTMLElement
 iframe interfaceName=HTMLIFrameElement
 image interfaceName=HTMLUnknownElement
-img interfaceName=HTMLImageElement, constructorNeedsFormElement
-input constructorNeedsFormElement, constructorNeedsCreatedByParser
+img interfaceName=HTMLImageElement
+input constructorNeedsCreatedByParser
 ins interfaceName=HTMLModElement
 kbd interfaceName=HTMLElement
 keygen interfaceName=HTMLUnknownElement
@@ -89,11 +89,11 @@ nav interfaceName=HTMLElement
 nobr interfaceName=HTMLElement
 noembed interfaceName=HTMLElement
 noframes interfaceName=HTMLElement
-object constructorNeedsFormElement
+object
 ol interfaceName=HTMLOListElement
 optgroup interfaceName=HTMLOptGroupElement
 option
-output constructorNeedsFormElement
+output
 p interfaceName=HTMLParagraphElement
 param
 picture interfaceName=HTMLPictureElement
@@ -111,7 +111,7 @@ samp interfaceName=HTMLElement
 script constructorNeedsCreatedByParser
 search interfaceName=HTMLElement
 section interfaceName=HTMLElement
-select constructorNeedsFormElement
+select
 selectedcontent interfaceName=HTMLSelectedContentElement, settingsConditional=htmlEnhancedSelectParsingEnabled&htmlEnhancedSelectEnabled&!mutationEventsEnabled
 slot
 small interfaceName=HTMLElement
@@ -127,7 +127,7 @@ table
 tbody interfaceName=HTMLTableSectionElement
 td interfaceName=HTMLTableCellElement
 template
-textarea interfaceName=HTMLTextAreaElement, constructorNeedsFormElement
+textarea interfaceName=HTMLTextAreaElement
 tfoot interfaceName=HTMLTableSectionElement
 th interfaceName=HTMLTableCellElement
 thead interfaceName=HTMLTableSectionElement

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -74,23 +74,23 @@ static inline unsigned NODELETE computeLengthForAPIValue(StringView text)
     return text.length() - crlfCount;
 }
 
-HTMLTextAreaElement::HTMLTextAreaElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLTextFormControlElement(tagName, document, form)
+HTMLTextAreaElement::HTMLTextAreaElement(const QualifiedName& tagName, Document& document)
+    : HTMLTextFormControlElement(tagName, document)
 {
     ASSERT(hasTagName(textareaTag));
     setFormControlValueMatchesRenderer(true);
 }
 
-Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(const QualifiedName& tagName, Document& document)
 {
-    Ref textArea = adoptRef(*new HTMLTextAreaElement(tagName, document, form));
+    Ref textArea = adoptRef(*new HTMLTextAreaElement(tagName, document));
     textArea->ensureUserAgentShadowRoot();
     return textArea;
 }
 
 Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(Document& document)
 {
-    return create(textareaTag, document, nullptr);
+    return create(textareaTag, document);
 }
 
 void HTMLTextAreaElement::didAddUserAgentShadowRoot(ShadowRoot& root)

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -37,7 +37,7 @@ class HTMLTextAreaElement final : public HTMLTextFormControlElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTextAreaElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLTextAreaElement> create(Document&);
-    static Ref<HTMLTextAreaElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLTextAreaElement> create(const QualifiedName&, Document&);
 
     unsigned rows() const { return m_rows; }
     WEBCORE_EXPORT void setRows(unsigned);
@@ -61,7 +61,7 @@ public:
     bool dirAutoUsesValue() const final { return true; }
 
 private:
-    HTMLTextAreaElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLTextAreaElement(const QualifiedName&, Document&);
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -124,8 +124,8 @@ static unsigned innerTextLengthFrom(TextControlInnerTextElement& innerText)
     return length;
 }
 
-HTMLTextFormControlElement::HTMLTextFormControlElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+HTMLTextFormControlElement::HTMLTextFormControlElement(const QualifiedName& tagName, Document& document)
+    : HTMLFormControlElement(tagName, document)
     , m_cachedSelectionDirection(document.frame() && document.frame()->editor().behavior().shouldConsiderSelectionAsDirectional() ? SelectionHasForwardDirection : SelectionHasNoDirection)
 {
 }

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -121,7 +121,7 @@ public:
     WEBCORE_EXPORT void dispatchUserTextInputEvent();
 
 protected:
-    HTMLTextFormControlElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLTextFormControlElement(const QualifiedName&, Document&);
     virtual void updatePlaceholderText() = 0;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -64,8 +64,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ValidatedFormListedElement);
 
 using namespace HTMLNames;
 
-ValidatedFormListedElement::ValidatedFormListedElement(HTMLFormElement* form)
-    : FormListedElement { form }
+ValidatedFormListedElement::ValidatedFormListedElement()
 {
     ASSERT(!supportsReadOnly() || readOnlyBarsFromConstraintValidation());
 }

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -46,7 +46,7 @@ class ValidatedFormListedElement : public FormListedElement {
     friend class DelayedUpdateValidityScope;
     friend class HTMLMaybeFormAssociatedCustomElement;
 public:
-    ValidatedFormListedElement(HTMLFormElement*);
+    ValidatedFormListedElement();
     virtual ~ValidatedFormListedElement();
 
     // "willValidate" means "is a candidate for constraint validation".

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -823,14 +823,9 @@ static CustomElementRegistry* registryForCurrentNode(Node& currentNode, TreeScop
 
 std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomElementRegistry>> HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface(AtomHTMLToken& token)
 {
-    // FIXME: This can't use HTMLConstructionSite::createElement because we
-    // have to pass the current form element.  We should rework form association
-    // to occur after construction to allow better code sharing here.
-    // http://www.whatwg.org/specs/web-apps/current-work/multipage/tree-construction.html#create-an-element-for-the-token
     Ref treeScope = treeScopeForCurrentNode();
     Ref ownerDocument = treeScope->documentScope();
-    bool insideTemplateElement = m_openElements.containsTemplateElement();
-    RefPtr element = HTMLElementFactory::createKnownElement(token.tagName(), ownerDocument, insideTemplateElement ? nullptr : form(), true);
+    RefPtr element = HTMLElementFactory::createKnownElement(token.tagName(), ownerDocument, true);
     RefPtr<CustomElementRegistry> registry = m_openElements.stackDepth() > 1 ? RefPtr { registryForCurrentNode(currentNode(), treeScope) } : m_registry;
     if (!element) [[unlikely]] {
         RefPtr elementInterface = registry ? registry->findInterface(token.name()) : nullptr;
@@ -865,6 +860,11 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
     ASSERT(element);
     if (registry && registry->isScoped() && registry != treeScope->customElementRegistry()) [[unlikely]]
         CustomElementRegistry::addToScopedCustomElementRegistryMap(*element, *registry);
+
+    if (form() && !m_openElements.containsTemplateElement()) {
+        if (RefPtr formAssociated = element->asFormAssociatedElement())
+            formAssociated->setFormSetByParser(form());
+    }
 
     // FIXME: This is a hack to connect images to pictures before the image has
     // been inserted into the document. It can be removed once asynchronous image

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -519,7 +519,7 @@ private:
 
             static Ref<HTMLInputElement> create(Document& document)
             {
-                return HTMLInputElement::create(HTMLNames::inputTag, document, /* form */ nullptr, /* createdByParser */ true);
+                return HTMLInputElement::create(HTMLNames::inputTag, document, /* createdByParser */ true);
             }
         };
 

--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -174,7 +174,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
         style->setTextContent(String { shadowStyle });
         controlLayer->appendChild(WTF::move(style));
 
-        Ref button = HTMLButtonElement::create(HTMLNames::buttonTag, document.get(), nullptr);
+        Ref button = HTMLButtonElement::create(HTMLNames::buttonTag, document.get());
         button->setIdAttribute(spatialImageControlsButtonIdentifier());
         button->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString(localizedMediaControlElementString("EnterFullscreenButton"_s)));
         controlLayer->appendChild(button);


### PR DESCRIPTION
#### 666fd351d376a96584c357fee973f74f701800be
<pre>
Remove constructorNeedsFormElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=316906">https://bugs.webkit.org/show_bug.cgi?id=316906</a>

Reviewed by Ryosuke Niwa.

Address the part of the FIXME from
HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface()
that can still be addressed. We cannot share more code due to custom
elements, but this does result in a simplification for many element
constructors.

Canonical link: <a href="https://commits.webkit.org/315567@main">https://commits.webkit.org/315567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/193792571e86407363862038234e04d71de86a4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178804 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127159 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d72c6b6c-2c63-459f-a59e-2752a116a5ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132001 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92934 "1 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2dfea867-84fa-4952-8b71-50672451ef76) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112504 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fba78fe-e285-44fa-9cda-944d2076bcd6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32141 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27503 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181405 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140451 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43025 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140287 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43714 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28717 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107832 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35561 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115479 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42224 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6804 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41872 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->