### PR TITLE
[JSC] YARR RegularExpression heap overflow - duplicate named capture groups

### DIFF
--- a/Source/JavaScriptCore/yarr/RegularExpression.cpp
+++ b/Source/JavaScriptCore/yarr/RegularExpression.cpp
@@ -109,7 +109,7 @@ int RegularExpression::match(StringView str, unsigned startFrom, int* matchLengt
     if (str.isNull())
         return -1;
 
-    int offsetVectorSize = (d->m_numSubpatterns + 1) * 2;
+    int offsetVectorSize = d->m_regExpByteCode->m_offsetsSize;
     unsigned* offsetVector;
     Vector<unsigned, 32> nonReturnedOvector;
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -177,6 +177,7 @@ if (ENABLE_JAVASCRIPTCORE)
         Tests/JavaScriptCore/InspectorConsoleMessage.cpp
         Tests/JavaScriptCore/MarkedVector.cpp
         Tests/JavaScriptCore/PropertySlot.cpp
+        Tests/JavaScriptCore/RegularExpression.cpp
     )
 
     set(TestJavaScriptCore_LIBRARIES

--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/RegularExpression.cpp
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/RegularExpression.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <JavaScriptCore/InitializeThreading.h>
+#include <JavaScriptCore/RegularExpression.h>
+#include <JavaScriptCore/YarrFlags.h>
+
+namespace TestWebKitAPI {
+
+using JSC::Yarr::RegularExpression;
+
+TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupSimple)
+{
+    JSC::initialize();
+
+    RegularExpression re("(?<a>x)|(?<a>y)"_s, { JSC::Yarr::Flags::UnicodeSets });
+    EXPECT_TRUE(re.isValid());
+
+    int matchLength = 0;
+    EXPECT_EQ(0, re.match("x"_s, 0, &matchLength));
+    EXPECT_EQ(1, matchLength);
+
+    EXPECT_EQ(0, re.match("y"_s, 0, &matchLength));
+    EXPECT_EQ(1, matchLength);
+}
+
+TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupMultiple)
+{
+    JSC::initialize();
+
+    RegularExpression re("(?<a>x)|(?<a>y)|(?<b>x)|(?<b>y)|(?<c>x)|(?<c>y)"_s, { JSC::Yarr::Flags::UnicodeSets });
+    EXPECT_TRUE(re.isValid());
+
+    int matchLength = 0;
+    EXPECT_EQ(0, re.match("x"_s, 0, &matchLength));
+    EXPECT_EQ(1, matchLength);
+
+    EXPECT_EQ(0, re.match("y"_s, 0, &matchLength));
+    EXPECT_EQ(1, matchLength);
+}
+
+TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupNoMatch)
+{
+    JSC::initialize();
+
+    RegularExpression re("(?<a>x)|(?<a>y)"_s, { JSC::Yarr::Flags::UnicodeSets });
+    EXPECT_TRUE(re.isValid());
+
+    int matchLength = 0;
+    EXPECT_EQ(-1, re.match("z"_s, 0, &matchLength));
+}
+
+TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupSearchRev)
+{
+    JSC::initialize();
+
+    RegularExpression re("(?<a>x)|(?<a>y)"_s, { JSC::Yarr::Flags::UnicodeSets });
+    EXPECT_TRUE(re.isValid());
+
+    EXPECT_EQ(3, re.searchRev("abxyz"_s));
+    EXPECT_EQ(1, re.matchedLength());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### e5368156542a8414366b922c6c8130099fc3df94
<pre>
[JSC] YARR RegularExpression heap overflow - duplicate named capture groups
<a href="https://bugs.webkit.org/show_bug.cgi?id=308707">https://bugs.webkit.org/show_bug.cgi?id=308707</a>
<a href="https://rdar.apple.com/171240602">rdar://171240602</a>

Reviewed by Keith Miller.

RegularExpression&apos;s offsets vector allocation size is incorrect: that
formula was updated when named captures are added, but
RegularExpression&apos;s computation was not updated correctly. This patch
fixes it.

Tests: Tools/TestWebKitAPI/CMakeLists.txt
       Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/JavaScriptCore/RegularExpression.cpp

* Source/JavaScriptCore/yarr/RegularExpression.cpp:
(JSC::Yarr::RegularExpression::match const):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/JavaScriptCore/RegularExpression.cpp: Added.
(TestWebKitAPI::TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupSimple)):
(TestWebKitAPI::TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupMultiple)):
(TestWebKitAPI::TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupNoMatch)):
(TestWebKitAPI::TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupSearchRev)):

Originally-landed-as: 305413.398@safari-7624-branch (86cffcf010ab). <a href="https://rdar.apple.com/176067468">rdar://176067468</a>
Canonical link: <a href="https://commits.webkit.org/315024@main">https://commits.webkit.org/315024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b59291515b7e307fadc04f0a7cdc3d37d5588f35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125534 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130596 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111113 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25643 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179453 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/29099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32500 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139015 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37405 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42110 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105354 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27200 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200530 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40614 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113866 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53868 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40011 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5302 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40262 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->