### PR TITLE
Navigation API: extract a MethodTrackerRegistry for the upcoming/ongoing tracker slots

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -420,13 +420,10 @@ ExceptionOr<RefPtr<SerializedScriptValue>> Navigation::serializeState(JSC::JSVal
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#maybe-set-the-upcoming-non-traverse-api-method-tracker
 RefPtr<NavigationAPIMethodTracker> Navigation::maybeSetUpcomingNonTraversalTracker(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&& serializedState)
 {
-    RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), WTF::move(serializedState));
+    Ref apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), WTF::move(serializedState));
 
-    // FIXME: We should be able to assert m_upcomingNonTraverseMethodTracker is empty.
-    if (!hasEntriesAndEventsDisabled()) {
-        Locker locker { m_apiMethodTrackersLock };
-        m_upcomingNonTraverseMethodTracker = apiMethodTracker;
-    }
+    if (!hasEntriesAndEventsDisabled())
+        m_methodTrackers.setUpcomingNonTraverse(apiMethodTracker.copyRef());
 
     return apiMethodTracker;
 }
@@ -434,13 +431,10 @@ RefPtr<NavigationAPIMethodTracker> Navigation::maybeSetUpcomingNonTraversalTrack
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#add-an-upcoming-traverse-api-method-tracker
 RefPtr<NavigationAPIMethodTracker> Navigation::addUpcomingTraverseAPIMethodTracker(JSC::JSGlobalObject& globalObject, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info)
 {
-    RefPtr apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), nullptr);
+    Ref apiMethodTracker = NavigationAPIMethodTracker::create(globalObject, WTF::move(committed), WTF::move(finished), WTF::move(info), nullptr);
     apiMethodTracker->setKey(key);
 
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        m_upcomingTraverseMethodTrackers.add(key, *apiMethodTracker);
-    }
+    m_methodTrackers.addUpcomingTraverse(key, apiMethodTracker.copyRef());
 
     return apiMethodTracker;
 }
@@ -516,16 +510,9 @@ Navigation::Result Navigation::navigate(JSC::JSGlobalObject& globalObject, const
     request.setIsFromNavigationAPI(true);
     frame()->loader().loadFrameRequest(WTF::move(request), nullptr, { });
 
-    // If the load() call never made it to the point that NavigateEvent was emitted, thus promoteUpcomingAPIMethodTracker() called, this will be true.
-    bool loadWasAborted = [&] {
-        Locker locker { m_apiMethodTrackersLock };
-        if (m_upcomingNonTraverseMethodTracker != apiMethodTracker)
-            return false;
-        m_upcomingNonTraverseMethodTracker = nullptr;
-        return true;
-    }();
-    if (loadWasAborted)
-        rejectFinishedPromise(apiMethodTracker.get());
+    // If the load() call never made it to the point that NavigateEvent was emitted, thus the upcoming-non-traverse slot was never promoted, this returns the tracker so we can reject it.
+    if (RefPtr aborted = m_methodTrackers.takeUpcomingNonTraverseIfEquals(*apiMethodTracker))
+        rejectFinishedPromise(aborted);
 
     return apiMethodTrackerDerivedResult(*apiMethodTracker);
 }
@@ -551,11 +538,8 @@ Navigation::Result Navigation::performTraversal(JSC::JSGlobalObject& globalObjec
         return { createDOMPromise(committed), createDOMPromise(finished) };
     }
 
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        if (auto existingMethodTracker = m_upcomingTraverseMethodTrackers.getOptional(key))
-            return apiMethodTrackerDerivedResult(*existingMethodTracker);
-    }
+    if (RefPtr existingMethodTracker = m_methodTrackers.upcomingTraverse(key))
+        return apiMethodTrackerDerivedResult(*existingMethodTracker);
 
     RefPtr apiMethodTracker = addUpcomingTraverseAPIMethodTracker(globalObject, WTF::move(committed), WTF::move(finished), key, options.info);
 
@@ -564,7 +548,7 @@ Navigation::Result Navigation::performTraversal(JSC::JSGlobalObject& globalObjec
         if (result != ScheduleHistoryNavigationResult::Aborted)
             return;
 
-        // Going through rejectFinishedPromise also removes the tracker from m_upcomingTraverseMethodTrackers;
+        // Going through rejectFinishedPromise also removes the tracker from the upcoming-traverse map;
         // otherwise a later traversal to the same key would be deduplicated against the settled promises.
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->rejectFinishedPromise(apiMethodTracker.get());
@@ -673,7 +657,7 @@ void Navigation::resolveFinishedPromise(NavigationAPIMethodTracker* apiMethodTra
 {
     apiMethodTracker->resolveFinished();
     if (apiMethodTracker->isSettled())
-        cleanupAPIMethodTracker(apiMethodTracker);
+        m_methodTrackers.unregister(*apiMethodTracker);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#reject-the-finished-promise
@@ -682,7 +666,7 @@ void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTrac
     RELEASE_LOG(Navigation, "rejectFinishedPromise: rejecting promises for tracker=%p with exception='%s'", apiMethodTracker, exception.message().utf8().data());
 
     apiMethodTracker->rejectFinished(exception, exceptionObject);
-    cleanupAPIMethodTracker(apiMethodTracker);
+    m_methodTrackers.unregister(*apiMethodTracker);
 }
 
 void Navigation::rejectFinishedPromise(NavigationAPIMethodTracker* apiMethodTracker)
@@ -712,7 +696,7 @@ void Navigation::notifyCommittedToEntry(NavigationAPIMethodTracker* apiMethodTra
 
     apiMethodTracker->commitTo(*entry, navigationType);
     if (apiMethodTracker->isSettled())
-        cleanupAPIMethodTracker(apiMethodTracker);
+        m_methodTrackers.unregister(*apiMethodTracker);
 }
 
 void Navigation::updateNavigationEntry(Ref<HistoryItem>&& item, ShouldCopyStateObjectFromCurrentEntry shouldCopyStateObjectFromCurrentEntry)
@@ -826,11 +810,7 @@ void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigati
             Ref { m_entries[*m_currentEntryIndex] }->setState(oldCurrentEntry->state());
     }
 
-    RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        ongoingAPIMethodTracker = m_ongoingAPIMethodTracker;
-    }
+    RefPtr ongoingAPIMethodTracker = m_methodTrackers.ongoing();
     if (ongoingAPIMethodTracker && shouldNotifyCommitted == ShouldNotifyCommitted::Yes)
         notifyCommittedToEntry(ongoingAPIMethodTracker.get(), protect(currentEntry()).get(), navigationType);
 
@@ -915,46 +895,100 @@ static bool documentCanHaveURLRewritten(const Document& document, const URL& tar
     return equalIgnoringFragmentIdentifier(documentURL, targetURL);
 }
 
-// https://html.spec.whatwg.org/multipage/nav-history-apis.html#promote-an-upcoming-api-method-tracker-to-ongoing
-void Navigation::promoteUpcomingAPIMethodTracker(const String& destinationKey)
+void Navigation::MethodTrackerRegistry::setUpcomingNonTraverse(Ref<NavigationAPIMethodTracker>&& tracker)
 {
-    // FIXME: We should be able to assert m_ongoingAPIMethodTracker is unset.
+    assertIsMainThread();
+    Locker locker { m_lock };
+    // FIXME: We should be able to assert m_upcomingNonTraverse is empty.
+    m_upcomingNonTraverse = WTF::move(tracker);
+}
 
-    Locker locker { m_apiMethodTrackersLock };
-    if (!destinationKey.isEmpty())
-        m_ongoingAPIMethodTracker = m_upcomingTraverseMethodTrackers.take(destinationKey);
-    else if (destinationKey.isNull()) {
-        m_ongoingAPIMethodTracker = WTF::move(m_upcomingNonTraverseMethodTracker);
-        m_upcomingNonTraverseMethodTracker = nullptr;
-    } else if (destinationKey.isEmpty() && !m_upcomingTraverseMethodTrackers.isEmpty()) {
-        // For traverse navigation where destination key is empty, try to use any available traverse method tracker.
-        // (e.g., cross-document navigation where NavigationHistoryEntry is not found).
-        auto firstTracker = m_upcomingTraverseMethodTrackers.begin();
-        if (firstTracker != m_upcomingTraverseMethodTrackers.end()) {
-            String trackerKey = firstTracker->key;
-            m_ongoingAPIMethodTracker = m_upcomingTraverseMethodTrackers.take(trackerKey);
-        }
-    }
+void Navigation::MethodTrackerRegistry::addUpcomingTraverse(const String& key, Ref<NavigationAPIMethodTracker>&& tracker)
+{
+    assertIsMainThread();
+    Locker locker { m_lock };
+    m_upcomingTraverse.add(key, WTF::move(tracker));
+}
+
+NavigationAPIMethodTracker* Navigation::MethodTrackerRegistry::upcomingTraverse(const String& key) const
+{
+    assertIsMainThread();
+    Locker locker { m_lock };
+    return m_upcomingTraverse.get(key);
+}
+
+NavigationAPIMethodTracker* Navigation::MethodTrackerRegistry::ongoing() const
+{
+    assertIsMainThread();
+    Locker locker { m_lock };
+    return m_ongoing.get();
+}
+
+RefPtr<NavigationAPIMethodTracker> Navigation::MethodTrackerRegistry::takeUpcomingNonTraverseIfEquals(NavigationAPIMethodTracker& tracker)
+{
+    assertIsMainThread();
+    Locker locker { m_lock };
+    if (m_upcomingNonTraverse != &tracker)
+        return nullptr;
+    return std::exchange(m_upcomingNonTraverse, nullptr);
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#promote-an-upcoming-api-method-tracker-to-ongoing
+NavigationAPIMethodTracker* Navigation::MethodTrackerRegistry::promoteUpcomingNonTraverseToOngoing()
+{
+    assertIsMainThread();
+    Locker locker { m_lock };
+    // FIXME: We should be able to assert m_ongoing is unset.
+    m_ongoing = WTF::move(m_upcomingNonTraverse);
+    return m_ongoing.get();
+}
+
+NavigationAPIMethodTracker* Navigation::MethodTrackerRegistry::promoteUpcomingTraverseToOngoing(const String& destinationKey)
+{
+    assertIsMainThread();
+    Locker locker { m_lock };
+    // FIXME: We should be able to assert m_ongoing is unset.
+    ASSERT(destinationKey.isNull() || !destinationKey.isEmpty());
+    m_ongoing = m_upcomingTraverse.take(destinationKey);
+    return m_ongoing.get();
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker-clean-up
-void Navigation::cleanupAPIMethodTracker(NavigationAPIMethodTracker* apiMethodTracker)
+void Navigation::MethodTrackerRegistry::unregister(NavigationAPIMethodTracker& tracker)
 {
-    Locker locker { m_apiMethodTrackersLock };
-    if (m_ongoingAPIMethodTracker == apiMethodTracker)
-        m_ongoingAPIMethodTracker = nullptr;
-    else {
-        auto& key = apiMethodTracker->key();
-        // FIXME: We should be able to assert key isn't null and m_upcomingTraverseMethodTrackers contains it.
-        if (!key.isNull())
-            m_upcomingTraverseMethodTrackers.remove(key);
+    assertIsMainThread();
+    Locker locker { m_lock };
+    if (m_ongoing == &tracker) {
+        m_ongoing = nullptr;
+        return;
     }
+    auto& key = tracker.key();
+    // FIXME: We should be able to assert key isn't null and m_upcomingTraverse contains it.
+    if (!key.isNull())
+        m_upcomingTraverse.remove(key);
+}
+
+bool Navigation::MethodTrackerRegistry::isEmpty() const
+{
+    assertIsMainThread();
+    Locker locker { m_lock };
+    return !m_ongoing && !m_upcomingNonTraverse && m_upcomingTraverse.isEmpty();
+}
+
+void Navigation::MethodTrackerRegistry::visitInGCThread(JSC::AbstractSlotVisitor& visitor) const
+{
+    Locker locker { m_lock };
+    if (m_ongoing)
+        m_ongoing->info().visitInGCThread(visitor);
+    if (m_upcomingNonTraverse)
+        m_upcomingNonTraverse->info().visitInGCThread(visitor);
+    for (auto& tracker : m_upcomingTraverse.values())
+        tracker->info().visitInGCThread(visitor);
 }
 
 NavigationAPIMethodTracker* Navigation::upcomingTraverseMethodTracker(const String& key) const
 {
-    Locker locker { m_apiMethodTrackersLock };
-    return m_upcomingTraverseMethodTrackers.get(key);
+    return m_methodTrackers.upcomingTraverse(key);
 }
 
 auto Navigation::registerAbortHandler() -> Ref<AbortHandler>
@@ -974,12 +1008,7 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
     auto* globalObject = scriptExecutionContext->globalObject();
     if (!globalObject) {
-        RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
-        {
-            Locker locker { m_apiMethodTrackersLock };
-            ongoingAPIMethodTracker = m_ongoingAPIMethodTracker;
-        }
-        if (ongoingAPIMethodTracker)
+        if (RefPtr ongoingAPIMethodTracker = m_methodTrackers.ongoing())
             globalObject = ongoingAPIMethodTracker->committedPromise().globalObject();
     }
     if (!globalObject)
@@ -1013,12 +1042,7 @@ void Navigation::abortOngoingNavigation(NavigateEvent& event)
 
     dispatchEvent(ErrorEvent::create(*globalObject, eventNames().navigateerrorEvent, exception.message(), errorInformation.sourceURL, errorInformation.line, errorInformation.column, { globalObject->vm(), domException }));
 
-    RefPtr<NavigationAPIMethodTracker> ongoingAPIMethodTracker;
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        ongoingAPIMethodTracker = m_ongoingAPIMethodTracker;
-    }
-    if (ongoingAPIMethodTracker)
+    if (RefPtr ongoingAPIMethodTracker = m_methodTrackers.ongoing())
         rejectFinishedPromise(ongoingAPIMethodTracker.get(), exception, domException);
 
     if (RefPtr transition = m_transition) {
@@ -1244,7 +1268,7 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
 
                 if (apiMethodTracker) {
                     apiMethodTracker->rejectFinished(result);
-                    protectedThis->cleanupAPIMethodTracker(apiMethodTracker.get());
+                    protectedThis->m_methodTrackers.unregister(*apiMethodTracker);
                 }
 
                 if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
@@ -1264,12 +1288,7 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
 Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationType, Ref<NavigationDestination>&& destination, const String& downloadRequestFilename, FormState* formState, SerializedScriptValue* classicHistoryAPIState, Element* sourceElement)
 {
     if (hasEntriesAndEventsDisabled()) {
-#if ASSERT_ENABLED
-        Locker locker { m_apiMethodTrackersLock };
-#endif
-        ASSERT(!m_ongoingAPIMethodTracker);
-        ASSERT(!m_upcomingNonTraverseMethodTracker);
-        ASSERT(m_upcomingTraverseMethodTrackers.isEmpty());
+        ASSERT(m_methodTrackers.isEmpty());
         return DispatchResult::Completed;
     }
 
@@ -1282,13 +1301,9 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     if (wasBeingDispatched && classicHistoryAPIState)
         return DispatchResult::Completed;
 
-    promoteUpcomingAPIMethodTracker(destination->key());
-
-    RefPtr<NavigationAPIMethodTracker> apiMethodTracker;
-    {
-        Locker locker { m_apiMethodTrackersLock };
-        apiMethodTracker = m_ongoingAPIMethodTracker;
-    }
+    RefPtr apiMethodTracker = navigationType == NavigationNavigationType::Traverse
+        ? m_methodTrackers.promoteUpcomingTraverseToOngoing(destination->key())
+        : m_methodTrackers.promoteUpcomingNonTraverseToOngoing();
 
     // Enforce rate limiting to prevent excessive navigation requests.
     if (!m_rateLimiter.navigationAllowed()) {
@@ -1506,13 +1521,7 @@ bool Navigation::RateLimiter::navigationAllowed()
 
 void Navigation::visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    Locker locker { m_apiMethodTrackersLock };
-    if (m_ongoingAPIMethodTracker)
-        m_ongoingAPIMethodTracker->info().visitInGCThread(visitor);
-    if (m_upcomingNonTraverseMethodTracker)
-        m_upcomingNonTraverseMethodTracker->info().visitInGCThread(visitor);
-    for (auto& tracker : m_upcomingTraverseMethodTrackers.values())
-        tracker->info().visitInGCThread(visitor);
+    m_methodTrackers.visitInGCThread(visitor);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -277,11 +277,9 @@ private:
 
     RefPtr<NavigationAPIMethodTracker> maybeSetUpcomingNonTraversalTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&);
     RefPtr<NavigationAPIMethodTracker> addUpcomingTraverseAPIMethodTracker(JSC::JSGlobalObject&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);
-    void cleanupAPIMethodTracker(NavigationAPIMethodTracker*) WTF_EXCLUDES_LOCK(m_apiMethodTrackersLock);
     void resolveFinishedPromise(NavigationAPIMethodTracker*);
     void rejectFinishedPromise(NavigationAPIMethodTracker*, const Exception&, JSC::JSValue exceptionObject);
     void abortOngoingNavigation(NavigateEvent&);
-    void promoteUpcomingAPIMethodTracker(const String& destinationKey) WTF_EXCLUDES_LOCK(m_apiMethodTrackersLock);
     void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*, NavigationNavigationType);
     Result apiMethodTrackerDerivedResult(const NavigationAPIMethodTracker&);
 
@@ -291,6 +289,33 @@ private:
     void disposeOfForwardEntriesInParents(BackForwardItemIdentifier);
     void recursivelyDisposeOfForwardEntriesInParents(BackForwardItemIdentifier, LocalFrame* navigatedFrame);
 
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker
+    class MethodTrackerRegistry {
+    public:
+        void setUpcomingNonTraverse(Ref<NavigationAPIMethodTracker>&&) WTF_EXCLUDES_LOCK(m_lock);
+        void addUpcomingTraverse(const String& key, Ref<NavigationAPIMethodTracker>&&) WTF_EXCLUDES_LOCK(m_lock);
+        NavigationAPIMethodTracker* upcomingTraverse(const String& key) const WTF_EXCLUDES_LOCK(m_lock);
+        NavigationAPIMethodTracker* ongoing() const WTF_EXCLUDES_LOCK(m_lock);
+
+        RefPtr<NavigationAPIMethodTracker> takeUpcomingNonTraverseIfEquals(NavigationAPIMethodTracker&) WTF_EXCLUDES_LOCK(m_lock);
+
+        // https://html.spec.whatwg.org/multipage/nav-history-apis.html#promote-an-upcoming-api-method-tracker-to-ongoing
+        NavigationAPIMethodTracker* promoteUpcomingNonTraverseToOngoing() WTF_EXCLUDES_LOCK(m_lock);
+        NavigationAPIMethodTracker* promoteUpcomingTraverseToOngoing(const String& destinationKey) WTF_EXCLUDES_LOCK(m_lock);
+
+        // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker-clean-up
+        void unregister(NavigationAPIMethodTracker&) WTF_EXCLUDES_LOCK(m_lock);
+
+        bool isEmpty() const WTF_EXCLUDES_LOCK(m_lock);
+        void visitInGCThread(JSC::AbstractSlotVisitor&) const WTF_EXCLUDES_LOCK(m_lock);
+
+    private:
+        mutable Lock m_lock;
+        RefPtr<NavigationAPIMethodTracker> m_ongoing WTF_GUARDED_BY_LOCK(m_lock);
+        RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverse WTF_GUARDED_BY_LOCK(m_lock);
+        HashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverse WTF_GUARDED_BY_LOCK(m_lock);
+    };
+
     std::optional<size_t> m_currentEntryIndex;
     RefPtr<NavigationTransition> m_transition;
     RefPtr<NavigationActivation> m_activation;
@@ -299,10 +324,7 @@ private:
     RefPtr<NavigateEvent> m_ongoingNavigateEvent;
     FocusDidChange m_focusChangedDuringOngoingNavigation { FocusDidChange::No };
     bool m_suppressNormalScrollRestorationDuringOngoingNavigation { false };
-    mutable Lock m_apiMethodTrackersLock;
-    RefPtr<NavigationAPIMethodTracker> m_ongoingAPIMethodTracker WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
-    RefPtr<NavigationAPIMethodTracker> m_upcomingNonTraverseMethodTracker WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
-    HashMap<String, Ref<NavigationAPIMethodTracker>> m_upcomingTraverseMethodTrackers WTF_GUARDED_BY_LOCK(m_apiMethodTrackersLock);
+    MethodTrackerRegistry m_methodTrackers;
     WeakHashSet<AbortHandler> m_abortHandlers;
     RateLimiter m_rateLimiter;
 };


### PR DESCRIPTION
#### 26559c13662dfdf3815d1e73fef7e3f56314b967
<pre>
Navigation API: extract a MethodTrackerRegistry for the upcoming/ongoing tracker slots
<a href="https://bugs.webkit.org/show_bug.cgi?id=316879">https://bugs.webkit.org/show_bug.cgi?id=316879</a>
<a href="https://rdar.apple.com/179303305">rdar://179303305</a>

Reviewed by Chris Dumez and Rupin Mittal.

m_apiMethodTrackersLock guarded three Navigation member slots that hold
NavigationAPIMethodTrackers (the ongoing tracker, the upcoming
non-traverse slot, and the upcoming-traverse map). All mutation happens
on the main thread; the lock exists only because
visitAdditionalChildrenInGCThread visits the trackers&apos; info() values
from the GC thread.

The lock granularity was correct, but its use was dispersed: about a
dozen call sites hand-rolled &quot;lock, copy RefPtr, unlock&quot; blocks, nothing
prevented new code from touching a slot without the lock, and the
long-standing FIXMEs about ongoing/upcoming-slot invariants had nowhere
to live.

The promoteUpcomingAPIMethodTracker(const String&amp;) algorithm also
encoded the traverse / non-traverse distinction in
null-vs-empty-vs-non-empty String semantics, with three branches:

  if (!destinationKey.isEmpty())          // take from upcoming-traverse
  else if (destinationKey.isNull())       // take from upcoming-non-traverse
  else if (destinationKey.isEmpty() &amp;&amp; !upcoming-traverse.isEmpty())
                                          // take HashMap first entry

The third branch was unreachable: NavigationDestination::key() returns
either a UUID (non-null, non-empty) or null, never a non-null empty
string, and even if reachable its HashMap-iteration-order semantics
were unspecified-behavior. The second branch was also a latent spec
deviation: if a navigation.navigate() call had registered an upcoming
non-traverse tracker, and a browser-driven cross-document Traverse then
arrived whose target HistoryItem wasn&apos;t in m_entries (so destination
key is null), the second branch would steal the non-traverse tracker
to satisfy the traversal — wiring the navigate()&apos;s committed/finished
promises to an unrelated traversal&apos;s outcome. That has been removed
along with the rest of the old dispatch.

Move the slots, the lock, and the spec&apos;s slot algorithms (promote-an-
upcoming-api-method-tracker-to-ongoing, navigation-api-method-tracker-
clean-up, the upcoming-traverse lookup, the GC-thread visit) into a
private nested class, MethodTrackerRegistry. Navigation keeps tracker
*creation* (it needs the global object and the promises); the registry
only stores, promotes, looks up, and cleans up. Its API:

    setUpcomingNonTraverse(Ref&lt;NavigationAPIMethodTracker&gt;&amp;&amp;);
    addUpcomingTraverse(const String&amp; key, Ref&lt;NavigationAPIMethodTracker&gt;&amp;&amp;);
    upcomingTraverse(const String&amp; key) const -&gt; RefPtr&lt;...&gt;;
    ongoing() const -&gt; RefPtr&lt;...&gt;;
    takeUpcomingNonTraverseIfEquals(NavigationAPIMethodTracker&amp;) -&gt; RefPtr&lt;...&gt;;
    promoteUpcomingNonTraverseToOngoing() -&gt; RefPtr&lt;...&gt;;
    promoteUpcomingTraverseToOngoing(const String&amp; destinationKey) -&gt; RefPtr&lt;...&gt;;
    unregister(NavigationAPIMethodTracker&amp;);
    isEmpty() const -&gt; bool;
    visitInGCThread(JSC::AbstractSlotVisitor&amp;) const;

The traverse / non-traverse distinction is now encoded as two methods
the caller picks based on its existing navigationType discriminator,
instead of a runtime branch on a String&apos;s null/empty state. The two
promote methods return the newly-promoted tracker, so the call site
inside innerDispatchNavigateEvent gets the ongoing tracker without a
second lock acquisition. takeUpcomingNonTraverseIfEquals returns the
taken tracker (or null) instead of a bool, matching the rest of the
registry&apos;s take→RefPtr shape. The pure slot-op methods on Navigation
(promoteUpcomingAPIMethodTracker, cleanupAPIMethodTracker) are removed;
their call sites now invoke the registry directly. The two facades
that still mix tracker creation with policy
(maybeSetUpcomingNonTraversalTracker, addUpcomingTraverseAPIMethodTracker)
stay on Navigation and forward storage to the registry.

upcomingTraverseMethodTracker(const String&amp;) — the public accessor used
by NavigationScheduler — now returns RefPtr instead of a raw pointer.
The returned pointer was previously fetched under the lock and used
after the lock released; the existing caller already assigned to a
local RefPtr at the call site, so the change is type-compatible and
makes lifetime safe by construction.

All Locker use and WTF_GUARDED_BY_LOCK annotations now live in one
screenful inside the registry. The pre-existing FIXME assertions about
the ongoing-tracker and upcoming-traverse-key invariants also moved
into the registry&apos;s promote / unregister paths.

This is preparation for the upcoming NavigationInterceptOptions
precommitHandler work: with the registry in place, precommit support
reduces to one more tracker state (added in 316812@main) and one more
registry slot, instead of another round of flags threaded through
Navigation.

Behavior change limited to the previously-described latent fix in the
null-key Traverse path; existing imported/w3c/web-platform-tests/
navigation-api tests pass in both release and debug.

* Source/WebCore/page/Navigation.h:
(WebCore::Navigation::MethodTrackerRegistry):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::maybeSetUpcomingNonTraversalTracker):
(WebCore::Navigation::addUpcomingTraverseAPIMethodTracker):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::resolveFinishedPromise):
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::notifyCommittedToEntry):
(WebCore::Navigation::updateForNavigation):
(WebCore::Navigation::abortOngoingNavigation):
(WebCore::Navigation::handleSameDocumentNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::visitAdditionalChildrenInGCThread):
(WebCore::Navigation::MethodTrackerRegistry::setUpcomingNonTraverse):
(WebCore::Navigation::MethodTrackerRegistry::addUpcomingTraverse):
(WebCore::Navigation::MethodTrackerRegistry::upcomingTraverse):
(WebCore::Navigation::MethodTrackerRegistry::ongoing):
(WebCore::Navigation::MethodTrackerRegistry::takeUpcomingNonTraverseIfEquals):
(WebCore::Navigation::MethodTrackerRegistry::promoteUpcomingNonTraverseToOngoing):
(WebCore::Navigation::MethodTrackerRegistry::promoteUpcomingTraverseToOngoing):
(WebCore::Navigation::MethodTrackerRegistry::unregister):
(WebCore::Navigation::MethodTrackerRegistry::isEmpty):
(WebCore::Navigation::MethodTrackerRegistry::visitInGCThread):
(WebCore::Navigation::upcomingTraverseMethodTracker):
(WebCore::Navigation::cleanupAPIMethodTracker): Deleted.
(WebCore::Navigation::promoteUpcomingAPIMethodTracker): Deleted.

Canonical link: <a href="https://commits.webkit.org/315301@main">https://commits.webkit.org/315301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdef8fda1a7e0ab1070ae7b351a7a87722ffdecb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126179 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d63c81c-cd6f-407a-a796-38fe4586bef6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131134 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92229 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aff90345-3787-4cbc-a4c4-4754cffc3c76) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111645 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dc6f6f4-5e0d-4d34-83c7-7cf6fafec8f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32579 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31282 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26502 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180406 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33130 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35445 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139572 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42047 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37585 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42735 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27784 "Too many flaky failures: http/tests/contentextensions/video-element-resource-type.html, http/tests/navigation/redirect-preserves-fragment.html, http/tests/resourceLoadStatistics/downgraded-referrer-for-navigation-with-link-query-from-prevalent-resource.html, http/tests/security/cached-cross-origin-preloaded-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/report-only.py, http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/webgpu/webgpu/web_platform/copyToTexture/image_file.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106388 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34717 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114495 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41239 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5867 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40636 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40887 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->