### PR TITLE
[WebDriver] Protect session instance in waitForNavigationToComplete callbacks

### DIFF
--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -1253,12 +1253,13 @@ void WebDriverService::go(RefPtr<JSON::Object>&& parameters, Function<void (Comm
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, url = WTF::move(url), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, url = WTF::move(url), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->go(url, WTF::move(completionHandler));
+        protectedSession->go(url, WTF::move(completionHandler));
     });
 }
 
@@ -1269,12 +1270,13 @@ void WebDriverService::getCurrentURL(RefPtr<JSON::Object>&& parameters, Function
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getCurrentURL(WTF::move(completionHandler));
+        protectedSession->getCurrentURL(WTF::move(completionHandler));
     });
 }
 
@@ -1285,12 +1287,13 @@ void WebDriverService::back(RefPtr<JSON::Object>&& parameters, Function<void (Co
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->back(WTF::move(completionHandler));
+        protectedSession->back(WTF::move(completionHandler));
     });
 }
 
@@ -1301,12 +1304,13 @@ void WebDriverService::forward(RefPtr<JSON::Object>&& parameters, Function<void 
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->forward(WTF::move(completionHandler));
+        protectedSession->forward(WTF::move(completionHandler));
     });
 }
 
@@ -1317,12 +1321,13 @@ void WebDriverService::refresh(RefPtr<JSON::Object>&& parameters, Function<void 
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->refresh(WTF::move(completionHandler));
+        protectedSession->refresh(WTF::move(completionHandler));
     });
 }
 
@@ -1333,12 +1338,13 @@ void WebDriverService::getTitle(RefPtr<JSON::Object>&& parameters, Function<void
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getTitle(WTF::move(completionHandler));
+        protectedSession->getTitle(WTF::move(completionHandler));
     });
 }
 
@@ -1437,14 +1443,15 @@ void WebDriverService::closeWindow(RefPtr<JSON::Object>&& parameters, Function<v
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->closeWindow([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    m_session->closeWindow([this, protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
 
         auto handles = result.result()->asArray();
-        if (handles && !handles->length())
+        if (handles && !handles->length() && m_session && protectedSession->id() == m_session->id())
             m_session = nullptr;
 
         completionHandler(WTF::move(result));
@@ -1535,12 +1542,13 @@ void WebDriverService::switchToFrame(RefPtr<JSON::Object>&& parameters, Function
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, frameID, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, frameID, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->switchToFrame(WTF::move(frameID), WTF::move(completionHandler));
+        protectedSession->switchToFrame(WTF::move(frameID), WTF::move(completionHandler));
     });
 }
 
@@ -1551,12 +1559,13 @@ void WebDriverService::switchToParentFrame(RefPtr<JSON::Object>&& parameters, Fu
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->switchToParentFrame(WTF::move(completionHandler));
+        protectedSession->switchToParentFrame(WTF::move(completionHandler));
     });
 }
 
@@ -1618,12 +1627,13 @@ void WebDriverService::findElement(RefPtr<JSON::Object>&& parameters, Function<v
     if (!findStrategyAndSelectorOrCompleteWithError(*parameters, completionHandler, Session::ElementIsShadowRoot::No, strategy, selector))
         return;
 
-    m_session->waitForNavigationToComplete([this, strategy = WTF::move(strategy), selector = WTF::move(selector), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, strategy = WTF::move(strategy), selector = WTF::move(selector), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->findElements(strategy, selector, Session::FindElementsMode::Single, emptyString(), Session::ElementIsShadowRoot::No, WTF::move(completionHandler));
+        protectedSession->findElements(strategy, selector, Session::FindElementsMode::Single, emptyString(), Session::ElementIsShadowRoot::No, WTF::move(completionHandler));
     });
 }
 
@@ -1638,12 +1648,13 @@ void WebDriverService::findElements(RefPtr<JSON::Object>&& parameters, Function<
     if (!findStrategyAndSelectorOrCompleteWithError(*parameters, completionHandler, Session::ElementIsShadowRoot::No, strategy, selector))
         return;
 
-    m_session->waitForNavigationToComplete([this, strategy = WTF::move(strategy), selector = WTF::move(selector), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, strategy = WTF::move(strategy), selector = WTF::move(selector), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->findElements(strategy, selector, Session::FindElementsMode::Multiple, emptyString(), Session::ElementIsShadowRoot::No, WTF::move(completionHandler));
+        protectedSession->findElements(strategy, selector, Session::FindElementsMode::Multiple, emptyString(), Session::ElementIsShadowRoot::No, WTF::move(completionHandler));
     });
 }
 
@@ -1721,12 +1732,13 @@ void WebDriverService::getActiveElement(RefPtr<JSON::Object>&& parameters, Funct
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getActiveElement(WTF::move(completionHandler));
+        protectedSession->getActiveElement(WTF::move(completionHandler));
     });
 }
 
@@ -1999,12 +2011,13 @@ void WebDriverService::executeScript(RefPtr<JSON::Object>&& parameters, Function
     if (!findScriptAndArgumentsOrCompleteWithError(*parameters, completionHandler, script, arguments))
         return;
 
-    m_session->waitForNavigationToComplete([this, script = WTF::move(script), arguments = WTF::move(arguments), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, script = WTF::move(script), arguments = WTF::move(arguments), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->executeScript(script, WTF::move(arguments), Session::ExecuteScriptMode::Sync, WTF::move(completionHandler));
+        protectedSession->executeScript(script, WTF::move(arguments), Session::ExecuteScriptMode::Sync, WTF::move(completionHandler));
     });
 }
 
@@ -2020,12 +2033,13 @@ void WebDriverService::executeAsyncScript(RefPtr<JSON::Object>&& parameters, Fun
     if (!findScriptAndArgumentsOrCompleteWithError(*parameters, completionHandler, script, arguments))
         return;
 
-    m_session->waitForNavigationToComplete([this, script = WTF::move(script), arguments = WTF::move(arguments), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, script = WTF::move(script), arguments = WTF::move(arguments), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->executeScript(script, WTF::move(arguments), Session::ExecuteScriptMode::Async, WTF::move(completionHandler));
+        protectedSession->executeScript(script, WTF::move(arguments), Session::ExecuteScriptMode::Async, WTF::move(completionHandler));
     });
 }
 
@@ -2036,12 +2050,13 @@ void WebDriverService::getAllCookies(RefPtr<JSON::Object>&& parameters, Function
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getAllCookies(WTF::move(completionHandler));
+        protectedSession->getAllCookies(WTF::move(completionHandler));
     });
 }
 
@@ -2058,12 +2073,13 @@ void WebDriverService::getNamedCookie(RefPtr<JSON::Object>&& parameters, Functio
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, name = WTF::move(name), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, name = WTF::move(name), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getNamedCookie(name, WTF::move(completionHandler));
+        protectedSession->getNamedCookie(name, WTF::move(completionHandler));
     });
 }
 
@@ -2138,12 +2154,13 @@ void WebDriverService::addCookie(RefPtr<JSON::Object>&& parameters, Function<voi
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, cookie = WTF::move(cookie), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, cookie = WTF::move(cookie), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->addCookie(cookie.value(), WTF::move(completionHandler));
+        protectedSession->addCookie(cookie.value(), WTF::move(completionHandler));
     });
 }
 
@@ -2160,12 +2177,13 @@ void WebDriverService::deleteCookie(RefPtr<JSON::Object>&& parameters, Function<
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, name = WTF::move(name), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, name = WTF::move(name), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->deleteCookie(name, WTF::move(completionHandler));
+        protectedSession->deleteCookie(name, WTF::move(completionHandler));
     });
 }
 
@@ -2176,12 +2194,13 @@ void WebDriverService::deleteAllCookies(RefPtr<JSON::Object>&& parameters, Funct
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->deleteAllCookies(WTF::move(completionHandler));
+        protectedSession->deleteAllCookies(WTF::move(completionHandler));
     });
 }
 
@@ -2625,12 +2644,13 @@ void WebDriverService::dismissAlert(RefPtr<JSON::Object>&& parameters, Function<
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->dismissAlert(WTF::move(completionHandler));
+        protectedSession->dismissAlert(WTF::move(completionHandler));
     });
 }
 
@@ -2641,12 +2661,13 @@ void WebDriverService::acceptAlert(RefPtr<JSON::Object>&& parameters, Function<v
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->acceptAlert(WTF::move(completionHandler));
+        protectedSession->acceptAlert(WTF::move(completionHandler));
     });
 }
 
@@ -2657,12 +2678,13 @@ void WebDriverService::getAlertText(RefPtr<JSON::Object>&& parameters, Function<
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->getAlertText(WTF::move(completionHandler));
+        protectedSession->getAlertText(WTF::move(completionHandler));
     });
 }
 
@@ -2679,12 +2701,13 @@ void WebDriverService::sendAlertText(RefPtr<JSON::Object>&& parameters, Function
         return;
     }
 
-    m_session->waitForNavigationToComplete([this, text = WTF::move(text), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, text = WTF::move(text), completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->sendAlertText(text, WTF::move(completionHandler));
+        protectedSession->sendAlertText(text, WTF::move(completionHandler));
     });
 }
 
@@ -2695,12 +2718,13 @@ void WebDriverService::takeScreenshot(RefPtr<JSON::Object>&& parameters, Functio
     if (!findSessionOrCompleteWithError(*parameters, completionHandler))
         return;
 
-    m_session->waitForNavigationToComplete([this, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->takeScreenshot(std::nullopt, std::nullopt, WTF::move(completionHandler));
+        protectedSession->takeScreenshot(std::nullopt, std::nullopt, WTF::move(completionHandler));
     });
 }
 
@@ -2715,12 +2739,13 @@ void WebDriverService::takeElementScreenshot(RefPtr<JSON::Object>&& parameters, 
     if (!elementID)
         return;
 
-    m_session->waitForNavigationToComplete([this, elementID, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
+    auto protectedSession = Ref { *m_session };
+    protectedSession->waitForNavigationToComplete([protectedSession, elementID, completionHandler = WTF::move(completionHandler)](CommandResult&& result) mutable {
         if (result.isError()) {
             completionHandler(WTF::move(result));
             return;
         }
-        m_session->takeScreenshot(elementID.value(), true, WTF::move(completionHandler));
+        protectedSession->takeScreenshot(elementID.value(), true, WTF::move(completionHandler));
     });
 }
 


### PR DESCRIPTION
#### 6b6622bd96de7f729b1231f55778427dc864badd
<pre>
[WebDriver] Protect session instance in waitForNavigationToComplete callbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=315736">https://bugs.webkit.org/show_bug.cgi?id=315736</a>

Reviewed by Carlos Garcia Campos and BJ Burg.

Currently, the waitForNavigationToComplete callbacks access
WebDriverService::m_session directly, although this member could be
null if the callback arrives after we started to delete or to replace
the session.

This commit protects the session instance in these callbacks, as just
adding a null check would leave the door open for the callback to be
called on an already replaced session. This creates a temporary cycle
between the Session, the callback, and the SessionHost (who stashes the
pending requests), but the cycle is broken when either the session is
closed or the browser disconnects, flushing the pending requests.

* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::go):
(WebDriver::WebDriverService::getCurrentURL):
(WebDriver::WebDriverService::back):
(WebDriver::WebDriverService::forward):
(WebDriver::WebDriverService::refresh):
(WebDriver::WebDriverService::getTitle):
(WebDriver::WebDriverService::closeWindow):
(WebDriver::WebDriverService::switchToFrame):
(WebDriver::WebDriverService::switchToParentFrame):
(WebDriver::WebDriverService::findElement):
(WebDriver::WebDriverService::findElements):
(WebDriver::WebDriverService::getActiveElement):
(WebDriver::WebDriverService::executeScript):
(WebDriver::WebDriverService::executeAsyncScript):
(WebDriver::WebDriverService::getAllCookies):
(WebDriver::WebDriverService::getNamedCookie):
(WebDriver::WebDriverService::addCookie):
(WebDriver::WebDriverService::deleteCookie):
(WebDriver::WebDriverService::deleteAllCookies):
(WebDriver::WebDriverService::dismissAlert):
(WebDriver::WebDriverService::acceptAlert):
(WebDriver::WebDriverService::getAlertText):
(WebDriver::WebDriverService::sendAlertText):
(WebDriver::WebDriverService::takeScreenshot):
(WebDriver::WebDriverService::takeElementScreenshot):

Canonical link: <a href="https://commits.webkit.org/316713@main">https://commits.webkit.org/316713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc81ca9a09ceb0683eaf5b126d50d0560266d107

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40711 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182823 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130806 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134714 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176208 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38129 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115184 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36774 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31308 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185245 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143559 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46850 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38715 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47529 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112624 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38388 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119278 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46035 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9802 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->