### PR TITLE
AX: Accessibility thread's implementation of NSAccessibilityLineTextMarkerRangeForTextMarkerAttribute should include trailing line breaks just as the main-thread implementation does

### DIFF
--- a/LayoutTests/accessibility/mac/line-range-includes-trailing-line-break-expected.txt
+++ b/LayoutTests/accessibility/mac/line-range-includes-trailing-line-break-expected.txt
@@ -1,0 +1,10 @@
+This tests that a line's text marker range includes its trailing line break.
+
+PASS: editable.textMarkerRangeLength(firstLineRange) === 12
+PASS: editable.stringForTextMarkerRange(firstLineRange) === 'First line.\n' === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+First line.
+Second line.

--- a/LayoutTests/accessibility/mac/line-range-includes-trailing-line-break.html
+++ b/LayoutTests/accessibility/mac/line-range-includes-trailing-line-break.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div contenteditable id="editable">First line.<br>Second line.</div>
+
+<script>
+var output = "This tests that a line's text marker range includes its trailing line break.\n\n";
+
+if (window.accessibilityController) {
+    var editable = accessibilityController.accessibleElementById("editable");
+    var fullRange = editable.textMarkerRangeForElement(editable);
+    var startMarker = editable.startTextMarkerForTextMarkerRange(fullRange);
+    var firstLineRange = editable.lineTextMarkerRangeForTextMarker(startMarker);
+
+    // "First line." is 11 characters; the line range must also include the trailing line break (the <br>) for 12.
+    output += expect("editable.textMarkerRangeLength(firstLineRange)", "12");
+    output += expect("editable.stringForTextMarkerRange(firstLineRange) === 'First line.\\n'", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3422,8 +3422,14 @@ enum class TextUnit {
 {
     if (AXObjectCache::useAXThreadTextApis()) {
         auto rangeType = LineRangeType::Current;
+        auto includeTrailingLineBreak = IncludeTrailingLineBreak::No;
         switch (textUnit) {
         case TextUnit::Line:
+            // Match the live-tree path below (lineRangeForPosition), which returns the current line's
+            // range including its trailing line break. The left/right-line variants intentionally keep
+            // IncludeTrailingLineBreak::No to match leftLineVisiblePositionRange /
+            // rightLineVisiblePositionRange, which end at endOfLine (before the break).
+            includeTrailingLineBreak = IncludeTrailingLineBreak::Yes;
             break;
         case TextUnit::LeftLine:
             rangeType = LineRangeType::Left;
@@ -3435,7 +3441,7 @@ enum class TextUnit {
             AX_ASSERT_NOT_REACHED();
             break;
         }
-        return AXTextMarker { textMarker }.lineRange(rangeType).platformData().bridgingAutorelease();
+        return AXTextMarker { textMarker }.lineRange(rangeType, includeTrailingLineBreak).platformData().bridgingAutorelease();
     }
 
     return (id)Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRangeRef>([textMarker = retainPtr(textMarker), &textUnit, protectedSelf = retainPtr(self)] () ->  RetainPtr<AXTextMarkerRangeRef> {


### PR DESCRIPTION
#### e45d28fa049b26e8a2c1d67ad4974c50c37b89b3
<pre>
AX: Accessibility thread&apos;s implementation of NSAccessibilityLineTextMarkerRangeForTextMarkerAttribute should include trailing line breaks just as the main-thread implementation does
<a href="https://bugs.webkit.org/show_bug.cgi?id=316909">https://bugs.webkit.org/show_bug.cgi?id=316909</a>
<a href="https://rdar.apple.com/179366035">rdar://179366035</a>

Reviewed by Dominic Mazzoni.

The TextUnit::Line branch of -lineTextMarkerRangeForTextMarker:forUnit: called
AXTextMarker::lineRange() with the default IncludeTrailingLineBreak::No, so the
isolated tree dropped a line&apos;s trailing &lt;br&gt;, diverging from the non-isolated
tree and from AXRangeForLine (doAXRangeForLine / characterRangeForLine, which
already include it). Pass IncludeTrailingLineBreak::Yes for the Line unit
(LeftLine/RightLine keep No, matching left/rightLineVisiblePositionRange).

This change also gets accessibility/mac/content-editable-attributed-string.html
closer to passing with --accessibility-isolated-tree.

* LayoutTests/accessibility/mac/line-range-includes-trailing-line-break-expected.txt: Added.
* LayoutTests/accessibility/mac/line-range-includes-trailing-line-break.html: Added.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper lineTextMarkerRangeForTextMarker:forUnit:]):

Canonical link: <a href="https://commits.webkit.org/315042@main">https://commits.webkit.org/315042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d23395a6df71ec6c378e3f0491359ffbfa19287

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125560 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130609 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111126 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32043 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30746 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25658 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179468 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32515 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139028 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37415 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150334 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105379 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27214 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113881 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40026 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5316 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40277 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->