### PR TITLE
[WebAuthn] Fix crash during requestPIN

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -359,8 +359,10 @@ void AuthenticatorManager::authenticatorStatusUpdated(WebAuthenticationStatus st
 
 void AuthenticatorManager::requestPin(uint64_t retries, CompletionHandler<void(const WTF::String&)>&& completionHandler)
 {
-    if (!m_pendingRequest || !m_pendingRequest->completionHandler)
+    if (!m_pendingRequest || !m_pendingRequest->completionHandler) {
+        completionHandler(nullString());
         return;
+    }
 
     // Cache the PIN to improve NFC user experience so that a momentary movement of the NFC key away from the scanner doesn't
     // force the PIN entry to be re-entered.
@@ -373,8 +375,10 @@ void AuthenticatorManager::requestPin(uint64_t retries, CompletionHandler<void(c
 
     auto callback = [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (const WTF::String& pin) mutable {
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
+        if (!protectedThis) {
+            completionHandler(nullString());
             return;
+        }
 
         protectedThis->m_pendingRequest->data.cachedPin = pin;
         completionHandler(pin);
@@ -393,13 +397,17 @@ void AuthenticatorManager::requestPin(uint64_t retries, CompletionHandler<void(c
 
 void AuthenticatorManager::requestNewPin(uint64_t minLength, CompletionHandler<void(const WTF::String&)>&& completionHandler)
 {
-    if (!m_pendingRequest || !m_pendingRequest->completionHandler)
+    if (!m_pendingRequest || !m_pendingRequest->completionHandler) {
+        completionHandler(nullString());
         return;
+    }
 
     auto callback = [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (const WTF::String& pin) mutable {
         RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
+        if (!protectedThis) {
+            completionHandler(nullString());
             return;
+        }
 
         protectedThis->m_pendingRequest->data.cachedPin = pin;
         completionHandler(pin);


### PR DESCRIPTION
#### 4e561e6e24860adba388f722794bb9bd9bc11f2c
<pre>
[WebAuthn] Fix crash during requestPIN
<a href="https://rdar.apple.com/179212159">rdar://179212159</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316911">https://bugs.webkit.org/show_bug.cgi?id=316911</a>

Reviewed by Abrar Rahman Protyasha, Richard Robinson, and Aditya Keerthi.

Call completionHandler(nullString()) on early-return paths in requestPin() and
requestNewPin() instead of letting the CompletionHandler be destroyed uncalled.
The caller already handles a null pin gracefully.

* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::requestPin):
(WebKit::AuthenticatorManager::requestNewPin):

Canonical link: <a href="https://commits.webkit.org/315116@main">https://commits.webkit.org/315116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/471b7d81b74b8181af393705b469401247632ced

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125567 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1caf4ea7-aadc-463a-b825-91dddf868498) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130612 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91808 "3 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/450e46a4-8928-4e09-903e-e2b0743b746d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111129 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcad425e-ee3c-4d46-9a2c-f40e61ab2f6f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32049 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30753 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25867 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142039 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179770 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32521 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139035 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138919 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37467 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42131 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105408 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27221 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40032 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5323 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40177 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->