### PR TITLE
REGRESSION: Use-after-free in Node::m_shadowIncludingRoot via destructor cascade not propagating into shadow roots

### DIFF
--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -180,6 +180,8 @@ void removeDetachedChildrenInContainer(ContainerNode& container)
         node->setTreeScopeRecursively(Ref<Document> { container.document() });
         if (node->isInTreeScope())
             notifyChildNodeRemoved(container, *node);
+        else if (node->refCount() > 1)
+            node->updateShadowIncludingRootForSubtree();
         ASSERT_WITH_SECURITY_IMPLICATION(!node->isInTreeScope());
     }
 }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1517,6 +1517,15 @@ void Node::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemo
     }
 }
 
+void Node::updateShadowIncludingRootForSubtree()
+{
+    SUPPRESS_UNCOUNTED_LOCAL for (auto* current = this; current; current = NodeTraversal::next(*current, this)) {
+        current->updateShadowIncludingRoot();
+        SUPPRESS_UNCOUNTED_LOCAL if (auto* shadowRoot = current->shadowRoot())
+            shadowRoot->updateShadowIncludingRootForSubtree();
+    }
+}
+
 bool Node::isRootEditableElement() const
 {
     return hasEditableStyle() && isElementNode() && (!parentNode() || !parentNode()->hasEditableStyle()

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -508,6 +508,8 @@ public:
     // https://dom.spec.whatwg.org/#concept-node-move-ext
     virtual void movingSteps(bool, ContainerNode&) { };
 
+    void updateShadowIncludingRootForSubtree();
+
     virtual String description() const;
     virtual String debugDescription() const;
 


### PR DESCRIPTION
#### 9414a9722a8439557c0c3972eec476dc922a1566
<pre>
REGRESSION: Use-after-free in Node::m_shadowIncludingRoot via destructor cascade not propagating into shadow roots
<a href="https://bugs.webkit.org/show_bug.cgi?id=312712">https://bugs.webkit.org/show_bug.cgi?id=312712</a>
<a href="https://rdar.apple.com/175103172">rdar://175103172</a>

Reviewed by Geoffrey Garen.

When a document is torn down via Document::removedLastRef through removeDetachedChildrenInContainer,
the &lt;html&gt; element is removed from the document. Since &lt;html&gt; is still in tree scope at this point,
notifyChildNodeRemoved is called, which walks the entire subtree - including shadow roots - and sets
m_shadowIncludingRoot to &lt;html&gt; for all descendants. This is correct at that moment.

Then &lt;html&gt; is freed when the loop&apos;s RefPtr releases it (children don&apos;t ref-count their parents -
m_parentNode is CheckedPtr). This triggers a destructor cascade: ~ContainerNode(&lt;html&gt;) via
removeDetachedChildrenInContainer(&lt;html&gt;) processes &lt;body&gt;, then ~ContainerNode(&lt;body&gt;) processes
the &lt;video&gt; element, and so on. Each step calls resetShadowIncludingRoot() on the direct child,
fixing that node&apos;s cache. However, since IsConnected and IsInShadowTree flags were cleared during
the initial notifyChildNodeRemoved walk, isInTreeScope() returns false, so notifyChildNodeRemoved
is skipped in this case. This means the shadow root and its descendants are never updated -
m_shadowIncludingRoot of these nodes still point to the now-freed &lt;html&gt;.

Nodes kept alive by mechanisms other than JS wrappers - such as HTMLMediaElement which survives as
an ActiveDOMObject - retain their shadow DOM with dangling m_shadowIncludingRoot pointers. When
these nodes are subsequently used (e.g., VTT cue display tree updates via an event loop task), the
stale pointer is dereferenced, causing an use-after-free.

This PR fixes this use-after-free bug by updating m_shadowIncludingRoot for removed subtrees when
the root&apos;s refCount is greater than 1 (i.e. there is an external reference to the node beyond the
RefPtr in removeDetachedChildrenInContainer).

No new tests since existing media tests such as media/track/webvtt-parser-does-not-leak.html would
hit debug assertions without this fix, and this bug requires a node to be kept alive by C++ code.

* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::removeDetachedChildrenInContainer):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::updateShadowIncludingRootForSubtree):
* Source/WebCore/dom/Node.h:

Originally-landed-as: 305413.700@safari-7624-branch (5d07bda85f02). <a href="https://rdar.apple.com/176059252">rdar://176059252</a>
Canonical link: <a href="https://commits.webkit.org/315148@main">https://commits.webkit.org/315148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5073eeed13ae620ce83d6513de8f2f4a00f4ac91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130622 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91810 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32056 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30757 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179772 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32524 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139042 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138926 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37487 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42134 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105416 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34196 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27227 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113890 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40035 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5329 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->