### PR TITLE
[Site Isolation] Iframe pushState misroutes history.back() under UseUIProcessForBackForwardItemLoading

### DIFF
--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -1079,8 +1079,7 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
 
     bool shouldRestoreScrollPosition = currentItem->shouldRestoreScrollPosition();
 
-    // Get a HistoryItem tree for the current frame tree.
-    Ref topItem = frame->rootFrame().loader().history().createItemTree(page->historyItemClient(), frame, false, BackForwardItemIdentifier::generate());
+    Ref topItem = frame->loader().history().createItemTree(page->historyItemClient(), frame, false, BackForwardItemIdentifier::generate());
 
     RefPtr document = frame->document();
     if (document && !document->hasRecentUserInteractionForNavigationFromJS())

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9481,6 +9481,46 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithDifferentCrossSiteIframes)
     });
 }
 
+TEST(SiteIsolation, IframePushStateBackForwardRoutesToIframe)
+{
+    HTTPServer server({
+        { "/main"_s, { "<iframe src='https://a.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    WKFrameInfo *iframe = [webView firstChildFrame];
+
+    [webView objectByEvaluatingJavaScript:@"history.pushState(null, '', '?1')" inFrame:iframe];
+    [webView objectByEvaluatingJavaScript:@"history.pushState(null, '', '?2')" inFrame:iframe];
+    [webView objectByEvaluatingJavaScript:@"history.pushState(null, '', '?3')" inFrame:iframe];
+
+    EXPECT_WK_STREQ(@"?3", [webView objectByEvaluatingJavaScript:@"location.search" inFrame:iframe]);
+    EXPECT_WK_STREQ(@"https://a.com/main", [webView URL].absoluteString);
+
+    [webView objectByEvaluatingJavaScript:@"history.back()" inFrame:iframe];
+    while (![[webView objectByEvaluatingJavaScript:@"location.search" inFrame:iframe] isEqualToString:@"?2"])
+        TestWebKitAPI::Util::spinRunLoop();
+    EXPECT_WK_STREQ(@"?2", [webView objectByEvaluatingJavaScript:@"location.search" inFrame:iframe]);
+    EXPECT_WK_STREQ(@"https://a.com/main", [webView URL].absoluteString);
+
+    [webView objectByEvaluatingJavaScript:@"history.back()" inFrame:iframe];
+    while (![[webView objectByEvaluatingJavaScript:@"location.search" inFrame:iframe] isEqualToString:@"?1"])
+        TestWebKitAPI::Util::spinRunLoop();
+    EXPECT_WK_STREQ(@"?1", [webView objectByEvaluatingJavaScript:@"location.search" inFrame:iframe]);
+    EXPECT_WK_STREQ(@"https://a.com/main", [webView URL].absoluteString);
+
+    [webView objectByEvaluatingJavaScript:@"history.back()" inFrame:iframe];
+    while (![[webView objectByEvaluatingJavaScript:@"location.search" inFrame:iframe] isEqualToString:@""])
+        TestWebKitAPI::Util::spinRunLoop();
+    EXPECT_WK_STREQ(@"", [webView objectByEvaluatingJavaScript:@"location.search" inFrame:iframe]);
+    EXPECT_WK_STREQ(@"https://a.com/main", [webView URL].absoluteString);
+}
+
 TEST(SiteIsolation, ClearSiteDataClearsRemoteProcessMemoryCache)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 74720ee2b7df6a33982136654d14bc3cd4236ab7
<pre>
[Site Isolation] Iframe pushState misroutes history.back() under UseUIProcessForBackForwardItemLoading
<a href="https://bugs.webkit.org/show_bug.cgi?id=316881">https://bugs.webkit.org/show_bug.cgi?id=316881</a>
<a href="https://rdar.apple.com/179304807">rdar://179304807</a>

Reviewed by Charlie Wolfe and Sihui Liu.

HistoryController::pushState built the topItem from frame-&gt;rootFrame(), so the
IPC payload&apos;s frameID identified the rootFrame even when an iframe initiated
the navigation. Under UseUIProcessForBackForwardItemLoading (auto-enabled with
SiteIsolation), UIProcess routes history.back() by currentItem-&gt;navigatedFrameID()
and so navigated the main frame to its own URL — back() became a no-op and the
iframe stayed at the latest pushed entry.

Build the tree from the navigating frame, matching what regular iframe
navigations already do via WebLocalFrameLoaderClient::createHistoryItemTree.
The IPC payload&apos;s root frameID then identifies the iframe directly, and
WebBackForwardList::completeFrameStateForNavigation handles grafting the
iframe-rooted FrameState onto the main tree as it does for any other
sub-frame navigation.

Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
IframePushStateBackForwardRoutesToIframe.

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::pushState):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:

Canonical link: <a href="https://commits.webkit.org/315125@main">https://commits.webkit.org/315125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e182a7f7b42029ed3f02b9bd74d97f1c1121fd11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177440 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125813 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07151f86-36a1-473c-b721-dafe175519ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130809 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1b51af0-89a5-44b7-b8fa-f28fd64b8795) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111321 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f81dd3c9-91ff-44fc-8e67-113a0372bf24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32269 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30968 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26136 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142255 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180040 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32763 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139240 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139112 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37472 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42369 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105723 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27441 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40873 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114129 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40270 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5537 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40521 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40415 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->