### PR TITLE
Remove ScriptExecutionContext requirement from URLPattern matching

### DIFF
--- a/LayoutTests/fast/url/invalid-url-pattern-context-crash.html
+++ b/LayoutTests/fast/url/invalid-url-pattern-context-crash.html
@@ -13,7 +13,7 @@
             testFrame.remove();
 
             const result = (new FrameURLPattern()).exec();
-            assert_equals(result, null);
+            assert_not_equals(result, null);
         }, "URLPattern with stopped document");
     </script>
     <p>This test passes if WebKit does not crash.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-detached-frame-regexp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-detached-frame-regexp-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Named regexp group matches after the owning frame is detached assert_not_equals: regexp pattern should match got disallowed value null
+PASS Named regexp group matches after the owning frame is detached
 PASS Non-matching regexp input returns null after the owning frame is detached
-FAIL Anonymous regexp group via test() after the owning frame is detached assert_true: anonymous regexp alternation should match after detach expected true got false
-FAIL Regexp groups across multiple components after the owning frame is detached assert_not_equals: multi-component regexp pattern should match after detach got disallowed value null
+PASS Anonymous regexp group via test() after the owning frame is detached
+PASS Regexp groups across multiple components after the owning frame is detached
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -706,6 +706,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/url-pattern/URLPattern.h
     Modules/url-pattern/URLPatternComponent.h
     Modules/url-pattern/URLPatternInit.h
+    Modules/url-pattern/URLPatternOptions.h
+    Modules/url-pattern/URLPatternResult.h
 
     Modules/web-locks/WebLock.h
     Modules/web-locks/WebLockIdentifier.h

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -27,15 +27,12 @@
 #include "URLPattern.h"
 
 #include "ExceptionOr.h"
-#include "ScriptExecutionContext.h"
 #include "URLPatternCanonical.h"
 #include "URLPatternConstructorStringParser.h"
 #include "URLPatternInit.h"
 #include "URLPatternOptions.h"
 #include "URLPatternParser.h"
 #include "URLPatternResult.h"
-#include <JavaScriptCore/JSGlobalObjectInlines.h>
-#include <JavaScriptCore/RegExp.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
@@ -44,7 +41,6 @@
 #include <wtf/text/StringToIntegerConversion.h>
 
 namespace WebCore {
-using namespace JSC;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(URLPattern);
 
@@ -212,12 +208,12 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
 }
 
 // https://urlpattern.spec.whatwg.org/#url-pattern-create
-ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, URLPatternInput&& input, String&& baseURL, URLPatternOptions&& options)
+ExceptionOr<Ref<URLPattern>> URLPattern::create(URLPatternInput&& input, String&& baseURL, URLPatternOptions&& options)
 {
     URLPatternInit init;
 
     if (std::holds_alternative<String>(input) && !std::get<String>(input).isNull()) {
-        auto maybeInit = URLPatternConstructorStringParser(std::get<String>(input)).parse(context);
+        auto maybeInit = URLPatternConstructorStringParser(std::get<String>(input)).parse();
         if (maybeInit.hasException())
             return maybeInit.releaseException();
         init = maybeInit.releaseReturnValue();
@@ -261,7 +257,7 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
 
     Ref result = adoptRef(*new URLPattern(options.ignoreCase));
 
-    auto maybeCompileException = result->compileAllComponents(context, WTF::move(processedInit));
+    auto maybeCompileException = result->compileAllComponents(WTF::move(processedInit));
     if (maybeCompileException.hasException())
         return maybeCompileException.releaseException();
 
@@ -269,13 +265,13 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
 }
 
 // https://urlpattern.spec.whatwg.org/#urlpattern-initialize
-ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, URLPatternInput&& input, URLPatternOptions&& options)
+ExceptionOr<Ref<URLPattern>> URLPattern::create(URLPatternInput&& input, URLPatternOptions&& options)
 {
-    return create(context, WTF::move(input), String { }, WTF::move(options));
+    return create(WTF::move(input), { }, WTF::move(options));
 }
 
 // https://urlpattern.spec.whatwg.org/#build-a-url-pattern-from-a-web-idl-value
-ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, Compatible&& value, const String& baseURL)
+ExceptionOr<Ref<URLPattern>> URLPattern::create(Compatible&& value, const String& baseURL)
 {
     return switchOn(WTF::move(value),
         [&](Ref<URLPattern>&& pattern) -> ExceptionOr<Ref<URLPattern>> {
@@ -284,10 +280,10 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
         [&](URLPatternInit&& init) -> ExceptionOr<Ref<URLPattern>> {
             if (init.baseURL.isNull())
                 init.baseURL = baseURL;
-            return URLPattern::create(context, WTF::move(init), { }, { });
+            return URLPattern::create(WTF::move(init), { }, URLPatternOptions { });
         },
         [&](String&& string) -> ExceptionOr<Ref<URLPattern>> {
-            return URLPattern::create(context, WTF::move(string), String { baseURL }, { });
+            return URLPattern::create(WTF::move(string), String { baseURL }, URLPatternOptions { });
         }
     );
 }
@@ -295,9 +291,9 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
 URLPattern::~URLPattern() = default;
 
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-test
-ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, URLPatternInput&& input, String&& baseURL) const
+ExceptionOr<bool> URLPattern::test(URLPatternInput&& input, String&& baseURL) const
 {
-    auto maybeResult = match(context, WTF::move(input), WTF::move(baseURL));
+    auto maybeResult = match(WTF::move(input), WTF::move(baseURL));
     if (maybeResult.hasException())
         return maybeResult.releaseException();
 
@@ -305,57 +301,54 @@ ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, URLPatternIn
 }
 
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec
-ExceptionOr<std::optional<URLPatternResult>> URLPattern::exec(ScriptExecutionContext& context, URLPatternInput&& input, String&& baseURL) const
+ExceptionOr<std::optional<URLPatternResult>> URLPattern::exec(URLPatternInput&& input, String&& baseURL) const
 {
-    return match(context, WTF::move(input), WTF::move(baseURL));
+    return match(WTF::move(input), WTF::move(baseURL));
 }
 
-ExceptionOr<void> URLPattern::compileAllComponents(ScriptExecutionContext& context, URLPatternInit&& processedInit)
+ExceptionOr<void> URLPattern::compileAllComponents(URLPatternInit&& processedInit)
 {
-    Ref vm = context.vm();
-    JSC::JSLockHolder lock(vm);
-
-    auto maybeProtocolComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.protocol, EncodingCallbackType::Protocol, URLPatternUtilities::URLPatternStringOptions { });
+    auto maybeProtocolComponent = URLPatternUtilities::URLPatternComponent::compile(processedInit.protocol, EncodingCallbackType::Protocol, { });
     if (maybeProtocolComponent.hasException())
         return maybeProtocolComponent.releaseException();
     m_protocolComponent = maybeProtocolComponent.releaseReturnValue();
 
-    auto maybeUsernameComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.username, EncodingCallbackType::Username, URLPatternUtilities::URLPatternStringOptions { });
+    auto maybeUsernameComponent = URLPatternUtilities::URLPatternComponent::compile(processedInit.username, EncodingCallbackType::Username, { });
     if (maybeUsernameComponent.hasException())
         return maybeUsernameComponent.releaseException();
     m_usernameComponent = maybeUsernameComponent.releaseReturnValue();
 
-    auto maybePasswordComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.password, EncodingCallbackType::Password, URLPatternUtilities::URLPatternStringOptions { });
+    auto maybePasswordComponent = URLPatternUtilities::URLPatternComponent::compile(processedInit.password, EncodingCallbackType::Password, { });
     if (maybePasswordComponent.hasException())
         return maybePasswordComponent.releaseException();
     m_passwordComponent = maybePasswordComponent.releaseReturnValue();
 
     auto hostnameEncodingCallbackType = isHostnamePatternIPv6(processedInit.hostname) ? EncodingCallbackType::IPv6Host : EncodingCallbackType::Host;
-    auto maybeHostnameComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.hostname, hostnameEncodingCallbackType, URLPatternUtilities::URLPatternStringOptions { .delimiterCodepoint = "."_s });
+    auto maybeHostnameComponent = URLPatternUtilities::URLPatternComponent::compile(processedInit.hostname, hostnameEncodingCallbackType, { .delimiterCodepoint = "."_s });
     if (maybeHostnameComponent.hasException())
         return maybeHostnameComponent.releaseException();
     m_hostnameComponent = maybeHostnameComponent.releaseReturnValue();
 
-    auto maybePortComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.port, EncodingCallbackType::Port, URLPatternUtilities::URLPatternStringOptions { });
+    auto maybePortComponent = URLPatternUtilities::URLPatternComponent::compile(processedInit.port, EncodingCallbackType::Port, { });
     if (maybePortComponent.hasException())
         return maybePortComponent.releaseException();
     m_portComponent = maybePortComponent.releaseReturnValue();
 
     URLPatternUtilities::URLPatternStringOptions compileOptions { .ignoreCase = m_shouldIgnoreCase };
 
-    auto maybePathnameComponent = m_protocolComponent.matchSpecialSchemeProtocol(context)
-    ? URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.pathname, EncodingCallbackType::Path, URLPatternUtilities::URLPatternStringOptions  { "/"_s, "/"_s, m_shouldIgnoreCase })
-    : URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.pathname, EncodingCallbackType::OpaquePath, compileOptions);
+    auto maybePathnameComponent = m_protocolComponent.matchSpecialSchemeProtocol()
+        ? URLPatternUtilities::URLPatternComponent::compile(processedInit.pathname, EncodingCallbackType::Path, { "/"_s, "/"_s, m_shouldIgnoreCase })
+        : URLPatternUtilities::URLPatternComponent::compile(processedInit.pathname, EncodingCallbackType::OpaquePath, compileOptions);
     if (maybePathnameComponent.hasException())
         return maybePathnameComponent.releaseException();
     m_pathnameComponent = maybePathnameComponent.releaseReturnValue();
 
-    auto maybeSearchComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.search, EncodingCallbackType::Search, compileOptions);
+    auto maybeSearchComponent = URLPatternUtilities::URLPatternComponent::compile(processedInit.search, EncodingCallbackType::Search, compileOptions);
     if (maybeSearchComponent.hasException())
         return maybeSearchComponent.releaseException();
     m_searchComponent = maybeSearchComponent.releaseReturnValue();
 
-    auto maybeHashComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.hash, EncodingCallbackType::Hash, compileOptions);
+    auto maybeHashComponent = URLPatternUtilities::URLPatternComponent::compile(processedInit.hash, EncodingCallbackType::Hash, compileOptions);
     if (maybeHashComponent.hasException())
         return maybeHashComponent.releaseException();
     m_hashComponent = maybeHashComponent.releaseReturnValue();
@@ -388,7 +381,7 @@ static inline void matchHelperAssignInputsFromInit(const URLPatternInit& input, 
 }
 
 // https://urlpattern.spec.whatwg.org/#url-pattern-match
-ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionContext& context, Variant<URL, URLPatternInput>&& input, String&& baseURLString) const
+ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(Variant<URL, URLPatternInput>&& input, String&& baseURLString) const
 {
     URLPatternResult result;
     String protocol, username, password, hostname, port, pathname, search, hash;
@@ -434,49 +427,45 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
             return { std::nullopt };
     }
 
-    auto protocolExecResult = m_protocolComponent.componentExec(context, protocol);
-    if (protocolExecResult.isNull() || protocolExecResult.isUndefined())
+    auto protocolExecResult = m_protocolComponent.componentExec(protocol);
+    if (!protocolExecResult)
         return { std::nullopt };
+    result.protocol = m_protocolComponent.createComponentMatchResult(WTF::move(protocol), *protocolExecResult);
 
-    auto* globalObject = context.globalObject();
-    if (!globalObject)
-        return  { std::nullopt };
-    result.protocol = m_protocolComponent.createComponentMatchResult(globalObject, WTF::move(protocol), protocolExecResult);
-
-    auto usernameExecResult = m_usernameComponent.componentExec(context, username);
-    if (usernameExecResult.isNull() || usernameExecResult.isUndefined())
+    auto usernameExecResult = m_usernameComponent.componentExec(username);
+    if (!usernameExecResult)
         return { std::nullopt };
-    result.username = m_usernameComponent.createComponentMatchResult(globalObject, WTF::move(username), usernameExecResult);
+    result.username = m_usernameComponent.createComponentMatchResult(WTF::move(username), *usernameExecResult);
 
-    auto passwordExecResult = m_passwordComponent.componentExec(context, password);
-    if (passwordExecResult.isNull() || passwordExecResult.isUndefined())
+    auto passwordExecResult = m_passwordComponent.componentExec(password);
+    if (!passwordExecResult)
         return { std::nullopt };
-    result.password = m_passwordComponent.createComponentMatchResult(globalObject, WTF::move(password), passwordExecResult);
+    result.password = m_passwordComponent.createComponentMatchResult(WTF::move(password), *passwordExecResult);
 
-    auto hostnameExecResult = m_hostnameComponent.componentExec(context, hostname);
-    if (hostnameExecResult.isNull() || hostnameExecResult.isUndefined())
+    auto hostnameExecResult = m_hostnameComponent.componentExec(hostname);
+    if (!hostnameExecResult)
         return { std::nullopt };
-    result.hostname = m_hostnameComponent.createComponentMatchResult(globalObject, WTF::move(hostname), hostnameExecResult);
+    result.hostname = m_hostnameComponent.createComponentMatchResult(WTF::move(hostname), *hostnameExecResult);
 
-    auto pathnameExecResult = m_pathnameComponent.componentExec(context, pathname);
-    if (pathnameExecResult.isNull() || pathnameExecResult.isUndefined())
+    auto pathnameExecResult = m_pathnameComponent.componentExec(pathname);
+    if (!pathnameExecResult)
         return { std::nullopt };
-    result.pathname = m_pathnameComponent.createComponentMatchResult(globalObject, WTF::move(pathname), pathnameExecResult);
+    result.pathname = m_pathnameComponent.createComponentMatchResult(WTF::move(pathname), *pathnameExecResult);
 
-    auto portExecResult = m_portComponent.componentExec(context, port);
-    if (portExecResult.isNull() || portExecResult.isUndefined())
+    auto portExecResult = m_portComponent.componentExec(port);
+    if (!portExecResult)
         return { std::nullopt };
-    result.port = m_portComponent.createComponentMatchResult(globalObject, WTF::move(port), portExecResult);
+    result.port = m_portComponent.createComponentMatchResult(WTF::move(port), *portExecResult);
 
-    auto searchExecResult = m_searchComponent.componentExec(context, search);
-    if (searchExecResult.isNull() || searchExecResult.isUndefined())
+    auto searchExecResult = m_searchComponent.componentExec(search);
+    if (!searchExecResult)
         return { std::nullopt };
-    result.search = m_searchComponent.createComponentMatchResult(globalObject, WTF::move(search), searchExecResult);
+    result.search = m_searchComponent.createComponentMatchResult(WTF::move(search), *searchExecResult);
 
-    auto hashExecResult = m_hashComponent.componentExec(context, hash);
-    if (hashExecResult.isNull() || hashExecResult.isUndefined())
+    auto hashExecResult = m_hashComponent.componentExec(hash);
+    if (!hashExecResult)
         return { std::nullopt };
-    result.hash = m_hashComponent.createComponentMatchResult(globalObject, WTF::move(hash), hashExecResult);
+    result.hash = m_hashComponent.createComponentMatchResult(WTF::move(hash), *hashExecResult);
 
     return { result };
 }

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,12 +31,10 @@
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
-class ScriptExecutionContext;
 struct URLPatternOptions;
 struct URLPatternResult;
 template<typename> class ExceptionOr;
@@ -51,17 +50,17 @@ class URLPattern final : public RefCounted<URLPattern> {
 public:
     using URLPatternInput = Variant<String, URLPatternInit>;
 
-    static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, URLPatternInput&&, String&& baseURL, URLPatternOptions&&);
-    static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, URLPatternInput&&, URLPatternOptions&&);
+    static ExceptionOr<Ref<URLPattern>> create(URLPatternInput&&, String&& baseURL, URLPatternOptions&&);
+    static ExceptionOr<Ref<URLPattern>> create(URLPatternInput&&, URLPatternOptions&&);
 
     using Compatible = Variant<String, URLPatternInit, Ref<URLPattern>>;
-    static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, Compatible&&, const String&);
+    static ExceptionOr<Ref<URLPattern>> create(Compatible&&, const String&);
 
     ~URLPattern();
 
-    ExceptionOr<bool> test(ScriptExecutionContext&, URLPatternInput&&, String&& baseURL) const;
+    ExceptionOr<bool> test(URLPatternInput&&, String&& baseURL) const;
 
-    ExceptionOr<std::optional<URLPatternResult>> exec(ScriptExecutionContext&, URLPatternInput&&, String&& baseURL) const;
+    ExceptionOr<std::optional<URLPatternResult>> exec(URLPatternInput&&, String&& baseURL) const;
 
     const String& protocol() const LIFETIME_BOUND { return m_protocolComponent.patternString(); }
     const String& username() const LIFETIME_BOUND { return m_usernameComponent.patternString(); }
@@ -81,8 +80,8 @@ private:
     {
     }
 
-    ExceptionOr<void> compileAllComponents(ScriptExecutionContext&, URLPatternInit&&);
-    ExceptionOr<std::optional<URLPatternResult>> match(ScriptExecutionContext&, Variant<URL, URLPatternInput>&&, String&& baseURLString) const;
+    ExceptionOr<void> compileAllComponents(URLPatternInit&&);
+    ExceptionOr<std::optional<URLPatternResult>> match(Variant<URL, URLPatternInput>&&, String&& baseURLString) const;
 
     const bool m_shouldIgnoreCase;
     URLPatternUtilities::URLPatternComponent m_protocolComponent;

--- a/Source/WebCore/Modules/url-pattern/URLPattern.idl
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.idl
@@ -33,12 +33,12 @@ typedef (USVString or URLPatternInit) URLPatternInput;
 [
     Exposed=(Window,Worker)
 ] interface URLPattern {
-    [CallWith=CurrentScriptExecutionContext] constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options = {});
-    [CallWith=CurrentScriptExecutionContext] constructor(optional URLPatternInput input = {}, optional URLPatternOptions options = {});
+    constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options = {});
+    constructor(optional URLPatternInput input = {}, optional URLPatternOptions options = {});
 
-    [CallWith=CurrentScriptExecutionContext] boolean test(optional URLPatternInput input = {}, optional USVString baseURL);
+    boolean test(optional URLPatternInput input = {}, optional USVString baseURL);
 
-    [CallWith=CurrentScriptExecutionContext] URLPatternResult? exec(optional URLPatternInput input = {}, optional USVString baseURL);
+    URLPatternResult? exec(optional URLPatternInput input = {}, optional USVString baseURL);
 
     readonly attribute USVString protocol;
     readonly attribute USVString username;

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,35 +28,46 @@
 #include "URLPatternComponent.h"
 
 #include "ExceptionOr.h"
-#include "ScriptExecutionContext.h"
 #include "URLPatternCanonical.h"
 #include "URLPatternParser.h"
 #include "URLPatternResult.h"
-#include <JavaScriptCore/JSCJSValueInlines.h>
-#include <JavaScriptCore/JSGlobalObject.h>
-#include <JavaScriptCore/JSObjectInlines.h>
-#include <JavaScriptCore/JSString.h>
-#include <JavaScriptCore/RegExpObject.h>
-#include <JavaScriptCore/StrongInlines.h>
-#include <JavaScriptCore/StructureInlines.h>
-#include <ranges>
+#include <JavaScriptCore/YarrFlags.h>
+#include <JavaScriptCore/YarrInterpreter.h>
+#include <JavaScriptCore/YarrPattern.h>
+#include <wtf/BumpPointerAllocator.h>
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
-using namespace JSC;
 namespace URLPatternUtilities {
 
 URLPatternComponent::URLPatternComponent() = default;
 
-URLPatternComponent::URLPatternComponent(String&& patternString, JSC::Strong<JSC::RegExp>&& regex, Vector<String>&& groupNameList, bool hasRegexpGroupsFromPartsList)
+URLPatternComponent::~URLPatternComponent() = default;
+
+URLPatternComponent::URLPatternComponent(URLPatternComponent&&) = default;
+
+URLPatternComponent& URLPatternComponent::operator=(URLPatternComponent&& other)
+{
+    m_patternString = WTF::move(other.m_patternString);
+    if (other.m_compiledPattern)
+        m_compiledPattern.emplace(WTF::move(*other.m_compiledPattern));
+    else
+        m_compiledPattern.reset();
+    m_groupNameList = WTF::move(other.m_groupNameList);
+    m_hasRegexGroupsFromPartList = other.m_hasRegexGroupsFromPartList;
+    return *this;
+}
+
+URLPatternComponent::URLPatternComponent(String&& patternString, std::optional<CompiledPattern>&& compiled, Vector<String>&& groupNameList, bool hasRegexpGroupsFromPartsList)
     : m_patternString(WTF::move(patternString))
-    , m_regularExpression(WTF::move(regex))
+    , m_compiledPattern(WTF::move(compiled))
     , m_groupNameList(WTF::move(groupNameList))
     , m_hasRegexGroupsFromPartList(hasRegexpGroupsFromPartsList)
 {
 }
 
 // https://urlpattern.spec.whatwg.org/#compile-a-component
-ExceptionOr<URLPatternComponent> URLPatternComponent::compile(Ref<JSC::VM> vm, StringView input, EncodingCallbackType type, const URLPatternStringOptions& options)
+ExceptionOr<URLPatternComponent> URLPatternComponent::compile(StringView input, EncodingCallbackType type, const URLPatternStringOptions& options)
 {
     auto maybePartList = URLPatternParser::parse(input, options, type);
     if (maybePartList.hasException())
@@ -68,68 +80,73 @@ ExceptionOr<URLPatternComponent> URLPatternComponent::compile(Ref<JSC::VM> vm, S
     if (options.ignoreCase)
         flags.add(JSC::Yarr::Flags::IgnoreCase);
 
-    JSC::RegExp* regularExpression = JSC::RegExp::create(vm, regularExpressionString, flags);
-    if (!regularExpression->isValid())
-        return Exception { ExceptionCode::TypeError, "Unable to create RegExp object regular expression from provided URLPattern string."_s };
+    JSC::Yarr::ErrorCode errorCode = JSC::Yarr::ErrorCode::NoError;
+    JSC::Yarr::YarrPattern yarrPattern(regularExpressionString, flags, errorCode);
+    if (JSC::Yarr::hasError(errorCode))
+        return Exception { ExceptionCode::TypeError, makeString("Unable to create RegExp object regular expression from provided URLPattern string: "_s, JSC::Yarr::errorMessage(errorCode)) };
+
+    auto allocator = makeUniqueRef<WTF::BumpPointerAllocator>();
+    auto bytecode = JSC::Yarr::byteCompile(yarrPattern, allocator.ptr(), errorCode, nullptr);
+    if (JSC::Yarr::hasError(errorCode) || !bytecode)
+        return Exception { ExceptionCode::TypeError, "Unable to compile RegExp bytecode from provided URLPattern string."_s };
+
+    // The output offset vector must hold at least (numSubpatterns + 1) * 2 capture offsets.
+    ASSERT(bytecode->m_offsetsSize >= (yarrPattern.m_numSubpatterns + 1) * 2);
 
     String patternString = generatePatternString(partList, options);
-
     bool hasRegexGroups = partList.containsIf([](auto& part) {
         return part.type == PartType::Regexp;
     });
 
-    return URLPatternComponent { WTF::move(patternString), JSC::Strong<JSC::RegExp> { vm, regularExpression }, WTF::move(nameList), hasRegexGroups };
+    CompiledPattern compiled { WTF::move(allocator), makeUniqueRefFromNonNullUniquePtr(WTF::move(bytecode)) };
+
+    return URLPatternComponent { WTF::move(patternString), WTF::move(compiled), WTF::move(nameList), hasRegexGroups };
 }
 
 // https://urlpattern.spec.whatwg.org/#protocol-component-matches-a-special-scheme
-bool URLPatternComponent::matchSpecialSchemeProtocol(ScriptExecutionContext& context) const
+bool URLPatternComponent::matchSpecialSchemeProtocol() const
 {
-    Ref vm = context.vm();
-    JSC::JSLockHolder lock(vm);
-
     static constexpr std::array specialSchemeList { "ftp"_s, "file"_s, "http"_s, "https"_s, "ws"_s, "wss"_s };
-    auto contextObject = context.globalObject();
-    if (!contextObject)
-        return false;
-    auto protocolRegex = JSC::RegExpObject::create(vm, contextObject->regExpStructure(), m_regularExpression.get(), true);
-
-    auto isSchemeMatch = std::ranges::find_if(specialSchemeList, [context = protect(context), &vm, &protocolRegex](const String& scheme) {
-        auto maybeMatch = protocolRegex->exec(context->globalObject(), JSC::jsString(vm, scheme));
-        return !maybeMatch.isNull();
+    return std::ranges::any_of(specialSchemeList, [this](const String& scheme) {
+        return componentExec(scheme).has_value();
     });
-
-    return isSchemeMatch != specialSchemeList.end();
 }
 
-JSC::JSValue URLPatternComponent::componentExec(ScriptExecutionContext& context, StringView comparedString) const
+std::optional<Vector<unsigned>> URLPatternComponent::componentExec(StringView comparedString) const
 {
-    Ref vm = context.vm();
-    JSC::JSLockHolder lock(vm);
+    if (!m_compiledPattern)
+        return std::nullopt;
 
-    auto contextObject = context.globalObject();
-    if (!contextObject)
-        return JSC::JSValue::JSFalse;
-    auto regex = JSC::RegExpObject::create(vm, contextObject->regExpStructure(), m_regularExpression.get(), true);
-    return regex->exec(contextObject, JSC::jsString(vm, comparedString));
+    // m_offsetsSize accounts for (numSubpatterns+1)*2 capture offsets plus any
+    // additional slots for duplicate named capture groups.
+    unsigned outputSize = m_compiledPattern->bytecode->m_offsetsSize;
+    Vector<unsigned> output(outputSize);
+    std::ranges::fill(output, std::numeric_limits<unsigned>::max());
+
+    unsigned result = JSC::Yarr::interpret(m_compiledPattern->bytecode.ptr(), comparedString, 0, output.begin());
+    if (result == std::numeric_limits<unsigned>::max())
+        return std::nullopt;
+
+    return output;
 }
 
 // https://urlpattern.spec.whatwg.org/#create-a-component-match-result
-URLPatternComponentResult URLPatternComponent::createComponentMatchResult(JSC::JSGlobalObject* globalObject, String&& input, const JSC::JSValue& execResult) const
+URLPatternComponentResult URLPatternComponent::createComponentMatchResult(String&& input, const Vector<unsigned>& offsets) const
 {
     URLPatternComponentResult::GroupsRecord groups;
 
-    Ref vm = globalObject->vm();
-
-    auto length = std::min<unsigned>(execResult.get(globalObject, vm->propertyNames->length).toIntegerOrInfinity(globalObject), m_groupNameList.size() + 1);
-
-    for (unsigned index = 1; index < length; ++index) {
-        auto match = execResult.get(globalObject, index);
+    ASSERT(offsets.size() >= (m_groupNameList.size() + 1) * 2);
+    // Offsets 0 and 1 hold the full match; per-group captures start at index 2.
+    unsigned offsetIndex = 2;
+    for (unsigned index = 0; index < m_groupNameList.size(); ++index) {
+        unsigned start = offsets[offsetIndex++];
+        unsigned end = offsets[offsetIndex++];
 
         Variant<std::monostate, String> value;
-        if (!match.isNull() && !match.isUndefined())
-            value = match.toWTFString(globalObject);
+        if (start != std::numeric_limits<unsigned>::max() && end != std::numeric_limits<unsigned>::max())
+            value = StringView(input).substring(start, end - start).toString();
 
-        groups.append(URLPatternComponentResult::NameMatchPair { m_groupNameList[index - 1], WTF::move(value) });
+        groups.append(URLPatternComponentResult::NameMatchPair { m_groupNameList[index], WTF::move(value) });
     }
 
     return URLPatternComponentResult { !input.isEmpty() ? WTF::move(input) : emptyString(), WTF::move(groups) };

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,17 +26,22 @@
 
 #pragma once
 
-#include <JavaScriptCore/Strong.h>
+#include <optional>
+#include <wtf/UniqueRef.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+class BumpPointerAllocator;
+}
 
 namespace JSC {
-class RegExp;
-class VM;
-class JSValue;
-}
+namespace Yarr {
+struct BytecodePattern;
+} }
 
 namespace WebCore {
 
-class ScriptExecutionContext;
 struct URLPatternComponentResult;
 enum class EncodingCallbackType : uint8_t;
 template<typename> class ExceptionOr;
@@ -45,19 +51,27 @@ struct URLPatternStringOptions;
 
 class URLPatternComponent {
 public:
-    static ExceptionOr<URLPatternComponent> compile(Ref<JSC::VM>, StringView, EncodingCallbackType, const URLPatternStringOptions&);
+    static ExceptionOr<URLPatternComponent> compile(StringView, EncodingCallbackType, const URLPatternStringOptions&);
     const String& patternString() const LIFETIME_BOUND { return m_patternString; }
     bool hasRegexGroupsFromPartList() const { return m_hasRegexGroupsFromPartList; }
-    bool matchSpecialSchemeProtocol(ScriptExecutionContext&) const;
-    JSC::JSValue componentExec(ScriptExecutionContext&, StringView) const;
-    URLPatternComponentResult createComponentMatchResult(JSC::JSGlobalObject*, String&& input, const JSC::JSValue& execResult) const;
+    bool matchSpecialSchemeProtocol() const;
+    std::optional<Vector<unsigned>> componentExec(StringView) const;
+    URLPatternComponentResult createComponentMatchResult(String&& input, const Vector<unsigned>& offsets) const;
     URLPatternComponent();
+    ~URLPatternComponent();
+    URLPatternComponent(URLPatternComponent&&);
+    URLPatternComponent& operator=(URLPatternComponent&&);
 
 private:
-    URLPatternComponent(String&&, JSC::Strong<JSC::RegExp>&&, Vector<String>&&, bool);
+    struct CompiledPattern {
+        UniqueRef<WTF::BumpPointerAllocator> allocator;
+        UniqueRef<JSC::Yarr::BytecodePattern> bytecode;
+    };
+
+    URLPatternComponent(String&&, std::optional<CompiledPattern>&&, Vector<String>&&, bool);
 
     String m_patternString;
-    JSC::Strong<JSC::RegExp> m_regularExpression;
+    std::optional<CompiledPattern> m_compiledPattern;
     Vector<String> m_groupNameList;
     bool m_hasRegexGroupsFromPartList { false };
 };

--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
@@ -32,11 +32,8 @@
 #include "URLPatternInit.h"
 #include "URLPatternParser.h"
 #include "URLPatternTokenizer.h"
-#include <JavaScriptCore/RegExp.h>
-#include <JavaScriptCore/StrongInlines.h>
 
 namespace WebCore {
-using namespace JSC;
 
 URLPatternConstructorStringParser::URLPatternConstructorStringParser(StringView input)
     : m_input(input)
@@ -147,18 +144,14 @@ static inline void setInitComponentFromState(URLPatternInit& init, URLPatternCon
 }
 
 // https://urlpattern.spec.whatwg.org/#compute-protocol-matches-a-special-scheme-flag
-ExceptionOr<void> URLPatternConstructorStringParser::computeProtocolMatchSpecialSchemeFlag(ScriptExecutionContext& context)
+ExceptionOr<void> URLPatternConstructorStringParser::computeProtocolMatchSpecialSchemeFlag()
 {
-    Ref vm = context.vm();
-    JSC::JSLockHolder lock(vm);
-
-    auto maybeProtocolComponent = URLPatternUtilities::URLPatternComponent::compile(vm, makeComponentString(), EncodingCallbackType::Protocol, URLPatternUtilities::URLPatternStringOptions { });
+    auto maybeProtocolComponent = URLPatternUtilities::URLPatternComponent::compile(makeComponentString(), EncodingCallbackType::Protocol, URLPatternUtilities::URLPatternStringOptions { });
     if (maybeProtocolComponent.hasException())
         return maybeProtocolComponent.releaseException();
 
     auto protocolComponent = maybeProtocolComponent.releaseReturnValue();
-    m_protocolMatchesSpecialSchemeFlag = protocolComponent.matchSpecialSchemeProtocol(context);
-
+    m_protocolMatchesSpecialSchemeFlag = protocolComponent.matchSpecialSchemeProtocol();
     return { };
 }
 
@@ -202,7 +195,7 @@ void URLPatternConstructorStringParser::changeState(URLPatternConstructorStringP
     m_tokenIncrement = 0;
 }
 
-void URLPatternConstructorStringParser::updateState(ScriptExecutionContext& context)
+void URLPatternConstructorStringParser::updateState()
 {
     switch (m_state) {
     case URLPatternConstructorStringParserState::Init:
@@ -215,7 +208,7 @@ void URLPatternConstructorStringParser::updateState(ScriptExecutionContext& cont
     case URLPatternConstructorStringParserState::Protocol:
         // Look for protocol prefix.
         if (isNonSpecialPatternChararacter(m_tokenIndex, ':')) {
-            auto maybeMatchesSpecialSchemeProtocol = computeProtocolMatchSpecialSchemeFlag(context);
+            auto maybeMatchesSpecialSchemeProtocol = computeProtocolMatchSpecialSchemeFlag();
             if (maybeMatchesSpecialSchemeProtocol.hasException())
                 break; // FIXME: Return exceptions.
             auto nextState = URLPatternConstructorStringParserState::Pathname;
@@ -303,7 +296,7 @@ void URLPatternConstructorStringParser::updateState(ScriptExecutionContext& cont
     }
 }
 
-void URLPatternConstructorStringParser::performParse(ScriptExecutionContext& context)
+void URLPatternConstructorStringParser::performParse()
 {
     while (m_tokenIndex < m_tokenList.size()) {
         m_tokenIncrement = 1;
@@ -347,7 +340,7 @@ void URLPatternConstructorStringParser::performParse(ScriptExecutionContext& con
             }
         }
 
-        updateState(context);
+        updateState();
         m_tokenIndex += m_tokenIncrement;
     }
     if (!m_result.hostname.isNull() && m_result.port.isNull())
@@ -355,14 +348,14 @@ void URLPatternConstructorStringParser::performParse(ScriptExecutionContext& con
 }
 
 // https://urlpattern.spec.whatwg.org/#parse-a-constructor-string
-ExceptionOr<URLPatternInit> URLPatternConstructorStringParser::parse(ScriptExecutionContext& context)
+ExceptionOr<URLPatternInit> URLPatternConstructorStringParser::parse()
 {
     auto maybeTokenList = URLPatternUtilities::Tokenizer(m_input, URLPatternUtilities::TokenizePolicy::Lenient).tokenize();
     if (maybeTokenList.hasException())
         return maybeTokenList.releaseException();
     m_tokenList = maybeTokenList.releaseReturnValue();
 
-    performParse(context);
+    performParse();
 
     return WTF::move(m_result);
 }

--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ScriptExecutionContext.h"
 #include "URLPatternInit.h"
 
 namespace WebCore {
@@ -46,10 +45,10 @@ enum class URLPatternConstructorStringParserState : uint8_t { Init, Protocol, Au
 class URLPatternConstructorStringParser {
 public:
     explicit URLPatternConstructorStringParser(StringView input);
-    ExceptionOr<URLPatternInit> parse(ScriptExecutionContext&);
+    ExceptionOr<URLPatternInit> parse();
 
 private:
-    void performParse(ScriptExecutionContext&);
+    void performParse();
     void NODELETE rewind();
     const URLPatternUtilities::Token& NODELETE getSafeToken(size_t index) const;
     bool NODELETE isNonSpecialPatternChararacter(size_t index, char value) const;
@@ -57,8 +56,8 @@ private:
     bool NODELETE isAuthoritySlashesNext() const;
     String makeComponentString() const;
     void changeState(URLPatternConstructorStringParserState, size_t skip);
-    void updateState(ScriptExecutionContext&);
-    ExceptionOr<void> computeProtocolMatchSpecialSchemeFlag(ScriptExecutionContext&);
+    void updateState();
+    ExceptionOr<void> computeProtocolMatchSpecialSchemeFlag();
 
     StringView m_input;
     Vector<URLPatternUtilities::Token> m_tokenList;

--- a/Source/WebCore/dom/SpeculationRulesMatcher.cpp
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.cpp
@@ -68,12 +68,12 @@ static bool matches(const SpeculationRules::DocumentPredicate&, Document&, HTMLA
 static bool matches(const SpeculationRules::URLPatternPredicate& predicate, HTMLAnchorElement& anchor)
 {
     for (const auto& patternString : predicate.patterns) {
-        ExceptionOr<Ref<URLPattern>> exceptionOrPattern = URLPattern::create(protect(anchor.document()), patternString, String(anchor.document().baseURL().string()), URLPatternOptions());
+        ExceptionOr<Ref<URLPattern>> exceptionOrPattern = URLPattern::create(patternString, String(anchor.document().baseURL().string()), URLPatternOptions());
         if (exceptionOrPattern.hasException())
             continue;
 
         Ref<URLPattern> pattern = exceptionOrPattern.returnValue();
-        auto result = pattern->test(protect(anchor.document()), anchor.href().string(), String(anchor.document().baseURL().string()));
+        auto result = pattern->test(anchor.href().string(), String(anchor.document().baseURL().string()));
         if (!result.hasException() && result.returnValue())
             return true;
     }

--- a/Source/WebCore/workers/service/InstallEvent.cpp
+++ b/Source/WebCore/workers/service/InstallEvent.cpp
@@ -122,7 +122,7 @@ static std::optional<Exception> verifyRouterCondition(RouterCondition& condition
 {
     bool hasCondition = false;
     if (condition.urlPattern) {
-        auto urlPatternOrException = URLPattern::create(scope, std::exchange(*condition.urlPattern, { }), scope.contextData().scriptURL.string());
+        auto urlPatternOrException = URLPattern::create(std::exchange(*condition.urlPattern, { }), scope.contextData().scriptURL.string());
         if (urlPatternOrException.hasException())
             return urlPatternOrException.releaseException();
         condition.urlPattern = urlPatternOrException.releaseReturnValue();

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -267,6 +267,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/TimeRanges.cpp
         Tests/WebCore/TransformationMatrix.cpp
         Tests/WebCore/URLParserTextEncoding.cpp
+        Tests/WebCore/URLPatternTests.cpp
         Tests/WebCore/WritingModeTests.cpp
         Tests/WebCore/XRCompositionLayer.cpp
     )

--- a/Tools/TestWebKitAPI/Tests/WebCore/URLPatternTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/URLPatternTests.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <JavaScriptCore/InitializeThreading.h>
+#include <WebCore/ExceptionOr.h>
+#include <WebCore/URLPattern.h>
+#include <WebCore/URLPatternInit.h>
+#include <WebCore/URLPatternOptions.h>
+#include <WebCore/URLPatternResult.h>
+#include <wtf/MainThread.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+class URLPatternTest : public testing::Test {
+public:
+    void SetUp() override
+    {
+        JSC::initialize();
+        WTF::initializeMainThread();
+    }
+
+protected:
+    RefPtr<WebCore::URLPattern> makePattern(ASCIILiteral pattern, WebCore::URLPatternOptions options = { }) const
+    {
+        auto result = WebCore::URLPattern::create(String(pattern), String(), WTF::move(options));
+        if (result.hasException())
+            return nullptr;
+        return result.releaseReturnValue().ptr();
+    }
+
+    RefPtr<WebCore::URLPattern> makePattern(WebCore::URLPatternInit&& init) const
+    {
+        auto result = WebCore::URLPattern::create(WTF::move(init), WebCore::URLPatternOptions { });
+        if (result.hasException())
+            return nullptr;
+        return result.releaseReturnValue().ptr();
+    }
+};
+
+TEST_F(URLPatternTest, BasicAccessors)
+{
+    auto pattern = makePattern("https://example.com/foo/:id"_s);
+    ASSERT_NE(pattern, nullptr);
+
+    EXPECT_EQ(pattern->protocol(), "https"_s);
+    EXPECT_EQ(pattern->hostname(), "example.com"_s);
+    EXPECT_EQ(pattern->port(), emptyString());
+    EXPECT_FALSE(pattern->pathname().isEmpty());
+}
+
+TEST_F(URLPatternTest, TestMatchesExactURL)
+{
+    auto pattern = makePattern("https://example.com/foo/:id"_s);
+    ASSERT_NE(pattern, nullptr);
+
+    auto result = pattern->test(String("https://example.com/foo/bar"_s), String());
+    ASSERT_FALSE(result.hasException());
+    EXPECT_TRUE(result.returnValue());
+}
+
+TEST_F(URLPatternTest, TestNoMatchDifferentHost)
+{
+    auto pattern = makePattern("https://example.com/foo/:id"_s);
+    ASSERT_NE(pattern, nullptr);
+
+    auto result = pattern->test(String("https://other.com/foo/bar"_s), String());
+    ASSERT_FALSE(result.hasException());
+    EXPECT_FALSE(result.returnValue());
+}
+
+TEST_F(URLPatternTest, TestNoMatchDifferentProtocol)
+{
+    auto pattern = makePattern("https://example.com/foo/:id"_s);
+    ASSERT_NE(pattern, nullptr);
+
+    auto result = pattern->test(String("http://example.com/foo/bar"_s), String());
+    ASSERT_FALSE(result.hasException());
+    EXPECT_FALSE(result.returnValue());
+}
+
+TEST_F(URLPatternTest, ExecReturnsNamedGroup)
+{
+    auto pattern = makePattern("https://example.com/foo/:id"_s);
+    ASSERT_NE(pattern, nullptr);
+
+    auto result = pattern->exec(String("https://example.com/foo/bar"_s), String());
+    ASSERT_FALSE(result.hasException());
+    ASSERT_TRUE(result.returnValue().has_value());
+
+    const auto& match = *result.returnValue();
+    bool foundId = false;
+    for (const auto& group : match.pathname.groups) {
+        if (group.key == "id"_s) {
+            foundId = true;
+            ASSERT_TRUE(std::holds_alternative<String>(group.value));
+            EXPECT_EQ(std::get<String>(group.value), "bar"_s);
+        }
+    }
+    EXPECT_TRUE(foundId);
+}
+
+TEST_F(URLPatternTest, ExecNoMatch)
+{
+    auto pattern = makePattern("https://example.com/foo/:id"_s);
+    ASSERT_NE(pattern, nullptr);
+
+    auto result = pattern->exec(String("https://example.com/other/bar"_s), String());
+    ASSERT_FALSE(result.hasException());
+    EXPECT_FALSE(result.returnValue().has_value());
+}
+
+TEST_F(URLPatternTest, WildcardPathMatches)
+{
+    WebCore::URLPatternInit init;
+    init.protocol = "https"_s;
+    init.hostname = "example.com"_s;
+    init.pathname = "*"_s;
+    auto pattern = makePattern(WTF::move(init));
+    ASSERT_NE(pattern, nullptr);
+
+    auto result = pattern->test(String("https://example.com/anything/at/all"_s), String());
+    ASSERT_FALSE(result.hasException());
+    EXPECT_TRUE(result.returnValue());
+}
+
+TEST_F(URLPatternTest, IgnoreCaseOption)
+{
+    WebCore::URLPatternOptions options;
+    options.ignoreCase = true;
+    auto pattern = makePattern("https://example.com/Foo/:id"_s, WTF::move(options));
+    ASSERT_NE(pattern, nullptr);
+
+    auto result = pattern->test(String("https://example.com/foo/bar"_s), String());
+    ASSERT_FALSE(result.hasException());
+    EXPECT_TRUE(result.returnValue());
+}
+
+TEST_F(URLPatternTest, HasRegExpGroupsFalseForNamedSegments)
+{
+    auto pattern = makePattern("https://example.com/:id"_s);
+    ASSERT_NE(pattern, nullptr);
+    EXPECT_FALSE(pattern->hasRegExpGroups());
+}
+
+TEST_F(URLPatternTest, HasRegExpGroupsTrueForExplicitRegex)
+{
+    WebCore::URLPatternInit init;
+    init.protocol = "https"_s;
+    init.hostname = "example.com"_s;
+    init.pathname = "/(\\d+)"_s;
+    auto pattern = makePattern(WTF::move(init));
+    ASSERT_NE(pattern, nullptr);
+    EXPECT_TRUE(pattern->hasRegExpGroups());
+}
+
+TEST_F(URLPatternTest, ExplicitRegexGroupMatchesAndReturnsCapture)
+{
+    WebCore::URLPatternInit init;
+    init.protocol = "https"_s;
+    init.hostname = "example.com"_s;
+    init.pathname = "/(\\d+)"_s;
+    auto pattern = makePattern(WTF::move(init));
+    ASSERT_NE(pattern, nullptr);
+    ASSERT_TRUE(pattern->hasRegExpGroups());
+
+    auto testResult = pattern->test(String("https://example.com/42"_s), String());
+    ASSERT_FALSE(testResult.hasException());
+    EXPECT_TRUE(testResult.returnValue());
+
+    auto execResult = pattern->exec(String("https://example.com/42"_s), String());
+    ASSERT_FALSE(execResult.hasException());
+    ASSERT_TRUE(execResult.returnValue().has_value());
+
+    const auto& match = *execResult.returnValue();
+    ASSERT_FALSE(match.pathname.groups.isEmpty());
+    ASSERT_TRUE(std::holds_alternative<String>(match.pathname.groups[0].value));
+    EXPECT_EQ(std::get<String>(match.pathname.groups[0].value), "42"_s);
+}
+
+TEST_F(URLPatternTest, InvalidPatternReturnsException)
+{
+    WebCore::URLPatternInit init;
+    init.protocol = "https"_s;
+    init.hostname = "example.com"_s;
+    init.pathname = "/([invalid"_s;
+    auto result = WebCore::URLPattern::create(WTF::move(init), WebCore::URLPatternOptions { });
+    EXPECT_TRUE(result.hasException());
+}
+
+TEST_F(URLPatternTest, BaseURLRelativePattern)
+{
+    auto result = WebCore::URLPattern::create(
+        String("/foo/:id"_s),
+        String("https://example.com"_s),
+        WebCore::URLPatternOptions { });
+    ASSERT_FALSE(result.hasException());
+    auto pattern = result.releaseReturnValue();
+    auto testResult = pattern->test(String("https://example.com/foo/42"_s), String());
+    ASSERT_FALSE(testResult.hasException());
+    EXPECT_TRUE(testResult.returnValue());
+}
+
+TEST_F(URLPatternTest, RelativePatternWithoutBaseURLThrows)
+{
+    auto result = WebCore::URLPattern::create(
+        String("/foo/:id"_s),
+        String(),
+        WebCore::URLPatternOptions { });
+    EXPECT_TRUE(result.hasException());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### c37e989dd6c6c42aa492c194ace00999ffd0841f
<pre>
Remove ScriptExecutionContext requirement from URLPattern matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=316912">https://bugs.webkit.org/show_bug.cgi?id=316912</a>

Reviewed by Youenn Fablet.

In Firefox and Chromium these APIs work even without a valid context,
the WPT tests reproduce this by detaching a frame.

The YARR interpreter works totally fine in this context and should
have feature parity.

Test: Tools/TestWebKitAPI/Tests/WebCore/URLPatternTests.cpp

* LayoutTests/fast/url/invalid-url-pattern-context-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-detached-frame-regexp-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::create):
(WebCore::URLPattern::test const):
(WebCore::URLPattern::exec const):
(WebCore::URLPattern::compileAllComponents):
(WebCore::URLPattern::match const):
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Modules/url-pattern/URLPattern.idl:
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::operator=):
(WebCore::URLPatternUtilities::URLPatternComponent::URLPatternComponent):
(WebCore::URLPatternUtilities::URLPatternComponent::compile):
(WebCore::URLPatternUtilities::URLPatternComponent::matchSpecialSchemeProtocol const):
(WebCore::URLPatternUtilities::URLPatternComponent::componentExec const):
(WebCore::URLPatternUtilities::URLPatternComponent::createComponentMatchResult const):
* Source/WebCore/Modules/url-pattern/URLPatternComponent.h:
* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp:
(WebCore::URLPatternConstructorStringParser::computeProtocolMatchSpecialSchemeFlag):
(WebCore::URLPatternConstructorStringParser::updateState):
(WebCore::URLPatternConstructorStringParser::performParse):
(WebCore::URLPatternConstructorStringParser::parse):
* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h:
* Source/WebCore/dom/SpeculationRulesMatcher.cpp:
(WebCore::matches):
* Source/WebCore/workers/service/InstallEvent.cpp:
(WebCore::verifyRouterCondition):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WebCore/URLPatternTests.cpp: Added.
(TestWebKitAPI::URLPatternTest::makePattern):
(TestWebKitAPI::URLPatternTest::makePattern const):
(TestWebKitAPI::TEST_F(URLPatternTest, BasicAccessors)):
(TestWebKitAPI::TEST_F(URLPatternTest, TestMatchesExactURL)):
(TestWebKitAPI::TEST_F(URLPatternTest, TestNoMatchDifferentHost)):
(TestWebKitAPI::TEST_F(URLPatternTest, TestNoMatchDifferentProtocol)):
(TestWebKitAPI::TEST_F(URLPatternTest, ExecReturnsNamedGroup)):
(TestWebKitAPI::TEST_F(URLPatternTest, ExecNoMatch)):
(TestWebKitAPI::TEST_F(URLPatternTest, WildcardPathMatches)):
(TestWebKitAPI::TEST_F(URLPatternTest, IgnoreCaseOption)):
(TestWebKitAPI::TEST_F(URLPatternTest, HasRegExpGroupsFalseForNamedSegments)):
(TestWebKitAPI::TEST_F(URLPatternTest, HasRegExpGroupsTrueForExplicitRegex)):
(TestWebKitAPI::TEST_F(URLPatternTest, ExplicitRegexGroupMatchesAndReturnsCapture)):
(TestWebKitAPI::TEST_F(URLPatternTest, InvalidPatternReturnsException)):
(TestWebKitAPI::TEST_F(URLPatternTest, BaseURLRelativePattern)):
(TestWebKitAPI::TEST_F(URLPatternTest, RelativePatternWithoutBaseURLThrows)):

Canonical link: <a href="https://commits.webkit.org/317625@main">https://commits.webkit.org/317625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9bfadf006239e51adb93c59d3fa88c6ee261150

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185447 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136938 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117417 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39041 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37422 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37207 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33917 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187868 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145931 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39256 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50134 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145771 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40567 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122330 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116184 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48641 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12187 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48043 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->