### PR TITLE
Don't sandbox symlink scripts in xcodebuild

### DIFF
--- a/Source/JavaScriptCore/Configurations/Base.xcconfig
+++ b/Source/JavaScriptCore/Configurations/Base.xcconfig
@@ -25,7 +25,7 @@
 
 ALWAYS_SEARCH_USER_PATHS = NO;
 ENABLE_USER_SCRIPT_SANDBOXING = YES;
-EXCLUDED_USER_SCRIPT_SANDBOXING_PHASE_NAMES = $(inherited) "Generate Unified Sources" "Generate Derived Sources" "Generate <wtf/Platform.h> args" "Check For Inappropriate Files In Framework" "Check For Inappropriate Macros in External Headers" "Check .xcfilelists" "Copy jsc into JavaScriptCore.framework" "Audit SPI use";
+EXCLUDED_USER_SCRIPT_SANDBOXING_PHASE_NAMES = $(inherited) "Generate Unified Sources" "Generate Derived Sources" "Generate <wtf/Platform.h> args" "Check For Inappropriate Files In Framework" "Check For Inappropriate Macros in External Headers" "Check .xcfilelists" "Copy jsc into JavaScriptCore.framework" "Audit SPI use" "Create Versions/Current/Helpers symlink";
 
 CLANG_CXX_LANGUAGE_STANDARD = c++2b;
 CLANG_CXX_LIBRARY = libc++;

--- a/Source/WebKit/Configurations/Base.xcconfig
+++ b/Source/WebKit/Configurations/Base.xcconfig
@@ -28,7 +28,7 @@ ENABLE_DAEMON_SYMLINKS[sdk=embedded*] = NO
 
 ALWAYS_SEARCH_USER_PATHS = NO;
 ENABLE_USER_SCRIPT_SANDBOXING = YES;
-EXCLUDED_USER_SCRIPT_SANDBOXING_PHASE_NAMES = $(inherited) "Generate Unified Sources" "Generate Derived Sources" "Generate Swift platform args" "Generate Swift TBA availability macros" "Check For Inappropriate Files In Framework" "Check For Inappropriate Macros in External Headers" "Check For Framework Include Consistency" "Check .xcfilelists" "Migrate WebCore and WebKitLegacy Headers" "Copy Custom WebContent Resources to Framework Private Headers" "Copy Profiling Data" "Process WebContent entitlements" "Process Network entitlements" "Process GPU entitlements" "Process Model entitlements" "Process webpushd Entitlements" "Process adattributiond Entitlements" "Process entitlements" "Audit SPI use" "Update Info.plist for RunningBoard management";
+EXCLUDED_USER_SCRIPT_SANDBOXING_PHASE_NAMES = $(inherited) "Generate Unified Sources" "Generate Derived Sources" "Generate Swift platform args" "Generate Swift TBA availability macros" "Check For Inappropriate Files In Framework" "Check For Inappropriate Macros in External Headers" "Check For Framework Include Consistency" "Check .xcfilelists" "Migrate WebCore and WebKitLegacy Headers" "Copy Custom WebContent Resources to Framework Private Headers" "Copy Profiling Data" "Process WebContent entitlements" "Process Network entitlements" "Process GPU entitlements" "Process Model entitlements" "Process webpushd Entitlements" "Process adattributiond Entitlements" "Process entitlements" "Audit SPI use" "Update Info.plist for RunningBoard management" "Create symlinks to XPC services and dylibs";
 
 CLANG_CXX_LANGUAGE_STANDARD = c++2b;
 CLANG_CXX_LIBRARY = libc++;


### PR DESCRIPTION
#### 973d3b16b28b2786090468fdfb5a78db1412a2ee
<pre>
Don&apos;t sandbox symlink scripts in xcodebuild
<a href="https://bugs.webkit.org/show_bug.cgi?id=316916">https://bugs.webkit.org/show_bug.cgi?id=316916</a>
<a href="https://rdar.apple.com/179291122">rdar://179291122</a>

Unreviewed partial revert, EWS unblocker.

We need these symlinks for run-jsc-stress-tests on EWS. This appears to
un-break EWS queues.

Canonical link: <a href="https://commits.webkit.org/315030@main">https://commits.webkit.org/315030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af2c63cf89cecadcfce3ab2d47abcc42e09fb02a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34978 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/177181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bd27b1a-f151-45c2-83da-dc9e27a62a1a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41396 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/177181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf46a045-931e-4b00-8e4d-d2bb61543a21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170845 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/177181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b237883-6a31-4c70-9cee-a83002a2432b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/25883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28554 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/179781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/29132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30272 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/179781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41455 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/179781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42143 "Built successfully") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/105421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25560 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34200 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200563 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40647 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/53879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40044 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5328 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40295 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->