### PR TITLE
Data race in TrackBase::opaqueRoot during GC leading to use-after-free

### DIFF
--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -107,24 +107,18 @@ void TrackBase::setSourceBuffer(SourceBuffer* buffer)
 void TrackBase::setTrackList(TrackListBase& trackList)
 {
     m_trackList = trackList;
+    m_opaqueRoot = WebCoreOpaqueRoot { &trackList };
 }
 
 void TrackBase::clearTrackList()
 {
     m_trackList = nullptr;
+    m_opaqueRoot = WebCoreOpaqueRoot { this };
 }
 
 TrackListBase* TrackBase::trackList() const
 {
     return m_trackList.get();
-}
-
-WebCoreOpaqueRoot TrackBase::opaqueRoot() const
-{
-    // Runs on GC thread.
-    if (SUPPRESS_UNCOUNTED_LOCAL auto* trackList = this->trackList())
-        return trackList->opaqueRoot();
-    return WebCoreOpaqueRoot { const_cast<TrackBase*>(this) };
 }
 
 // See: https://tools.ietf.org/html/bcp47#section-2.1

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/ContextDestructionObserver.h>
 #include <WebCore/WebCoreOpaqueRoot.h>
+#include <atomic>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -80,7 +81,7 @@ public:
     void setTrackList(TrackListBase&);
     void clearTrackList();
     TrackListBase* NODELETE trackList() const;
-    WebCoreOpaqueRoot NODELETE opaqueRoot() const;
+    WebCoreOpaqueRoot NODELETE opaqueRoot() const { return m_opaqueRoot; }
 
     virtual bool enabled() const = 0;
 
@@ -122,6 +123,7 @@ private:
     uint64_t m_logIdentifier { 0 };
 #endif
     WeakPtr<TrackListBase, WeakPtrImplWithEventTargetData> m_trackList;
+    std::atomic<WebCoreOpaqueRoot> m_opaqueRoot { WebCoreOpaqueRoot { this } };
     size_t m_clientRegistrationId;
 };
 


### PR DESCRIPTION
#### 18fef72a7ca0a8567749a2c65ab0b7378f00d80d
<pre>
Data race in TrackBase::opaqueRoot during GC leading to use-after-free
<a href="https://bugs.webkit.org/show_bug.cgi?id=311800">https://bugs.webkit.org/show_bug.cgi?id=311800</a>
<a href="https://rdar.apple.com/173766033">rdar://173766033</a>

Reviewed by Jer Noble.

Store the opaque root value separately from m_trackList to avoid data race during GC.

No new tests since there is no reliable way to test this data race.

* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::setTrackList):
(WebCore::TrackBase::clearTrackList):
(WebCore::TrackBase::opaqueRoot): Deleted.
* Source/WebCore/html/track/TrackBase.h:
(WebCore::TrackBase::opaqueRoot const):

Originally-landed-as: <a href="https://commits.webkit.org/305413.636@safari-7624-branch">305413.636@safari-7624-branch</a> (33be61fed07c). rdar://176058579
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18fef72a7ca0a8567749a2c65ab0b7378f00d80d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125590 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/580aed2a-d216-4eab-a56f-edaa3c1b5b03) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41407 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130626 "Found 2 new test failures: media/track/text-track-cue-is-reachable.html media/track/text-track-is-reachable.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91815 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39d91a38-cb36-4fa6-bb1a-0dd429e2bc7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170856 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33087 "Found 2 new test failures: media/track/text-track-cue-is-reachable.html media/track/text-track-is-reachable.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111143 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/544cfc4f-d892-485c-b81d-c6178db244e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32068 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30771 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25894 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179792 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32544 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30285 "Found 7 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-duration.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region.html media/track/text-track-cue-is-reachable.html media/track/text-track-is-reachable.html media/track/track-description-cue.html media/track/track-extended-descriptions.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139045 "Found 3 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-enter-exit.html media/track/text-track-cue-is-reachable.html media/track/text-track-is-reachable.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41466 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34928 "Found 7 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-duration.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-add-new-track.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-missed.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-sorted-before-dispatch.html media/track/text-track-cue-is-reachable.html media/track/text-track-is-reachable.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138928 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42154 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105433 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34210 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27240 "Found 5 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cue-negative-duration.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-pause-on-exit.html media/track/text-track-cue-is-reachable.html media/track/text-track-is-reachable.html media/track/track-extended-descriptions.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113910 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40055 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5341 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40306 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40200 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->