### PR TITLE
[GFC] Grid items ignore row-gap/column-gap

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-gutters-explicit-placement-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-gutters-explicit-placement-expected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: a 3x3 grid of blue squares on a green background</title>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<style>
+    #grid {
+        width: 310px;
+        height: 310px;
+        background-color: green;
+        position: relative;
+    }
+
+    #grid > div {
+        background-color: blue;
+        width: 90px;
+        height: 90px;
+        position: absolute;
+    }
+
+    #grid :nth-child(1) { top: 0; left: 0; }
+    #grid :nth-child(2) { top: 0; left: 110px; }
+    #grid :nth-child(3) { top: 0; left: 220px; }
+    #grid :nth-child(4) { top: 110px; left: 0; }
+    #grid :nth-child(5) { top: 110px; left: 110px; }
+    #grid :nth-child(6) { top: 110px; left: 220px; }
+    #grid :nth-child(7) { top: 220px; left: 0; }
+    #grid :nth-child(8) { top: 220px; left: 110px; }
+    #grid :nth-child(9) { top: 220px; left: 220px; }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-gutters-explicit-placement.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-gutters-explicit-placement.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: explicitly-placed grid items honor gutters in position and size</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="match" href="grid-gutters-explicit-placement-expected.html">
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<meta name="assert" content="Grid items placed with explicit grid-row and grid-column lines are offset and sized to account for the row-gap and column-gap between the lines they span.">
+<style>
+    #grid {
+        display: grid;
+        width: 310px;
+        gap: 20px;
+        grid-template-columns: 90px 90px 90px;
+        grid-template-rows: 90px 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: blue;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div style="grid-row: 1 / 2; grid-column: 1 / 2;"></div>
+    <div style="grid-row: 1 / 2; grid-column: 2 / 3;"></div>
+    <div style="grid-row: 1 / 2; grid-column: 3 / 4;"></div>
+    <div style="grid-row: 2 / 3; grid-column: 1 / 2;"></div>
+    <div style="grid-row: 2 / 3; grid-column: 2 / 3;"></div>
+    <div style="grid-row: 2 / 3; grid-column: 3 / 4;"></div>
+    <div style="grid-row: 3 / 4; grid-column: 1 / 2;"></div>
+    <div style="grid-row: 3 / 4; grid-column: 2 / 3;"></div>
+    <div style="grid-row: 3 / 4; grid-column: 3 / 4;"></div>
+</div>

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -385,8 +385,10 @@ LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes& track
     auto trackSizesBefore = trackSizes.subspan(0, gridLineIndex);
     auto sumOfTrackSizes = std::reduce(trackSizesBefore.begin(), trackSizesBefore.end());
 
-    // For grid line i, there are i-1 gaps before it (between the i tracks)
-    auto numberOfGaps = gridLineIndex > 0 ? gridLineIndex - 1 : 0;
+    // https://drafts.csswg.org/css-grid-1/#gutters
+    // A grid line used as an item's start edge is preceded by gridLineIndex tracks, and a
+    // gutter follows each of those tracks. So the line is offset by gridLineIndex gutters.
+    auto numberOfGaps = gridLineIndex;
 
     return sumOfTrackSizes + (numberOfGaps * gap);
 }
@@ -395,11 +397,16 @@ LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSi
 {
     ASSERT(endLine > startLine);
 
-    auto startPosition = computeGridLinePosition(startLine, trackSizes, gap);
-    auto endPosition = computeGridLinePosition(endLine, trackSizes, gap);
-    ASSERT(endPosition >= startPosition);
+    // https://drafts.csswg.org/css-grid-1/#gutters
+    // The size of a grid area is the sum of the sizes of the tracks it spans, plus the gutters
+    // *between* those tracks. A span of N tracks contains only N - 1 interior gutters — the
+    // gutter that follows the area's last track belongs to the space between grid areas, not
+    // to the area itself.
+    auto spannedTrackSizes = trackSizes.subspan(startLine, endLine - startLine);
 
-    return endPosition - startPosition;
+    auto sumOfTrackSizes = std::reduce(spannedTrackSizes.begin(), spannedTrackSizes.end());
+    auto numberOfInteriorGaps = spannedTrackSizes.size() - 1;
+    return sumOfTrackSizes + (numberOfInteriorGaps * gap);
 }
 
 LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)


### PR DESCRIPTION
#### 0ea898a2ff9f4b6605ffaf93891267858f1b5e71
<pre>
[GFC] Grid items ignore row-gap/column-gap
<a href="https://bugs.webkit.org/show_bug.cgi?id=316923">https://bugs.webkit.org/show_bug.cgi?id=316923</a>
&lt;<a href="https://rdar.apple.com/179385621">rdar://179385621</a>&gt;

Reviewed by Sammy Gill.

This PR fixes two off by one errors that caused grid items to be mispositioned
and/or oversized with row/column gap set.

computeGridLinePosition accumulates grid track sizes and grid gaps up to line X
and should include X gutters, not x-1 gutters.

gridAreaDimensionSize from grid lines start to end was incorrectly counting
span (end - start) gutters when it should be counting span - 1 gutters.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-gutters-explicit-placement-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-gutters-explicit-placement.html: Added.
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::computeGridLinePosition):
(WebCore::Layout::GridLayoutUtils::gridAreaDimensionSize):

Canonical link: <a href="https://commits.webkit.org/315136@main">https://commits.webkit.org/315136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34b1150362cd8c3cddc74295d8b29f378d932cd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125841 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bb9175b-32e3-4eac-9c83-d5422e73ff5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130836 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e63707b4-b8e9-4c2e-b761-1813b1c01e00) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111348 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04bab0e8-35b0-4558-a0cf-9de8987a99f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32297 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30996 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26164 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142282 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180068 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32791 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139269 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139137 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150585 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105757 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34428 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27472 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114157 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40298 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5568 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->