### PR TITLE
[Site Isolation] Make UserGestureIndicator not require the mainFrameDocument

### DIFF
--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -184,13 +184,9 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
 
     if (isProcessingUserGesture && document && currentToken(vm)->processingUserGesture()) {
         document->updateLastHandledUserGestureTimestamp(currentToken(vm)->startTime());
-        if (processInteractionStyle == ProcessInteractionStyle::Immediate) {
-            RefPtr mainFrameDocument = document->mainFrameDocument();
-            if (mainFrameDocument)
-                ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
-            else
-                LOG_ONCE(SiteIsolation, "Unable to properly construct UserGestureIndicator::UserGestureIndicator() without access to the main frame document ");
-        }
+        if (processInteractionStyle == ProcessInteractionStyle::Immediate)
+            ResourceLoadObserver::singleton().logUserInteractionWithReducedTimeResolution(*document);
+
         if (RefPtr page = document->page()) {
             page->setUserDidInteractWithPage(true);
             page->setUserDidInteractWithPageExcludingForcedUserGestures(processInteractionStyle != ProcessInteractionStyle::Never);


### PR DESCRIPTION
#### 9681e24c3b287eab1f380c38ed7488db874d66fa
<pre>
[Site Isolation] Make UserGestureIndicator not require the mainFrameDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=316924">https://bugs.webkit.org/show_bug.cgi?id=316924</a>
<a href="https://rdar.apple.com/179386506">rdar://179386506</a>

Reviewed by Aditya Keerthi.

After 314903@main, logUserInteractionWithReducedTimeResolution() is capable of
working with a non-mainFrame document. So we amend UserGestureIndicator to not
need to pass in the mainFrameDocument.

It&apos;s not possible to add a new test for this. UserGestureIndicator only calls
logUserInteractionWithReducedTimeResolution() when the ProcessInteractionStyle
passed in is ProcessInteractionStyle::Immediate. This only happens for mouse
and touch events (see EventHandler::handleMousePressEvent and handleTouchEvent)
which are always processed in the main frame first. This means that for those
events, the user interaction is already attributed to the main frame&apos;s origin.
This scenario is covered by existing tests which still pass after this change
with and without site isolation (user-interaction-in-cross-origin-sub-frame.html).

Even though we can&apos;t add a new test, it still makes sense to ensure that
UserGestureIndicator isn&apos;t dependent on accessing the mainFrameDocument.

* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureIndicator::UserGestureIndicator):

Canonical link: <a href="https://commits.webkit.org/315122@main">https://commits.webkit.org/315122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f90a7a5e28d3a57b2c698fac60d195c52c0d8315

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125834 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4875b3a-b871-409c-9ba5-fddacafb495b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130828 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb6153b1-0fc5-473b-aa0f-5bb5c63a4b92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111340 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe3f4792-b13d-48d5-b1a3-3979666a865a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30989 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142277 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180061 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139261 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41702 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37466 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42390 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105747 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34418 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40894 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114150 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40291 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5553 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40542 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->