### PR TITLE
[CMake] DEVELOPER_MODE should be enabled for Apple CMake builds to match Xcode -Werror behavior

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2908,7 +2908,7 @@ sub generateBuildSystemFromCMakeProject
     push @args, '-DSHOW_BINDINGS_GENERATION_PROGRESS=1' unless ($willUseNinja && -t STDOUT);
 
     # Some ports have production mode, but build-webkit should always use developer mode.
-    push @args, "-DDEVELOPER_MODE=ON" unless isAppleWebKit();
+    push @args, "-DDEVELOPER_MODE=ON" if isCMakeBuild();
 
     if (architecture() eq "x86_64" && shouldBuild32Bit()) {
         # CMAKE_LIBRARY_ARCHITECTURE is needed to get the right .pc


### PR DESCRIPTION
#### 479e978939737cbcac5d4c7df0609569a0e50909
<pre>
[CMake] DEVELOPER_MODE should be enabled for Apple CMake builds to match Xcode -Werror behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=316922">https://bugs.webkit.org/show_bug.cgi?id=316922</a>
<a href="https://rdar.apple.com/179383908">rdar://179383908</a>

Reviewed by Elliott Williams.

Tools/Scripts/build-webkit --cmake on Apple ports does not pass -DDEVELOPER_MODE=ON,
so -Werror is never enabled in the CMake build. Warnings that the Xcode build flags
as errors (e.g. -Wmismatched-tags from a struct/class forward-declaration mismatch in
a generated IPC header) slip through silently in a local CMake build and only surface
on the Xcode-based EWS builders. The CMake build should match the Xcode build&apos;s
strictness so the same class of mistakes is caught at the same place during local
development.

Root cause: the conditional in webkitdirs.pm dates back to bug 238556 (2022) when
Apple ports had no CMake path. Now that Mac port can use CMake for local development,
&quot;unless isAppleWebKit()&quot; is stale: Apple CMake builds get configured with
DEVELOPER_MODE off and DEVELOPER_MODE_CXX_FLAGS ends up empty, so
Source/cmake/WebKitMacros.cmake never adds -Werror to the per-target compile options.

Switch the conditional to gate on isCMakeBuild(), which returns true unconditionally
for non-Apple ports and only when --cmake was passed for Apple ports. Behavior:
  - Non-Apple ports: unchanged (still get DEVELOPER_MODE=ON).
  - Apple Xcode build: unchanged (still no DEVELOPER_MODE; xcconfig manages its own
    warning-as-error policy).
  - Apple CMake build: gains DEVELOPER_MODE=ON, which enables -Werror via
    WebKitCompilerFlags.cmake, Swift -Werror flags via WebKitMacros.cmake,
    CMAKE_EXPORT_COMPILE_COMMANDS=ON for IDE integration, and
    -fno-omit-frame-pointer for JSC backtraces.

* Tools/Scripts/webkitdirs.pm:
(generateBuildSystemFromCMakeProject):

Canonical link: <a href="https://commits.webkit.org/315057@main">https://commits.webkit.org/315057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/650305a5ea160b1342b9b98e928fd372ee74d536

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177247 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6ede9b0-b973-4d3d-8baa-2e72b0cbd266) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41464 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130663 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e22d6c6-9abf-4242-adaa-e37a97b9c307) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33139 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111180 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/def65556-8f89-4204-9e55-4f1dc8342bad) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25950 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179847 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/29198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139087 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37424 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42209 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105488 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34257 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200629 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40713 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53898 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40110 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5388 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40361 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40255 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->