### PR TITLE
Substitutions menu item does not have identifier

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
@@ -80,3 +80,11 @@ NSString * const _WKMenuItemIdentifierPlayAllAnimations = @"WKMenuItemIdentifier
 NSString * const _WKMenuItemIdentifierPauseAllAnimations = @"WKMenuItemIdentifierPauseAllAnimations";
 NSString * const _WKMenuItemIdentifierPlayAnimation = @"WKMenuItemIdentifierPlayAnimation";
 NSString * const _WKMenuItemIdentifierPauseAnimation = @"WKMenuItemIdentifierPauseAnimation";
+
+NSString * const _WKMenuItemIdentifierSubstitutionsMenu = @"WKMenuItemIdentifierSubstitutionsMenu";
+NSString * const _WKMenuItemIdentifierShowSubstitutions = @"WKMenuItemIdentifierShowSubstitutions";
+NSString * const _WKMenuItemIdentifierSmartCopyPaste = @"WKMenuItemIdentifierSmartCopyPaste";
+NSString * const _WKMenuItemIdentifierSmartQuotes = @"WKMenuItemIdentifierSmartQuotes";
+NSString * const _WKMenuItemIdentifierSmartDashes = @"WKMenuItemIdentifierSmartDashes";
+NSString * const _WKMenuItemIdentifierSmartLinks = @"WKMenuItemIdentifierSmartLinks";
+NSString * const _WKMenuItemIdentifierTextReplacement = @"WKMenuItemIdentifierTextReplacement";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
@@ -77,3 +77,11 @@ WK_EXTERN NSString * const _WKMenuItemIdentifierPlayAllAnimations WK_API_AVAILAB
 WK_EXTERN NSString * const _WKMenuItemIdentifierPauseAllAnimations WK_API_AVAILABLE(macos(13.3), ios(16.4));
 WK_EXTERN NSString * const _WKMenuItemIdentifierPlayAnimation  WK_API_AVAILABLE(macos(14.0), ios(17.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierPauseAnimation  WK_API_AVAILABLE(macos(14.0), ios(17.0));
+
+WK_EXTERN NSString * const _WKMenuItemIdentifierSubstitutionsMenu WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierShowSubstitutions WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSmartCopyPaste WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSmartQuotes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSmartDashes WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierSmartLinks WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierTextReplacement WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -743,6 +743,27 @@ static RetainPtr<NSString> menuItemIdentifier(const WebCore::ContextMenuAction a
         return _WKMenuItemIdentifierPauseAnimation;
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 
+    case ContextMenuItemTagSubstitutionsMenu:
+        return _WKMenuItemIdentifierSubstitutionsMenu;
+
+    case ContextMenuItemTagShowSubstitutions:
+        return _WKMenuItemIdentifierShowSubstitutions;
+
+    case ContextMenuItemTagSmartCopyPaste:
+        return _WKMenuItemIdentifierSmartCopyPaste;
+
+    case ContextMenuItemTagSmartQuotes:
+        return _WKMenuItemIdentifierSmartQuotes;
+
+    case ContextMenuItemTagSmartDashes:
+        return _WKMenuItemIdentifierSmartDashes;
+
+    case ContextMenuItemTagSmartLinks:
+        return _WKMenuItemIdentifierSmartLinks;
+
+    case ContextMenuItemTagTextReplacement:
+        return _WKMenuItemIdentifierTextReplacement;
+
     default:
         return nil;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
@@ -143,6 +143,38 @@ TEST(ContextMenuTests, ProposedMenuContainsSpellingMenu)
     EXPECT_NOT_NULL([spellingSubmenu itemWithIdentifier:_WKMenuItemIdentifierCheckGrammarWithSpelling]);
 }
 
+TEST(ContextMenuTests, ProposedMenuContainsSubstitutionsMenu)
+{
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block RetainPtr<NSMenu> proposedMenu;
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        proposedMenu = menu;
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate];
+    [webView _setEditable:YES];
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+    [webView mouseDownAtPoint:NSMakePoint(10, 10) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+
+    RetainPtr substitutionsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSubstitutionsMenu];
+    EXPECT_NOT_NULL(substitutionsMenuItem.get());
+
+    RetainPtr substitutionsSubmenu = [substitutionsMenuItem submenu];
+    EXPECT_NOT_NULL([substitutionsSubmenu itemWithIdentifier:_WKMenuItemIdentifierShowSubstitutions]);
+    EXPECT_NOT_NULL([substitutionsSubmenu itemWithIdentifier:_WKMenuItemIdentifierSmartCopyPaste]);
+    EXPECT_NOT_NULL([substitutionsSubmenu itemWithIdentifier:_WKMenuItemIdentifierSmartQuotes]);
+    EXPECT_NOT_NULL([substitutionsSubmenu itemWithIdentifier:_WKMenuItemIdentifierSmartDashes]);
+    EXPECT_NOT_NULL([substitutionsSubmenu itemWithIdentifier:_WKMenuItemIdentifierSmartLinks]);
+    EXPECT_NOT_NULL([substitutionsSubmenu itemWithIdentifier:_WKMenuItemIdentifierTextReplacement]);
+}
+
 TEST(ContextMenuTests, NavigationTypeWhenOpeningLink)
 {
     RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);


### PR DESCRIPTION
#### b6b9714f5ecd35f819fb120cc84e3725aac307ab
<pre>
Substitutions menu item does not have identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=316927">https://bugs.webkit.org/show_bug.cgi?id=316927</a>
<a href="https://rdar.apple.com/178186993">rdar://178186993</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Add an identifier for substitutions menu item so clients can identify
and manipulate it. Extend the support for substitutions submenu items.
Add an API test that mirrors the spelling menu item test, only in this
case it uses the substitutions menu identifier.

* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::menuItemIdentifier):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, ProposedMenuContainsSubstitutionsMenu)):

Canonical link: <a href="https://commits.webkit.org/315060@main">https://commits.webkit.org/315060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c29c341e9546e440d139b3f2f47f0fdb82c2e1e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177272 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f39b8ad0-be4f-4cd9-8c5c-78ff6e7d3b96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41488 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/641aac42-69c6-4469-97cf-a008f2c7bfbf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33151 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111200 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c7764f9-ab0b-46ba-a6ea-25c13fbdeefb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25974 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179871 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30348 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41545 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138989 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37426 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42233 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105513 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34274 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40737 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/113989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40134 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5404 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40279 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->