### PR TITLE
Use-after-free in Element::dispatchBlurEvent

### DIFF
--- a/LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash-expected.txt
+++ b/LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+PASS

--- a/LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash.html
+++ b/LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<div id="host"></div>
+<div id="result"></div>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+
+let shadowRoot = host.attachShadow({ mode: 'open' });
+let victim = document.createElement('div');
+victim.tabIndex = 0;
+victim.textContent = 'Focusable';
+shadowRoot.appendChild(victim);
+victim.focus();
+
+async function runTest() {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.addEventListener('blur', () => {
+        victim.remove();
+        victim = null;
+        GCController.collect();
+    }, true);
+
+    await UIHelper.setWindowIsKey(false);
+    await new Promise((resolve) => {
+        requestAnimationFrame(() => setTimeout(resolve, 0));
+    });
+
+    result.textContent = 'PASS';
+    testRunner.notifyDone();
+}
+
+if (!window.testRunner)
+    document.write('<p>This test requires testRunner.</p>');
+else
+    runTest();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -418,27 +418,26 @@ static inline void dispatchEventsOnWindowAndFocusedElement(Document* document, b
             return;
     }
 
-    if (!focused && document->focusedElement()) {
-        if (document->focusedElement()->transferredFocusToPicker()) {
+    if (RefPtr focusedElement = document->focusedElement(); !focused && focusedElement) {
+        if (focusedElement->transferredFocusToPicker()) {
             // The webpage lost focus because the focused element transferred focus to
             // a non-web-content picker when it was activated. We don't want to post any
             // web-exposed events (e.g. blur) in these cases, so return.
-            document->focusedElement()->didSuppressBlurDueToPickerFocusTransfer();
+            focusedElement->didSuppressBlurDueToPickerFocusTransfer();
             return;
         }
 
-        if (RefPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(*document->focusedElement())) {
+        if (RefPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(*focusedElement)) {
             if (formControlElement->wasChangedSinceLastFormControlChangeEvent())
                 formControlElement->dispatchFormControlChangeEvent();
         }
 
-        if (RefPtr focusedElement = document->focusedElement())
-            focusedElement->dispatchBlurEvent(nullptr);
+        focusedElement->dispatchBlurEvent(nullptr);
     }
 
     document->dispatchWindowEvent(Event::create(focused ? eventNames().focusEvent : eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));
-    if (focused && document->focusedElement())
-        document->focusedElement()->dispatchFocusEvent(nullptr, { });
+    if (RefPtr focusedElement = document->focusedElement(); focused && focusedElement)
+        focusedElement->dispatchFocusEvent(nullptr, { });
 }
 
 static inline bool isFocusableElementOrScopeOwner(Element& element, const FocusEventData& focusEventData)


### PR DESCRIPTION
#### 7aacc6579a0267ca6db554536c3fff0d406686c5
<pre>
Use-after-free in Element::dispatchBlurEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=312365">https://bugs.webkit.org/show_bug.cgi?id=312365</a>
<a href="https://rdar.apple.com/174646151">rdar://174646151</a>

Reviewed by Rupin Mittal, Chris Dumez, and Anne van Kesteren.

Deployed more smart pointers to fix the bug.

Test: fast/events/blur-window-with-focus-in-shadow-tree-crash.html

* LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash-expected.txt: Added.
* LayoutTests/fast/events/blur-window-with-focus-in-shadow-tree-crash.html: Added.
* Source/WebCore/page/FocusController.cpp:
(WebCore::dispatchEventsOnWindowAndFocusedElement):

Originally-landed-as: 305413.673@safari-7624-branch (f045966f731c). <a href="https://rdar.apple.com/176058798">rdar://176058798</a>
Canonical link: <a href="https://commits.webkit.org/315098@main">https://commits.webkit.org/315098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2675ef48b25deb696f13dc50df0f33995c98301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125613 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69ff5adb-6b7b-4ef7-b66c-8ade3661f154) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130637 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/599c454a-b9af-4f8a-a3ba-74d5610e5906) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111154 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f66ee51-fb9a-4a02-87d2-f8684e50d993) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32094 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30797 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25918 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179815 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32567 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139059 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138941 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105456 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25590 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27262 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40681 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113933 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40078 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5362 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40329 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40223 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->