### PR TITLE
Web Inspector: populate Event Listeners sidebar for cross-origin iframe nodes (re)

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/event-listeners-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/event-listeners-frame-target-expected.txt
@@ -1,0 +1,48 @@
+Tests FrameDOMAgent event listener queries and the shadow-tree editing flag: getEventListenersForNode, setEventListenerDisabled, setAllowEditingUserAgentShadowTrees.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.EventListeners
+-- Running test case: Setup
+PASS: Should find a cross-origin frame target.
+PASS: Frame target should have a document.
+PASS: Should find #container.
+PASS: Should find #heading.
+PASS: Should find #button.
+
+-- Running test case: SiteIsolation.DOM.EventListeners.Basic
+PASS: Should return one listener.
+PASS: Listener type should be 'click'.
+PASS: Listener should be a bubble-phase listener.
+PASS: Listener should not be an attribute listener.
+PASS: Listener should have an eventListenerId.
+PASS: Listener handlerName should match the function name.
+
+-- Running test case: SiteIsolation.DOM.EventListeners.CaptureAndBubble
+PASS: Should find the capture listener.
+PASS: Should find the bubble listener.
+PASS: Capture listener should have useCapture=true.
+PASS: Bubble listener should have useCapture=false.
+
+-- Running test case: SiteIsolation.DOM.EventListeners.OnceAndPassive
+PASS: Should find the once listener.
+PASS: Once listener should have once=true.
+PASS: Should find the passive listener.
+PASS: Passive listener should have passive=true.
+
+-- Running test case: SiteIsolation.DOM.EventListeners.IncludeAncestors
+PASS: Should find the ancestor listener attached to document.body.
+
+-- Running test case: SiteIsolation.DOM.EventListeners.SetDisabled
+PASS: Baseline: handler should fire once before being disabled.
+PASS: Should find the basicClickHandler to disable.
+PASS: Handler should not fire while disabled.
+PASS: Handler should fire again once re-enabled.
+
+-- Running test case: SiteIsolation.DOM.EventListeners.SetDisabled.UnknownId
+PASS: setEventListenerDisabled with an unknown id should fail.
+
+-- Running test case: SiteIsolation.DOM.EventListeners.SetAllowEditingUserAgentShadowTrees
+PASS: setAllowEditingUserAgentShadowTrees(true) should succeed.
+PASS: setAllowEditingUserAgentShadowTrees(false) should succeed.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/event-listeners-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/event-listeners-frame-target.html
@@ -1,0 +1,194 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.EventListeners");
+
+    let frameTarget = null;
+    let frameDoc = null;
+    let containerNode = null;
+    let headingNode = null;
+    let buttonNode = null;
+
+    async function evaluateInFrame(expression) {
+        let {result, wasThrown} = await frameTarget.RuntimeAgent.evaluate.invoke({
+            expression,
+            objectGroup: "test",
+            returnByValue: true,
+        });
+        InspectorTest.assert(!wasThrown, `Evaluation should not throw: ${expression}`);
+        return result.value;
+    }
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and expand the DOM tree.",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            if (frameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                frameTarget = committedEvent.data.target;
+            }
+
+            await frameTarget.ensureTargetExecutionContext();
+
+            frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!frameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = docEvent.data.document;
+            }
+            InspectorTest.expectNotNull(frameDoc, "Frame target should have a document.");
+
+            let htmlNode = frameDoc.children.find((child) => child.nodeName() === "HTML");
+            await new Promise((resolve) => htmlNode.getChildNodes(resolve));
+
+            let bodyNode = htmlNode.children.find((child) => child.nodeName() === "BODY");
+            await new Promise((resolve) => bodyNode.getChildNodes(resolve));
+
+            containerNode = bodyNode.children.find((child) => child.getAttribute("id") === "container");
+            InspectorTest.expectNotNull(containerNode, "Should find #container.");
+            await new Promise((resolve) => containerNode.getChildNodes(resolve));
+
+            headingNode = containerNode.children.find((child) => child.getAttribute("id") === "heading");
+            InspectorTest.expectNotNull(headingNode, "Should find #heading.");
+
+            buttonNode = containerNode.children.find((child) => child.getAttribute("id") === "button");
+            InspectorTest.expectNotNull(buttonNode, "Should find #button.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.EventListeners.Basic",
+        description: "getEventListeners should return a listener registered inside the frame.",
+        async test() {
+            await evaluateInFrame("attachBasicClickListener()");
+
+            let {listeners} = await headingNode.getEventListeners({includeAncestors: false});
+            InspectorTest.expectEqual(listeners.length, 1, "Should return one listener.");
+
+            let listener = listeners[0];
+            InspectorTest.expectEqual(listener.type, "click", "Listener type should be 'click'.");
+            InspectorTest.expectEqual(listener.useCapture, false, "Listener should be a bubble-phase listener.");
+            InspectorTest.expectEqual(listener.isAttribute, false, "Listener should not be an attribute listener.");
+            InspectorTest.expectNotEqual(listener.eventListenerId, 0, "Listener should have an eventListenerId.");
+            InspectorTest.expectEqual(listener.handlerName, "basicClickHandler", "Listener handlerName should match the function name.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.EventListeners.CaptureAndBubble",
+        description: "getEventListeners should distinguish capture and bubble listeners.",
+        async test() {
+            await evaluateInFrame("attachCaptureAndBubbleListeners()");
+
+            let {listeners} = await buttonNode.getEventListeners({includeAncestors: false});
+            let captureListener = listeners.find((l) => l.handlerName === "captureHandler");
+            let bubbleListener = listeners.find((l) => l.handlerName === "bubbleHandler");
+
+            InspectorTest.expectNotNull(captureListener, "Should find the capture listener.");
+            InspectorTest.expectNotNull(bubbleListener, "Should find the bubble listener.");
+            InspectorTest.expectEqual(captureListener.useCapture, true, "Capture listener should have useCapture=true.");
+            InspectorTest.expectEqual(bubbleListener.useCapture, false, "Bubble listener should have useCapture=false.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.EventListeners.OnceAndPassive",
+        description: "getEventListeners should report once and passive flags.",
+        async test() {
+            await evaluateInFrame("attachOnceAndPassiveListeners()");
+
+            let {listeners} = await buttonNode.getEventListeners({includeAncestors: false});
+            let onceListener = listeners.find((l) => l.handlerName === "onceHandler");
+            let passiveListener = listeners.find((l) => l.handlerName === "passiveHandler");
+
+            InspectorTest.expectNotNull(onceListener, "Should find the once listener.");
+            InspectorTest.expectEqual(onceListener.once, true, "Once listener should have once=true.");
+
+            InspectorTest.expectNotNull(passiveListener, "Should find the passive listener.");
+            InspectorTest.expectEqual(passiveListener.passive, true, "Passive listener should have passive=true.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.EventListeners.IncludeAncestors",
+        description: "getEventListeners with includeAncestors should return listeners on ancestors.",
+        async test() {
+            await evaluateInFrame("attachAncestorListener()");
+
+            let {listeners} = await headingNode.getEventListeners({includeAncestors: true});
+            let ancestorListener = listeners.find((l) => l.handlerName === "ancestorHandler");
+            InspectorTest.expectNotNull(ancestorListener, "Should find the ancestor listener attached to document.body.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.EventListeners.SetDisabled",
+        description: "setEventListenerDisabled should prevent the handler from firing.",
+        async test() {
+            await evaluateInFrame("resetFireCount()");
+            await evaluateInFrame("dispatchClick('heading')");
+            let baselineCount = await evaluateInFrame("window.fireCount");
+            InspectorTest.expectEqual(baselineCount, 1, "Baseline: handler should fire once before being disabled.");
+
+            let {listeners} = await headingNode.getEventListeners({includeAncestors: false});
+            let basicListener = listeners.find((l) => l.handlerName === "basicClickHandler");
+            InspectorTest.expectNotNull(basicListener, "Should find the basicClickHandler to disable.");
+
+            await frameTarget.DOMAgent.setEventListenerDisabled(basicListener.eventListenerId, true);
+
+            await evaluateInFrame("resetFireCount()");
+            await evaluateInFrame("dispatchClick('heading')");
+            let disabledCount = await evaluateInFrame("window.fireCount");
+            InspectorTest.expectEqual(disabledCount, 0, "Handler should not fire while disabled.");
+
+            await frameTarget.DOMAgent.setEventListenerDisabled(basicListener.eventListenerId, false);
+
+            await evaluateInFrame("resetFireCount()");
+            await evaluateInFrame("dispatchClick('heading')");
+            let reenabledCount = await evaluateInFrame("window.fireCount");
+            InspectorTest.expectEqual(reenabledCount, 1, "Handler should fire again once re-enabled.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.EventListeners.SetDisabled.UnknownId",
+        description: "setEventListenerDisabled with an unknown id should be rejected.",
+        async test() {
+            let threw = false;
+            try {
+                await frameTarget.DOMAgent.setEventListenerDisabled(999999, true);
+            } catch (e) {
+                threw = true;
+            }
+            InspectorTest.expectThat(threw, "setEventListenerDisabled with an unknown id should fail.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.EventListeners.SetAllowEditingUserAgentShadowTrees",
+        description: "setAllowEditingUserAgentShadowTrees should succeed on the frame target.",
+        async test() {
+            await frameTarget.DOMAgent.setAllowEditingUserAgentShadowTrees(true);
+            InspectorTest.pass("setAllowEditingUserAgentShadowTrees(true) should succeed.");
+
+            await frameTarget.DOMAgent.setAllowEditingUserAgentShadowTrees(false);
+            InspectorTest.pass("setAllowEditingUserAgentShadowTrees(false) should succeed.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests FrameDOMAgent event listener queries and the shadow-tree editing flag: getEventListenersForNode, setEventListenerDisabled, setAllowEditingUserAgentShadowTrees.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/event-listeners-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/resources/event-listeners-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/resources/event-listeners-frame.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cross-Origin Event Listeners Frame</title>
+</head>
+<body>
+    <div id="container" data-role="frame-root">
+        <h1 id="heading">Cross-Origin Heading</h1>
+        <button id="button">Click</button>
+    </div>
+    <script>
+    window.fireCount = 0;
+
+    window.basicClickHandler = function basicClickHandler() {
+        window.fireCount++;
+    };
+
+    window.captureHandler = function captureHandler() { };
+    window.bubbleHandler = function bubbleHandler() { };
+    window.onceHandler = function onceHandler() { };
+    window.passiveHandler = function passiveHandler() { };
+    window.ancestorHandler = function ancestorHandler() { };
+
+    window.attachBasicClickListener = function attachBasicClickListener() {
+        document.getElementById("heading").addEventListener("click", window.basicClickHandler);
+    };
+
+    window.attachCaptureAndBubbleListeners = function attachCaptureAndBubbleListeners() {
+        let button = document.getElementById("button");
+        button.addEventListener("click", window.captureHandler, true);
+        button.addEventListener("click", window.bubbleHandler, false);
+    };
+
+    window.attachOnceAndPassiveListeners = function attachOnceAndPassiveListeners() {
+        let button = document.getElementById("button");
+        button.addEventListener("click", window.onceHandler, {once: true});
+        button.addEventListener("wheel", window.passiveHandler, {passive: true});
+    };
+
+    window.attachAncestorListener = function attachAncestorListener() {
+        document.body.addEventListener("click", window.ancestorHandler);
+    };
+
+    window.dispatchClick = function dispatchClick(id) {
+        document.getElementById(id).dispatchEvent(new Event("click", {bubbles: true}));
+    };
+
+    window.resetFireCount = function resetFireCount() {
+        window.fireCount = 0;
+    };
+    </script>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -440,6 +440,7 @@
         {
             "name": "getEventListenersForNode",
             "description": "Returns event listeners relevant to the node.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." },
                 { "name": "includeAncestors", "type": "boolean", "optional": true, "description": "Controls whether ancestor event listeners are included. Defaults to true." }
@@ -451,6 +452,7 @@
         {
             "name": "setEventListenerDisabled",
             "description": "Enable/disable the given event listener. A disabled event listener will not fire.",
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "eventListenerId", "$ref": "EventListenerId" },
                 { "name": "disabled", "type": "boolean" }
@@ -803,7 +805,7 @@
         {
             "name": "setAllowEditingUserAgentShadowTrees",
             "description": "Controls whether any DOM commands work for nodes inside a UserAgent shadow tree.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "allow", "type": "boolean" }
             ]

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -460,6 +460,10 @@ void InspectorInstrumentation::willRemoveEventListenerImpl(InstrumentingAgents& 
 
 bool InspectorInstrumentation::isEventListenerDisabledImpl(InstrumentingAgents& instrumentingAgents, EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
 {
+    if (CheckedPtr frameDOMAgent = instrumentingAgents.persistentFrameDOMAgent()) {
+        if (frameDOMAgent->isEventListenerDisabled(target, eventType, listener, capture))
+            return true;
+    }
     if (CheckedPtr domAgent = instrumentingAgents.persistentDOMAgent())
         return domAgent->isEventListenerDisabled(target, eventType, listener, capture);
     return false;

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -33,6 +33,8 @@
 #include "DocumentInlines.h"
 #include "DocumentType.h"
 #include "ElementInlines.h"
+#include "Event.h"
+#include "EventListener.h"
 #include "EventNames.h"
 #include "FrameInlines.h"
 #include "HTMLFrameOwnerElement.h"
@@ -44,16 +46,22 @@
 #include "InspectorDOMAgent.h"
 #include "InspectorNodeFinder.h"
 #include "InstrumentingAgents.h"
+#include "JSEventListener.h"
+#include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "NodeList.h"
 #include "PseudoElement.h"
+#include "RegisteredEventListener.h"
+#include "ScriptController.h"
 #include "ShadowRoot.h"
 #include "Text.h"
 #include "TextNodeTraversal.h"
 #include "markup.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/TopExceptionScope.h>
 #include <pal/crypto/CryptoDigest.h>
 #include <pal/text/TextEncoding.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -480,6 +488,8 @@ void FrameDOMAgent::reset()
     discardBindings();
     m_document = nullptr;
     m_searchResults.clear();
+    m_eventListenerEntries.clear();
+    m_lastEventListenerId = 1;
 
     m_destroyedDetachedNodeIdentifiers.clear();
     m_destroyedAttachedNodeIdentifiers.clear();
@@ -943,6 +953,212 @@ Inspector::CommandResult<int> FrameDOMAgent::pushNodeByPathToFrontend(const Stri
     }
 
     return makeUnexpected("Missing node for given path"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setAllowEditingUserAgentShadowTrees(bool allow)
+{
+    m_allowEditingUserAgentShadowTrees = allow;
+    return { };
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>>> FrameDOMAgent::getEventListenersForNode(int nodeId, std::optional<bool>&& includeAncestors)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    Vector<RefPtr<EventTarget>> ancestors;
+    ancestors.append(node.get());
+    if (includeAncestors.value_or(true)) {
+        for (RefPtr ancestor = node->parentOrShadowHostNode(); ancestor; ancestor = ancestor->parentOrShadowHostNode())
+            ancestors.append(ancestor.get());
+        if (RefPtr window = node->document().window())
+            ancestors.append(window.get());
+    }
+
+    struct EventListenerInfo {
+        RefPtr<EventTarget> eventTarget;
+        const AtomString eventType;
+        const EventListenerVector eventListeners;
+    };
+
+    Vector<EventListenerInfo> eventInformation;
+    for (size_t i = ancestors.size(); i; --i) {
+        auto& ancestor = ancestors[i - 1];
+        for (auto& eventType : ancestor->eventTypes()) {
+            EventListenerVector filteredListeners;
+            for (auto& listener : ancestor->eventListeners(eventType)) {
+                if (listener->callback().type() == EventListener::JSEventListenerType)
+                    filteredListeners.append(listener);
+            }
+            if (!filteredListeners.isEmpty())
+                eventInformation.append({ ancestor, eventType, WTF::move(filteredListeners) });
+        }
+    }
+
+    auto listeners = JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>::create();
+
+    auto addListener = [&](const Ref<RegisteredEventListener>& listener, const EventListenerInfo& info) {
+        Inspector::Protocol::DOM::EventListenerId identifier = 0;
+        bool disabled = false;
+
+        Ref eventTarget = *info.eventTarget;
+
+        for (auto& inspectorEventListener : m_eventListenerEntries.values()) {
+            if (inspectorEventListener.matches(eventTarget, info.eventType, listener->callback(), listener->useCapture())) {
+                identifier = inspectorEventListener.identifier;
+                disabled = inspectorEventListener.disabled;
+                break;
+            }
+        }
+
+        if (!identifier) {
+            InspectorEventListener inspectorEventListener(m_lastEventListenerId++, eventTarget, info.eventType, listener->callback(), listener->useCapture());
+
+            identifier = inspectorEventListener.identifier;
+            disabled = inspectorEventListener.disabled;
+
+            m_eventListenerEntries.add(identifier, inspectorEventListener);
+        }
+
+        listeners->addItem(buildObjectForEventListener(listener, identifier, eventTarget, info.eventType, disabled));
+    };
+
+    // Get Capturing Listeners (in this order)
+    size_t eventInformationLength = eventInformation.size();
+    for (auto& info : eventInformation) {
+        for (auto& listener : info.eventListeners) {
+            if (listener->useCapture())
+                addListener(listener, info);
+        }
+    }
+
+    // Get Bubbling Listeners (reverse order)
+    for (size_t i = eventInformationLength; i; --i) {
+        const EventListenerInfo& info = eventInformation[i - 1];
+        for (auto& listener : info.eventListeners) {
+            if (!listener->useCapture())
+                addListener(listener, info);
+        }
+    }
+
+    return listeners;
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::setEventListenerDisabled(int eventListenerId, bool disabled)
+{
+    auto it = m_eventListenerEntries.find(eventListenerId);
+    if (it == m_eventListenerEntries.end())
+        return makeUnexpected("Missing event listener for given eventListenerId"_s);
+
+    it->value.disabled = disabled;
+
+    return { };
+}
+
+bool FrameDOMAgent::isEventListenerDisabled(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
+{
+    for (auto& inspectorEventListener : m_eventListenerEntries.values()) {
+        if (inspectorEventListener.matches(target, eventType, listener, capture))
+            return inspectorEventListener.disabled;
+    }
+    return false;
+}
+
+Ref<Inspector::Protocol::DOM::EventListener> FrameDOMAgent::buildObjectForEventListener(const Ref<RegisteredEventListener>& registeredEventListener, Inspector::Protocol::DOM::EventListenerId identifier, EventTarget& eventTarget, const AtomString& eventType, bool disabled)
+{
+    Ref<EventListener> eventListener = registeredEventListener->callback();
+
+    String handlerName;
+    int lineNumber = 0;
+    int columnNumber = 0;
+    String scriptID;
+    if (RefPtr scriptListener = dynamicDowncast<JSEventListener>(eventListener); scriptListener && scriptListener->isolatedWorld()) {
+        RefPtr<Document> document;
+        if (RefPtr scriptExecutionContext = eventTarget.scriptExecutionContext())
+            document = dynamicDowncast<Document>(*scriptExecutionContext);
+        else if (RefPtr node = dynamicDowncast<Node>(eventTarget))
+            document = node->document();
+
+        JSC::JSObject* handlerObject = nullptr;
+        JSC::JSGlobalObject* globalObject = nullptr;
+
+        RefPtr isolatedWorld = scriptListener->isolatedWorld();
+        JSC::JSLockHolder lock(isolatedWorld->vm());
+
+        if (document) {
+            handlerObject = scriptListener->ensureJSFunction(*document);
+            if (RefPtr frame = document->frame()) {
+                CheckedRef script = frame->script();
+                // FIXME: Why do we need the canExecuteScripts check here?
+                if (script->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+                    globalObject = script->globalObject(*isolatedWorld);
+            }
+        }
+
+        if (handlerObject && globalObject) {
+            JSC::VM& vm = globalObject->vm();
+            JSC::JSFunction* handlerFunction = dynamicDowncast<JSC::JSFunction>(handlerObject);
+
+            if (!handlerFunction) {
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+                // If the handler is not actually a function, see if it implements the EventListener interface and use that.
+                auto handleEventValue = handlerObject->get(globalObject, JSC::Identifier::fromString(vm, "handleEvent"_s));
+
+                if (scope.exception()) [[unlikely]]
+                    scope.clearException();
+
+                if (handleEventValue)
+                    handlerFunction = dynamicDowncast<JSC::JSFunction>(handleEventValue);
+            }
+
+            if (handlerFunction && !handlerFunction->isHostOrBuiltinFunction()) {
+                // If the listener implements the EventListener interface, use the class name instead of
+                // "handleEvent", unless it is a plain object.
+                if (handlerFunction != handlerObject)
+                    handlerName = JSC::JSObject::calculatedClassName(handlerObject);
+                if (handlerName.isEmpty() || handlerName == "Object"_s)
+                    handlerName = handlerFunction->calculatedDisplayName(vm);
+
+                if (auto executable = handlerFunction->jsExecutable()) {
+                    lineNumber = executable->firstLine() - 1;
+                    columnNumber = executable->startColumn() - 1;
+                    scriptID = executable->sourceID() == JSC::SourceProvider::nullID ? emptyString() : String::number(executable->sourceID());
+                }
+            }
+        }
+    }
+
+    auto value = Inspector::Protocol::DOM::EventListener::create()
+        .setEventListenerId(identifier)
+        .setType(eventType)
+        .setUseCapture(registeredEventListener->useCapture())
+        .setIsAttribute(eventListener->isAttribute())
+        .release();
+    if (RefPtr node = dynamicDowncast<Node>(eventTarget))
+        value->setNodeId(pushNodePathToFrontend(node.get()));
+    else if (is<LocalDOMWindow>(eventTarget))
+        value->setOnWindow(true);
+    if (!scriptID.isNull()) {
+        auto location = Inspector::Protocol::Debugger::Location::create()
+            .setScriptId(scriptID)
+            .setLineNumber(lineNumber)
+            .release();
+        location->setColumnNumber(columnNumber);
+        value->setLocation(WTF::move(location));
+    }
+    if (!handlerName.isEmpty())
+        value->setHandlerName(handlerName);
+    if (registeredEventListener->isPassive())
+        value->setPassive(true);
+    if (registeredEventListener->isOnce())
+        value->setOnce(true);
+    if (disabled)
+        value->setDisabled(disabled);
+    return value;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
@@ -42,9 +42,12 @@ namespace WebCore {
 class CharacterData;
 class Document;
 class Element;
+class EventListener;
+class EventTarget;
 class LocalFrame;
 class Node;
 class PseudoElement;
+class RegisteredEventListener;
 class ShadowRoot;
 
 // FrameDOMAgent is the per-frame DOM agent for Site Isolation.
@@ -140,6 +143,7 @@ public:
     void pseudoElementCreated(PseudoElement&);
     void pseudoElementDestroyed(PseudoElement&);
     void frameDocumentUpdated(LocalFrame&);
+    bool isEventListenerDisabled(EventTarget&, const AtomString& eventType, EventListener&, bool capture);
 
     // Public accessors
     Node* nodeForId(Inspector::Protocol::DOM::NodeId);
@@ -167,6 +171,41 @@ private:
 
     RefPtr<Node> nodeForPath(const String& path);
 
+    struct InspectorEventListener {
+        Inspector::Protocol::DOM::EventListenerId identifier { 1 };
+        RefPtr<EventTarget> eventTarget;
+        RefPtr<EventListener> eventListener;
+        AtomString eventType;
+        bool useCapture { false };
+        bool disabled { false };
+
+        InspectorEventListener() { }
+
+        InspectorEventListener(Inspector::Protocol::DOM::EventListenerId identifier, EventTarget& target, const AtomString& type, EventListener& listener, bool capture)
+            : identifier(identifier)
+            , eventTarget(&target)
+            , eventListener(&listener)
+            , eventType(type)
+            , useCapture(capture)
+        {
+        }
+
+        bool matches(EventTarget& target, const AtomString& type, EventListener& listener, bool capture)
+        {
+            if (eventTarget.get() != &target)
+                return false;
+            if (eventListener.get() != &listener)
+                return false;
+            if (eventType != type)
+                return false;
+            if (useCapture != capture)
+                return false;
+            return true;
+        }
+    };
+
+    Ref<Inspector::Protocol::DOM::EventListener> buildObjectForEventListener(const Ref<RegisteredEventListener>&, Inspector::Protocol::DOM::EventListenerId, EventTarget&, const AtomString& eventType, bool disabled);
+
     const UniqueRef<Inspector::DOMFrontendDispatcher> m_frontendDispatcher;
     const Ref<Inspector::DOMBackendDispatcher> m_backendDispatcher;
     WeakRef<InstrumentingAgents> m_instrumentingAgents;
@@ -185,8 +224,12 @@ private:
     using SearchResults = HashMap<String, Vector<RefPtr<Node>>>;
     SearchResults m_searchResults;
 
+    HashMap<Inspector::Protocol::DOM::EventListenerId, InspectorEventListener> m_eventListenerEntries;
+    Inspector::Protocol::DOM::EventListenerId m_lastEventListenerId { 1 };
+
     bool m_suppressAttributeModifiedEvent { false };
     bool m_documentRequested { false };
+    bool m_allowEditingUserAgentShadowTrees { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
@@ -72,16 +72,6 @@ Inspector::CommandResult<String> FrameDOMAgent::getAssociatedDataForNode(int)
 }
 #endif
 
-Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>>> FrameDOMAgent::getEventListenersForNode(int, std::optional<bool>&&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::setEventListenerDisabled(int, bool)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
 Inspector::CommandResult<void> FrameDOMAgent::setBreakpointForEventListener(int, RefPtr<JSON::Object>&&)
 {
     return makeUnexpected("Not supported for frame targets"_s);
@@ -229,11 +219,6 @@ Inspector::CommandResult<void> FrameDOMAgent::focus(int)
 Inspector::CommandResult<void> FrameDOMAgent::setInspectedNode(int)
 {
     return makeUnexpected("Not supported for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::setAllowEditingUserAgentShadowTrees(bool)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
 }
 
 Inspector::CommandResult<Ref<Inspector::Protocol::DOM::MediaStats>> FrameDOMAgent::getMediaStats(int)

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -998,17 +998,13 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this._destroyed)
             return Promise.reject("ERROR: node is destroyed");
 
-        // FIXME: <https://webkit.org/b/298980> Event listeners for cross-origin frame nodes are not yet supported.
-        if (this.owningTarget)
-            return Promise.resolve({listeners: []});
-
         includeAncestors ??= true;
 
         console.assert(WI.domManager.inspectedNode === this || !includeAncestors, this, includeAncestors);
 
-        let target = WI.assumingMainTarget();
+        let target = this.owningTarget || WI.assumingMainTarget();
         return target.DOMAgent.getEventListenersForNode.invoke({
-            nodeId: this.id,
+            nodeId: this.backendNodeId,
             includeAncestors,
         });
     }


### PR DESCRIPTION
#### 25f3ce5a5cc11d88871ef07762ce9a4874ab4003
<pre>
Web Inspector: populate Event Listeners sidebar for cross-origin iframe nodes (re)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314761">https://bugs.webkit.org/show_bug.cgi?id=314761</a>
<a href="https://rdar.apple.com/177011541">rdar://177011541</a>

Reviewed by Qianlang Chen.

Wires up the Event Listeners sidebar for cross-origin iframe nodes in the
Elements panel. Ports getEventListenersForNode and setEventListenerDisabled
from InspectorDOMAgent, skipping the debugger-breakpoint bits. Routes
isEventListenerDisabled through FrameDOMAgent so the per-listener disable
toggle is honored during event dispatch in the frame&apos;s process. Declares
the three commands with targetTypes [&quot;frame&quot;, &quot;page&quot;] so FrameTarget exposes
them. Drops the {listeners: []} guard in DOMNode.getEventListeners and
routes through owningTarget + backendNodeId.

setAllowEditingUserAgentShadowTrees is backend storage only; the gate that
reads the flag lands with DOM editing in a follow-up. Relanding after revert.

Test: http/tests/site-isolation/inspector/dom/event-listeners-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/event-listeners-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/event-listeners-frame-target.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/resources/event-listeners-frame.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::isEventListenerDisabledImpl):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
(WebCore::FrameDOMAgent::reset):
(WebCore::FrameDOMAgent::setAllowEditingUserAgentShadowTrees):
(WebCore::FrameDOMAgent::getEventListenersForNode):
(WebCore::FrameDOMAgent::setEventListenerDisabled):
(WebCore::FrameDOMAgent::isEventListenerDisabled):
(WebCore::FrameDOMAgent::buildObjectForEventListener):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp:
(WebCore::FrameDOMAgent::getEventListenersForNode): Deleted.
(WebCore::FrameDOMAgent::setEventListenerDisabled): Deleted.
(WebCore::FrameDOMAgent::setAllowEditingUserAgentShadowTrees): Deleted.
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.getEventListeners):

Canonical link: <a href="https://commits.webkit.org/315055@main">https://commits.webkit.org/315055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff176bfd80231e84b06f1f18daaa89243b2d72a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177221 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21fabf69-6328-4fb0-a6de-90c9c25954f1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130642 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fc36065-ab5e-4b13-b0ef-6dd91c4592ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111159 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58ed5366-7140-4a11-9fea-ff32f33c7644) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25924 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179821 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/29172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32573 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139063 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37425 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105462 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27265 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200603 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40687 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113939 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40084 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5365 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->