### PR TITLE
AX: WebKit should not stitch text across br-elements

### DIFF
--- a/LayoutTests/accessibility/text-stitching-line-break-expected.txt
+++ b/LayoutTests/accessibility/text-stitching-line-break-expected.txt
@@ -1,0 +1,11 @@
+This test ensures we do not stitch text across a line break.
+
+PASS: platformStaticTextValue(text).includes("Hello world!") === true
+PASS: platformStaticTextValue(text).includes("It's me, here to chat.") === false
+PASS: platformStaticTextValue(text).includes("It's me, here to chat.") === true
+PASS: platformStaticTextValue(text).includes("Hello world!") === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world!It's me, here to chat.

--- a/LayoutTests/accessibility/text-stitching-line-break.html
+++ b/LayoutTests/accessibility/text-stitching-line-break.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+Hello world!<br id="line-break">It's me, here to chat.
+
+<script>
+var output = "This test ensures we do not stitch text across a line break.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var text = webArea.childAtIndex(0);
+
+    // A <br> separates the text around it, so the two lines should not stitch into one object.
+    output += expect(`platformStaticTextValue(text).includes("Hello world!")`, "true");
+    output += expect(`platformStaticTextValue(text).includes("It's me, here to chat.")`, "false");
+
+    // Removing the line break should let the now-adjacent text stitch into a single object.
+    document.getElementById("line-break").remove();
+    setTimeout(async function() {
+        output += await expectAsync(`platformStaticTextValue(text).includes("It's me, here to chat.")`, "true");
+        output += expect(`platformStaticTextValue(text).includes("Hello world!")`, "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -981,6 +981,7 @@ accessibility/text-stitching-across-inline-elements.html [ Skip ]
 accessibility/text-stitching-after-atomic-inline.html [ Skip ]
 accessibility/text-stitching-end-text-marker.html [ Skip ]
 accessibility/text-stitching-inside-links.html [ Skip ]
+accessibility/text-stitching-line-break.html [ Skip ]
 
 webkit.org/b/316359 accessibility/aria-hidden-deep-dom-no-crash.html [ Timeout Pass ]
 

--- a/Source/WebCore/accessibility/AXStitchUtilities.cpp
+++ b/Source/WebCore/accessibility/AXStitchUtilities.cpp
@@ -34,6 +34,7 @@
 #include "HTMLLabelElement.h"
 #include "HTMLTableCellElement.h"
 #include "RenderElementInlines.h"
+#include "RenderLineBreak.h"
 #include "RenderObjectStyle.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include <wtf/Scope.h>
@@ -115,6 +116,11 @@ static bool isStitchBreakingElement(Element& element)
 
 StitchAction stitchActionFor(const RenderObject& renderer, const AccessibilityObject& object, StitchingContext& context)
 {
+    if (CheckedPtr lineBreak = dynamicDowncast<RenderLineBreak>(renderer); lineBreak && lineBreak->isBR()) {
+        // A <br> visually separates the text around it, so don't stitch across it.
+        return StitchAction::BreakAndSkip;
+    }
+
     auto isInsideLink = [] (const RenderObject& renderer) {
         return renderer.style().insideLink() != InsideLink::NotInside;
     };


### PR DESCRIPTION
#### d6345c1b144b1d71c17459dcaf209d6a33135922
<pre>
AX: WebKit should not stitch text across br-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=316802">https://bugs.webkit.org/show_bug.cgi?id=316802</a>
<a href="https://rdar.apple.com/179250716">rdar://179250716</a>

Reviewed by Dominic Mazzoni.

Accessibility text-stitching walks a block flow&apos;s inline leaf boxes and
groups adjacent text into a single stitched object. &lt;br&gt; line-break boxes
were never handled, so text on both sides of any number of consecutive
&lt;br&gt;s was stitched together. &lt;br&gt;s typically denote a meaningful separation,
so they should break the stitch instead.

In stitchActionFor(), break and skip when encountering a &lt;br&gt;.

* LayoutTests/accessibility/text-stitching-adjacent-br-elements-expected.txt: Added.
* LayoutTests/accessibility/text-stitching-adjacent-br-elements.html: Added.
* LayoutTests/platform/glib/TestExpectations: Skip new test.
* Source/WebCore/accessibility/AXStitchUtilities.cpp:
(WebCore::stitchActionFor):

Canonical link: <a href="https://commits.webkit.org/315199@main">https://commits.webkit.org/315199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a05c46f4d635134d88b73f8d247588335485d3f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41749 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35324 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177521 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125894 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0657629-d7bc-422b-9035-c386f160d2e3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130884 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91998 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9514e440-cb41-4ecc-9e2b-fffa3c75bfac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111396 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfc67c6d-7839-460c-8d06-dfe29f9441c7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31044 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26217 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142325 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180121 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32844 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139321 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37520 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105824 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34471 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27521 "Unexpected infrastructure issue, retrying build") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40954 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114210 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40351 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5615 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->