### PR TITLE
Changing color-scheme of iframe does not invalidate appearance of embedded document

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin-ref.html
@@ -1,0 +1,16 @@
+<!doctype html>
+
+<style>
+  iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<iframe srcdoc="
+  <style>
+    :root { background-color: purple; }
+  </style>
+"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub-expected.html
@@ -1,0 +1,16 @@
+<!doctype html>
+
+<style>
+  iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<iframe srcdoc="
+  <style>
+    :root { background-color: purple; }
+  </style>
+"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub.html
@@ -1,0 +1,40 @@
+<!doctype html>
+
+<html class="reftest-wait">
+
+<title>prefers-color-scheme propagation to cross-origin iframe - dynamic change</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="color-scheme-iframe-preferred-change-cross-origin-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<style>
+  #iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+
+<iframe id="iframe" style="color-scheme: light"></iframe>
+
+<script>
+  (async () => {
+    await new Promise((resolve) => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html";
+    });
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    iframe.style.colorScheme = "dark";
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    takeScreenshot();
+  })();
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-expected.txt
@@ -1,4 +1,0 @@
-
-
-FAIL Preferred color-scheme of iframe document changed through iframe element color-scheme assert_equals: expected "rgb(128, 0, 128)" but got "rgb(0, 0, 255)"
-

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Preferred color-scheme of same-origin iframe document changed through iframe element color-scheme
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-same-origin.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<title>prefers-color-scheme propagation - dynamic change</title>
+<title>prefers-color-scheme propagation to same-origin iframe - dynamic change</title>
 <link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
 <style>
   iframe {
     display: block;
@@ -18,8 +19,14 @@
       frm.addEventListener("load", resolve, { once: true });
       frm.src = "support/prefers-color-scheme-blue-purple.html";
     });
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
     assert_equals(getComputedStyle(frm.contentDocument.documentElement).backgroundColor, "rgb(0, 0, 255)");
+
     frm.style.colorScheme = "dark";
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
     assert_equals(getComputedStyle(frm.contentDocument.documentElement).backgroundColor, "rgb(128, 0, 128)");
-  }, "Preferred color-scheme of iframe document changed through iframe element color-scheme");
+  }, "Preferred color-scheme of same-origin iframe document changed through iframe element color-scheme");
 </script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10021,6 +10021,12 @@ bool Document::useDarkAppearance([[maybe_unused]] const Style::ComputedStyle* st
 
 void Document::appearanceDidChange()
 {
+    styleScope().didChangeStyleSheetEnvironment();
+    styleScope().evaluateMediaQueriesForAppearanceChange();
+    updateElementsAffectedByMediaQueries();
+    scheduleRenderingUpdate(RenderingUpdateStep::MediaQueryEvaluation);
+    invalidateScrollbars();
+
     if (std::exchange(m_cachedThemeColor, Color()) != themeColor())
         themeColorChanged();
 }

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -362,7 +362,7 @@ void Frame::updateFrameTreeSyncData(const FrameTreeSyncSerializationData& data)
             if (!oldFrameInfo || !newFrameInfo || oldFrameInfo->ownerElementAppearance().contains(FrameOwnerElementAppearance::IsDark) != newFrameInfo->ownerElementAppearance().contains(FrameOwnerElementAppearance::IsDark)) {
                 RefPtr localChildView = localChild->view();
 
-                localChildView->invalidateForBaseBackgroundOrColorSchemeChange();
+                localChildView->invalidateForFrameOwnerColorSchemeChange();
                 protect(localChildView->layoutContext())->scheduleLayout();
             }
         }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4375,7 +4375,15 @@ Color LocalFrameView::baseBackgroundColor() const
     return m_baseBackgroundColor;
 }
 
-void LocalFrameView::invalidateForBaseBackgroundOrColorSchemeChange()
+void LocalFrameView::invalidateForFrameOwnerColorSchemeChange()
+{
+    invalidateForBaseBackgroundChange();
+
+    if (RefPtr document = frame().document())
+        document->appearanceDidChange();
+}
+
+void LocalFrameView::invalidateForBaseBackgroundChange()
 {
     recalculateScrollbarOverlayStyle();
     setNeedsLayoutAfterViewConfigurationChange();
@@ -4396,7 +4404,7 @@ void LocalFrameView::setBaseBackgroundColor(const Color& backgroundColor)
     if (!isViewForDocumentInFrame())
         return;
 
-    invalidateForBaseBackgroundOrColorSchemeChange();
+    invalidateForBaseBackgroundChange();
 }
 
 #if ENABLE(DARK_MODE_CSS)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -215,7 +215,9 @@ public:
     // True if the FrameView is not transparent, and the base background color is opaque.
     bool NODELETE hasOpaqueBackground() const;
 
-    WEBCORE_EXPORT void invalidateForBaseBackgroundOrColorSchemeChange();
+    void invalidateForFrameOwnerColorSchemeChange();
+
+    void invalidateForBaseBackgroundChange();
     WEBCORE_EXPORT Color NODELETE baseBackgroundColor() const;
     WEBCORE_EXPORT void setBaseBackgroundColor(const Color&);
     WEBCORE_EXPORT void updateBackgroundRecursively(const std::optional<Color>& backgroundColor);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4281,11 +4281,6 @@ void Page::accessibilitySettingsDidChange()
 void Page::appearanceDidChange()
 {
     forEachDocument([] (auto& document) {
-        document.styleScope().didChangeStyleSheetEnvironment();
-        document.styleScope().evaluateMediaQueriesForAppearanceChange();
-        document.updateElementsAffectedByMediaQueries();
-        document.scheduleRenderingUpdate(RenderingUpdateStep::MediaQueryEvaluation);
-        document.invalidateScrollbars();
         document.appearanceDidChange();
     });
 }

--- a/Source/WebCore/rendering/RenderFrameBase.cpp
+++ b/Source/WebCore/rendering/RenderFrameBase.cpp
@@ -60,7 +60,7 @@ void RenderFrameBase::styleDidChange(Style::Difference diff, const Style::Comput
     RefPtr document = this->document();
 
     if (document->useDarkAppearance(oldStyle) != document->useDarkAppearance(protect(&style()))) {
-        childFrameView->invalidateForBaseBackgroundOrColorSchemeChange();
+        childFrameView->invalidateForFrameOwnerColorSchemeChange();
         protect(childFrameView->layoutContext())->scheduleLayout();
     }
 }


### PR DESCRIPTION
#### acfa8b8be70ce57a15f18042de84c21197a674d1
<pre>
Changing color-scheme of iframe does not invalidate appearance of embedded document
<a href="https://rdar.apple.com/179177141">rdar://179177141</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316738">https://bugs.webkit.org/show_bug.cgi?id=316738</a>

Reviewed by Antti Koivisto.

The value of color-scheme property on an &lt;iframe&gt; element affects the used color
scheme of the embedded document, which has various consequences that must be
accounted for. 309567@main invalidates the FrameView of the embedded document,
so the iframe background gets repainted (background is transparent or opaque
depending on the color scheme of the &lt;iframe&gt; vs embedded document). But we miss
one thing: the evaluation result of style features like light-dark, system color
and @prefers-color-scheme also changes, so we need to invalidate the style too.

Tests: imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-same-origin.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-same-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change-same-origin.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-change.html.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::appearanceDidChange):
    - Move code that originally was in Page::appearanceDidChange to here, so we could
      use it in LocalFrameView::invalidateForPreferredColorSchemeChange.

* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::updateFrameTreeSyncData):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::invalidateForFrameOwnerColorSchemeChange):
    - New method that calls invalidateForBaseBackgroundChange and appearanceDidChange.

(WebCore::LocalFrameView::invalidateForBaseBackgroundChange):
    - Renamed from invalidateForBaseBackgroundOrColorSchemeChange. Turns out
      color scheme changes requires more invalidation.

(WebCore::LocalFrameView::setBaseBackgroundColor):
(WebCore::LocalFrameView::invalidateForBaseBackgroundOrColorSchemeChange): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::appearanceDidChange):
    - Move all code into Document::appearanceDidChange instead.

* Source/WebCore/rendering/RenderFrameBase.cpp:
(WebCore::RenderFrameBase::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/316467@main">https://commits.webkit.org/316467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/768ddfa7b3f89f0c6505e70229ceb6e94fcb7797

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129464 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133744 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94350 "1 flakes 20 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114215 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34024 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29963 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183881 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36497 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38222 "Found 1 new test failure: http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142450 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142340 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38544 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46174 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110831 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37438 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117862 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44692 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8693 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44092 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44151 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->