### PR TITLE
WKJSHandle keeps documents alive after navigation

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -455,6 +455,9 @@ void JSDOMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
         for (auto& guarded : thisObject->m_guardedObjects)
             guarded->visitAggregateInGCThread(visitor);
+
+        for (auto& slot : thisObject->m_jsHandles.values())
+            visitor.append(slot.object);
     }
 
     if (thisObject->m_readableStreamByteStrategySize)
@@ -467,6 +470,47 @@ void JSDOMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 }
 
 DEFINE_VISIT_CHILDREN(JSDOMGlobalObject);
+
+void JSDOMGlobalObject::addJSHandle(JSHandleIdentifier identifier, JSObject& object)
+{
+    Locker locker { m_gcLock };
+    auto& vm = this->vm();
+    auto result = m_jsHandles.ensure(identifier, [&] {
+        return JSHandleSlot { WriteBarrier<JSObject> { vm, this, &object }, 0 };
+    });
+    ++result.iterator->value.refCount;
+}
+
+void JSDOMGlobalObject::refJSHandle(JSHandleIdentifier identifier)
+{
+    Locker locker { m_gcLock };
+    auto it = m_jsHandles.find(identifier);
+    if (it == m_jsHandles.end())
+        return;
+    ++it->value.refCount;
+}
+
+bool JSDOMGlobalObject::derefJSHandle(JSHandleIdentifier identifier)
+{
+    Locker locker { m_gcLock };
+    auto it = m_jsHandles.find(identifier);
+    if (it == m_jsHandles.end())
+        return false;
+    if (--it->value.refCount)
+        return false;
+    m_jsHandles.remove(it);
+    return true;
+}
+
+JSObject* JSDOMGlobalObject::jsHandle(JSHandleIdentifier identifier) const WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+{
+    // We don't need to grab m_gcLock here because m_jsHandles is only mutated on the main thread.
+    // m_gcLock is only used to protect against the main thread mutating m_jsHandles at the same
+    // time as the GC thread reading from m_jsHandles.
+    ASSERT(!Thread::mayBeGCThread());
+    auto it = m_jsHandles.find(identifier);
+    return it == m_jsHandles.end() ? nullptr : it->value.object.get();
+}
 
 void JSDOMGlobalObject::promiseRejectionTracker(JSGlobalObject* jsGlobalObject, JSPromise* promise, JSPromiseRejectionOperation operation)
 {

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -28,8 +28,10 @@
 
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/WeakGCMap.h>
+#include <WebCore/ProcessQualified.h>
 #include <wtf/Compiler.h>
 #include <wtf/Forward.h>
+#include <wtf/ObjectIdentifier.h>
 #include <wtf/RefPtr.h>
 
 namespace JSC {
@@ -49,6 +51,10 @@ class JSBuiltinInternalFunctions;
 class Event;
 class DOMWrapperWorld;
 class ScriptExecutionContext;
+
+struct JSHandleIdentifierType;
+using WebProcessJSHandleIdentifier = ObjectIdentifier<JSHandleIdentifierType>;
+using JSHandleIdentifier = ProcessQualified<WebProcessJSHandleIdentifier>;
 
 using JSDOMStructureMap = HashMap<const JSC::ClassInfo*, JSC::WriteBarrier<JSC::Structure>>;
 using DOMGuardedObjectSet = HashSet<DOMGuardedObject*>;
@@ -124,6 +130,11 @@ public:
     bool hasScriptErrorCallbacks() const;
     void invokeScriptErrorCallbacks(const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber) const;
 
+    void addJSHandle(JSHandleIdentifier, JSC::JSObject&);
+    void refJSHandle(JSHandleIdentifier);
+    bool derefJSHandle(JSHandleIdentifier);
+    JSC::JSObject* jsHandle(JSHandleIdentifier) const;
+
 protected:
     JSDOMGlobalObject(JSC::VM&, JSC::Structure*, Ref<DOMWrapperWorld>&&, const JSC::GlobalObjectMethodTable* = nullptr);
     void finishCreation(JSC::VM&);
@@ -162,6 +173,12 @@ private:
     JSC::WeakGCMap<CrossOriginMapKey, JSC::GetterSetter> m_crossOriginGetterSetterMap;
     JSC::Weak<JSC::JSObject> m_readableStreamByteStrategySize;
     Vector<ScriptErrorCallback> m_scriptErrorCallbacks;
+
+    struct JSHandleSlot {
+        JSC::WriteBarrier<JSC::JSObject> object;
+        size_t refCount { 0 };
+    };
+    HashMap<JSHandleIdentifier, JSHandleSlot> m_jsHandles WTF_GUARDED_BY_LOCK(m_gcLock);
 };
 
 JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext&, DOMWrapperWorld&);

--- a/Source/WebCore/page/WebKitJSHandle.cpp
+++ b/Source/WebCore/page/WebKitJSHandle.cpp
@@ -28,23 +28,25 @@
 
 #include "DOMWindow.h"
 #include "Frame.h"
+#include "JSDOMGlobalObject.h"
 #include "JSWindowProxy.h"
-#include <JavaScriptCore/JSCellInlines.h>
-#include <JavaScriptCore/JSObject.h>
-#include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/Weak.h>
+#include <JavaScriptCore/WeakInlines.h>
 
 namespace WebCore {
 
-struct JSHandleData {
-    JSC::Strong<JSC::JSObject> strongReference;
-    size_t refCount { 0 };
-};
-using HandleMap = HashMap<JSHandleIdentifier, JSHandleData>;
-static HandleMap& NODELETE handleMap()
+using HandleToGlobalMap = HashMap<JSHandleIdentifier, JSC::Weak<JSDOMGlobalObject>>;
+static HandleToGlobalMap& handleToGlobalMap()
 {
-    static MainThreadNeverDestroyed<HandleMap> map;
+    static MainThreadNeverDestroyed<HandleToGlobalMap> map;
     return map.get();
+}
+
+static JSDOMGlobalObject* globalObjectForIdentifier(JSHandleIdentifier identifier)
+{
+    auto it = handleToGlobalMap().find(identifier);
+    return it == handleToGlobalMap().end() ? nullptr : it->value.get();
 }
 
 Ref<WebKitJSHandle> WebKitJSHandle::create(JSC::JSObject* object)
@@ -59,34 +61,23 @@ WebKitJSHandle::~WebKitJSHandle()
 
 void WebKitJSHandle::jsHandleSentToAnotherProcess(JSHandleIdentifier identifier)
 {
-    auto it = handleMap().find(identifier);
-    if (it == handleMap().end()) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    ASSERT(it->value.refCount);
-    ++it->value.refCount;
+    if (auto* global = globalObjectForIdentifier(identifier))
+        global->refJSHandle(identifier);
 }
 
 void WebKitJSHandle::jsHandleDestroyed(JSHandleIdentifier identifier)
 {
-    auto it = handleMap().find(identifier);
-    if (it == handleMap().end()) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    if (!--it->value.refCount)
-        handleMap().remove(identifier);
+    auto* global = globalObjectForIdentifier(identifier);
+    if (!global || global->derefJSHandle(identifier))
+        handleToGlobalMap().remove(identifier);
 }
 
 JSC::JSObject* WebKitJSHandle::objectForIdentifier(JSHandleIdentifier identifier)
 {
-    auto it = handleMap().find(identifier);
-    if (it == handleMap().end()) {
-        ASSERT_NOT_REACHED();
+    auto* global = globalObjectForIdentifier(identifier);
+    if (!global)
         return nullptr;
-    }
-    return it->value.strongReference.get();
+    return global->jsHandle(identifier);
 }
 
 static Markable<FrameIdentifier> NODELETE windowFrameIdentifier(JSC::JSObject* object)
@@ -102,14 +93,11 @@ WebKitJSHandle::WebKitJSHandle(JSC::JSObject* object)
     : m_identifier(JSHandleIdentifier(WebProcessJSHandleIdentifier(reinterpret_cast<uintptr_t>(object)), Process::identifier()))
     , m_windowFrameIdentifier(WebCore::windowFrameIdentifier(object))
 {
-    auto addResult = handleMap().ensure(m_identifier, [&] {
-        return JSHandleData {
-            JSC::Strong<JSC::JSObject> { object->vm(), object },
-            0 // Immediately incremented.
-        };
-    });
-    auto& data = addResult.iterator->value;
-    data.refCount++;
+    auto* global = dynamicDowncast<JSDOMGlobalObject>(object->realmMayBeNull());
+    if (!global)
+        return;
+    global->addJSHandle(m_identifier, *object);
+    handleToGlobalMap().set(m_identifier, JSC::Weak<JSDOMGlobalObject> { global });
 }
 
 }

--- a/Source/WebCore/page/WebKitJSHandle.h
+++ b/Source/WebCore/page/WebKitJSHandle.h
@@ -47,9 +47,9 @@ using JSHandleIdentifier = ProcessQualified<WebProcessJSHandleIdentifier>;
 class WEBCORE_EXPORT WebKitJSHandle : public RefCountedAndCanMakeWeakPtr<WebKitJSHandle> {
 public:
     static Ref<WebKitJSHandle> create(JSC::JSObject*);
-    static JSC::JSObject* NODELETE objectForIdentifier(JSHandleIdentifier);
+    static JSC::JSObject* objectForIdentifier(JSHandleIdentifier);
     static void jsHandleDestroyed(JSHandleIdentifier);
-    static void NODELETE jsHandleSentToAnotherProcess(JSHandleIdentifier);
+    static void jsHandleSentToAnotherProcess(JSHandleIdentifier);
     ~WebKitJSHandle();
 
     JSHandleIdentifier identifier() const { return m_identifier; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1025,6 +1025,16 @@ static WebCore::EditableLinkBehavior NODELETE toEditableLinkBehavior(_WKEditable
     protect(*_preferences)->setServiceWorkerEntitlementDisabledForTesting(disable);
 }
 
+- (void)_setUsesPageCache:(BOOL)enabled
+{
+    protect(*_preferences)->setUsesBackForwardCache(enabled);
+}
+
+- (BOOL)_usesPageCache
+{
+    return protect(*_preferences)->usesBackForwardCache();
+}
+
 #if PLATFORM(MAC)
 - (void)_setCanvasUsesAcceleratedDrawing:(BOOL)enabled
 {
@@ -1084,16 +1094,6 @@ static WebCore::EditableLinkBehavior NODELETE toEditableLinkBehavior(_WKEditable
 - (BOOL)_localFileContentSniffingEnabled
 {
     return protect(*_preferences)->localFileContentSniffingEnabled();
-}
-
-- (void)_setUsesPageCache:(BOOL)enabled
-{
-    protect(*_preferences)->setUsesBackForwardCache(enabled);
-}
-
-- (BOOL)_usesPageCache
-{
-    return protect(*_preferences)->usesBackForwardCache();
 }
 
 - (void)_setShouldPrintBackgrounds:(BOOL)enabled

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -207,6 +207,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setUpdateSceneGeometryEnabled:) BOOL _updateSceneGeometryEnabled WK_API_AVAILABLE(visionos(26.4));
 @property (nonatomic, setter=_setRequiresPageVisibilityForVideoToBeNowPlayingForTesting:) BOOL _requiresPageVisibilityForVideoToBeNowPlayingForTesting WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 @property (nonatomic, setter=_setSiteIsolationEnabled:) BOOL _siteIsolationEnabled WK_API_AVAILABLE(macos(26.0), ios(26.0), visionos(26.0));
+@property (nonatomic, setter=_setUsesPageCache:) BOOL _usesPageCache WK_API_AVAILABLE(macos(10.13.4), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setWebGLEnabled:) BOOL _webGLEnabled WK_API_AVAILABLE(macos(10.13.4));
@@ -216,7 +217,6 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setDOMTimersThrottlingEnabled:) BOOL _domTimersThrottlingEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setWebArchiveDebugModeEnabled:) BOOL _webArchiveDebugModeEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setLocalFileContentSniffingEnabled:) BOOL _localFileContentSniffingEnabled WK_API_AVAILABLE(macos(10.13.4));
-@property (nonatomic, setter=_setUsesPageCache:) BOOL _usesPageCache WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setShouldPrintBackgrounds:) BOOL _shouldPrintBackgrounds WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setWebSecurityEnabled:) BOOL _webSecurityEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setUniversalAccessFromFileURLsAllowed:) BOOL _universalAccessFromFileURLsAllowed WK_API_AVAILABLE(macos(10.13.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -158,6 +158,8 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 - (void)_isLayerTreeFrozenForTesting:(void (^)(BOOL frozen))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
+- (void)_numberOfLiveDocumentsForTesting:(void (^)(NSUInteger count))completionHandler;
+
 - (void)_computePagesForPrinting:(_WKFrameHandle *)handle completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 - (void)_setConnectedToHardwareConsoleForTesting:(BOOL)connected;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -750,6 +750,17 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     });
 }
 
+- (void)_numberOfLiveDocumentsForTesting:(void (^)(NSUInteger count))completionHandler
+{
+    RefPtr pageForTesting = _page->pageForTesting();
+    if (!pageForTesting)
+        return completionHandler(0);
+
+    pageForTesting->numberOfLiveDocuments([completionHandler = makeBlockPtr(completionHandler)](uint64_t count) {
+        completionHandler(static_cast<NSUInteger>(count));
+    });
+}
+
 - (void)_computePagesForPrinting:(_WKFrameHandle *)handle completionHandler:(void(^)(void))completionHandler
 {
     WebKit::PrintInfo printInfo;

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -89,6 +89,11 @@ void WebPageProxyTesting::isLayerTreeFrozen(CompletionHandler<void(bool)>&& comp
     sendWithAsyncReply(Messages::WebPageTesting::IsLayerTreeFrozen(), WTF::move(completionHandler));
 }
 
+void WebPageProxyTesting::numberOfLiveDocuments(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::WebPageTesting::NumberOfLiveDocuments(), WTF::move(completionHandler));
+}
+
 void WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&& completionHandler)
 {
     protect(protect(protect(page())->websiteDataStore())->networkProcess())->setCrossSiteLoadWithLinkDecorationForTesting(protect(page())->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTF::move(completionHandler));

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -46,6 +46,7 @@ public:
     static Ref<WebPageProxyTesting> create(WebPageProxy& page) { return adoptRef(*new WebPageProxyTesting(page)); }
 
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);
+    void numberOfLiveDocuments(CompletionHandler<void(uint64_t)>&&);
     void dispatchActivityStateUpdate();
     void setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&&);
     void setPermissionLevel(const String& origin, bool allowed);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1678,7 +1678,7 @@ void WebFrame::findFocusableElementContinuingFromFrame(WebCore::FocusDirection d
     }
 }
 
-static RefPtr<Node> NODELETE nodeFromJSHandleIdentifier(JSHandleIdentifier identifier)
+static RefPtr<Node> nodeFromJSHandleIdentifier(JSHandleIdentifier identifier)
 {
     auto* object = WebKitJSHandle::objectForIdentifier(identifier);
     if (!object)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -35,6 +35,7 @@
 #include "WebPageTestingMessages.h"
 #include "WebProcess.h"
 #include <WebCore/BackForwardController.h>
+#include <WebCore/Document.h>
 #include <WebCore/DocumentView.h>
 #include <WebCore/Editor.h>
 #include <WebCore/FocusController.h>
@@ -71,6 +72,11 @@ WebPageTesting::~WebPageTesting()
 void WebPageTesting::isLayerTreeFrozen(CompletionHandler<void(bool)>&& completionHandler)
 {
     completionHandler(m_page && !!m_page->layerTreeFreezeReasons());
+}
+
+void WebPageTesting::numberOfLiveDocuments(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    completionHandler(WebCore::Document::allDocuments().size());
 }
 
 void WebPageTesting::setPermissionLevel(const String& origin, bool allowed)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -56,6 +56,7 @@ private:
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
 
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);
+    void numberOfLiveDocuments(CompletionHandler<void(uint64_t)>&&);
     void setPermissionLevel(const String& origin, bool allowed);
     void isEditingCommandEnabled(const String& commandName, CompletionHandler<void(bool)>&&);
     void resetStateBetweenTests();

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -26,6 +26,7 @@
 ]
 messages -> WebPageTesting {
     IsLayerTreeFrozen() -> (bool isFrozen)
+    NumberOfLiveDocuments() -> (uint64_t count)
     SetPermissionLevel(String origin, bool allowed)
     IsEditingCommandEnabled(String commandName) -> (bool result) Synchronous
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandle.mm
@@ -32,6 +32,9 @@
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKContentWorldPrivate.h>
 #import <WebKit/WKJSHandle.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebpagePreferencesPrivate.h>
 #import <WebKit/_WKContentWorldConfiguration.h>
 #import <WebKit/_WKFeature.h>
@@ -56,6 +59,7 @@ TEST(JSHandle, Basic)
     HTTPServer server({
         { "/example"_s, { "<iframe id=onlyframe src='https://webkit.org/webkit'></iframe><div id=onlydiv></div>"_s } },
         { "/webkit"_s, { "hi"_s } },
+        { "/foobar"_s, { "<p>after navigation</p>"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
     RetainPtr configuration = server.httpsProxyConfiguration();
@@ -104,9 +108,23 @@ TEST(JSHandle, Basic)
 
     result = [webView objectByEvaluatingJavaScript:@"function returnThirty() { return '30'; }; window.webkit.createJSHandle(returnThirty)" inFrame:nil inContentWorld:world.get()];
     EXPECT_WK_STREQ([webView objectByCallingAsyncFunction:@"return n()" withArguments:@{ @"n" : result.get() } inFrame:nil inContentWorld:world.get()], "30");
+    RetainPtr<WKJSHandle> funcRef = (WKJSHandle *)result.get();
+
+    result = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle({greeting: 'hi'})" inFrame:nil inContentWorld:world.get()];
+    EXPECT_WK_STREQ([webView objectByCallingAsyncFunction:@"return n.greeting" withArguments:@{ @"n" : result.get() } inFrame:nil inContentWorld:world.get()], "hi");
+    RetainPtr<WKJSHandle> plainObjectRef = (WKJSHandle *)result.get();
 
     result = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(window.parent)" inFrame:[webView firstChildFrame] inContentWorld:world.get()];
     EXPECT_WK_STREQ(getWindowFrameInfo(result).request.URL.absoluteString, "https://example.com/example");
+
+    // After top-level navigation, old JSHandles should be undefined.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/foobar"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView.get().configuration.processPool _garbageCollectJavaScriptObjectsForTesting];
+
+    EXPECT_TRUE([[webView objectByCallingAsyncFunction:@"return n === undefined" withArguments:@{ @"n" : iframeRef.get() } inFrame:nil inContentWorld:world.get()] boolValue]);
+    EXPECT_TRUE([[webView objectByCallingAsyncFunction:@"return n === undefined" withArguments:@{ @"n" : funcRef.get() } inFrame:nil inContentWorld:world.get()] boolValue]);
+    EXPECT_TRUE([[webView objectByCallingAsyncFunction:@"return n === undefined" withArguments:@{ @"n" : plainObjectRef.get() } inFrame:nil inContentWorld:world.get()] boolValue]);
 }
 
 TEST(JSHandle, Equality)
@@ -218,6 +236,51 @@ TEST(JSHandle, Reuse)
     }
     WKJSHandle *fun = [webView objectByEvaluatingJavaScript:@"f" inFrame:nil inContentWorld:world.get()];
     EXPECT_TRUE([[webView objectByCallingAsyncFunction:@"return fun()" withArguments:@{ @"fun":fun } inFrame:nil inContentWorld:world.get()] isEqual:@42]);
+}
+
+TEST(JSHandle, HandleDoesNotKeepDocumentAliveAfterNavigation)
+{
+    HTTPServer server({
+        { "/page1"_s, { "<div id=mydiv></div>"_s } },
+        { "/page2"_s, { "<p>after navigation</p>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [configuration.get().preferences _setUsesPageCache:NO];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page1"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    auto liveDocumentsCount = [&] {
+        __block NSUInteger count = 0;
+        __block bool done = false;
+        [webView _numberOfLiveDocumentsForTesting:^(NSUInteger value) {
+            count = value;
+            done = true;
+        }];
+        Util::run(&done);
+        return count;
+    };
+
+    auto baselineDocuments = liveDocumentsCount();
+
+    RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
+    worldConfiguration.get().jsHandleCreationEnabled = YES;
+    RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
+
+    RetainPtr<WKJSHandle> divHandle = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(mydiv)" inFrame:nil inContentWorld:world.get()];
+    EXPECT_TRUE([divHandle isKindOfClass:WKJSHandle.class]);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page2"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView.get().configuration.processPool _garbageCollectJavaScriptObjectsForTesting];
+
+    EXPECT_EQ(baselineDocuments, liveDocumentsCount());
 }
 
 }


### PR DESCRIPTION
#### b1f2174caabb523dc409920affacad770d003514
<pre>
WKJSHandle keeps documents alive after navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=316933">https://bugs.webkit.org/show_bug.cgi?id=316933</a>
<a href="https://rdar.apple.com/170087117">rdar://170087117</a>

Reviewed by Ryosuke Niwa.

WKJSHandle extends the lifetime of the document it is associated with. This is not intended and can
lead to unwanted memory accumulation. For instance:

1. WKJSHandle wraps a DOM node, which keeps the DOM node alive forever (due to the strong handle map)
2. JSNode holds a strong reference to the underlying C++ Node
3. Node keeps Document alive (through incrementReferencingNodeCount)
4. Document never dies for the lifetime of WKJSHandle in the UIProcess

Instead, the handle should only live for as long as its associated document. To do this, each
JSDOMGlobalObject now keeps track of associated handles and adds it to the GC set in its
visitChildren.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandle.mm

* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::visitChildrenImpl):
(WebCore::JSDOMGlobalObject::addJSHandle):
(WebCore::JSDOMGlobalObject::refJSHandle):
(WebCore::JSDOMGlobalObject::derefJSHandle):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/page/WebKitJSHandle.cpp:
(WebCore::handleToGlobalMap):
(WebCore::globalObjectForIdentifier):
(WebCore::WebKitJSHandle::jsHandleSentToAnotherProcess):
(WebCore::WebKitJSHandle::jsHandleDestroyed):
(WebCore::WebKitJSHandle::objectForIdentifier):
(WebCore::WebKitJSHandle::WebKitJSHandle):
(WebCore::handleMap): Deleted.
* Source/WebCore/page/WebKitJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setUsesPageCache:]):
(-[WKPreferences _usesPageCache]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _numberOfLiveDocumentsForTesting:]):
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::numberOfLiveDocuments):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::nodeFromJSHandleIdentifier):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::numberOfLiveDocuments):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSHandle.mm:
(TestWebKitAPI::TEST(JSHandle, Basic)):
(TestWebKitAPI::TEST(JSHandle, HandleDoesNotKeepDocumentAliveAfterNavigation)):

Canonical link: <a href="https://commits.webkit.org/315168@main">https://commits.webkit.org/315168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f64484593cc9d3c7bcb89aa8c2d864e43afa777

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168213 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125914 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e317421-a7f8-4865-b67e-cbb2cd86c885) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130907 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4554535d-d7ca-49a1-b6c0-26dfdb639881) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33366 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151172 "Found 4 new API test failures: TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInBackground, TestWebKitAPI.WKWebExtensionContext.UnhandledPromiseRejectionInServiceWorkerBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInServiceWorkerBackground, TestWebKitAPI.WKWebExtensionContext.LoadNonExistentImage (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111419 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91657850-036f-48d3-a2f4-e6c1a72a1c38) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32352 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31060 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26237 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142338 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180141 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32864 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139344 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41782 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35219 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37497 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42470 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105844 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34489 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27540 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-properties.html imported/w3c/web-platform-tests/css/css-images/tiled-radial-gradients.html imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40371 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5632 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->