### PR TITLE
[Build Speed] Add a style checker for #include of StyleComputedStyle+[GS]ettersInlines.h

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -42,6 +42,7 @@ from webkitpy.port.config import apple_additions
 from webkitpy.style.checkers.basexcconfig import BaseXcconfigChecker
 from webkitpy.style.checkers.common import categories as CommonCategories
 from webkitpy.style.checkers.common import CarriageReturnChecker
+from webkitpy.style.checkers.computed_style_inline_includes import categories as ComputedStyleInlineIncludesCategories
 from webkitpy.style.checkers.contributors import ContributorsChecker
 from webkitpy.style.checkers.changelog import ChangeLogChecker
 from webkitpy.style.checkers.cpp import CppChecker
@@ -663,6 +664,7 @@ def _all_categories():
     categories = CommonCategories.union(CppChecker.categories)
     categories = categories.union(CMakeChecker.categories)
     categories = categories.union(DeprecatedJSTestIncludesCategories)
+    categories = categories.union(ComputedStyleInlineIncludesCategories)
     categories = categories.union(JSChecker.categories)
     categories = categories.union(JSONChecker.categories)
     categories = categories.union(JSTestChecker.categories)

--- a/Tools/Scripts/webkitpy/style/checkers/computed_style_inline_includes.py
+++ b/Tools/Scripts/webkitpy/style/checkers/computed_style_inline_includes.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Flags #includes of the StyleComputedStyle getter/setter inline headers from outside the rendering engine."""
+
+import re
+
+
+categories = {'build/include/computed-style-inlines'}
+
+
+class ComputedStyleInlineIncludesChecker(object):
+    """Forbids #including StyleComputedStyle+GettersInlines.h and
+    StyleComputedStyle+SettersInlines.h from source files outside the
+    style/, rendering/, and layout/ directories.
+
+    These headers expand the full RenderStyle getter/setter closure, which is
+    expensive to compile. Only core rendering engine code should pay that cost;
+    other consumers should reach for an out-of-line helper instead.
+    """
+
+    CATEGORY = 'build/include/computed-style-inlines'
+
+    # Source files in these directories are the core rendering engine and are
+    # allowed to include the headers.
+    _EXEMPT_DIRECTORIES = frozenset(('style', 'rendering', 'layout'))
+
+    _FORBIDDEN_HEADERS = frozenset((
+        'StyleComputedStyle+GettersInlines.h',
+        'StyleComputedStyle+SettersInlines.h',
+    ))
+
+    # Matches a #include of either quoted or angle-bracketed form, capturing the
+    # included path so we can compare its basename against the forbidden set.
+    _INCLUDE_RE = re.compile(r'^\s*#\s*include\s+["<](?P<path>[^">]+)[">]')
+
+    def __init__(self, file_path, handle_style_error):
+        self._file_path = file_path
+        self._handle_style_error = handle_style_error
+
+    def _is_exempt(self):
+        components = re.split(r'[/\\]', self._file_path)
+        return any(component in self._EXEMPT_DIRECTORIES for component in components)
+
+    def check(self, lines, line_numbers=None):
+        if self._is_exempt():
+            return
+        for line_number, line in enumerate(lines, start=1):
+            if line_numbers is not None and line_number not in line_numbers:
+                continue
+            match = self._INCLUDE_RE.match(line)
+            if not match:
+                continue
+            basename = re.split(r'[/\\]', match.group('path'))[-1]
+            if basename not in self._FORBIDDEN_HEADERS:
+                continue
+            self._handle_style_error(
+                line_number,
+                self.CATEGORY,
+                5,
+                '{} adds 6 seconds of compile time per translation unit, and should '
+                'only be used in core rendering engine code. Consider an out of line '
+                'helper function instead.'.format(basename),
+            )

--- a/Tools/Scripts/webkitpy/style/checkers/computed_style_inline_includes_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/computed_style_inline_includes_unittest.py
@@ -1,0 +1,175 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit tests for computed_style_inline_includes.py."""
+
+import unittest
+
+from webkitpy.style.checkers.computed_style_inline_includes import ComputedStyleInlineIncludesChecker
+
+
+class ComputedStyleInlineIncludesCheckerTest(unittest.TestCase):
+
+    def _collect_errors(self, file_path, lines, line_numbers=None):
+        errors = []
+
+        def record(line_number, category, confidence, message):
+            errors.append((line_number, category, confidence, message))
+
+        checker = ComputedStyleInlineIncludesChecker(file_path, record)
+        checker.check(lines, line_numbers)
+        return errors
+
+    def assertError(self, file_path, lines, expected_line_number, expected_header, line_numbers=None):
+        errors = self._collect_errors(file_path, lines, line_numbers)
+        self.assertEqual(1, len(errors), 'expected exactly one error, got: {}'.format(errors))
+        line_number, category, confidence, message = errors[0]
+        self.assertEqual(expected_line_number, line_number)
+        self.assertEqual('build/include/computed-style-inlines', category)
+        self.assertEqual(5, confidence)
+        self.assertIn(expected_header, message)
+        self.assertIn('6 seconds', message)
+        self.assertIn('out of line helper', message)
+
+    def assertNoError(self, file_path, lines, line_numbers=None):
+        errors = self._collect_errors(file_path, lines, line_numbers)
+        self.assertEqual([], errors)
+
+    def test_flags_getters_include_quoted(self):
+        self.assertError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            ['#include "StyleComputedStyle+GettersInlines.h"'],
+            1,
+            'StyleComputedStyle+GettersInlines.h',
+        )
+
+    def test_flags_setters_include_quoted(self):
+        self.assertError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            ['#include "StyleComputedStyle+SettersInlines.h"'],
+            1,
+            'StyleComputedStyle+SettersInlines.h',
+        )
+
+    def test_flags_angle_bracket_include(self):
+        self.assertError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            ['#include <WebCore/StyleComputedStyle+GettersInlines.h>'],
+            1,
+            'StyleComputedStyle+GettersInlines.h',
+        )
+
+    def test_flags_include_with_directory_prefix(self):
+        self.assertError(
+            'Source/WebKitLegacy/mac/DOM/DOM.mm',
+            ['#include "style/computed/StyleComputedStyle+SettersInlines.h"'],
+            1,
+            'StyleComputedStyle+SettersInlines.h',
+        )
+
+    def test_reports_correct_line_number(self):
+        self.assertError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            [
+                '#include "config.h"',
+                '#include "WebPage.h"',
+                '#include "StyleComputedStyle+GettersInlines.h"',
+            ],
+            3,
+            'StyleComputedStyle+GettersInlines.h',
+        )
+
+    def test_exempt_style_directory(self):
+        self.assertNoError(
+            'Source/WebCore/style/StyleAdjuster.cpp',
+            ['#include "StyleComputedStyle+GettersInlines.h"'],
+        )
+
+    def test_exempt_rendering_directory(self):
+        self.assertNoError(
+            'Source/WebCore/rendering/RenderBox.cpp',
+            ['#include "StyleComputedStyle+GettersInlines.h"'],
+        )
+
+    def test_exempt_layout_directory(self):
+        self.assertNoError(
+            'Source/WebCore/layout/LayoutState.cpp',
+            ['#include "StyleComputedStyle+SettersInlines.h"'],
+        )
+
+    def test_exempt_header_in_computed_subdirectory_of_style(self):
+        self.assertNoError(
+            'Source/WebCore/style/computed/StyleComputedStyle+GettersInlines.h',
+            ['#include "StyleComputedStyle+SettersInlines.h"'],
+        )
+
+    def test_does_not_flag_unrelated_include(self):
+        self.assertNoError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            ['#include "StyleComputedStyle.h"'],
+        )
+
+    def test_does_not_flag_other_inline_header(self):
+        self.assertNoError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            ['#include "StyleComputedStyleBase+GettersInlines.h"'],
+        )
+
+    def test_does_not_flag_plain_filename_mention(self):
+        self.assertNoError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            ['// See StyleComputedStyle+GettersInlines.h for the closure.'],
+        )
+
+    def test_only_checks_modified_lines(self):
+        lines = [
+            '#include "StyleComputedStyle+GettersInlines.h"',
+            '#include "StyleComputedStyle+SettersInlines.h"',
+        ]
+        # Only line 2 was modified, so only it should be flagged.
+        self.assertError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            lines,
+            2,
+            'StyleComputedStyle+SettersInlines.h',
+            line_numbers=[2],
+        )
+
+    def test_empty_line_numbers_suppresses_all_errors(self):
+        self.assertNoError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            ['#include "StyleComputedStyle+GettersInlines.h"'],
+            line_numbers=[],
+        )
+
+    def test_handles_extra_whitespace(self):
+        self.assertError(
+            'Source/WebKit/WebProcess/WebPage/WebPage.cpp',
+            ['  #  include   "StyleComputedStyle+GettersInlines.h"'],
+            1,
+            'StyleComputedStyle+GettersInlines.h',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -48,6 +48,7 @@ import unicodedata
 from webkitcorepy import unicode, Version
 
 from webkitpy.style.checkers.common import match, search, sub, subn
+from webkitpy.style.checkers.computed_style_inline_includes import ComputedStyleInlineIncludesChecker
 from webkitpy.style.checkers.inclusive_language import InclusiveLanguageChecker
 from webkitpy.common.memoized import memoized
 from webkitpy.common.version_name_map import VersionNameMap
@@ -5360,6 +5361,7 @@ class CppChecker(object):
         self.handle_style_error = handle_style_error
         self.min_confidence = min_confidence
         self._inclusive_language_checker = InclusiveLanguageChecker(handle_style_error)
+        self._computed_style_inline_includes_checker = ComputedStyleInlineIncludesChecker(file_path, handle_style_error)
         _unit_test_config = unit_test_config
 
     # Useful for unit testing.
@@ -5395,3 +5397,4 @@ class CppChecker(object):
                        self.handle_style_error, self.min_confidence,
                        set(line_numbers) if line_numbers is not None else None)
         self._inclusive_language_checker.check(lines)
+        self._computed_style_inline_includes_checker.check(lines, line_numbers)


### PR DESCRIPTION
#### 1e156f0030f5d401649fc529c5eab0c0464c8d69
<pre>
[Build Speed] Add a style checker for #include of StyleComputedStyle+[GS]ettersInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=316938">https://bugs.webkit.org/show_bug.cgi?id=316938</a>
<a href="https://rdar.apple.com/179406272">rdar://179406272</a>

Reviewed by Mike Wyrzykowski.

* Tools/Scripts/webkitpy/style/checker.py:
* Tools/Scripts/webkitpy/style/checkers/cpp.py: List the new checker

* Tools/Scripts/webkitpy/style/checkers/computed_style_inline_includes.py: Warn about #include
outside the core layout + rendering folders.

* Tools/Scripts/webkitpy/style/checkers/computed_style_inline_includes_unittest.py: Unit test.

Canonical link: <a href="https://commits.webkit.org/315065@main">https://commits.webkit.org/315065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7f374e6164200e8c58568b3e1f3b8b23dbcdccb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177257 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ada005c-b50c-4ab8-a9f9-e0bd401bd6f0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78024563-9b76-48a2-a5c0-8eca07993fcb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33142 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111189 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0784e9f1-0191-46b1-a54a-2c8496b61bd6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/167283 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25960 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179857 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139094 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138976 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42219 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105498 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34261 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40723 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40120 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5407 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40371 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->