### PR TITLE
[macOS Golden Gate] Notify Me: add support for PDFs

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1230,7 +1230,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
         if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(node); iframe && item) {
             if (RefPtr frame = dynamicDowncast<LocalFrame>(iframe->contentFrame())) {
                 if (RefPtr document = frame->document(); document && areSameOrigin(*document, protect(node.document()))) {
-                    auto [rootItem, textLength] = extractItem([&] {
+                    auto [rootItem, textLength, pdfContent] = extractItem([&] {
                         auto request = context.originalRequest;
                         request.targetNodeHandleIdentifier = { };
                         return request;
@@ -1402,11 +1402,11 @@ Result extractItem(Request&& request, LocalFrame& frame)
     Item root { ScrollableItemData { }, { }, { }, { }, { }, frameID, { }, { }, { }, { }, { }, { }, { }, 0 };
     RefPtr document = frame.document();
     if (!document)
-        return { root, 0 };
+        return { root, 0, { } };
 
     RefPtr bodyElement = document->body();
     if (!bodyElement)
-        return { root, 0 };
+        return { root, 0, { } };
 
     document->updateLayoutIgnorePendingStylesheets();
 
@@ -1429,11 +1429,11 @@ Result extractItem(Request&& request, LocalFrame& frame)
         addBoxShadowIfNeeded(*extractionRootNode, extractingWithDataDetectors ? "#0088FF"_s : "#ff8d28"_s);
 
     if (!extractionRootNode)
-        return { root, 0 };
+        return { root, 0, { } };
 
     RefPtr view = frame.view();
     if (!view)
-        return { root, 0 };
+        return { root, 0, { } };
 
     root.data = { ScrollableItemData {
         .contentSize = view->contentsSize(),
@@ -1444,7 +1444,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
 
     root.rectInRootView = view->contentsToRootView(IntRect { IntPoint::zero(), view->contentsSize() });
     if (root.rectInRootView.isEmpty())
-        return { root, 0 };
+        return { root, 0, { } };
 
     unsigned visibleTextLength = 0;
     {
@@ -1526,7 +1526,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
     pruneWhitespaceRecursive(root);
     pruneEmptyContainersRecursive(root);
 
-    return { WTF::move(root), visibleTextLength };
+    return { WTF::move(root), visibleTextLength, { } };
 }
 
 using Token = Variant<String, IntSize>;

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -243,6 +243,7 @@ struct Result {
 
     Item rootItem;
     unsigned visibleTextLength { 0 };
+    std::optional<String> pdfMarkdownContent;
 };
 
 struct PageResults {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1931,4 +1931,44 @@ void convertToText(TextExtraction::Item&& item, TextExtractionOptions&& options,
     addTextRepresentationRecursive(item, { }, 0, aggregator);
 }
 
+String formatPDFMarkdownForOutput(const String& pdfText, TextExtractionOutputFormat outputFormat)
+{
+    using enum TextExtractionOutputFormat;
+    switch (outputFormat) {
+    case Markdown:
+    case PlainText:
+        return pdfText;
+
+    case TextTree: {
+        auto visibleText = trimAndSimplifyWhitespace(pdfText);
+        return makeString("root\n\t'"_s, escapeString(visibleText), '\'');
+    }
+
+    case HTMLMarkup: {
+        auto escaped = trimAndSimplifyWhitespace(pdfText);
+        escaped = makeStringByReplacingAll(escaped, '&', "&amp;"_s);
+        escaped = makeStringByReplacingAll(escaped, '<', "&lt;"_s);
+        escaped = makeStringByReplacingAll(escaped, '>', "&gt;"_s);
+        return makeString("<body>"_s, WTF::move(escaped), "</body>"_s);
+    }
+
+    case MinifiedJSON: {
+        Ref textObject = JSON::Object::create();
+        textObject->setString("type"_s, "text"_s);
+        textObject->setString("content"_s, trimAndSimplifyWhitespace(pdfText));
+
+        Ref children = JSON::Array::create();
+        children->pushObject(WTF::move(textObject));
+
+        Ref root = JSON::Object::create();
+        root->setString("type"_s, "root"_s);
+        root->setArray("children"_s, WTF::move(children));
+        return root->toJSONString();
+    }
+    }
+
+    ASSERT_NOT_REACHED();
+    return pdfText;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -119,6 +119,8 @@ struct TextExtractionResult {
 
 void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, CompletionHandler<void(TextExtractionResult&&)>&&);
 
+String formatPDFMarkdownForOutput(const String& pdfText, TextExtractionOutputFormat);
+
 std::optional<ExtractedNodeInfo> parseExtractedNodeInfo(StringView);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4885,6 +4885,7 @@ header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Result {
     WebCore::TextExtraction::Item rootItem;
     unsigned visibleTextLength;
+    std::optional<String> pdfMarkdownContent;
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7336,6 +7336,19 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
             WTF::move(maxWordsPerParagraph),
             WTF::move(topHostName),
         };
+        if (result->pdfMarkdownContent) {
+            RELEASE_LOG(TextExtraction, "<%@: %p> PDF extraction complete (%.0f ms)", [strongSelf class], strongSelf.get(), (MonotonicTime::now() - startTime).milliseconds());
+            auto formattedText = WebKit::formatPDFMarkdownForOutput(*result->pdfMarkdownContent, outputFormat);
+            completionHandler(adoptNS([[_WKTextExtractionResult alloc]
+                initWithWebView:strongSelf
+                origin:wrapper(API::SecurityOrigin::create(origin))
+                textContent:formattedText.createNSString()
+                filteredOutAnyText:NO
+                shortenedURLs:@{ }
+                textToContainerMap:{ }]));
+            return;
+        }
+
         WebKit::convertToText(WTF::move(result->rootItem), WTF::move(options), [weakSelf, startTime, urlCache, origin = WTF::move(origin), completionHandler = WTF::move(completionHandler), endTextExtractionScope = WTF::move(endTextExtractionScope)](auto&& result) {
             RetainPtr strongSelf = weakSelf.get();
             if (!strongSelf)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1733,6 +1733,25 @@ void WebFrame::requestTextExtraction(TextExtraction::Request&& request, Completi
     if (!frame)
         return completion({ });
 
+#if ENABLE(PDF_PLUGIN)
+    if (RefPtr pluginView = WebPage::pluginViewForFrame(frame.get())) {
+        if (auto pdfText = pluginView->fullDocumentString(); !pdfText.isEmpty()) {
+            TextExtraction::Result result;
+            TextExtraction::ScrollableItemData scrollableData;
+            if (RefPtr view = frame->view()) {
+                scrollableData.contentSize = view->contentsSize();
+                scrollableData.scrollPosition = view->scrollPosition();
+            }
+            scrollableData.isRoot = true;
+            result.rootItem.data = WTF::move(scrollableData);
+            result.rootItem.frameIdentifier = frame->frameID();
+            result.visibleTextLength = pdfText.length();
+            result.pdfMarkdownContent = WTF::move(pdfText);
+            return completion(WTF::move(result));
+        }
+    }
+#endif
+
     completion(TextExtraction::extractItem(WTF::move(request), *frame));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -27,6 +27,7 @@
 
 #import "ClassMethodSwizzler.h"
 #import "Helpers/cocoa/HTTPServer.h"
+#import "Helpers/cocoa/PDFTestHelpers.h"
 #import "InstanceMethodSwizzler.h"
 #import "JSHandlePlugInProtocol.h"
 #import "Helpers/PlatformUtilities.h"
@@ -1949,5 +1950,101 @@ TEST(TextExtractionTests, FilterExtractedStringEmptyInput)
 }
 
 #endif // ENABLE(TEXT_EXTRACTION_FILTER) && HAVE(SAFARI_SAFE_BROWSING_NAMESPACED_LISTS)
+
+#if ENABLE(UNIFIED_PDF)
+
+static RetainPtr<TestWKWebView> loadPDFInWebView()
+{
+    RetainPtr configuration = configurationForWebViewTestingUnifiedPDF();
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadData:testPDFData() MIMEType:@"application/pdf" characterEncodingName:@"" baseURL:[NSURL URLWithString:@"https://www.example.com/test.pdf"]];
+    [webView _test_waitForDidFinishNavigation];
+    return webView;
+}
+
+TEST(TextExtractionTests, ExtractFromPDFAsMarkdown)
+{
+    RetainPtr webView = loadPDFInWebView();
+
+    RetainPtr text = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatMarkdown];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([text containsString:@"Test PDF Content"]);
+    EXPECT_TRUE([text containsString:@"555-555-1234"]);
+}
+
+TEST(TextExtractionTests, ExtractFromPDFAsTextTree)
+{
+    RetainPtr webView = loadPDFInWebView();
+
+    RetainPtr text = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatTextTree];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([text hasPrefix:@"root"]);
+    EXPECT_TRUE([text containsString:@"Test PDF Content"]);
+    EXPECT_TRUE([text containsString:@"555-555-1234"]);
+}
+
+TEST(TextExtractionTests, ExtractFromPDFAsHTML)
+{
+    RetainPtr webView = loadPDFInWebView();
+
+    RetainPtr text = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatHTML];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([text hasPrefix:@"<body>"]);
+    EXPECT_TRUE([text hasSuffix:@"</body>"]);
+    EXPECT_TRUE([text containsString:@"Test PDF Content"]);
+    EXPECT_TRUE([text containsString:@"555-555-1234"]);
+}
+
+TEST(TextExtractionTests, ExtractFromPDFAsJSON)
+{
+    RetainPtr webView = loadPDFInWebView();
+
+    RetainPtr text = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatJSON];
+        return configuration.autorelease();
+    }()];
+
+    NSError *error = nil;
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:[text dataUsingEncoding:NSUTF8StringEncoding] options:0 error:&error];
+    EXPECT_NULL(error);
+    EXPECT_WK_STREQ("root", [json objectForKey:@"type"]);
+    NSArray *children = [json objectForKey:@"children"];
+    EXPECT_EQ([children count], 1u);
+    EXPECT_WK_STREQ("text", [[children firstObject] objectForKey:@"type"]);
+    NSString *content = [[children firstObject] objectForKey:@"content"];
+    EXPECT_TRUE([content containsString:@"Test PDF Content"]);
+    EXPECT_TRUE([content containsString:@"555-555-1234"]);
+}
+
+TEST(TextExtractionTests, ExtractFromPDFAsPlainText)
+{
+    RetainPtr webView = loadPDFInWebView();
+
+    RetainPtr text = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setOutputFormat:_WKTextExtractionOutputFormatPlainText];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([text containsString:@"Test PDF Content"]);
+    EXPECT_TRUE([text containsString:@"555-555-1234"]);
+}
+
+#endif // ENABLE(UNIFIED_PDF)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6a685086c9911b31715b157db67cf81cfd87e091
<pre>
[macOS Golden Gate] Notify Me: add support for PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=316940">https://bugs.webkit.org/show_bug.cgi?id=316940</a>
<a href="https://rdar.apple.com/179406752">rdar://179406752</a>

Reviewed by Abrar Rahman Protyasha.

Add basic support for extracting text representations from PDF documents as markdown, HTML, JSON and
text tree formats.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::formatPDFMarkdownForOutput):

For now, leave PDF content as plain text underneath a single root node when extracting HTML, JSON
and text tree. In the future, we could find more elaborate ways to represent PDFs in better fidelity
(including links and images).

* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::requestTextExtraction):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::(TextExtractionTests, ExtractFromPDFAsMarkdown)):
(TestWebKitAPI::(TextExtractionTests, ExtractFromPDFAsTextTree)):
(TestWebKitAPI::(TextExtractionTests, ExtractFromPDFAsHTML)):
(TestWebKitAPI::(TextExtractionTests, ExtractFromPDFAsJSON)):
(TestWebKitAPI::(TextExtractionTests, ExtractFromPDFAsPlainText)):

Canonical link: <a href="https://commits.webkit.org/315072@main">https://commits.webkit.org/315072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f46afdacf8c83e05d41521960ecf67a12c5c12ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167988 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125681 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130695 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111212 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25986 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179883 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32635 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139120 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139001 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37438 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42245 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105525 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34287 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27322 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40749 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114001 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40146 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5422 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40397 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40291 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->