### PR TITLE
WPT linter failing with errors

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/wpt_linter.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_linter.py
@@ -58,21 +58,11 @@ class WPTLinter(object):
 
     def _run_lint(self, cmd):
         _log.debug('Running WPT linter: %s (cwd=%s)', ' '.join(cmd), self.wpt_path)
-        try:
-            result = subprocess.run(
-                cmd,
-                cwd=self.wpt_path,
-                capture_output=True,
-                check=True,
-            )
-        except subprocess.CalledProcessError as e:
-            # lint exits with 1 when there's lint errors; any other exit code is an
-            # actual failure.
-            if e.returncode != 1:
-                raise RuntimeError(
-                    'WPT linter failed:\n' + e.stderr.decode('utf-8', 'replace')
-                ) from e
-            result = e
+        result = subprocess.run(
+            cmd,
+            cwd=self.wpt_path,
+            capture_output=True,
+        )
         for line in result.stdout.splitlines():
             if not line.strip():
                 continue


### PR DESCRIPTION
#### 8a18f8b8098a774f5778c3b0dfe18a950a7c82cd
<pre>
WPT linter failing with errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=316941">https://bugs.webkit.org/show_bug.cgi?id=316941</a>
<a href="https://rdar.apple.com/179407377">rdar://179407377</a>

Reviewed by Cole Carley.

Fixing WPT linter&apos;s behaviour is slightly too complex; we should just
disable the exit code check until we have a meaningful exit code from
the linter.

* Tools/Scripts/webkitpy/w3c/wpt_linter.py:
(WPTLinter._run_lint):

Canonical link: <a href="https://commits.webkit.org/315832@main">https://commits.webkit.org/315832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feab98f4e6c8f4c82e9099f575131b5c7977ab9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125661 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e9d326b-a491-49e8-87d7-add70f6a502a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130677 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91842 "4 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28ef3dce-87d2-4c0e-8f86-3c6c1e30fd56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33152 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150931 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionContext.UnhandledPromiseRejectionInBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88be7761-35bd-46e4-8ad3-2f8b9af614b8) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/167289 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32133 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30832 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25966 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179863 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139098 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41537 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138980 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42225 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27299 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105504 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25954 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34270 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40729 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5399 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40126 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40377 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->