### PR TITLE
[GTK][WPE] Expose search inputs as WEBKIT_INPUT_PURPOSE_SEARCH

### DIFF
--- a/Source/WebKit/Shared/glib/InputMethodState.cpp
+++ b/Source/WebKit/Shared/glib/InputMethodState.cpp
@@ -58,6 +58,7 @@ void InputMethodState::setPurposeOrHintForInputMode(WebCore::InputMode inputMode
         purpose = Purpose::Number;
         break;
     case WebCore::InputMode::Search:
+        purpose = Purpose::Search;
         break;
     }
 }
@@ -82,6 +83,8 @@ void InputMethodState::setPurposeForInputElement(WebCore::HTMLInputElement& elem
         purpose = Purpose::Url;
     else if (element.isText() && inputElementHasDigitsPattern(element))
         purpose = Purpose::Digits;
+    else if (element.isSearchField())
+        purpose = Purpose::Search;
 }
 
 void InputMethodState::addHintsForAutocapitalizeType(WebCore::AutocapitalizeType autocapitalizeType)

--- a/Source/WebKit/Shared/glib/InputMethodState.h
+++ b/Source/WebKit/Shared/glib/InputMethodState.h
@@ -48,7 +48,8 @@ struct InputMethodState {
         Phone,
         Url,
         Email,
-        Password
+        Password,
+        Search,
     };
 
     enum class Hint : uint8_t {

--- a/Source/WebKit/Shared/glib/InputMethodState.serialization.in
+++ b/Source/WebKit/Shared/glib/InputMethodState.serialization.in
@@ -30,7 +30,8 @@ header: "InputMethodState.h"
     Phone,
     Url,
     Email,
-    Password
+    Password,
+    Search,
 };
 
 [Nested, OptionSet] enum class WebKit::InputMethodState::Hint : uint8_t {

--- a/Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp
+++ b/Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp
@@ -162,6 +162,8 @@ static WebKitInputPurpose toWebKitPurpose(InputMethodState::Purpose purpose)
         return WEBKIT_INPUT_PURPOSE_EMAIL;
     case InputMethodState::Purpose::Password:
         return WEBKIT_INPUT_PURPOSE_PASSWORD;
+    case InputMethodState::Purpose::Search:
+        return WEBKIT_INPUT_PURPOSE_SEARCH;
     }
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in
@@ -66,7 +66,16 @@ typedef enum {
     WEBKIT_INPUT_PURPOSE_PHONE,
     WEBKIT_INPUT_PURPOSE_URL,
     WEBKIT_INPUT_PURPOSE_EMAIL,
-    WEBKIT_INPUT_PURPOSE_PASSWORD
+    WEBKIT_INPUT_PURPOSE_PASSWORD,
+
+    /**
+     * WEBKIT_INPUT_PURPOSE_SEARCH:
+     *
+     * Edited field contents will be used for searching data.
+     *
+     * Since: 2.54
+     */
+    WEBKIT_INPUT_PURPOSE_SEARCH,
 } WebKitInputPurpose;
 
 /**

--- a/Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp
@@ -39,6 +39,7 @@ static GtkInputPurpose toGtkInputPurpose(WebKitInputPurpose purpose)
 {
     switch (purpose) {
     case WEBKIT_INPUT_PURPOSE_FREE_FORM:
+    case WEBKIT_INPUT_PURPOSE_SEARCH:
         return GTK_INPUT_PURPOSE_FREE_FORM;
     case WEBKIT_INPUT_PURPOSE_DIGITS:
         return GTK_INPUT_PURPOSE_DIGITS;

--- a/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp
@@ -50,6 +50,8 @@ static WPEInputPurpose toWPEInputPurpose(WebKitInputPurpose purpose)
         return WPE_INPUT_PURPOSE_EMAIL;
     case WEBKIT_INPUT_PURPOSE_PASSWORD:
         return WPE_INPUT_PURPOSE_PASSWORD;
+    case WEBKIT_INPUT_PURPOSE_SEARCH:
+        return WPE_INPUT_PURPOSE_SEARCH;
     }
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
@@ -76,6 +76,15 @@ typedef enum
   WPE_INPUT_PURPOSE_PASSWORD,
   WPE_INPUT_PURPOSE_PIN,
   WPE_INPUT_PURPOSE_TERMINAL,
+
+  /**
+   * WPE_INPUT_PURPOSE_SEARCH:
+   *
+   * Edited field contents will be used for searching data.
+   *
+   * Since: 2.54
+   */
+  WPE_INPUT_PURPOSE_SEARCH,
 } WPEInputPurpose;
 
 /**

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestInputMethodContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestInputMethodContext.cpp
@@ -1027,6 +1027,20 @@ static void testWebKitInputMethodContextContentType(InputMethodTest* test, gcons
     g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
+    test->loadHtml("<input id='editable' type='search' spellcheck='false'>", nullptr);
+    test->waitUntilLoadFinished();
+    test->focusEditableAndWaitUntilInputMethodEnabled();
+    g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_SEARCH);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    test->unfocusEditableAndWaitUntilInputMethodDisabled();
+
+    test->loadHtml("<input id='editable' type='search' spellcheck='true'>", nullptr);
+    test->waitUntilLoadFinished();
+    test->focusEditableAndWaitUntilInputMethodEnabled();
+    g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_SEARCH);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK);
+    test->unfocusEditableAndWaitUntilInputMethodDisabled();
+
     test->loadHtml("<div contenteditable id='editable' inputmode='text' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
@@ -1072,7 +1086,7 @@ static void testWebKitInputMethodContextContentType(InputMethodTest* test, gcons
     test->loadHtml("<div contenteditable id='editable' inputmode='search' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
-    g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_FREE_FORM);
+    g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_SEARCH);
     g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 


### PR DESCRIPTION
#### cf16656cdaabfbd898f3c3542a7ad9c95fbbd25c
<pre>
[GTK][WPE] Expose search inputs as WEBKIT_INPUT_PURPOSE_SEARCH
<a href="https://bugs.webkit.org/show_bug.cgi?id=316942">https://bugs.webkit.org/show_bug.cgi?id=316942</a>

Reviewed by Carlos Garcia Campos.

Expose the internal WebCore::InputMode::Search / HTMLInputElement::isSearchField()
as WEBKIT_INPUT_PURPOSE_SEARCH in the public API for the GTK and WPE ports, and as
WPE_INPUT_PURPOSE_SEARCH in WPEPlatform.

In the case of the GTK port the WEBKIT_INPUT_PURPOSE_SEARCH value is folded into
GTK_INPUT_PURPOSE_FREE_FORM because the toolkit does not provide an equivalent.
Applications can still use the WebKitInputPurpose value, though.

* Source/WebKit/Shared/glib/InputMethodState.cpp:
(WebKit::InputMethodState::setPurposeOrHintForInputMode):
(WebKit::InputMethodState::setPurposeForInputElement):
* Source/WebKit/Shared/glib/InputMethodState.h:
* Source/WebKit/Shared/glib/InputMethodState.serialization.in:
* Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp:
(WebKit::toWebKitPurpose):
* Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp:
(toGtkInputPurpose):
* Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp:
(toWPEInputPurpose):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestInputMethodContext.cpp:
(testWebKitInputMethodContextContentType):

Canonical link: <a href="https://commits.webkit.org/315091@main">https://commits.webkit.org/315091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/333ba34bfda6e3b6df1f00e5b9c3670e76ef5e1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130769 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111286 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30926 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26067 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179964 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32716 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139208 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139074 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37448 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42326 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105641 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34360 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27399 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114082 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40227 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5498 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->