### PR TITLE
[LBSE] Position non-layered transformed SVG content in the paint transform recursion

### DIFF
--- a/LayoutTests/svg/transforms/transformed-container-self-outline-expected.svg
+++ b/LayoutTests/svg/transforms/transformed-container-self-outline-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
+<g style="outline: 5px solid blue">
+  <rect x="100" y="100" width="60" height="60" fill="green"/>
+</g>
+</svg>

--- a/LayoutTests/svg/transforms/transformed-container-self-outline.svg
+++ b/LayoutTests/svg/transforms/transformed-container-self-outline.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
+<g transform="translate(40, 40)" style="outline: 5px solid blue">
+  <rect x="60" y="60" width="60" height="60" fill="green"/>
+</g>
+</svg>

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -464,10 +464,8 @@ std::optional<RenderLayer::SVGRendererTransform> RenderLayer::computeRendererTra
     auto referenceBoxRect = layerModelObject->transformReferenceBoxRect(style);
 
     // For non-layer renderers, undo the alignReferenceBox shift applied in transformReferenceBoxRect().
-    if (!rendererRef->hasSelfPaintingLayer()) {
-        if (CheckedPtr svgModel = dynamicDowncast<RenderSVGModelObject>(rendererRef.get()))
-            referenceBoxRect.moveBy(svgModel->nominalSVGLayoutLocation());
-    }
+    if (!rendererRef->hasSelfPaintingLayer() && rendererRef->isSVGLayerAwareRenderer())
+        referenceBoxRect.moveBy(layerModelObject->nominalSVGLayoutLocation());
 
     layerModelObject->applyTransform(transform, style, referenceBoxRect, Style::TransformResolver::allTransformOperations);
 
@@ -533,34 +531,40 @@ void RenderLayer::paintRendererByApplyingTransformForSVG(GraphicsContext& contex
 
         childLayer->paintLayer(context, childPaintingInfo,
             adjustedPaintFlags | PaintLayerFlag::AppliedTransform);
-    } else if (rendererToPaint->isRenderSVGContainer()) {
-        LayoutPoint containerPaintOffset;
-        if (auto* viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(rendererToPaint.get()); viewportContainer && viewportContainer->isAnonymous()) {
-            // Outermost viewport container: coordinate system starts at (0, 0).
-        } else if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererToPaint.get()))
-            containerPaintOffset = svgModel->nominalSVGLayoutLocation();
-        paintSubtreeWithinTransformScopeForSVG(context, rendererToPaint.get(), containerPaintOffset, scope.transformedPaintingInfo(), adjustedPaintFlags, paintBehavior, subtreePaintRoot, outerPaintingInfo, newAccumulatedTransform);
-
-        auto& transformedPaintingInfo = scope.transformedPaintingInfo();
-        PaintInfo outlinePaintInfo(context, transformedPaintingInfo.paintDirtyRect, PaintPhase::SelfOutline, paintBehavior, subtreePaintRoot,
-            nullptr, nullptr, &transformedPaintingInfo.rootLayer->renderer(), this,
-            transformedPaintingInfo.requireSecurityOriginAccessForWidgets);
-        rendererToPaint->paint(outlinePaintInfo, containerPaintOffset);
     } else {
-        LayoutPoint leafPaintOffset;
-        if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererToPaint.get())) {
-            leafPaintOffset = svgModel->nominalSVGLayoutLocation();
-            leafPaintOffset.moveBy(-svgModel->currentSVGLayoutLocation());
-        }
+        // Non-layer renderer painted directly within the transform scope.
         auto& transformedPaintingInfo = scope.transformedPaintingInfo();
-        LayoutRect dirtyRect = transformedPaintingInfo.paintDirtyRect;
-        PaintInfo paintInfo(context, dirtyRect, PaintPhase::Foreground, paintBehavior, subtreePaintRoot,
-            nullptr, nullptr, &transformedPaintingInfo.rootLayer->renderer(), this,
-            transformedPaintingInfo.requireSecurityOriginAccessForWidgets);
-        rendererToPaint->paint(paintInfo, leafPaintOffset);
-        PaintInfo outlinePaintInfo(paintInfo);
-        outlinePaintInfo.phase = PaintPhase::Outline;
-        rendererToPaint->paint(outlinePaintInfo, leafPaintOffset);
+        auto paintInScope = [&](PaintPhase phase, const LayoutPoint& offset) {
+            PaintInfo paintInfo(context, transformedPaintingInfo.paintDirtyRect, phase, paintBehavior, subtreePaintRoot,
+                nullptr, nullptr, &transformedPaintingInfo.rootLayer->renderer(), this,
+                transformedPaintingInfo.requireSecurityOriginAccessForWidgets);
+            rendererToPaint->paint(paintInfo, offset);
+        };
+
+        // A renderer's own paint() positions content at paintOffset + currentSVGLayoutLocation() - at a
+        // transform-scope root we want it at the visual top-left, so pass (nominal - current). This is
+        // uniform for shapes, images, text and a container's own outline.
+        LayoutPoint selfPaintOffset;
+        if (rendererToPaint->isSVGLayerAwareRenderer()) {
+            CheckedRef layerModelObject = downcast<RenderLayerModelObject>(rendererToPaint.get());
+            selfPaintOffset = layerModelObject->nominalSVGLayoutLocation();
+            selfPaintOffset.moveBy(-layerModelObject->currentSVGLayoutLocation());
+        }
+
+        if (rendererToPaint->isRenderSVGContainer()) {
+            // Children recurse from the container's nominal origin (= selfPaintOffset + current) and
+            // re-add their own currentSVGLayoutLocation; the anonymous outermost viewport starts at (0, 0).
+            LayoutPoint recursionBase;
+            if (auto* viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(rendererToPaint.get()); viewportContainer && viewportContainer->isAnonymous()) {
+                // Outermost viewport container: coordinate system starts at (0, 0).
+            } else if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererToPaint.get()))
+                recursionBase = svgModel->nominalSVGLayoutLocation();
+            paintSubtreeWithinTransformScopeForSVG(context, rendererToPaint.get(), recursionBase, transformedPaintingInfo, adjustedPaintFlags, paintBehavior, subtreePaintRoot, outerPaintingInfo, newAccumulatedTransform);
+            paintInScope(PaintPhase::SelfOutline, selfPaintOffset);
+        } else {
+            paintInScope(PaintPhase::Foreground, selfPaintOffset);
+            paintInScope(PaintPhase::Outline, selfPaintOffset);
+        }
     }
 }
 


### PR DESCRIPTION
#### 834967406989dc98e038dc03a810f085db79738a
<pre>
[LBSE] Position non-layered transformed SVG content in the paint transform recursion
<a href="https://bugs.webkit.org/show_bug.cgi?id=316943">https://bugs.webkit.org/show_bug.cgi?id=316943</a>

Reviewed by Rob Buis.

An SVG renderer with a 2D transform but no RenderLayer is painted by walking
the transform recursion in paintRendererByApplyingTransformForSVG() rather than
through the RenderLayer paint paths. This makes that recursion position containers,
text and shape content correctly without a self-painting layer.

computeRendererTransform() undoes the alignReferenceBox shift that
transformReferenceBoxRect() applies to non-layer renderers. That correction was
keyed on RenderSVGModelObject, which excludes RenderSVGText - it now applies to
every non-layered isSVGLayerAwareRenderer(), so text is covered too.

paintRendererByApplyingTransformForSVG() folds its separate container and leaf
branches into a shared paintInScope() helper. A renderer paints its own content
at paintOffset + currentSVGLayoutLocation(), so at a transform-scope root the
self offset is (nominal - current), placing content at its visual top-left.
This drives shapes, images, text and a container&apos;s own outline uniformly -
containers also recurse into their children from the nominal origin, with the
anonymous outermost viewport starting at (0, 0).

The code stays dormant until requiresLayer() becomes conditional.
Add a test for outlines on transformed containers that was broken in the
conditional layer LBSE variant, and is now fixed.

Tests: svg/transforms/transformed-container-self-outline.svg

* LayoutTests/svg/transforms/transformed-container-self-outline-expected.svg: Added.
* LayoutTests/svg/transforms/transformed-container-self-outline.svg: Added.
* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::computeRendererTransformForSVG const):
(WebCore::RenderLayer::paintRendererByApplyingTransformForSVG):

Canonical link: <a href="https://commits.webkit.org/315084@main">https://commits.webkit.org/315084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2594567203894f8832789e12e1d46a7bcbc8f018

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130682 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32131 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30839 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25973 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179870 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32622 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139106 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138988 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37444 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150419 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105512 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27301 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40736 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113988 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40133 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5401 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->