### PR TITLE
[Site Isolation] Emit live Page.frameNavigated/frameDetached from cross-origin processes

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -348,7 +348,6 @@
         {
             "name": "frameDetached",
             "description": "Fired when frame has been detached from its parent.",
-            "targetTypes": ["page"],
             "parameters": [
                 { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has been detached." }
             ]

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -64,6 +64,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "NetworkAgentInstrumentation.h"
+#include "PageAgentInstrumentation.h"
 #include "PageCanvasAgent.h"
 #include "PageDOMDebuggerAgent.h"
 #include "PageDebuggerAgent.h"
@@ -820,6 +821,11 @@ void InspectorInstrumentation::frameDetachedFromParentImpl(InstrumentingAgents& 
 {
     if (CheckedPtr pageAgent = instrumentingAgents.enabledPageAgent())
         pageAgent->frameDetached(frame);
+
+    // Under Site Isolation the cross-process proxy (PageAgentProxy) forwards this to the
+    // UIProcess ProxyingPageAgent, so frames hosted in non-main processes are reported too.
+    if (CheckedPtr pageProxy = instrumentingAgents.enabledPageProxy())
+        pageProxy->frameDetached(frame);
 }
 
 void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, DocumentLoader* loader)
@@ -865,6 +871,11 @@ void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrument
 
     if (CheckedPtr pageAgent = instrumentingAgents.enabledPageAgent())
         pageAgent->frameNavigated(frame);
+
+    // Under Site Isolation the cross-process proxy (PageAgentProxy) forwards this to the
+    // UIProcess ProxyingPageAgent, so frames hosted in non-main processes are reported too.
+    if (CheckedPtr pageProxy = instrumentingAgents.enabledPageProxy())
+        pageProxy->frameNavigated(frame);
 
     if (auto* pageRuntimeAgent = instrumentingAgents.enabledPageRuntimeAgent())
         pageRuntimeAgent->frameNavigated(frame);

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js
@@ -921,7 +921,10 @@ WI.DOMDebuggerManager = class DOMDebuggerManager extends WI.Object
 
     _mainFrameDidChange(event)
     {
-        this._speculativelyResolveDOMBreakpointsForURL(WI.networkManager.mainFrame.url);
+        // The main frame can be transiently null (e.g. while frame events from multiple
+        // Site Isolation processes are being reconciled). webkit.org/b/308896
+        if (WI.networkManager.mainFrame)
+            this._speculativelyResolveDOMBreakpointsForURL(WI.networkManager.mainFrame.url);
     }
 
     _mainResourceDidChange(event)

--- a/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
@@ -141,14 +141,20 @@ void PageAgentProxy::frameNavigated(LocalFrame& frame)
             name = ownerElement->attributeWithoutSynchronization(WebCore::HTMLNames::idAttr);
     }
 
-    protect(WebProcess::singleton().parentProcessConnection())->send(
+    RefPtr connection = WebProcess::singleton().parentProcessConnection();
+    if (!connection)
+        return;
+    connection->send(
         Messages::ProxyingPageAgent::FrameNavigated(frameID, url, mimeType, securityOrigin, parentFrameID, name),
         m_page->identifier());
 }
 
 void PageAgentProxy::frameDetached(LocalFrame& frame)
 {
-    protect(WebProcess::singleton().parentProcessConnection())->send(
+    RefPtr connection = WebProcess::singleton().parentProcessConnection();
+    if (!connection)
+        return;
+    connection->send(
         Messages::ProxyingPageAgent::FrameDetached(frame.frameID()),
         m_page->identifier());
 }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -436,6 +436,12 @@ void WebInspectorBackend::disablePageInstrumentation()
     if (!m_pageInstrumentationEnabled)
         return;
 
+    // disable() clears the enabledPageProxy slot in the page's InstrumentingAgents. Without it,
+    // destroying m_pageAgentProxy below would leave a dangling pointer there, and the next frame
+    // commit in this process would crash dereferencing it from InspectorInstrumentation. The page
+    // is still alive here (this is an explicit DisablePageInstrumentation IPC, not process teardown).
+    if (CheckedPtr pageAgentProxy = m_pageAgentProxy.get())
+        pageAgentProxy->disable();
     m_pageAgentProxy = nullptr;
     m_pageInstrumentationEnabled = false;
 }


### PR DESCRIPTION
#### 719a73b464bfaf60a7e3c2c716ce5045f4ae838e
<pre>
[Site Isolation] Emit live Page.frameNavigated/frameDetached from cross-origin processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=316664">https://bugs.webkit.org/show_bug.cgi?id=316664</a>
<a href="https://rdar.apple.com/179117260">rdar://179117260</a>

Reviewed by BJ Burg.

Under Site Isolation a cross-origin frame commits in its own WebContent process, so
the per-page InspectorPageAgent (which lives in the main frame&apos;s process) never sees
it. The UIProcess ProxyingPageAgent aggregates frame state across processes, but it
received no frame lifecycle events from non-main processes, so dynamically added or
removed cross-origin iframes were invisible to it.

Re-enable the dispatch of frameNavigated/frameDetached to the cross-process
PageAgentProxy (registered in the enabledPageProxy slot of each participating
process&apos;s InstrumentingAgents). PageAgentProxy forwards them over IPC to the
UIProcess ProxyingPageAgent. Late-joining processes are already instrumented via
WebPageInspectorController::didCreateFrame, and the frame&apos;s InstrumentingAgents
falls back to the page&apos;s, where the proxy is registered -- so no additional
instrumentation plumbing is needed.

This dispatch was reverted previously because it crashed. The crash was a
use-after-free: WebInspectorBackend::disablePageInstrumentation() destroyed the
PageAgentProxy without clearing it from the page&apos;s InstrumentingAgents enabledPageProxy
slot, so the next frame commit in that process dereferenced a freed pointer. Fix by
disabling (which clears the slot) before destroying.

* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::frameDetachedFromParentImpl):
(WebCore::InspectorInstrumentation::didCommitLoadImpl):
Dispatch to enabledPageProxy() alongside enabledPageAgent(). Include
PageAgentInstrumentation.h for the now-required complete type.

* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::disablePageInstrumentation):
Call PageAgentProxy::disable() (clears the enabledPageProxy slot) before destroying
it, fixing the dangling-pointer crash.

* Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp:
(WebKit::PageAgentProxy::frameNavigated):
(WebKit::PageAgentProxy::frameDetached):
Guard against a null parentProcessConnection() rather than dereferencing it.

* Source/JavaScriptCore/inspector/protocol/Page.json:
Remove frameDetached&apos;s targetTypes:[&quot;page&quot;] restriction so it is available on the
&quot;web-page&quot; multiplexing target (matching frameNavigated), where the ProxyingPageAgent
dispatches it. Without this the frontend rejected it as an unspecified method.

* Source/WebInspectorUI/UserInterface/Controllers/DOMDebuggerManager.js:
(WI.DOMDebuggerManager.prototype._mainFrameDidChange):
Guard against a transiently-null mainFrame while frame events from multiple Site
Isolation processes are reconciled. Full cross-process merge is the live-UI follow-up.

Canonical link: <a href="https://commits.webkit.org/315108@main">https://commits.webkit.org/315108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0549caa4bc0363c7ba02008dfa104da68cc19a98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125814 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1f91fae-5ca7-47cb-a825-82f9a33a3e4a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e68c8512-0fa2-4184-8826-db0600024149) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111322 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8024bc18-e81b-4d2f-a8e4-3d0f7bb845ee) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32270 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30969 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26137 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160732 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142256 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180041 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29360 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139238 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37460 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42370 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105724 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34404 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27443 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200791 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114130 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53938 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40271 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5539 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40522 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40416 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->