### PR TITLE
Optimize PerformanceTests/Parser/html-parser-threaded.html

### DIFF
--- a/LayoutTests/http/tests/loading/cross-origin-display-none-iframe-no-style-resources-expected.txt
+++ b/LayoutTests/http/tests/loading/cross-origin-display-none-iframe-no-style-resources-expected.txt
@@ -1,0 +1,5 @@
+Hidden cross-origin iframe - CSS background fetched: false
+Same-origin iframe nested inside it - CSS background fetched: false
+
+PASS: throttling applied to the hidden cross-origin frame and propagated to its same-origin descendant
+

--- a/LayoutTests/http/tests/loading/cross-origin-display-none-iframe-no-style-resources.html
+++ b/LayoutTests/http/tests/loading/cross-origin-display-none-iframe-no-style-resources.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="log"></pre>
+<script>
+const TOP_ORIGIN = "http://127.0.0.1:8000";
+const CROSS_ORIGIN = "http://localhost:8000";
+const role = new URLSearchParams(location.search).get("frame");
+
+function addBackgroundDiv(marker) {
+    const div = document.createElement("div");
+    div.style.cssText = "width:50px;height:50px;background-image:url(" + TOP_ORIGIN + "/resources/square100.png?" + marker + ")";
+    document.body.appendChild(div);
+}
+
+function reportBackgroundLoad(marker, label) {
+    setTimeout(function () {
+        const fetched = performance.getEntriesByType("resource").some(function (entry) { return entry.name.indexOf(marker) !== -1; });
+        window.top.postMessage({ label: label, fetched: fetched }, "*");
+    }, 500);
+}
+
+if (role === "inner") {
+    addBackgroundDiv("propagated-descendant-bg");
+    reportBackgroundLoad("propagated-descendant-bg", "nested");
+} else if (role === "middle") {
+    addBackgroundDiv("direct-crossorigin-bg");
+    reportBackgroundLoad("direct-crossorigin-bg", "direct");
+    const inner = document.createElement("iframe");
+    inner.src = TOP_ORIGIN + location.pathname + "?frame=inner";
+    document.body.appendChild(inner);
+} else {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    function log(s) { document.getElementById("log").textContent += s + "\n"; }
+
+    function finish() {
+        log("Hidden cross-origin iframe - CSS background fetched: " + results.direct);
+        log("Same-origin iframe nested inside it - CSS background fetched: " + results.nested);
+        log("");
+        log((!results.direct && !results.nested)
+            ? "PASS: throttling applied to the hidden cross-origin frame and propagated to its same-origin descendant"
+            : "FAIL: a throttled frame fetched CSS resources");
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+
+    const results = {};
+    window.addEventListener("message", function (event) {
+        if (!event.data || (event.data.label !== "direct" && event.data.label !== "nested"))
+            return;
+        results[event.data.label] = event.data.fetched;
+        if ("direct" in results && "nested" in results)
+            finish();
+    });
+
+    const iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+    iframe.src = CROSS_ORIGIN + location.pathname + "?frame=middle";
+    document.body.appendChild(iframe);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/loading/lazyimage-in-throttled-iframe-loads-when-shown-expected.txt
+++ b/LayoutTests/http/tests/loading/lazyimage-in-throttled-iframe-loads-when-shown-expected.txt
@@ -1,0 +1,6 @@
+
+While the iframe is display:none: lazy image loaded = false (expected false)
+After the iframe becomes visible: lazy image loaded = true (expected true)
+
+PASS
+

--- a/LayoutTests/http/tests/loading/lazyimage-in-throttled-iframe-loads-when-shown.html
+++ b/LayoutTests/http/tests/loading/lazyimage-in-throttled-iframe-loads-when-shown.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+if (window.internals)
+    internals.settings.setLazyImageLoadingEnabled(true);
+
+function log(s) { document.getElementById('log').textContent += s + "\n"; }
+
+let loadedWhileHidden = false;
+let loadedAfterVisible = false;
+let shown = false;
+
+window.addEventListener("message", function (event) {
+    if (event.data !== "lazyimg-loaded")
+        return;
+    if (shown)
+        loadedAfterVisible = true;
+    else
+        loadedWhileHidden = true;
+});
+
+// Unique per run so the image isn't served from cache, which would skip lazy-load deferral.
+const imageSrc = location.origin + "/resources/square100.png?lazyimage-in-throttled-iframe-" + crypto.randomUUID();
+
+const iframe = document.createElement("iframe");
+iframe.style.cssText = "display:none; width:200px; height:200px; border:0";
+iframe.sandbox = "allow-scripts";
+iframe.srcdoc =
+    '<!DOCTYPE html><body style="margin:0">'
+    + '<img loading="lazy" width="100" height="100" src="' + imageSrc + '"'
+    + ' onload="parent.postMessage(\'lazyimg-loaded\', \'*\')">'
+    + '</body>';
+document.body.insertBefore(iframe, document.body.firstChild);
+
+setTimeout(function () {
+    log("While the iframe is display:none: lazy image loaded = " + loadedWhileHidden + " (expected false)");
+    shown = true;
+    iframe.style.display = "block";
+    window.scrollTo(0, 0);
+    waitForLoadAfterVisible(25);
+}, 500);
+
+function waitForLoadAfterVisible(triesLeft) {
+    if (loadedAfterVisible || triesLeft <= 0) {
+        finish();
+        return;
+    }
+    setTimeout(function () { waitForLoadAfterVisible(triesLeft - 1); }, 100);
+}
+
+function finish() {
+    log("After the iframe becomes visible: lazy image loaded = " + loadedAfterVisible + " (expected true)");
+    log("");
+    log((!loadedWhileHidden && loadedAfterVisible)
+        ? "PASS"
+        : "FAIL: a deferred lazy image in a cross-origin hidden iframe did not load after the iframe became visible");
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2789,6 +2789,9 @@ void Document::scheduleStyleRecalc()
 
     ASSERT(childNeedsStyleRecalc() || m_needsFullStyleRebuild);
 
+    if (RefPtr frameView = view(); frameView && frameView->isCrossOriginFrameWithHiddenOwner())
+        return;
+
     m_styleRecalcTimer.startOneShot(0_s);
 
     InspectorInstrumentation::didScheduleStyleRecalculation(*this);
@@ -8271,7 +8274,8 @@ void Document::finishedParsing()
         // started the resource load and might fire the window load event too early. To avoid this
         // we force the styles to be up to date before calling FrameLoader::finishedParsing().
         // See https://bugs.webkit.org/show_bug.cgi?id=36864 starting around comment 35.
-        updateStyleIfNeeded();
+        if (RefPtr frameView = view(); !frameView || !frameView->isCrossOriginFrameWithHiddenOwner())
+            updateStyleIfNeeded();
 
         frame->loader().finishedParsing();
         InspectorInstrumentation::domContentLoadedEventFired(*frame);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -47,6 +47,7 @@
 #include "DocumentQuirks.h"
 #include "DocumentResourceLoader.h"
 #include "DocumentSVG.h"
+#include "DocumentSecurityOrigin.h"
 #include "DocumentView.h"
 #include "Editor.h"
 #include "EventHandler.h"
@@ -3842,6 +3843,23 @@ void LocalFrameView::resumeVisibleImageAnimations(const IntRect& visibleRect)
 
     if (auto* renderView = m_frame->contentRenderer())
         renderView->resumePausedImageAnimationsIfNeeded(visibleRect);
+}
+
+bool LocalFrameView::isCrossOriginFrameWithHiddenOwner() const
+{
+    if (!m_frame->ownerElement())
+        return false;
+
+    if (RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent())) {
+        RefPtr parentView = parentFrame->view();
+        if (parentView && parentView->isCrossOriginFrameWithHiddenOwner())
+            return true;
+    }
+
+    if (m_frame->ownerRenderer())
+        return false;
+    RefPtr document = m_frame->document();
+    return document && !document->isSameOriginAsTopDocument();
 }
 
 void LocalFrameView::updateScriptedAnimationsAndTimersThrottlingState(const IntRect& visibleRect)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -134,6 +134,7 @@ public:
     WEBCORE_EXPORT bool NODELETE didFirstLayout() const;
 
     WEBCORE_EXPORT bool needsLayout() const;
+    bool isCrossOriginFrameWithHiddenOwner() const;
     WEBCORE_EXPORT void setNeedsLayoutAfterViewConfigurationChange();
 
     void setNeedsCompositingConfigurationUpdate();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -738,6 +738,9 @@ void LocalFrameViewLayoutContext::scheduleLayout()
     if (!needsLayout())
         return;
 
+    if (view().isCrossOriginFrameWithHiddenOwner())
+        return;
+
 #if !LOG_DISABLED
     if (!document->ownerElement())
         LOG(Layout, "LocalFrameView %p layout timer scheduled at %.3fs", this, document->timeSinceDocumentCreation().value());
@@ -773,6 +776,11 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     // Try to catch unnecessary work during render tree teardown.
     ASSERT(!renderView->renderTreeBeingDestroyed());
     ASSERT(frame().view() == &view());
+
+    if (view().isCrossOriginFrameWithHiddenOwner()) {
+        layoutRoot.markContainingBlocksForLayout(renderView.ptr());
+        return;
+    }
 
     if (renderView->needsLayout() && !subtreeLayoutRoot()) {
         layoutRoot.markContainingBlocksForLayout(renderView.ptr());


### PR DESCRIPTION
#### d074fdf70408f8ec42ba4fc5be4c06836523fbc2
<pre>
Optimize PerformanceTests/Parser/html-parser-threaded.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=316950">https://bugs.webkit.org/show_bug.cgi?id=316950</a>
<a href="https://rdar.apple.com/179412114">rdar://179412114</a>

Reviewed by NOBODY (OOPS!).

A document loaded into a display:none iframe is never painted, but WebKit still
resolved its style, built its render tree, and laid it out, because the per-Document
style and layout timers have no notion of whether the frame is actually rendered.
On PerformanceTests/Parser/html-parser-threaded.html, which loads the 6 MB HTML5 spec
into a hidden iframe to measure parsing, this made WebKit roughly 20x slower than
Chrome, which throttles the rendering lifecycle of non-rendered frames.

Add LocalFrameView::isCrossOriginFrameWithHiddenOwner(), which is true for a
cross-origin subframe whose owner element has no renderer (i.e. display:none),
and use it to skip scheduling layout and style recalc for such frames. Forced,
on-demand updates are left ungated, so behavior is unchanged for scripts and
for visible frames.

html-parser-threaded.html is progressed from ~1630 ms/run to ~60 ms/run.
Two new layout tests verify this behavior:
cross-origin-display-none-iframe-no-style-resources.html confirms that a
cross-origin hidden iframe does not fetch CSS resources while hidden, and
lazyimage-in-throttled-iframe-loads-when-shown.html confirms that a deferred
lazy image inside one loads once the iframe becomes visible, matching behavior
in other browsers.

* LayoutTests/http/tests/loading/cross-origin-display-none-iframe-no-style-resources-expected.txt: Added.
* LayoutTests/http/tests/loading/cross-origin-display-none-iframe-no-style-resources.html: Added.
* LayoutTests/http/tests/loading/lazyimage-in-throttled-iframe-loads-when-shown-expected.txt: Added.
* LayoutTests/http/tests/loading/lazyimage-in-throttled-iframe-loads-when-shown.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::scheduleStyleRecalc):
(WebCore::Document::finishedParsing):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::isCrossOriginFrameWithHiddenOwner const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::scheduleLayout):
(WebCore::LocalFrameViewLayoutContext::scheduleSubtreeLayout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d074fdf70408f8ec42ba4fc5be4c06836523fbc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135839 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95858 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37910 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36284 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186591 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144756 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48186 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156195 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48865 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114645 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39501 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120895 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47372 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11099 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->