### PR TITLE
Cherry-pick 314892@main (c263bec093ba). https://bugs.webkit.org/show_bug.cgi?id=316645

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -735,7 +735,8 @@ FileHandle createDumpFile(StringView filename, StringView extension, StringView 
         auto [p, handle] = openTemporaryFile(filename, extension);
         return WTF::move(handle);
     }
-    return openFile(makeString(path, pathSeparator, filename, extension), FileOpenMode::Truncate);
+    // Why ReadWrite? On linux, we need to mmap dump files so that perf can see them, which will fail without read permission.
+    return openFile(makeString(path, pathSeparator, filename, extension), FileOpenMode::ReadWrite);
 }
 
 #if !PLATFORM(PLAYSTATION)

--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -95,6 +95,9 @@ static bool urlRequiresFirefoxBrowser(const String& domain)
 
     if (domain == "www.disneyplus.com"_s)
         return true;
+
+    if (domain == "www.hbomax.com"_s || domain == "auth.hbomax.com"_s)
+        return true;
 #endif
 
     return false;

--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -452,6 +452,11 @@ static void bindGStreamerData(Vector<CString>& args)
     bindIfExists(args, scannerPath);
     bindIfExists(args, installPluginsHelperPath);
     bindIfExists(args, ptpHelperPath);
+
+    // Since GStreamer 1.28.0 software video decoders are likely to use a udmabuf allocator, so
+    // allow access to the corresponding device in the sandbox. Note: We are in the UIProcess so a
+    // runtime GStreamer version check is not wanted here.
+    args.appendList({ "--dev-bind-try", "/dev/udmabuf", "/dev/udmabuf" });
 }
 
 static void bindOpenGL(Vector<CString>& args)

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -389,6 +389,10 @@ if (USE_LIBHYPHEN)
     endif ()
 endif ()
 
+# Resolve FreeType so WOFF2Checks can detect its builtin WOFF2 support. Skia
+# resolves it again later, in a subdirectory scope that is not visible here.
+find_package(Freetype 2.9.0 REQUIRED)
+
 include(WOFF2Checks)
 if (FREETYPE_WOFF2_SUPPORT_IS_AVAILABLE)
     SET_AND_EXPOSE_TO_BUILD(HAVE_WOFF_SUPPORT ON)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -265,6 +265,10 @@ if (USE_LIBHYPHEN)
     endif ()
 endif ()
 
+# Resolve FreeType so WOFF2Checks can detect its builtin WOFF2 support. Skia
+# resolves it again later, in a subdirectory scope that is not visible here.
+find_package(Freetype 2.9.0 REQUIRED)
+
 include(WOFF2Checks)
 if (FREETYPE_WOFF2_SUPPORT_IS_AVAILABLE)
     SET_AND_EXPOSE_TO_BUILD(HAVE_WOFF_SUPPORT ON)

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -119,6 +119,8 @@ TEST(UserAgentTest, Quirks)
 #if ENABLE(THUNDER)
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.netflix.com/");
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.disneyplus.com/");
+    assertUserAgentForURLHasFirefoxBrowserQuirk("http://www.hbomax.com/");
+    assertUserAgentForURLHasFirefoxBrowserQuirk("http://auth.hbomax.com/");
 #endif
 
 #if ENABLE(WEBXR) && PLATFORM(WPE)


### PR DESCRIPTION
#### e3e70dd80139fab38ef548c109d48fd9bdf33404
<pre>
Cherry-pick 314892@main (c263bec093ba). <a href="https://bugs.webkit.org/show_bug.cgi?id=316645">https://bugs.webkit.org/show_bug.cgi?id=316645</a>

    [GStreamer] Allow access to udmabuf device in bwrap sandbox
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316645">https://bugs.webkit.org/show_bug.cgi?id=316645</a>

    Reviewed by Xabier Rodriguez-Calvar and Patrick Griffis.

    Since GStreamer 1.28.0 software video decoders are likely to use a udmabuf allocator, so
    allow access to the corresponding device in the sandbox.

    * Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
    (WebKit::bindGStreamerData):

    Canonical link: <a href="https://commits.webkit.org/314892@main">https://commits.webkit.org/314892@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.731@webkitglib/2.52">https://commits.webkit.org/305877.731@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 84ad7fb66f74fc6c7e2c01888df74c62598def81
<pre>
Cherry-pick 314881@main (01b18233e58e). <a href="https://bugs.webkit.org/show_bug.cgi?id=316641">https://bugs.webkit.org/show_bug.cgi?id=316641</a>

    [CMake][GTK][WPE] Detect FreeType&apos;s builtin WOFF2 support on Skia builds
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316641">https://bugs.webkit.org/show_bug.cgi?id=316641</a>

    Reviewed by Adrian Perez de Castro.

    WOFF2Checks reads the FREETYPE_* variables to skip libwoff2dec when
    FreeType provides WOFF2 itself. 803415e3f940 removed the Cairo
    find_package(Freetype) that set those variables, so Skia builds no
    longer resolve FreeType in this scope and configuration fails with
    &quot;libwoff2dec is required for USE_WOFF2&quot; (unless libwoff2 is available).

    Resolve FreeType before WOFF2Checks: find_package is idempotent, so
    Skia-s later call is a cache hit.

    * Source/cmake/OptionsGTK.cmake:
    * Source/cmake/OptionsWPE.cmake:

    Canonical link: <a href="https://commits.webkit.org/314881@main">https://commits.webkit.org/314881@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.730@webkitglib/2.52">https://commits.webkit.org/305877.730@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6869232f5629ca77ee901e8c8e662a91e53d47f7
<pre>
Cherry-pick 314746@main (5eb4c53b5c67). <a href="https://bugs.webkit.org/show_bug.cgi?id=316519">https://bugs.webkit.org/show_bug.cgi?id=316519</a>

    [WPE][GTK] Add User-Agent quirk for HBO Max
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316519">https://bugs.webkit.org/show_bug.cgi?id=316519</a>

    Reviewed by Adrian Perez de Castro.

    Make sure the User-Agent used for HBO Max is the one matching Firefox, otherwise if the application
    uses a non-default (like Android) User-Agent WebSetting we might be redirected to a page asking the
    user to install the HBO Android app.

    Test: Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp

    * Source/WebCore/platform/glib/UserAgentQuirks.cpp:
    (WebCore::urlRequiresFirefoxBrowser):
    * Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp:
    (TestWebKitAPI::TEST(UserAgentTest, Quirks)):

    Canonical link: <a href="https://commits.webkit.org/314746@main">https://commits.webkit.org/314746@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.729@webkitglib/2.52">https://commits.webkit.org/305877.729@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e037f78c47aa6ff11e71ba3a615e5afd4b9b3ef6
<pre>
Cherry-pick 310321@main (fa7de87229e7). <a href="https://bugs.webkit.org/show_bug.cgi?id=311124">https://bugs.webkit.org/show_bug.cgi?id=311124</a>

    Fix failing mmap for jit dump on linux
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311124">https://bugs.webkit.org/show_bug.cgi?id=311124</a>

    Reviewed by Yusuke Suzuki.

    The mmap for perf fails without read privileges because of
    PROT_EXEC. This fixes samply.

    Canonical link: <a href="https://commits.webkit.org/310321@main">https://commits.webkit.org/310321@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.728@webkitglib/2.52">https://commits.webkit.org/305877.728@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d66729be0040386a8bb3f7035376300de07d74ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167993 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/41490 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35086 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177289 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125686 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169859 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/41925 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41505 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130703 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125686 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170952 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/41925 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/35086 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111220 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/41925 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41505 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25991 "Built successfully") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160611 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/41925 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/35086 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179888 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/29239 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32640 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35086 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139124 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/41562 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/41505 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139005 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/42250 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/35086 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/105530 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25582 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/42250 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35086 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200671 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/40754 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114006 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53907 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/40151 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/35086 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/40402 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/40296 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->