### PR TITLE
NSCrossWebsiteTrackingUsageDescription is not working on Mac, ITP is always enabled

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2009 Torch Mobile, Inc.
  * Copyright (C) 2010, 2011 Research In Motion Limited. All rights reserved.
  *
@@ -398,4 +398,8 @@
 
 #if !defined(USE_SANDBOX_PARAMS) && PLATFORM(MAC)
 #define USE_SANDBOX_PARAMS 1
+#endif
+
+#if PLATFORM(IOS) || PLATFORM(VISION)
+#define USE_ITP_TCC_CHECK 1
 #endif

--- a/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
+++ b/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -124,11 +124,13 @@ static bool determineTrackingPreventionStateInternal(bool appWasLinkedOnOrAfter,
     if (!isFullWebBrowser && !hasRequestedCrossWebsiteTrackingPermission())
         return true;
 
-    TCCAccessPreflightResult result = kTCCAccessPreflightDenied;
-#if PLATFORM(IOS) || PLATFORM(MAC) || PLATFORM(VISION)
-    result = TCCAccessPreflight(get_TCC_kTCCServiceWebKitIntelligentTrackingPreventionSingleton(), nullptr);
-#endif
+#if USE(ITP_TCC_CHECK)
+    TCCAccessPreflightResult result = TCCAccessPreflight(get_TCC_kTCCServiceWebKitIntelligentTrackingPreventionSingleton(), nullptr);
     return result != kTCCAccessPreflightDenied;
+#else
+    // FIXME(rdar://72817121): We should use the normal TCC Check once this bug is fixed.
+    return false;
+#endif
 }
 
 static RefPtr<WorkQueue>& NODELETE itpQueue()
@@ -175,8 +177,8 @@ bool doesParentProcessHaveTrackingPreventionEnabled(AuxiliaryProcess& auxiliaryP
         return true;
 
     static bool trackingPreventionEnabled = [&] {
+#if USE(ITP_TCC_CHECK)
         TCCAccessPreflightResult result = kTCCAccessPreflightDenied;
-#if PLATFORM(IOS) || PLATFORM(MAC) || PLATFORM(VISION)
         RefPtr<IPC::Connection> connection = auxiliaryProcess.parentProcessConnection();
         if (!connection) {
             ASSERT_NOT_REACHED();
@@ -191,8 +193,12 @@ bool doesParentProcessHaveTrackingPreventionEnabled(AuxiliaryProcess& auxiliaryP
             return true;
         }
         result = TCCAccessPreflightWithAuditToken(get_TCC_kTCCServiceWebKitIntelligentTrackingPreventionSingleton(), auditToken.value(), nullptr);
-#endif
         return result != kTCCAccessPreflightDenied;
+#else
+        // FIXME(rdar://72817121): We should use the normal TCC Check once this bug is fixed.
+        UNUSED_PARAM(auxiliaryProcess);
+        return false;
+#endif
     }();
     return trackingPreventionEnabled;
 }


### PR DESCRIPTION
#### 30f40ca4af988af84766e91c57cf130164412ef4
<pre>
NSCrossWebsiteTrackingUsageDescription is not working on Mac, ITP is always enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=220190">https://bugs.webkit.org/show_bug.cgi?id=220190</a>
&lt;<a href="https://rdar.apple.com/problem/72817121">rdar://problem/72817121</a>&gt;

Reviewed by Matthew Finkel.

This is a rebase of 232788@main, which was reverted due to a build issue.

Consider the presence of the NSCrossWebsiteTrackingUsageDescription key as an indication
to disable ITP for WKWebView until the Settings app on macOS provides a UI to allow users
to disabling it for a specific app, like we do for iOS.

* Source/WTF/wtf/PlatformUse.h:
* Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm:
(WebKit::determineTrackingPreventionStateInternal):
(WebKit::doesParentProcessHaveTrackingPreventionEnabled):

Canonical link: <a href="https://commits.webkit.org/316474@main">https://commits.webkit.org/316474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3415b12032b9a4d2471768c90fbbc0901e5b6296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181810 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129914 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e58d240-313d-4f75-8869-527ca598d719) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134054 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79894612-0a95-41dd-83db-ae64a71cb504) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114525 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47d45bb3-a136-4e27-9558-1752ef986e89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36118 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34390 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30415 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3146 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184345 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33619 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142824 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45948 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38553 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46626 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111353 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37772 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118377 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205036 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45143 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9063 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54738 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44543 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44775 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->