### PR TITLE
Convert models off the main thread in the model process

### DIFF
--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -64,7 +64,7 @@ class DestinationColorSpace;
 class FloatSize;
 struct ModelPlayerGraphicsLayerConfiguration;
 
-class WEBCORE_EXPORT ModelPlayer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelPlayer> {
+class WEBCORE_EXPORT ModelPlayer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelPlayer, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ModelPlayer, WEBCORE_EXPORT);
 public:
     virtual ~ModelPlayer();

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -63,7 +63,9 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/WeakPtr.h>
+#import <wtf/WorkQueue.h>
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/TextStream.h>
 
@@ -236,12 +238,17 @@ public:
     RKUSDModelLoadScheduler() = default;
 
     Ref<REModelLoader> scheduleModelLoad(Model&, const std::optional<String>& attributionTaskID, std::optional<int> entityMemoryLimit, REModelLoaderClient&);
+    void scheduleModelConversion(Ref<WebCore::SharedBuffer>&&, ThreadSafeWeakPtr<ModelProcessModelPlayerProxy>&&, Function<void(ModelProcessModelPlayerProxy&, RetainPtr<NSData>&&)>&&);
 
 private:
     void loadNextModel();
 
+    static constexpr size_t maxLimitOnParallelLoads = 3;
+
     Deque<Ref<RKModelLoaderUSD>> m_pendingLoads;
     size_t m_inProgressLoadsCount { 0 };
+
+    const Ref<WorkQueue> m_conversionQueue { WorkQueue::create("com.apple.WebKit.ModelProcess.USDConversion"_s, WorkQueue::QOS::UserInitiated) };
 };
 
 RKUSDModelLoadScheduler& RKUSDModelLoadScheduler::singleton()
@@ -262,11 +269,26 @@ Ref<REModelLoader> RKUSDModelLoadScheduler::scheduleModelLoad(Model& model, cons
     return loader;
 }
 
+void RKUSDModelLoadScheduler::scheduleModelConversion(Ref<WebCore::SharedBuffer>&& modelData, ThreadSafeWeakPtr<ModelProcessModelPlayerProxy>&& player, Function<void(ModelProcessModelPlayerProxy&, RetainPtr<NSData>&&)>&& completion)
+{
+    m_conversionQueue->dispatch([modelData = WTF::move(modelData), player = WTF::move(player), completion = WTF::move(completion)] () mutable {
+        // Skip the copy + conversion if the player is already gone (e.g. its <model> element was unloaded).
+        if (!player.get())
+            return;
+
+        RetainPtr usdzData = [WKUSDStageConverter convert:modelData->createNSData()];
+
+        dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([player = WTF::move(player), completion = WTF::move(completion), usdzData = WTF::move(usdzData)] () mutable {
+            if (RefPtr protectedPlayer = player.get())
+                completion(*protectedPlayer, WTF::move(usdzData));
+        }).get());
+    });
+}
+
 void RKUSDModelLoadScheduler::loadNextModel()
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
-    static const size_t maxLimitOnParallelLoads = 3;
     if (m_inProgressLoadsCount >= maxLimitOnParallelLoads)
         return;
 
@@ -388,23 +410,29 @@ void ModelProcessModelPlayerProxy::createLayer()
 
 void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, bool isForImmersive)
 {
+    dispatch_assert_queue(mainDispatchQueueSingleton());
+
 #if HAVE(CORE_RE)
     if (model->mimeType() != usdzMIMEType) {
-        RetainPtr<NSData> modelData = model->data()->createNSData();
-        RetainPtr<NSData> usdzData = [WKUSDStageConverter convert:modelData.get()];
+        Ref<WebCore::SharedBuffer> modelData = model->data();
+        RKUSDModelLoadScheduler::singleton().scheduleModelConversion(WTF::move(modelData), ThreadSafeWeakPtr { *this }, [model = WTF::move(model), layoutSize, isForImmersive](ModelProcessModelPlayerProxy& proxy, RetainPtr<NSData>&& usdzData) mutable {
+            dispatch_assert_queue(mainDispatchQueueSingleton());
 
-        if (usdzData) {
-            auto convertedBuffer = WebCore::SharedBuffer::create(usdzData.get());
+            if (usdzData) {
+                auto convertedBuffer = WebCore::SharedBuffer::create(usdzData.get());
 
-            // Send converted data back to WebContent for drag-and-drop
-            send(Messages::ModelProcessModelPlayer::DidConvertModelData(convertedBuffer.copyRef(), usdzMIMEType));
+                // Send converted data back to WebContent for drag-and-drop
+                proxy.send(Messages::ModelProcessModelPlayer::DidConvertModelData(convertedBuffer.copyRef(), usdzMIMEType));
 
-            auto convertedModel = WebCore::Model::create(WTF::move(convertedBuffer), usdzMIMEType, model->url());
-            load(convertedModel, layoutSize, isForImmersive);
-            return;
-        }
+                auto convertedModel = WebCore::Model::create(WTF::move(convertedBuffer), usdzMIMEType, model->url());
+                proxy.load(convertedModel, layoutSize, isForImmersive);
+                return;
+            }
 
-        RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy::loadModel(): Model conversion failed, continuing with original data", this);
+            RELEASE_LOG_ERROR(ModelElement, "%p - ModelProcessModelPlayerProxy::loadModel(): Model conversion failed, continuing with original data", &proxy);
+            proxy.load(model, layoutSize, isForImmersive);
+        });
+        return;
     }
 #endif
 


### PR DESCRIPTION
#### abc95c76eb7c76745bf91399fc658080d19ee4cb
<pre>
Convert models off the main thread in the model process
<a href="https://bugs.webkit.org/show_bug.cgi?id=316954">https://bugs.webkit.org/show_bug.cgi?id=316954</a>
<a href="https://rdar.apple.com/170323515">rdar://170323515</a>

Reviewed by Mike Wyrzykowski.

WKUSDStageConverter::convert() is a synchronous, CPU-heavy transform run
inline on the model process&apos;s main queue. That process is multi-tenant, so
one conversion stalls interaction for every &lt;model&gt; in every tab.

Move convert() onto a serial background WorkQueue owned by
RKUSDModelLoadScheduler, handing the data off as a SharedBuffer so even the
NSData copy happens off-main. Serial (not parallel) keeps at most one USD
stage materialized at once, since several would risk a jetsam.

Each conversion holds a ThreadSafeWeakPtr to its player: the worker skips
the convert, and the main thread skips delivery, if the &lt;model&gt; was
unloaded -- destruction is the cancellation signal, no explicit handle.
Resolving that weak ref off-main could drop the player&apos;s last reference on
the WorkQueue, running ~ModelProcessModelPlayerProxy() (RealityKit
teardown) off the main thread; ModelPlayer is pinned to
WTF::DestructionThread::Main so the final destruction hops back to main.

* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::RKUSDModelLoadScheduler::scheduleModelConversion):
(WebKit::RKUSDModelLoadScheduler::loadNextModel):
(WebKit::ModelProcessModelPlayerProxy::loadModel):

Canonical link: <a href="https://commits.webkit.org/316093@main">https://commits.webkit.org/316093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4151f11cedd3f52abcfdc07c79a96f9a8af414ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128573 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25731c1c-f427-4ebd-a5f9-29285d999752) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133261 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b984a56-9c89-4474-8a6b-b8098752e169) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36486 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153718 "Found 1 new API test failure: TestWebKitAPI.WritingTools.ProofreadingShowOriginalWithMultiwordSuggestions (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113747 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a526ac68-6d7e-442e-9d73-bd71bca5bc4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35109 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33420 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28916 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182822 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141723 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44439 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141534 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38162 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45128 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109833 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36803 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117019 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43639 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8195 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43285 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43174 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->