### PR TITLE
Synthetic bold adds advance width to zero-advance glyphs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/synthetic-bold-zero-advance-glyph-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/synthetic-bold-zero-advance-glyph-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Synthetic bold does not give width to a zero-advance (empty) font
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/synthetic-bold-zero-advance-glyph.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/synthetic-bold-zero-advance-glyph.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Synthetic bold must not add advance to zero-advance glyphs</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-synthesis-weight">
+<link rel="help" href="https://www.w3.org/TR/css-text-3/#letter-spacing-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@font-face {
+    /* resources/ChTestZeroWidthZero.woff has only a Regular face; U+0030 '0'
+       maps to a glyph whose advance width is 0, so any run of '0' is 0px wide.
+       Requesting bold has no bold face to use, so the UA synthesizes bold. */
+    font-family: "ChTestZeroWidthZero";
+    src: url("../css-values/resources/ChTestZeroWidthZero.woff") format("woff");
+}
+</style>
+<body>
+<script>
+// Lay out 100 zero-advance glyphs at the given weight and return the run width.
+// With no bold face present, the bold run gets synthetic bold; without the fix
+// each glyph was padded by font-size/36, making the run non-zero wide instead
+// of 0. A zero-advance glyph draws in place and must not advance the pen.
+function runWidth(weight) {
+    const span = document.createElement("span");
+    span.style.cssText = "display:inline-block; font-family:'ChTestZeroWidthZero';"
+        + " font-size:50px; white-space:nowrap; font-weight:" + weight;
+    span.textContent = "0".repeat(100);
+    document.body.appendChild(span);
+    const width = span.getBoundingClientRect().width;
+    span.remove();
+    return width;
+}
+
+promise_test(async () => {
+    await document.fonts.load("50px ChTestZeroWidthZero");
+    await document.fonts.ready;
+    assert_true(document.fonts.check("50px ChTestZeroWidthZero"), "the zero-advance font loaded");
+
+    assert_equals(runWidth("normal"), 0, "a run of zero-advance glyphs is 0px wide");
+    assert_equals(runWidth("bold"), 0, "synthetic bold must not add advance to zero-advance glyphs");
+}, "Synthetic bold does not give width to a zero-advance (empty) font");
+</script>
+</body>

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -785,7 +785,9 @@ void ComplexTextController::adjustGlyphsAndAdvances()
                     advance.expand(-origins[0].x(), -origins[0].y());
             }
 
-            advance.expand(font->syntheticBoldOffset(), 0);
+            // Only embolden glyphs that advance the pen, like the "zero width lurkers" guard below.
+            if (advance.width())
+                advance.expand(font->syntheticBoldOffset(), 0);
 
             if (hasExtraSpacing) {
                 // If we're a glyph with an advance, add in letter-spacing.

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Holger Hans Peter Freyther
  *
  * This library is free software; you can redistribute it and/or
@@ -748,10 +748,13 @@ void WidthIterator::applyCSSVisibilityRules(GlyphBuffer& glyphBuffer, unsigned g
     float yPosition = height(glyphBuffer.initialAdvance());
 
     auto adjustForSyntheticBold = [&](auto index) {
+        auto& advance = glyphBuffer.advances(index)[0];
+        // Only embolden glyphs that advance the pen, like the "zero width lurkers" letter-spacing guard.
+        if (!width(advance))
+            return;
         auto glyph = glyphBuffer.glyphAt(index);
         auto syntheticBoldOffset = glyph == deletedGlyph ? 0 : glyphBuffer.fontAt(index).syntheticBoldOffset();
         m_runWidthSoFar += syntheticBoldOffset;
-        auto& advance = glyphBuffer.advances(index)[0];
         setWidth(advance, width(advance) + syntheticBoldOffset);
     };
 


### PR DESCRIPTION
#### 720fc1082286802ee65af48d21b4a5dbac84ef5b
<pre>
Synthetic bold adds advance width to zero-advance glyphs
<a href="https://bugs.webkit.org/show_bug.cgi?id=316951">https://bugs.webkit.org/show_bug.cgi?id=316951</a>
<a href="https://rdar.apple.com/179418570">rdar://179418570</a>

Reviewed by Darin Adler and Brent Fulgham.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Synthetic bold padded every glyph&apos;s advance by syntheticBoldOffset()
(fontSize / 36), including glyphs whose real advance is 0 (combining
marks, zero-width spaces, empty/zero-width fonts). A run of such glyphs
measured N * fontSize / 36 wide instead of 0, e.g. a bold heading in a
zero-advance font reserved a visible gap not present in other engines.

A zero-advance glyph draws in place and must not advance the pen.
Letter-spacing already guards this with `if (advance.width())`; apply the
same guard to synthetic bold in both text paths. The simplified-measuring
path asserts no synthetic bold, so it needs no change.

Test: css/css-fonts/synthetic-bold-zero-advance-glyph.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/synthetic-bold-zero-advance-glyph-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/synthetic-bold-zero-advance-glyph.html: Added.
(WebCore::ComplexTextController::enclosingGlyphBoundsForTextRun):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::applyCSSVisibilityRules):

Canonical link: <a href="https://commits.webkit.org/315157@main">https://commits.webkit.org/315157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2164c54c407903140ea83067bccc03a4e6b43042

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41739 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35357 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125885 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e941999-6a4d-477e-922d-e4cc3d383062) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130873 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56da1f9b-5fff-499f-baad-0bd1ab93dea4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111385 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ca97026-5ed5-4bda-ba87-af716527f4d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32327 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31031 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26208 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142313 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180112 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32835 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139310 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41753 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35190 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139173 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37494 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150619 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105815 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34461 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114201 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40342 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5602 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->