### PR TITLE
WebAuthenticatorCoordinatorProxy signal methods must invoke reply CompletionHandler on the main run loop

### DIFF
--- a/LayoutTests/ipc/web-authenticator-signal-main-thread-expected.txt
+++ b/LayoutTests/ipc/web-authenticator-signal-main-thread-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/web-authenticator-signal-main-thread.html
+++ b/LayoutTests/ipc/web-authenticator-signal-main-thread.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/ipc.js"></script>
+<title>WebAuthenticatorCoordinatorProxy signal* messages must invoke their reply CompletionHandler on the main run loop.</title>
+</head>
+<body>
+<p>This test passes if WebKit does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+if (window.IPC) {
+    import('./coreipc.js').then(async ({ CoreIPC }) => {
+        const origin = { data: { variantType: 'WebCore::SecurityOriginData::Tuple', variant: { protocol: 'https', host: 'example.com', port: { } } } };
+        const rpId = 'example.com';
+        const userId = 'dGVzdA';
+        const credentialId = 'dGVzdA';
+
+        CoreIPC.UI.WebAuthenticatorCoordinatorProxy.SignalUnknownCredential(IPC.webPageProxyID, { origin, options: { rpId, credentialId } });
+        CoreIPC.UI.WebAuthenticatorCoordinatorProxy.SignalAllAcceptedCredentials(IPC.webPageProxyID, { origin, options: { rpId, userId, allAcceptedCredentialIds: [credentialId] } });
+        CoreIPC.UI.WebAuthenticatorCoordinatorProxy.SignalCurrentUserDetails(IPC.webPageProxyID, { origin, options: { rpId, userId, name: 'test', displayName: 'test' } });
+
+        await asyncFlush('UI');
+        // Give the platform credential-manager async callback time to fire on its background queue.
+        await new Promise(resolve => setTimeout(resolve, 500));
+        await asyncFlush('UI');
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }).catch(e => {
+        document.body.textContent = "FAIL: " + e;
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+} else if (window.testRunner) {
+    testRunner.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3370,6 +3370,7 @@ ipc/videoEncode.html [ Skip ]
 
 # WebAuthn not enabled
 ipc/web-authenticator-get-assertion.html [ Skip ]
+ipc/web-authenticator-signal-main-thread.html [ Skip ]
 
 # These tests require UseGPUProcessForMediaEnabled
 ipc/restrictedendpoints/allow-access-testOnlyIPC.html [ Skip ]

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -1408,12 +1408,14 @@ void WebAuthenticatorCoordinatorProxy::signalUnknownCredential(const WebCore::Se
 
 #if USE(APPLE_INTERNAL_SDK)
     [getCredentialUpdaterShimClassSingleton() signalUnknownCredentialWithRelyingPartyIdentifier:options.rpId.createNSString().get() credentialID:WTF::toNSData(*decodedCredentialId).get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](NSError *error) mutable {
-        if (error) {
-            RELEASE_LOG_ERROR(WebAuthn, "Error signaling unknown credential: %@.", error.localizedDescription);
-            completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling unknown credential."_s });
-            return;
-        }
-        completionHandler(std::nullopt);
+        ensureOnMainRunLoop([error = protect(error), completionHandler = WTF::move(completionHandler)] mutable {
+            if (error) {
+                RELEASE_LOG_ERROR(WebAuthn, "Error signaling unknown credential: %@.", error.get().localizedDescription);
+                completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling unknown credential."_s });
+                return;
+            }
+            completionHandler(std::nullopt);
+        });
     }).get()];
 #endif
 }
@@ -1439,12 +1441,14 @@ void WebAuthenticatorCoordinatorProxy::signalAllAcceptedCredentials(const WebCor
 
 #if USE(APPLE_INTERNAL_SDK)
     [getCredentialUpdaterShimClassSingleton() signalAllAcceptedCredentialsWithRelyingPartyIdentifier:options.rpId.createNSString().get() userHandle:WTF::toNSData(*userHandle).get() acceptedCredentialIDs:credentialIds.get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](NSError *error) mutable {
-        if (error) {
-            RELEASE_LOG_ERROR(WebAuthn, "Error signaling all accepted credentials: %@.", error.localizedDescription);
-            completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling all accepted credentials"_s });
-            return;
-        }
-        completionHandler(std::nullopt);
+        ensureOnMainRunLoop([completionHandler = WTF::move(completionHandler), error = retainPtr(error)]() mutable {
+            if (error) {
+                RELEASE_LOG_ERROR(WebAuthn, "Error signaling all accepted credentials: %@.", error.get().localizedDescription);
+                completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling all accepted credentials"_s });
+                return;
+            }
+            completionHandler(std::nullopt);
+        });
     }).get()];
 #endif
 }
@@ -1460,12 +1464,14 @@ void WebAuthenticatorCoordinatorProxy::signalCurrentUserDetails(const WebCore::S
 
 #if USE(APPLE_INTERNAL_SDK)
     [getCredentialUpdaterShimClassSingleton() signalCurrentUserDetailsWithRelyingPartyIdentifier:options.rpId.createNSString().get() userHandle:WTF::toNSData(*userHandle).get() newName:options.name.createNSString().get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](NSError *error) mutable {
-        if (error) {
-            RELEASE_LOG_ERROR(WebAuthn, "Error signaling current user details: %@.", error.localizedDescription);
-            completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling current user details."_s });
-            return;
-        }
-        completionHandler(std::nullopt);
+        ensureOnMainRunLoop([completionHandler = WTF::move(completionHandler), error = retainPtr(error)]() mutable {
+            if (error) {
+                RELEASE_LOG_ERROR(WebAuthn, "Error signaling current user details: %@.", error.get().localizedDescription);
+                completionHandler(ExceptionData { ExceptionCode::UnknownError, "Error signaling current user details."_s });
+                return;
+            }
+            completionHandler(std::nullopt);
+        });
     }).get()];
 #endif
 }


### PR DESCRIPTION
#### 3d1e0ca9e2eca53af1049bbde3b44ebbac70af50
<pre>
WebAuthenticatorCoordinatorProxy signal methods must invoke reply CompletionHandler on the main run loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=316955">https://bugs.webkit.org/show_bug.cgi?id=316955</a>
<a href="https://rdar.apple.com/175153657">rdar://175153657</a>

Reviewed by Chris Dumez.

Ensure WebAuthenticatorCoordinatorProxy signalUnknownCredential, signalAllAcceptedCredentials, and signalCurrentUserDetails invoke their reply CompletionHandlers on the main run loop

Test: ipc/web-authenticator-signal-main-thread.html

* LayoutTests/ipc/web-authenticator-signal-main-thread-expected.txt: Added.
* LayoutTests/ipc/web-authenticator-signal-main-thread.html: Added.
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:

Canonical link: <a href="https://commits.webkit.org/318615@main">https://commits.webkit.org/318615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86538a653ef5eeb08c16a469507b23bd1472d9a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188368 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139375 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119829 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41611 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39957 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39613 "Passed tests") | [⏳ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/GTK-GTK3-GCC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45291 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/44199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190796 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148556 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39892 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53040 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36240 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148323 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43021 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125307 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119968 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51558 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14591 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50943 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51005 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->