### PR TITLE
REGRESSION(6/11/2026)?: [macOS iOS] imported/w3c/web-platform-tests/largest-contentful-paint/image-TAO.sub.html is a flaky text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resources/largest-contentful-paint-helpers.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resources/largest-contentful-paint-helpers.js
@@ -40,7 +40,10 @@ function checkImage(entry, expectedUrl, expectedID, expectedSize, timeLowerBound
   if (options.includes('skip')) {
     return;
   }
-  assert_greater_than_equal(performance.now(), entry.renderTime,
+  // Different coarsening of performance.now() and entry.renderTime may result in rounding errors
+  // which cause performance.now() to be < renderTime.
+  const epsilon = 0.00001;
+  assert_greater_than_equal(performance.now() + epsilon, entry.renderTime,
     'renderTime should occur before the entry is dispatched to the observer.');
   assert_approx_equals(entry.startTime, entry.renderTime, 0.001,
     'startTime should be equal to renderTime to the precision of 1 millisecond.');


### PR DESCRIPTION
#### 4ab068e54b5cca59fd696c0b733b54af749ee9f3
<pre>
REGRESSION(6/11/2026)?: [macOS iOS] imported/w3c/web-platform-tests/largest-contentful-paint/image-TAO.sub.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=316939">https://bugs.webkit.org/show_bug.cgi?id=316939</a>
<a href="https://rdar.apple.com/179406190">rdar://179406190</a>

Reviewed by Anne van Kesteren.

The test was failing with values like &quot;expected a number greater than or equal to 36.00000000000001 but got 36&quot;.
This happens because `performance.now()` is coarsened with a resolution of 1ms, and `entry.renderTime` with 4ms.
Floating point rounding can cause the reduced-resolution &quot;now&quot; time to be fractionally less than the renderTime.

Fix with an epsilon of 0.1ms.

* LayoutTests/imported/w3c/web-platform-tests/largest-contentful-paint/resources/largest-contentful-paint-helpers.js:
(checkImage):

Canonical link: <a href="https://commits.webkit.org/315230@main">https://commits.webkit.org/315230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bf6fef8587dac1e9b8c7ef4e6e5824d40cf456c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125704 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5065d9e1-25cc-473d-95c8-c110c3c4afed) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130717 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91868 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ad40000-ec38-47a1-a512-93bff3c0fdb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111234 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa79498f-ff30-4136-a0e5-95a3cb6c9d9d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32168 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30874 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26009 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179906 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139142 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139022 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37534 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42268 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105548 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34306 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27342 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40772 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40169 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5442 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40420 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40314 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->