### PR TITLE
CSSParserTokenRange::consumeLast() ignores its empty-range guard

### DIFF
--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -105,7 +105,7 @@ void CSSParserTokenRange::trimTrailingWhitespace()
 const CSSParserToken& CSSParserTokenRange::consumeLast() LIFETIME_BOUND
 {
     if (atEnd())
-        eofToken();
+        return eofToken();
     return WTF::consumeLast(m_tokens);
 }
 


### PR DESCRIPTION
#### b4a7610d247da5708adc0e6c2b45feddc61d47aa
<pre>
CSSParserTokenRange::consumeLast() ignores its empty-range guard
<a href="https://bugs.webkit.org/show_bug.cgi?id=316960">https://bugs.webkit.org/show_bug.cgi?id=316960</a>

Reviewed by Darin Adler.

The empty-range guard in consumeLast() was missing a `return`, so the
result of eofToken() was discarded and control fell through to
WTF::consumeLast(m_tokens). On an empty span that calls span::back()
(forming an out-of-bounds pointer, likely crashing) and
span::first(size() - 1) with size() - 1 == SIZE_MAX (corrupting the
span length), instead of returning the EOF sentinel. Add the missing
`return` so the method honors the same EOF contract as consume() in the
header.

No test case is added because the buggy path is not reachable through
normal CSS parsing: the only in-tree caller of consumeLast()
(consumeTrailingImportantAndWhitespace() in CSSParser.cpp) trims
trailing whitespace and guards with range.size() &lt; 2 before calling it,
so the range is never empty at the call site. There is no CSS input
that drives consumeLast() onto an empty range, hence no observable
behavior a layout or API test could assert against. This is a latent
defect fixed to make the method honor its documented EOF contract for
any future caller.

* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
(WebCore::CSSParserTokenRange::consumeLast):

Canonical link: <a href="https://commits.webkit.org/315179@main">https://commits.webkit.org/315179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933abef3ec5473d4dfcf3fa9839ee62f742c5648

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125708 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd77ebc6-80ec-4da5-955d-ddb3b54df58a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130721 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91871 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ffe7b25-b155-4f36-9ac3-1f6caa255cd2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111238 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac706030-e783-4df7-ad7f-2505e272d5f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30878 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26013 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142161 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179910 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139146 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139026 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37503 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42272 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105559 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27347 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114028 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40173 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5447 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40424 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40318 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->