### PR TITLE
:nth-child() An+B coefficients are converted from double to int without clamping

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/nth-child-large-anplusb-clamp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/nth-child-large-anplusb-clamp-expected.txt
@@ -1,0 +1,5 @@
+
+PASS b term (NumberToken path) is clamped to INT_MAX
+PASS a term (DimensionToken path) is clamped to INT_MAX
+PASS b term following an a coefficient is clamped to INT_MAX
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/nth-child-large-anplusb-clamp.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/nth-child-large-anplusb-clamp.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Selectors: large An+B coefficients in :nth-child() are clamped to the int range</title>
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-nth-child-pseudo">
+<link rel="help" href="https://drafts.csswg.org/css-syntax-3/#anb-microsyntax">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+// An+B coefficients in :nth-child() that overflow a 32-bit int must be clamped to
+// the int range, not converted via an undefined double-to-int conversion. With
+// clamping, huge positive values serialize to INT_MAX (2147483647). Without it the
+// behavior is implementation-defined: on some architectures the value wraps to
+// INT_MIN (-2147483648).
+
+const INT_MAX = "2147483647";
+
+function selectorTextFor(selector)
+{
+    const sheet = document.head.appendChild(document.createElement("style")).sheet;
+    sheet.insertRule(selector + " { color: green; }", 0);
+    return sheet.cssRules[0].selectorText;
+}
+
+test(() => {
+    assert_equals(selectorTextFor(":nth-child(99999999999999999999)"), ":nth-child(" + INT_MAX + ")");
+}, "b term (NumberToken path) is clamped to INT_MAX");
+
+test(() => {
+    assert_equals(selectorTextFor(":nth-child(99999999999999999999n)"), ":nth-child(" + INT_MAX + "n)");
+}, "a term (DimensionToken path) is clamped to INT_MAX");
+
+test(() => {
+    assert_equals(selectorTextFor(":nth-child(2n+99999999999999999999)"), ":nth-child(2n+" + INT_MAX + ")");
+}, "b term following an a coefficient is clamped to INT_MAX");
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -43,6 +43,7 @@
 #include "SelectorPseudoTypeMap.h"
 #include "UserAgentParts.h"
 #include <memory>
+#include <wtf/MathExtras.h>
 #include <wtf/OptionSet.h>
 #include <wtf/SetForScope.h>
 #include <wtf/text/StringBuilder.h>
@@ -1177,7 +1178,7 @@ static bool consumeANPlusB(CSSParserTokenRange& range, std::pair<int, int>& resu
 {
     const CSSParserToken& token = range.consume();
     if (token.type() == NumberToken && token.numericValueType() == IntegerValueType) {
-        result = std::make_pair(0, static_cast<int>(token.numericValue()));
+        result = std::make_pair(0, clampTo<int>(token.numericValue()));
         return true;
     }
     if (token.type() == IdentToken) {
@@ -1199,7 +1200,7 @@ static bool consumeANPlusB(CSSParserTokenRange& range, std::pair<int, int>& resu
         result.first = 1;
         nString = range.consume().value();
     } else if (token.type() == DimensionToken && token.numericValueType() == IntegerValueType) {
-        result.first = token.numericValue();
+        result.first = clampTo<int>(token.numericValue());
         nString = token.unitString();
     } else if (token.type() == IdentToken) {
         if (token.value()[0] == '-') {
@@ -1245,7 +1246,7 @@ static bool consumeANPlusB(CSSParserTokenRange& range, std::pair<int, int>& resu
         return false;
     if ((b.numericSign() == NoSign) == (sign == NoSign))
         return false;
-    result.second = b.numericValue();
+    result.second = clampTo<int>(b.numericValue());
     if (sign == MinusSign)
         result.second = -result.second;
     return true;


### PR DESCRIPTION
#### fab4ac5572e0b4160bf6c2bfb5e6ce0855baae14
<pre>
:nth-child() An+B coefficients are converted from double to int without clamping
<a href="https://bugs.webkit.org/show_bug.cgi?id=316962">https://bugs.webkit.org/show_bug.cgi?id=316962</a>

Reviewed by Darin Adler.

CSSSelectorParser::consumeANPlusB() converted the An+B coefficients from
the token&apos;s numericValue() (a double) to int using a static_cast (for the
B term in the NumberToken path) or an implicit narrowing conversion (for
the A term and the trailing B term). numericValue() is computed by the
tokenizer with no magnitude clamping, and numericValueType() == IntegerValueType
only means the literal had no decimal point or exponent -- not that it fits
in an int. A selector such as :nth-child(99999999999999999999n) therefore
fed a ~1e20 double into a double-to-int conversion, which is undefined
behavior when the value is outside the range of int ([conv.fpint]).

In practice the result is architecture-dependent: ARM64&apos;s FCVTZS saturates
to INT_MAX, while x86-64&apos;s cvttsd2si yields INT_MIN, and a -fsanitize=float-cast-overflow
build traps outright.

Fix this by clamping with clampTo&lt;int&gt;() at all three conversion sites, so
huge coefficients deterministically saturate to INT_MAX / INT_MIN on every
architecture. This matches Blink, whose CSSSelectorParser::ConsumeANPlusB
already uses ClampTo&lt;int&gt;(token.NumericValue()) at the corresponding sites
(renderer/core/css/parser/css_selector_parser.cc).

A layout test is added that parses out-of-range coefficients and reads back
the serialized selectorText, asserting the clamped INT_MAX result. The test
passes everywhere with the fix. Without the fix it fails only on architectures
whose double-to-int conversion does not happen to saturate (e.g. x86-64, where
the value wraps to INT_MIN and serializes as &quot;-2147483648n&quot;); on ARM64 the
hardware already saturates to the same value clampTo&lt;int&gt;() produces, so it
cannot fail there. This is noted because the test deliberately validates the
correct result rather than relying on a sanitizer trap.

Test: imported/w3c/web-platform-tests/css/selectors/nth-child-large-anplusb-clamp.html

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/nth-child-large-anplusb-clamp-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/nth-child-large-anplusb-clamp.html: Added.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::consumeANPlusB):

Canonical link: <a href="https://commits.webkit.org/315197@main">https://commits.webkit.org/315197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7b17af70302f467ffa5567c9e29a816af3f734a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125985 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdd72678-96ad-499b-b981-3f641751f13f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130965 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92062 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43e46f70-8a5a-4421-8c0b-5e985c51f5da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111477 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4cd574a6-90b2-47ac-b7a1-510cd43a0606) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32418 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26308 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142404 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180212 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139402 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41853 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37519 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105980 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34554 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27612 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114301 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40442 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5697 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40693 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->