### PR TITLE
AX: AXTextOperations skip text input fields when isolated tree is enabled

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -65,7 +65,6 @@ accessibility/mac/text-marker-for-index-2.html [ Failure ]
 accessibility/mac/text-marker-word-nav.html [ Failure ]
 accessibility/mac/selected-visible-position-range.html [ Failure ]
 accessibility/mac/text-marker-word-nav.html [ Timeout ]
-accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html [ Failure ]
 accessibility/textarea-insertion-point-line-number.html [ Failure ]
 
 # We compute the wrong line index relative to what is actually visually laid out.

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3943,7 +3943,7 @@ VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarker
 
 CharacterOffset AXObjectCache::characterOffsetForTextMarkerData(const TextMarkerData& textMarkerData)
 {
-    if (textMarkerData.ignored)
+    if (textMarkerData.isRedacted)
         return { };
 
     RefPtr node = nodeForID(textMarkerData.axObjectID());
@@ -4222,9 +4222,9 @@ TextMarkerData AXObjectCache::textMarkerDataForCharacterOffset(const CharacterOf
         return { };
 
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(characterOffset.node.get()); input && input->isSecureField())
-        return { *this, { }, true, origin };
+        return { *this, { }, /* isRedacted */ true, origin };
 
-    return { *this, characterOffset, false, origin };
+    return { *this, characterOffset, /* isRedacted */ false, origin };
 }
 
 CharacterOffset AXObjectCache::startOrEndCharacterOffsetForRange(const SimpleRange& range, bool isStart, bool enterTextControls)
@@ -4355,7 +4355,7 @@ TextMarkerData AXObjectCache::textMarkerDataForNextCharacterOffset(const Charact
         if (!range || !lengthForRange(*range))
             shouldContinue = true;
         previous = next;
-    } while (data.ignored || shouldContinue);
+    } while (data.isRedacted || shouldContinue);
     return data;
 }
 
@@ -4387,7 +4387,7 @@ TextMarkerData AXObjectCache::textMarkerDataForPreviousCharacterOffset(const Cha
         if (!range || !lengthForRange(*range))
             shouldContinue = true;
         next = previous;
-    } while (data.ignored || shouldContinue);
+    } while (data.isRedacted || shouldContinue);
     return data;
 }
 
@@ -4484,7 +4484,7 @@ CharacterOffset AXObjectCache::characterOffsetFromVisiblePosition(const VisibleP
 
 AccessibilityObject* AXObjectCache::objectForTextMarkerData(const TextMarkerData& textMarkerData)
 {
-    if (textMarkerData.ignored)
+    if (textMarkerData.isRedacted)
         return nullptr;
 
     RefPtr object = m_objects.get(*textMarkerData.axObjectID());
@@ -4509,7 +4509,12 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
     if (!node)
         return std::nullopt;
 
-    if (RefPtr input = dynamicDowncast<HTMLInputElement>(node); input && input->isSecureField())
+    auto isSecureField = [&node] () {
+        auto* input = dynamicDowncast<HTMLInputElement>(node.get());
+        return input && input->isSecureField();
+    };
+
+    if (isSecureField())
         return std::nullopt;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -4518,12 +4523,15 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
         // the rendered, post-whitespace-collapse text.
         unsigned domOffset = position.deprecatedEditingOffset();
 
-        auto createFromRendererAndOffset = [&origin, &visiblePosition] (RenderObject& renderer, unsigned offset) -> std::optional<TextMarkerData> {
+        auto createFromRendererAndOffset = [&] (RenderObject& renderer, unsigned offset) -> std::optional<TextMarkerData> {
             CheckedPtr cache = renderer.document().axObjectCache();
             RefPtr object = cache ? cache->getOrCreate(renderer) : nullptr;
             if (!object)
                 return std::nullopt;
 
+            // We hardcode isRedacted to false below because we early-return for secure fields above.
+            // Assert here in case the check gets moved or changed.
+            AX_ASSERT(!isSecureField());
             return std::optional(TextMarkerData {
                 cache->treeID(),
                 object->objectID(),
@@ -4532,7 +4540,7 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
                 visiblePosition.affinity(),
                 0,
                 offset,
-                object->isIgnored(),
+                /* isRedacted */ false,
                 origin
             });
         };
@@ -4589,7 +4597,7 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
     if (!cache)
         return std::nullopt;
     return { { *cache, visiblePosition,
-        characterOffset.startIndex, characterOffset.offset, false, origin } };
+        characterOffset.startIndex, characterOffset.offset, /* isRedacted */ false, origin } };
 }
 
 CharacterOffset AXObjectCache::nextCharacterOffset(const CharacterOffset& characterOffset, bool ignoreNextNodeStart)

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -59,7 +59,7 @@ static std::optional<AXID> nodeID(AXObjectCache& cache, Node* node)
     return std::nullopt;
 }
 
-TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visiblePosition, int charStart, int charOffset, bool ignoredParam, TextMarkerOrigin originParam)
+TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visiblePosition, int charStart, int charOffset, bool isRedactedParam, TextMarkerOrigin originParam)
 {
     AX_ASSERT(isMainThread());
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -76,11 +76,11 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visi
     affinity = visiblePosition.affinity();
     characterStart = std::max(charStart, 0);
     characterOffset = std::max(charOffset, 0);
-    ignored = ignoredParam;
+    isRedacted = isRedactedParam;
     origin = originParam;
 }
 
-TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& characterOffsetParam, bool ignoredParam, TextMarkerOrigin originParam)
+TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& characterOffsetParam, bool isRedactedParam, TextMarkerOrigin originParam)
 {
     AX_ASSERT(isMainThread());
 
@@ -104,7 +104,7 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& char
     affinity = visiblePosition.affinity();
     characterStart = std::max(characterOffsetParam.startIndex, 0);
     characterOffset = std::max(characterOffsetParam.offset, 0);
-    ignored = ignoredParam;
+    isRedacted = isRedactedParam;
     origin = originParam;
 }
 
@@ -154,7 +154,7 @@ AXTextMarker::operator CharacterOffset() const
 {
     AX_ASSERT(isMainThread());
 
-    if (isIgnored() || isNull())
+    if (isRedacted() || isNull())
         return { };
 
     WeakPtr cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(m_data.axTreeID());
@@ -241,7 +241,7 @@ String AXTextMarker::description() const
 
     return makeString("{"_s
         , object ? makeString("role "_s, roleToString(object->role())) : "no object"_s
-        , isIgnored() ? makeString(separator, "ignored"_s) : ""_s
+        , isRedacted() ? makeString(separator, "redacted"_s) : ""_s
         // Anchor type and other fields below are not used for text markers processed off the main-thread.
         , isMainThread() ? makeString(separator, "anchor "_s, m_data.anchorType) : ""_s
         , affinity

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -165,7 +165,7 @@ struct TextMarkerData {
 
     unsigned characterStart;
     unsigned characterOffset;
-    bool ignored;
+    bool isRedacted;
     Affinity affinity;
 
     TextMarkerOrigin origin;
@@ -182,7 +182,7 @@ struct TextMarkerData {
         unsigned offsetParam = 0,
         Position::AnchorType anchorTypeParam = Position::PositionIsOffsetInAnchor,
         Affinity affinityParam = Affinity::Downstream,
-        unsigned charStart = 0, unsigned charOffset = 0, bool ignoredParam = false, TextMarkerOrigin originParam = TextMarkerOrigin::Unknown)
+        unsigned charStart = 0, unsigned charOffset = 0, bool isRedactedParam = false, TextMarkerOrigin originParam = TextMarkerOrigin::Unknown)
     {
         zeroBytes(*this);
         treeID = axTreeID ? axTreeID->toUInt64() : 0;
@@ -192,12 +192,12 @@ struct TextMarkerData {
         affinity = affinityParam;
         characterStart = charStart;
         characterOffset = charOffset;
-        ignored = ignoredParam;
+        isRedacted = isRedactedParam;
         origin = originParam;
     }
 
-    TextMarkerData(AXObjectCache&, const VisiblePosition&, int charStart = 0, int charOffset = 0, bool ignoredParam = false, TextMarkerOrigin originParam = TextMarkerOrigin::Unknown);
-    TextMarkerData(AXObjectCache&, const CharacterOffset&, bool ignoredParam = false, TextMarkerOrigin originParam = TextMarkerOrigin::Unknown);
+    TextMarkerData(AXObjectCache&, const VisiblePosition&, int charStart = 0, int charOffset = 0, bool isRedactedParam = false, TextMarkerOrigin originParam = TextMarkerOrigin::Unknown);
+    TextMarkerData(AXObjectCache&, const CharacterOffset&, bool isRedactedParam = false, TextMarkerOrigin originParam = TextMarkerOrigin::Unknown);
 
     friend bool operator==(const TextMarkerData&, const TextMarkerData&) = default;
 
@@ -267,7 +267,7 @@ public:
 #endif
     RefPtr<AXCoreObject> object() const;
     bool isValid() const { return object(); }
-    bool isIgnored() const { return m_data.ignored; }
+    bool isRedacted() const { return m_data.isRedacted; }
     Affinity affinity() const { return m_data.affinity; }
     bool isDownstream() const { return affinity() == Affinity::Downstream; }
     void setAffinity(Affinity affinity) { m_data.affinity = affinity; }

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -187,7 +187,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
         return nil;
 
     auto textMarkerData = cache->textMarkerDataForCharacterOffset(characterOffset);
-    if (!textMarkerData.objectID && !textMarkerData.ignored)
+    if (!textMarkerData.objectID && !textMarkerData.isRedacted)
         return nil;
     return adoptNS([[WebAccessibilityTextMarker alloc] initWithTextMarker:&textMarkerData cache:cache]).autorelease();
 }
@@ -220,7 +220,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 
 - (BOOL)isIgnored
 {
-    return _textMarkerData.ignored;
+    return _textMarkerData.isRedacted;
 }
 
 - (RefPtr<AccessibilityObject>)accessibilityObject

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -1075,7 +1075,7 @@ AXTextMarkerRef textMarkerForCharacterOffset(AXObjectCache* cache, const Charact
         return nil;
 
     auto textMarkerData = cache->textMarkerDataForCharacterOffset(characterOffset, origin);
-    if (!textMarkerData.objectID || textMarkerData.ignored)
+    if (!textMarkerData.objectID || textMarkerData.isRedacted)
         return nil;
     return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&textMarkerData, sizeof(textMarkerData))).autorelease();
 }


### PR DESCRIPTION
#### 42b3ecc4724deceda84578093f57f6fd842abf6e
<pre>
AX: AXTextOperations skip text input fields when isolated tree is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=316961">https://bugs.webkit.org/show_bug.cgi?id=316961</a>
<a href="https://rdar.apple.com/179428392">rdar://179428392</a>

Reviewed by Chris Fleizach.

With isolated tree mode enabled, AXTextOperations (e.g. replace) skip
text inputs. The cause is in AXObjectCache::textMarkerDataForVisiblePosition.
When shouldCreateAXThreadCompatibleMarkers() is true, it builds a TextMarkerData
with the `ignored` field set from object-&amp;gt;isIgnored(). An &amp;lt;input&amp;gt;&amp;apos;s inner
user-agent-shadow text is an AX-ignored object, so its marker was flagged ignored=true.
When that marker range was later converted back to a SimpleRange on the main thread,
characterOffsetForTextMarkerData / objectForTextMarkerData return null for an
ignored marker, so the range was dropped and never operated on.

The main reason this bug occurred is because TextMarkerData&amp;apos;s `ignored`
field did not actually map to the canonical notion of accessibility-is-ignored.
Based on how the live tree actually sets and uses it, the intent is to
denote whether the marker is within a secure field. The bug is fixed
by hardcoding `ignored` to false for anything that&amp;apos;s not a secure field.

To keep the name from inviting the same mistake again, this commit renames
the field from `ignored` to `isRedacted`.

This progresses test accessibility/mac/text-operation/text-operation-replace-across-multiple-fields.html
in isolated tree mode.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::characterOffsetForTextMarkerData):
(WebCore::AXObjectCache::textMarkerDataForCharacterOffset):
(WebCore::AXObjectCache::textMarkerDataForNextCharacterOffset):
(WebCore::AXObjectCache::textMarkerDataForPreviousCharacterOffset):
(WebCore::AXObjectCache::objectForTextMarkerData):
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarker::operator CharacterOffset const):
(WebCore::AXTextMarker::description const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarker::isRedacted const):
(WebCore::AXTextMarker::isIgnored const): Deleted.
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(+[WebAccessibilityTextMarker textMarkerWithCharacterOffset:cache:]):
(-[WebAccessibilityTextMarker isIgnored]):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::textMarkerForCharacterOffset):

Canonical link: <a href="https://commits.webkit.org/315101@main">https://commits.webkit.org/315101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2715a2b8e8989384621147a89a0755fddead1d14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168041 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40370fae-e643-4a0a-a85d-06c5d82cfa64) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130742 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9124b9d7-64ed-4a6d-8907-7ed302f31e9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111259 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9429a602-8b4a-45c7-80ab-a5652bbb67b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32195 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30900 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26039 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179936 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32688 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139167 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139047 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37455 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42298 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105598 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27373 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40802 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114054 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40199 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5472 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40450 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40344 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->