### PR TITLE
JSCustomElementInterface fails to visit m_connectedMoveCallback during GC

### DIFF
--- a/LayoutTests/fast/custom-elements/connectedMoveCallback-survives-gc-expected.txt
+++ b/LayoutTests/fast/custom-elements/connectedMoveCallback-survives-gc-expected.txt
@@ -1,0 +1,10 @@
+Tests that connectedMoveCallback is kept alive by the garbage collector. The callback is stored as a JSC::Weak, so JSCustomElementInterface::visitJSFunctionsInGCThread() must visit it. Otherwise it is collected once removed from the prototype, and moveBefore() fires disconnected/connected instead of connectedMove.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS reactions.join() is "connectedMove"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/custom-elements/connectedMoveCallback-survives-gc.html
+++ b/LayoutTests/fast/custom-elements/connectedMoveCallback-survives-gc.html
@@ -1,0 +1,41 @@
+<!-- webkit-test-runner [ MoveBeforeEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<section id="section"></section>
+<script src="../../resources/js-test.js"></script>
+<script>
+description('Tests that connectedMoveCallback is kept alive by the garbage collector. The callback is stored as a JSC::Weak, so JSCustomElementInterface::visitJSFunctionsInGCThread() must visit it. Otherwise it is collected once removed from the prototype, and moveBefore() fires disconnected/connected instead of connectedMove.');
+
+jsTestIsAsync = true;
+
+let reactions = [];
+
+class MoveElement extends HTMLElement {
+    connectedMoveCallback() { reactions.push('connectedMove'); }
+    connectedCallback() { reactions.push('connected'); }
+    disconnectedCallback() { reactions.push('disconnected'); }
+}
+customElements.define('move-element', MoveElement);
+
+// Leave m_connectedMoveCallback as the function's only reference, so it survives GC only if visited.
+delete MoveElement.prototype.connectedMoveCallback;
+
+const element = document.createElement('move-element');
+document.body.appendChild(element);
+
+(async () => {
+    await Promise.resolve();
+    reactions = [];
+
+    gc();
+
+    document.getElementById('section').moveBefore(element, null);
+    await Promise.resolve();
+
+    shouldBeEqualToString('reactions.join()', 'connectedMove');
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -467,6 +467,7 @@ void JSCustomElementInterface::visitJSFunctionsInGCThread(Visitor& visitor) cons
     visitor.append(m_constructor);
     visitor.append(m_connectedCallback);
     visitor.append(m_disconnectedCallback);
+    visitor.append(m_connectedMoveCallback);
     visitor.append(m_adoptedCallback);
     visitor.append(m_attributeChangedCallback);
     visitor.append(m_formAssociatedCallback);


### PR DESCRIPTION
#### 97721ca8c2a59ef7b9b3ad7bcf3b489fb767d34b
<pre>
JSCustomElementInterface fails to visit m_connectedMoveCallback during GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=316965">https://bugs.webkit.org/show_bug.cgi?id=316965</a>

Reviewed by Anne van Kesteren.

JSCustomElementInterface stores each custom element reaction callback as a
JSC::Weak&lt;JSObject&gt; with no custom WeakHandleOwner, so the visitor.append()
calls in visitJSFunctionsInGCThread() are the only thing keeping those
functions alive across a garbage collection. That function appended every
callback except m_connectedMoveCallback, which was added later (in the
connectedMoveCallback() implementation) without updating the visit list.

As a result, once the only other reference to the connectedMoveCallback
function is dropped (e.g. the method is deleted off the constructor&apos;s
prototype), the function can be collected while its custom element definition
is still live and registered. After collection hasConnectedMoveCallback()
returns false, so a subsequent moveBefore() enqueues the
disconnected/connected reactions instead of connectedMove, silently changing
observable behavior.

Fix this by visiting m_connectedMoveCallback alongside the other callbacks,
in member-declaration order.

Test: fast/custom-elements/connectedMoveCallback-survives-gc.html

* LayoutTests/fast/custom-elements/connectedMoveCallback-survives-gc-expected.txt: Added.
* LayoutTests/fast/custom-elements/connectedMoveCallback-survives-gc.html: Added.
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::visitJSFunctionsInGCThread const):

Canonical link: <a href="https://commits.webkit.org/315105@main">https://commits.webkit.org/315105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce1274987db9737139c9802cb4d7633a68fa9a6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125720 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b8059d8-7181-41df-bab7-8aa668a63675) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130731 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e51f3c52-c80c-4b59-bd3f-dcb256b0b496) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111248 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcc62879-55ce-46ba-9511-d46c7eecef72) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32182 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30888 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26025 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142172 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179922 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139156 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139036 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37458 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105577 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34321 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27358 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114040 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40185 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5458 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40436 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->