### PR TITLE
AX: An anchor element that has a click handler but no href should still be considered a link

### DIFF
--- a/LayoutTests/accessibility/anchor-with-click-handler-is-link-expected.txt
+++ b/LayoutTests/accessibility/anchor-with-click-handler-is-link-expected.txt
@@ -1,0 +1,24 @@
+This test ensures an anchor with a click handler but no href is exposed as a link.
+
+PASS: isExposedAsLink('anchor-with-onclick') === true
+PASS: isExposedAsLink('anchor-without-handler') === false
+
+Dynamically added anchor with onclick is a link:
+PASS: isExposedAsLink('dynamic-anchor-with-onclick') === true
+
+Adding a click handler to a hrefless anchor turns it into a link:
+PASS: isExposedAsLink('click-toggle-anchor') === true
+
+Removing the only click handler reverts it to not being a link:
+PASS: isExposedAsLink('click-toggle-anchor') === false
+
+Removing the href from a link with no click handler stops it being a link:
+PASS: isExposedAsLink('href-toggle-anchor') === false
+
+Restoring the href makes it a link again:
+PASS: isExposedAsLink('href-toggle-anchor') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Anchor with onclick Anchor without click handler or href Anchor that gains then loses a click handler Anchor that loses then regains its href Dynamically added anchor with onclick

--- a/LayoutTests/accessibility/anchor-with-click-handler-is-link.html
+++ b/LayoutTests/accessibility/anchor-with-click-handler-is-link.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<a onclick="this.dataset.clicked = 'true'" id="anchor-with-onclick">Anchor with onclick</a>
+<a id="anchor-without-handler">Anchor without click handler or href</a>
+<a id="click-toggle-anchor">Anchor that gains then loses a click handler</a>
+<a href="#destination" id="href-toggle-anchor">Anchor that loses then regains its href</a>
+
+<script>
+var output = "This test ensures an anchor with a click handler but no href is exposed as a link.\n\n";
+
+function isExposedAsLink(id) {
+    var element = accessibilityController.accessibleElementById(id);
+    return !!element && element.role.toLowerCase().includes("link");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("isExposedAsLink('anchor-with-onclick')", "true");
+    // An anchor with neither an href nor a click handler should not be exposed as a link.
+    output += expect("isExposedAsLink('anchor-without-handler')", "false");
+
+    var clickHandler = () => { };
+
+    setTimeout(async function() {
+        output += "\nDynamically added anchor with onclick is a link:\n";
+        var dynamicAnchor = document.createElement("a");
+        dynamicAnchor.id = "dynamic-anchor-with-onclick";
+        dynamicAnchor.textContent = "Dynamically added anchor with onclick";
+        dynamicAnchor.setAttribute("onclick", "this.dataset.clicked = 'true'");
+        document.body.appendChild(dynamicAnchor);
+        output += await expectAsync("isExposedAsLink('dynamic-anchor-with-onclick')", "true");
+
+        output += "\nAdding a click handler to a hrefless anchor turns it into a link:\n";
+        document.getElementById("click-toggle-anchor").addEventListener("click", clickHandler);
+        output += await expectAsync("isExposedAsLink('click-toggle-anchor')", "true");
+
+        output += "\nRemoving the only click handler reverts it to not being a link:\n";
+        document.getElementById("click-toggle-anchor").removeEventListener("click", clickHandler);
+        output += await expectAsync("isExposedAsLink('click-toggle-anchor')", "false");
+
+        output += "\nRemoving the href from a link with no click handler stops it being a link:\n";
+        document.getElementById("href-toggle-anchor").removeAttribute("href");
+        output += await expectAsync("isExposedAsLink('href-toggle-anchor')", "false");
+
+        output += "\nRestoring the href makes it a link again:\n";
+        document.getElementById("href-toggle-anchor").setAttribute("href", "#destination");
+        output += await expectAsync("isExposedAsLink('href-toggle-anchor')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -77,6 +77,7 @@
 #include "EventNames.h"
 #include "FocusController.h"
 #include "FrameLoader.h"
+#include "HTMLAnchorElement.h"
 #include "HTMLAreaElement.h"
 #include "HTMLButtonElement.h"
 #include "HTMLCanvasElement.h"
@@ -1498,14 +1499,12 @@ void AXObjectCache::onRendererCreated(Node& node)
     }
 }
 
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 static bool isClickEvent(const AtomString& eventType)
 {
     return eventType == eventNames().clickEvent
         || eventType == eventNames().mousedownEvent
         || eventType == eventNames().mouseupEvent;
 }
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
 void AXObjectCache::onDragElementChanged(Element* oldElement, Element* newElement)
 {
@@ -1551,33 +1550,31 @@ void AXObjectCache::onDraggingDropped(Element& dragTarget)
 
 void AXObjectCache::onEventListenerAdded(Node& node, const AtomString& eventType)
 {
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    if (!isClickEvent(eventType))
-        return;
-
-    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID)) {
-        if (RefPtr object = get(node))
-            tree->queueNodeUpdate(object->objectID(), { AXProperty::HasClickHandler });
-    }
-#else
-    UNUSED_PARAM(node);
-    UNUSED_PARAM(eventType);
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    handleClickHandlerChanged(node, eventType);
 }
 
 void AXObjectCache::onEventListenerRemoved(Node& node, const AtomString& eventType)
 {
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    handleClickHandlerChanged(node, eventType);
+}
+
+void AXObjectCache::handleClickHandlerChanged(Node& node, const AtomString& eventType)
+{
     if (!isClickEvent(eventType))
         return;
 
-    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID)) {
-        if (RefPtr object = get(node))
-            tree->queueNodeUpdate(object->objectID(), { AXProperty::HasClickHandler });
-    }
-#else
-    UNUSED_PARAM(node);
-    UNUSED_PARAM(eventType);
+    RefPtr object = get(node);
+    if (!object)
+        return;
+
+    // A hrefless anchor is exposed as a link only when it has a click handler, so adding or removing
+    // one can change its role. (An anchor with an href is a link regardless of its click handlers.)
+    if (RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(node); anchor && !anchor->isLink())
+        object->updateRole();
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
+        tree->queueNodeUpdate(object->objectID(), { AXProperty::HasClickHandler });
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 }
 
@@ -3519,6 +3516,16 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     if (relationAttributes().contains(attrName)) {
         m_elementsWithRelationAttributes.add(*element);
         updateRelations(*element, attrName);
+    }
+
+    if (attrName == hrefAttr) {
+        // An anchor's role depends on whether it is a link (Element::isLink(), i.e. whether it has an
+        // href). Recompute the role when href changes so a hrefless anchor with a click handler can
+        // become a link, and vice versa.
+        if (RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(element)) {
+            if (RefPtr object = get(*anchor))
+                object->updateRole();
+        }
     }
 
     if (attrName == roleAttr)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -914,6 +914,7 @@ private:
     void handleTabPanelSelected(Element*, Element*);
     void handleRowCountChanged(AccessibilityObject*, Document*);
     void handleAttributeChange(Element*, const QualifiedName&, const AtomString&, const AtomString&);
+    void handleClickHandlerChanged(Node&, const AtomString& eventType);
     bool shouldProcessAttributeChange(Element*, const QualifiedName&);
     void selectedChildrenChanged(Node*);
     void selectedChildrenChanged(RenderObject*);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -541,6 +541,10 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
 
     if (element->isLink())
         return AccessibilityRole::Link;
+    // Element::isLink() is false for an anchor without an href, but other engines (e.g. Chrome, Firefox)
+    // still expose such an anchor as a link when it has a click handler, so match that behavior.
+    if (is<HTMLAnchorElement>(*element) && hasClickHandler())
+        return AccessibilityRole::Link;
     if (auto* selectElement = dynamicDowncast<HTMLSelectElement>(*element)) {
         UNUSED_VARIABLE(selectElement);
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 2387eef3bad24a2fea2ba5f9943e38d446a07983
<pre>
AX: An anchor element that has a click handler but no href should still be considered a link
<a href="https://bugs.webkit.org/show_bug.cgi?id=316929">https://bugs.webkit.org/show_bug.cgi?id=316929</a>
<a href="https://rdar.apple.com/179398579">rdar://179398579</a>

Reviewed by Chris Fleizach.

As a markup repair, Chrome and Firefox expose an &lt;a&gt; with a click handler but
no href as a link. WebKit did not: Element::isLink() is only true for anchors
with an href, so a hrefless anchor with an onclick handler fell through role
determination to the generic Inline role and was ignored by the accessibility tree.

With this commit, we implement this markup repair.

* LayoutTests/accessibility/anchor-with-click-handler-is-link-expected.txt: Added.
* LayoutTests/accessibility/anchor-with-click-handler-is-link.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::isClickEvent):
(WebCore::AXObjectCache::onEventListenerAdded):
(WebCore::AXObjectCache::onEventListenerRemoved):
(WebCore::AXObjectCache::handleClickHandlerChanged):
(WebCore::AXObjectCache::handleAttributeChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):

Canonical link: <a href="https://commits.webkit.org/315102@main">https://commits.webkit.org/315102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db647b7d8c601a6d951775c92497a092bdebdbe2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125721 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db29ed45-f08a-4a2a-b97a-7bc01fedc67b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130732 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3d4da0b-1261-4f79-af76-bae747b405ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111249 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fe0313d-9a17-4b1a-ae41-b952b17e715d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32184 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30889 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26026 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179923 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32675 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139157 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139037 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37456 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105578 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34323 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27359 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40789 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114041 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40186 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5459 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40437 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40331 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->