### PR TITLE
Cherry-pick(s) 33ae1ab583c7. rdar://176067106

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2501,9 +2501,15 @@ void NetworkStorageManager::importServiceWorkerRegistrationsForOrigin(const WebC
     if (m_closed)
         return completionHandler(std::nullopt);
 
+<<<<<<< HEAD
     RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrationsForOrigin: Starting import", this);
     auto startTime = MonotonicTime::now();
     workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, topOrigin = crossThreadCopy(topOrigin), startTime, completionHandler = WTF::move(completionHandler)]() mutable {
+=======
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Starting import", this);
+    auto startTime = MonotonicTime::now();
+    workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, startTime, completionHandler = WTF::move(completionHandler)]() mutable {
+>>>>>>> 33ae1ab583c7 (Bump QoS of the work queue during service worker registrations import)
         assertIsCurrent(workQueue());
 
         std::optional<Vector<WebCore::ServiceWorkerContextData>> result;
@@ -2524,6 +2530,7 @@ void NetworkStorageManager::importServiceWorkerRegistrationsForOrigin(const WebC
         }
 
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), startTime, result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+<<<<<<< HEAD
 #if !RELEASE_LOG_DISABLED
             auto elapsed = MonotonicTime::now() - startTime;
             RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrationsForOrigin: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
@@ -2573,6 +2580,16 @@ void NetworkStorageManager::importServiceWorkerOriginList(CompletionHandler<void
             completionHandler(WTF::move(result));
         });
     }, WorkQueue::QOS::UserInitiated);
+=======
+            auto elapsed = MonotonicTime::now() - startTime;
+            if (elapsed > 2_s)
+                RELEASE_LOG_ERROR(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+            else
+                RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+            completionHandler(WTF::move(result));
+        });
+    }, WorkQueue::QOS::UserInitiated);
+>>>>>>> 33ae1ab583c7 (Bump QoS of the work queue during service worker registrations import)
 }
 
 void NetworkStorageManager::updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&& registrationsToUpdate, Vector<WebCore::ServiceWorkerRegistrationKey>&& registrationsToDelete, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&& completionHandler)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176067106 to main. [33ae1ab583c7] caused a merge conflict. 

```Bump QoS of the work queue during service worker registrations import
https://bugs.webkit.org/show_bug.cgi?id=309626
rdar://172236600

Reviewed by Sihui Liu.

Bump QoS of the work queue during service worker registrations import
from disk. Navigations are delayed until the import is complete and it
is thus important to treat the import with high (UserInitiated) priority.

* Source/WTF/wtf/SuspendableWorkQueue.cpp:
(WTF::SuspendableWorkQueue::dispatchWithQOS):
* Source/WTF/wtf/SuspendableWorkQueue.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::importServiceWorkerRegistrations):

Originally-landed-as: 305413.439@safari-7624-branch (33ae1ab583c7). rdar://176067106

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c3fdecb566ff34e278779f9e824a2fff0585a43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168029 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41526 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35122 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177325 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41961 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41541 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/177325 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170988 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/41961 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/35122 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/177325 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/41961 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/41541 "") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/26027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/41961 "") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/35122 "") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/179924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/35122 "") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/179924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41598 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/41541 "") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/179924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42286 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/35122 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105579 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/42286 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/35122 "") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40790 "") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40187 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/35122 "") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40438 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40332 "") | | | 
<!--EWS-Status-Bubble-End-->