### PR TITLE
IndexedDB transactions of a suspended process block other processes indefinitely

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
@@ -27,6 +27,7 @@
 #include "IDBConnectionToClient.h"
 
 #include "IDBDatabaseNameAndVersion.h"
+#include "UniqueIDBDatabase.h"
 #include "UniqueIDBDatabaseConnection.h"
 
 namespace WebCore {
@@ -213,6 +214,23 @@ void IDBConnectionToClient::connectionToClientClosed()
     });
 
     ASSERT(m_databaseConnections.isEmptyIgnoringNullReferences());
+}
+
+void IDBConnectionToClient::setClientProcessSuspended(bool isSuspended)
+{
+    if (m_isClientProcessSuspended == isSuspended)
+        return;
+
+    m_isClientProcessSuspended = isSuspended;
+    if (!isSuspended)
+        return;
+
+    // Transactions from other clients may already be queued behind this client's
+    // in-progress transactions, which cannot finish while the client is suspended.
+    m_databaseConnections.forEach([](UniqueIDBDatabaseConnection& connection) {
+        if (CheckedPtr database = connection.database())
+            database->abortInProgressTransactionsBlockedOnSuspendedClients();
+    });
 }
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
@@ -84,12 +84,16 @@ public:
     bool isClosed() { return m_isClosed; }
     void clearDelegate() { m_delegate = nullptr; }
 
+    WEBCORE_EXPORT void setClientProcessSuspended(bool);
+    bool isClientProcessSuspended() const { return m_isClientProcessSuspended; }
+
 private:
     IDBConnectionToClient(IDBConnectionToClientDelegate&);
     
     CheckedPtr<IDBConnectionToClientDelegate> m_delegate;
     WeakHashSet<UniqueIDBDatabaseConnection> m_databaseConnections;
     bool m_isClosed { false };
+    bool m_isClientProcessSuspended { false };
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -540,6 +540,8 @@ void UniqueIDBDatabase::clearTransactionsOnConnection(UniqueIDBDatabaseConnectio
     }
     for (auto& transaction : transactionsToAbort)
         transaction->abortWithoutCallback();
+
+    connection.deleteTransactionsAbortedForClientSuspension();
 }
 
 void UniqueIDBDatabase::didFireVersionChangeEvent(UniqueIDBDatabaseConnection& connection, const IDBResourceIdentifier& requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer connectionClosedOnBehalfOfServer)
@@ -1246,6 +1248,11 @@ void UniqueIDBDatabase::commitTransaction(UniqueIDBDatabaseTransaction& transact
 
     auto takenTransaction = m_inProgressTransactions.take(transaction.info().identifier());
     if (!takenTransaction) {
+        // The transaction may have been aborted and completed on the server while its client
+        // process was suspended; fail the commit with that abort result.
+        if (auto existingAbortResult = transaction.suspensionAbortResult())
+            return callback(existingAbortResult->isNull() ? IDBError { ExceptionCode::UnknownError, "Transaction was aborted while its process was suspended"_s } : *existingAbortResult);
+
         if (transaction.databaseConnection() && !m_openDatabaseConnections.contains(transaction.databaseConnection()))
             return;
 
@@ -1284,6 +1291,11 @@ void UniqueIDBDatabase::abortTransaction(UniqueIDBDatabaseTransaction& transacti
 
     auto takenTransaction = m_inProgressTransactions.take(transaction.info().identifier());
     if (!takenTransaction) {
+        // The transaction may have been aborted and completed on the server while its client
+        // process was suspended; tell the client about that abort now.
+        if (auto existingAbortResult = transaction.suspensionAbortResult())
+            return callback(*existingAbortResult);
+
         if (!m_openDatabaseConnections.contains(transaction.databaseConnection()))
             return;
 
@@ -1411,6 +1423,10 @@ void UniqueIDBDatabase::handleTransactions()
         transaction = takeNextRunnableTransaction(hadDeferredTransactions);
     }
     LOG(IndexedDB, "UniqueIDBDatabase::handleTransactions - There are %zu pending after this round of handling", m_pendingTransactions.size());
+
+    // In-progress transactions of a suspended client process can never finish while the client
+    // stays suspended, so transactions queued behind them would be blocked indefinitely.
+    abortInProgressTransactionsBlockedOnSuspendedClients();
 }
 
 void UniqueIDBDatabase::activateTransactionInBackingStore(UniqueIDBDatabaseTransaction& transaction)
@@ -1588,6 +1604,84 @@ void UniqueIDBDatabase::abortActiveTransactions()
     for (auto& identifier : copyToVector(m_inProgressTransactions.keys())) {
         RefPtr transaction = m_inProgressTransactions.get(identifier);
         transaction->setSuspensionAbortResult(protect(m_backingStore)->abortTransaction(transaction->info().identifier()));
+    }
+}
+
+bool UniqueIDBDatabase::transactionBlocksPendingTransactions(UniqueIDBDatabaseTransaction& inProgressTransaction)
+{
+    HashSet<IDBObjectStoreIdentifier> inProgressScopes;
+    for (auto objectStore : inProgressTransaction.objectStoreIdentifiers())
+        inProgressScopes.add(objectStore);
+
+    bool inProgressIsReadOnly = inProgressTransaction.isReadOnly();
+    CheckedPtr backingStore = m_backingStore.get();
+    bool serializesReadWrites = backingStore && !backingStore->supportsSimultaneousReadWriteTransactions();
+
+    for (auto& pendingTransaction : m_pendingTransactions) {
+        if (pendingTransaction->isReadOnly()) {
+            // A pending read-only transaction is only blocked by an overlapping in-progress write.
+            if (!inProgressIsReadOnly && scopesOverlap(inProgressScopes, pendingTransaction->objectStoreIdentifiers()))
+                return true;
+            continue;
+        }
+        // A pending read-write transaction is blocked by any overlapping in-progress transaction,
+        // or by any in-progress read-write transaction if the backing store serializes writes.
+        if (scopesOverlap(inProgressScopes, pendingTransaction->objectStoreIdentifiers()))
+            return true;
+        if (!inProgressIsReadOnly && serializesReadWrites)
+            return true;
+    }
+
+    return false;
+}
+
+void UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients()
+{
+    if (m_pendingTransactions.isEmpty() || m_inProgressTransactions.isEmpty())
+        return;
+
+    Vector<Ref<UniqueIDBDatabaseTransaction>> transactionsToAbort;
+    for (auto& transaction : m_inProgressTransactions.values()) {
+        RefPtr databaseConnection = transaction->databaseConnection();
+        if (!databaseConnection || !databaseConnection->connectionToClient().isClientProcessSuspended())
+            continue;
+        if (transactionBlocksPendingTransactions(transaction))
+            transactionsToAbort.append(transaction);
+    }
+
+    for (auto& transaction : transactionsToAbort) {
+        // transactionCompleted() below re-enters handleTransactions(), which may have already
+        // aborted this transaction in a nested pass.
+        auto transactionIdentifier = transaction->info().identifier();
+        auto takenTransaction = m_inProgressTransactions.take(transactionIdentifier);
+        if (!takenTransaction)
+            continue;
+
+        LOG(IndexedDB, "UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients - Aborting transaction %s of suspended client", transactionIdentifier.loggingString().utf8().data());
+
+        // Aborting a versionchange transaction must roll back the in-memory schema and clear the
+        // version-change connection, matching the standard abort path, so an interrupted upgrade
+        // doesn't leave the database in an inconsistent state. transactionCompleted() below clears
+        // m_versionChangeTransaction.
+        if (m_versionChangeTransaction && m_versionChangeTransaction->info().identifier() == transactionIdentifier) {
+            ASSERT(m_versionChangeTransaction->originalDatabaseInfo());
+            RefPtr versionChangeTransaction = m_versionChangeTransaction;
+            m_databaseInfo = makeUnique<IDBDatabaseInfo>(*versionChangeTransaction->originalDatabaseInfo());
+            m_versionChangeDatabaseConnection = nullptr;
+        }
+
+        // A null IDBError means the abort succeeded, matching backingStore->abortTransaction(); if
+        // the backing store is already gone there is nothing left to abort, so don't surface an
+        // internal error to the page when the client later learns about the suspension abort.
+        IDBError error;
+        if (CheckedPtr backingStore = m_backingStore.get())
+            error = backingStore->abortTransaction(transactionIdentifier);
+        transaction->setSuspensionAbortResult(error);
+
+        // Completing the transaction lets the next pending transaction begin. The transaction
+        // object stays in its connection's transaction map so a client that later resumes can
+        // still abort or commit it and learn about the suspension abort.
+        transactionCompleted(WTF::move(takenTransaction));
     }
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -120,6 +120,7 @@ public:
 
     bool NODELETE hasActiveTransactions() const;
     WEBCORE_EXPORT void abortActiveTransactions();
+    void abortInProgressTransactionsBlockedOnSuspendedClients();
     WEBCORE_EXPORT bool tryClose();
 
     WEBCORE_EXPORT String filePath() const;
@@ -146,6 +147,7 @@ private:
 
     void handleTransactions();
     RefPtr<UniqueIDBDatabaseTransaction> takeNextRunnableTransaction(bool& hadDeferredTransactions);
+    bool transactionBlocksPendingTransactions(UniqueIDBDatabaseTransaction&);
 
     void activateTransactionInBackingStore(UniqueIDBDatabaseTransaction&);
     void transactionCompleted(RefPtr<UniqueIDBDatabaseTransaction>&&);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
@@ -247,5 +247,15 @@ void UniqueIDBDatabaseConnection::deleteTransaction(UniqueIDBDatabaseTransaction
     m_transactionMap.remove(transactionIdentifier);
 }
 
+void UniqueIDBDatabaseConnection::deleteTransactionsAbortedForClientSuspension()
+{
+    // Transactions aborted on the server while this connection's client was suspended are kept
+    // in the map so the client can learn about the abort if it resumes; on connection close
+    // there is no client left to tell.
+    m_transactionMap.removeIf([](auto& entry) {
+        return entry.value->suspensionAbortResult().has_value();
+    });
+}
+
 } // namespace IDBServer
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -85,6 +85,7 @@ public:
     bool NODELETE connectionIsClosing() const;
 
     void deleteTransaction(UniqueIDBDatabaseTransaction&);
+    void deleteTransactionsAbortedForClientSuspension();
 
 private:
     UniqueIDBDatabaseConnection(UniqueIDBDatabase&, ServerOpenDBRequest&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3219,6 +3219,16 @@ void NetworkProcess::terminateIdleServiceWorkers(WebCore::ProcessIdentifier proc
     callback();
 }
 
+void NetworkProcess::setWebProcessSuspended(WebCore::ProcessIdentifier processIdentifier, bool isSuspended)
+{
+    RefPtr connection = webProcessConnection(processIdentifier);
+    if (!connection)
+        return;
+
+    if (CheckedPtr session = networkSession(connection->sessionID()))
+        session->storageManager().setWebProcessSuspended(processIdentifier, isSuspended);
+}
+
 Seconds NetworkProcess::randomClosedPortDelay()
 {
     // Random delay in the range [10ms, 110ms).

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -407,6 +407,7 @@ public:
     void clearCrossOriginPreflightResultCacheForTesting(CompletionHandler<void()>&&);
     Seconds serviceWorkerFetchTimeout() const { return m_serviceWorkerFetchTimeout; }
     void terminateIdleServiceWorkers(WebCore::ProcessIdentifier, CompletionHandler<void()>&&);
+    void setWebProcessSuspended(WebCore::ProcessIdentifier, bool isSuspended);
 
     void lastPageLoadNetworkActivityCompletionCodeForTesting(PAL::SessionID, WebCore::PageIdentifier, CompletionHandler<void(std::optional<NetworkActivityTracker::CompletionCode>)>&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -216,6 +216,8 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
     TerminateIdleServiceWorkers(WebCore::ProcessIdentifier processIdentifier) -> ()
 
+    SetWebProcessSuspended(WebCore::ProcessIdentifier processIdentifier, bool isSuspended)
+
     ResetQuota(PAL::SessionID sessionID) -> ()
     SetOriginQuotaRatioEnabledForTesting(PAL::SessionID sessionID, bool enabled) -> ();
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -54,6 +54,12 @@ WebCore::IDBServer::IDBConnectionToClient* IDBStorageRegistry::ensureConnectionT
     return &addResult.iterator->value->connectionToClient();
 }
 
+WebCore::IDBServer::IDBConnectionToClient* IDBStorageRegistry::existingConnectionToClient(WebCore::IDBConnectionIdentifier identifier)
+{
+    auto* connectionToClient = m_connectionsToClient.get(identifier);
+    return connectionToClient ? &connectionToClient->connectionToClient() : nullptr;
+}
+
 void IDBStorageRegistry::removeConnectionToClient(IPC::Connection::UniqueID connection)
 {
     auto allConnectionsToClient = std::exchange(m_connectionsToClient, { });

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -51,6 +51,7 @@ public:
     IDBStorageRegistry();
     ~IDBStorageRegistry();
     WebCore::IDBServer::IDBConnectionToClient* ensureConnectionToClient(IPC::Connection&, const WebCore::IDBResourceIdentifier&, NetworkStorageManager&);
+    WebCore::IDBServer::IDBConnectionToClient* existingConnectionToClient(WebCore::IDBConnectionIdentifier);
     void removeConnectionToClient(IPC::Connection::UniqueID);
     void registerConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);
     void unregisterConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1573,6 +1573,20 @@ void NetworkStorageManager::resume()
     workQueue().resume();
 }
 
+void NetworkStorageManager::setWebProcessSuspended(WebCore::ProcessIdentifier processIdentifier, bool isSuspended)
+{
+    ASSERT(RunLoop::isMain());
+
+    if (m_closed)
+        return;
+
+    workQueue().dispatch([this, protectedThis = Ref { *this }, processIdentifier, isSuspended] {
+        assertIsCurrent(workQueue());
+        if (RefPtr connectionToClient = m_idbStorageRegistry->existingConnectionToClient(processIdentifier))
+            connectionToClient->setClientProcessSuspended(isSuspended);
+    });
+}
+
 void NetworkStorageManager::handleLowMemoryWarning()
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -138,6 +138,7 @@ public:
     void suspend(CompletionHandler<void()>&&);
     bool isSuspended() const;
     void resume();
+    void setWebProcessSuspended(WebCore::ProcessIdentifier, bool isSuspended);
     void handleLowMemoryWarning();
     void syncLocalStorage(CompletionHandler<void()>&&);
     void fetchLocalStorage(CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2010,6 +2010,18 @@ void WebProcessProxy::didChangeThrottleState(ProcessThrottleState type)
         return;
     WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "didChangeThrottleState: type=%u", (unsigned)type);
 
+    bool isNowSuspended = type == ProcessThrottleState::Suspended;
+    if (m_lastNotifiedNetworkProcessSuspended != isNowSuspended) {
+        m_lastNotifiedNetworkProcessSuspended = isNowSuspended;
+        // The network process aborts in-progress IndexedDB transactions of a suspended process
+        // when they block transactions from other processes, so it needs to know about
+        // suspension state changes.
+        if (RefPtr dataStore = websiteDataStore()) {
+            if (RefPtr networkProcess = dataStore->networkProcessIfExists())
+                networkProcess->send(Messages::NetworkProcess::SetWebProcessSuspended(coreProcessIdentifier(), isNowSuspended), 0);
+        }
+    }
+
     if (isStandaloneServiceWorkerProcess()) {
         WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "didChangeThrottleState: Release all assertions for network process because this is a service worker process without page");
         m_foregroundToken = nullptr;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -842,6 +842,7 @@ private:
     ForegroundWebProcessToken m_foregroundToken;
     BackgroundWebProcessToken m_backgroundToken;
     bool m_areThrottleStateChangesEnabled { true };
+    bool m_lastNotifiedNetworkProcessSuspended { false };
 
 #if HAVE(DISPLAY_LINK)
     const UniqueRef<DisplayLinkProcessProxyClient> m_displayLinkClient;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
@@ -33,6 +33,7 @@
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/WebKit.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
@@ -154,3 +155,288 @@ TEST(IndexedDB, SuspendImminentlyForThirdPartyDatabases)
 }
 
 #endif // PLATFORM(IOS_FAMILY)
+
+TEST(IndexedDB, TransactionOfSuspendedProcessDoesNotBlockOtherProcesses)
+{
+    static NSString *firstClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('SuspendedProcessContentionDatabase'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('TestObjectStore'); \
+        }; \
+        request.onerror = function() { \
+            post('first database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction('TestObjectStore', 'readwrite'); \
+            transaction.onabort = function() { \
+                post('first transaction aborted'); \
+            }; \
+            transaction.oncomplete = function() { \
+                post('first transaction completed'); \
+            }; \
+            var objectStore = transaction.objectStore('TestObjectStore'); \
+            var started = false; \
+            function keepTransactionAlive() { \
+                var putRequest = objectStore.put('TestValue', 'TestKey'); \
+                putRequest.onsuccess = function() { \
+                    if (!started) { \
+                        started = true; \
+                        post('first transaction started'); \
+                    } \
+                    keepTransactionAlive(); \
+                }; \
+            } \
+            keepTransactionAlive(); \
+        }; \
+        </script>";
+
+    static NSString *secondClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('SuspendedProcessContentionDatabase'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('TestObjectStore'); \
+        }; \
+        request.onerror = function() { \
+            post('second database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction('TestObjectStore', 'readwrite'); \
+            transaction.onabort = function() { \
+                post('second transaction aborted'); \
+            }; \
+            transaction.oncomplete = function() { \
+                post('second transaction completed'); \
+            }; \
+            transaction.objectStore('TestObjectStore').put('OtherValue', 'OtherKey'); \
+        }; \
+        </script>";
+
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    // Two web views in different process pools so they run in different WebContent
+    // processes, sharing one data store so they use the same network process.
+    RetainPtr firstHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr firstConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [firstConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[firstConfiguration userContentController] addScriptMessageHandler:firstHandler.get() name:@"testHandler"];
+    RetainPtr firstWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:firstConfiguration.get()]);
+    [firstWebView loadHTMLString:firstClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transaction started");
+
+    // Mark the first web view's process as suspended; its read-write transaction can
+    // no longer finish on its own.
+    [firstWebView _setThrottleStateForTesting:0];
+
+    RetainPtr secondHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr secondConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [secondConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[secondConfiguration userContentController] addScriptMessageHandler:secondHandler.get() name:@"testHandler"];
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:secondConfiguration.get()]);
+    [secondWebView loadHTMLString:secondClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+
+    // Without aborting the suspended process's in-progress transaction, this transaction
+    // would be queued behind it forever.
+    EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second transaction completed");
+
+    // The first client learns about the abort the next time it uses the transaction.
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transaction aborted");
+}
+
+TEST(IndexedDB, ReadOnlyTransactionOfSuspendedProcessDoesNotBlockOtherProcesses)
+{
+    static NSString *firstClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('ReadOnlyContentionDatabase'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('TestObjectStore'); \
+        }; \
+        request.onerror = function() { \
+            post('first database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction('TestObjectStore', 'readonly'); \
+            transaction.onabort = function() { \
+                post('first transaction aborted'); \
+            }; \
+            var objectStore = transaction.objectStore('TestObjectStore'); \
+            var started = false; \
+            function keepTransactionAlive() { \
+                var getRequest = objectStore.get('TestKey'); \
+                getRequest.onsuccess = function() { \
+                    if (!started) { \
+                        started = true; \
+                        post('first transaction started'); \
+                    } \
+                    keepTransactionAlive(); \
+                }; \
+            } \
+            keepTransactionAlive(); \
+        }; \
+        </script>";
+
+    static NSString *secondClientString = @"<script> \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('ReadOnlyContentionDatabase'); \
+        request.onerror = function() { \
+            post('second database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction('TestObjectStore', 'readwrite'); \
+            transaction.oncomplete = function() { \
+                post('second transaction completed'); \
+            }; \
+            transaction.objectStore('TestObjectStore').put('OtherValue', 'OtherKey'); \
+        }; \
+        </script>";
+
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    RetainPtr firstHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr firstConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [firstConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[firstConfiguration userContentController] addScriptMessageHandler:firstHandler.get() name:@"testHandler"];
+    RetainPtr firstWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:firstConfiguration.get()]);
+    [firstWebView loadHTMLString:firstClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transaction started");
+
+    // The in-progress read-only transaction belongs to the suspended process and shares an object
+    // store with the second process's read-write transaction, so it blocks it through the
+    // scope-overlap path (rather than the read-write serialization path).
+    [firstWebView _setThrottleStateForTesting:0];
+
+    RetainPtr secondHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr secondConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [secondConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[secondConfiguration userContentController] addScriptMessageHandler:secondHandler.get() name:@"testHandler"];
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:secondConfiguration.get()]);
+    [secondWebView loadHTMLString:secondClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+
+    // The read-write transaction completes only if the suspended process's overlapping read-only
+    // transaction is aborted.
+    EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second transaction completed");
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transaction aborted");
+}
+
+TEST(IndexedDB, UncontendedTransactionOfSuspendedProcessIsNotAborted)
+{
+    static NSString *firstClientString = @"<script> \
+        var stopTransaction = false; \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        var request = indexedDB.open('UncontendedSuspensionDatabase'); \
+        request.onerror = function() { \
+            post('first database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            var transaction = event.target.result.transaction('FirstObjectStore', 'readonly'); \
+            transaction.onabort = function() { \
+                post('first transaction aborted'); \
+            }; \
+            transaction.oncomplete = function() { \
+                post('first transaction completed'); \
+            }; \
+            var objectStore = transaction.objectStore('FirstObjectStore'); \
+            var started = false; \
+            function keepTransactionAlive() { \
+                if (stopTransaction) \
+                    return; \
+                var getRequest = objectStore.get('TestKey'); \
+                getRequest.onsuccess = function() { \
+                    if (!started) { \
+                        started = true; \
+                        post('first transaction started'); \
+                    } \
+                    keepTransactionAlive(); \
+                }; \
+            } \
+            keepTransactionAlive(); \
+        }; \
+        </script>";
+
+    static NSString *secondClientString = @"<script> \
+        var database = null; \
+        function post(message) { \
+            window.webkit.messageHandlers.testHandler.postMessage(message); \
+        } \
+        function runTransaction() { \
+            var transaction = database.transaction('SecondObjectStore', 'readwrite'); \
+            transaction.oncomplete = function() { \
+                post('second transaction completed'); \
+            }; \
+            transaction.objectStore('SecondObjectStore').put('OtherValue', 'OtherKey'); \
+        } \
+        var request = indexedDB.open('UncontendedSuspensionDatabase'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('FirstObjectStore'); \
+            event.target.result.createObjectStore('SecondObjectStore'); \
+        }; \
+        request.onerror = function() { \
+            post('second database error'); \
+        }; \
+        request.onsuccess = function(event) { \
+            database = event.target.result; \
+            post('second ready'); \
+        }; \
+        </script>";
+
+    readyToContinue = false;
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    // Bring up the second web view first and create the database. Keeping its process unsuspended
+    // for the rest of the test keeps the network process out of suspension; otherwise, once the
+    // first process is suspended, the network process could suspend too and abort every in-progress
+    // transaction through its own suspension path, masking whether the new contention-based abort
+    // left the uncontended transaction alone.
+    RetainPtr secondHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr secondConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [secondConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[secondConfiguration userContentController] addScriptMessageHandler:secondHandler.get() name:@"testHandler"];
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:secondConfiguration.get()]);
+    [secondWebView loadHTMLString:secondClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second ready");
+
+    // Start the first process's read-only transaction on a different object store.
+    RetainPtr firstHandler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr firstConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [firstConfiguration setProcessPool:adoptNS([[WKProcessPool alloc] init]).get()];
+    [[firstConfiguration userContentController] addScriptMessageHandler:firstHandler.get() name:@"testHandler"];
+    RetainPtr firstWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:firstConfiguration.get()]);
+    [firstWebView loadHTMLString:firstClientString baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transaction started");
+
+    // Suspend the first process. Its in-progress read-only transaction touches a different object
+    // store than the second process's read-write transaction, so it doesn't block it and must be
+    // left alone.
+    [firstWebView _setThrottleStateForTesting:0];
+
+    // The second transaction runs concurrently because it doesn't overlap the suspended one.
+    [secondWebView evaluateJavaScript:@"runTransaction();" completionHandler:nil];
+    EXPECT_WK_STREQ([secondHandler waitForMessage].body, @"second transaction completed");
+
+    // Resume the first process and let its transaction finish. It should complete rather than
+    // abort, confirming the uncontended transaction was never touched.
+    [firstWebView _setThrottleStateForTesting:2];
+    [firstWebView evaluateJavaScript:@"stopTransaction = true;" completionHandler:nil];
+    EXPECT_WK_STREQ([firstHandler waitForMessage].body, @"first transaction completed");
+}


### PR DESCRIPTION
#### d910c7f32672e2ddc0a508253c5823f582ef2f00
<pre>
IndexedDB transactions of a suspended process block other processes indefinitely
<a href="https://bugs.webkit.org/show_bug.cgi?id=315804">https://bugs.webkit.org/show_bug.cgi?id=315804</a>

Reviewed by Sihui Liu.

When a WebContent or service worker process is suspended by the system (for
example in an iOS home screen web app), its in-progress IndexedDB transactions
are never committed or aborted: commits are client-driven, suspension is not a
connection close, and the IDB server has no inactivity timeout. Because the
SQLite backing store serializes read-write transactions, every transaction from
other processes on the same database then queues behind the suspended client&apos;s
transaction until the suspended process is killed, which can take over 30
minutes.

Notify the network process when a web process&apos;s throttle state crosses the
suspension boundary, and record that state on the matching IDBConnectionToClient.
When transaction scheduling in UniqueIDBDatabase cannot start a pending
transaction, abort in-progress transactions that belong to suspended clients and
actually block a pending transaction, reusing the suspension-abort result
machinery that network process suspension already uses. Uncontended transactions
of suspended clients are left untouched, so the existing behavior of resuming
them on process resume is preserved. Aborting an in-progress versionchange
transaction rolls back the in-memory database info and clears the version-change
connection, matching the standard abort path.

The aborted transaction object stays in its connection&apos;s transaction map, so a
client that later resumes learns about the abort through the stored suspension
abort result when it next aborts or commits, and the entry is dropped on
connection close otherwise.

* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp:
(WebCore::IDBServer::IDBConnectionToClient::setClientProcessSuspended):
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::clearTransactionsOnConnection):
(WebCore::IDBServer::UniqueIDBDatabase::commitTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::abortTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::handleTransactions):
(WebCore::IDBServer::UniqueIDBDatabase::transactionBlocksPendingTransactions):
(WebCore::IDBServer::UniqueIDBDatabase::abortInProgressTransactionsBlockedOnSuspendedClients):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseConnection::deleteTransactionsAbortedForClientSuspension):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setWebProcessSuspended):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp:
(WebKit::IDBStorageRegistry::existingConnectionToClient):
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::setWebProcessSuspended):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didChangeThrottleState):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm:
(TEST(IndexedDB, TransactionOfSuspendedProcessDoesNotBlockOtherProcesses)):
(TEST(IndexedDB, ReadOnlyTransactionOfSuspendedProcessDoesNotBlockOtherProcesses)):
(TEST(IndexedDB, UncontendedTransactionOfSuspendedProcessIsNotAborted)):

Canonical link: <a href="https://commits.webkit.org/315609@main">https://commits.webkit.org/315609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e6e9e5e74b611c99173c3f59d3690f276c5fda4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171299 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131986 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92920 "11 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172392 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112490 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32127 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181390 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140436 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43011 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140272 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37774 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43700 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28681 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107796 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35547 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115465 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42210 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6769 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->