### PR TITLE
Support both Canonical-link and Canonical link while doing canonicalisation

### DIFF
--- a/Tools/Scripts/git-webkit
+++ b/Tools/Scripts/git-webkit
@@ -28,6 +28,7 @@ import sys
 import webkitpy
 from webkitcorepy import run
 from webkitscmpy import local, program, remote, Contributor, log
+from webkitscmpy.program.canonicalize import IdentifierTrailer
 
 
 def is_webkit_filter(to_return):
@@ -63,7 +64,7 @@ if '__main__' == __name__:
     _script_dir = os.path.dirname(os.path.abspath(__file__))
     _root = os.path.dirname(os.path.dirname(_script_dir))
     sys.exit(program.main(
-        identifier_template=is_webkit_filter('Canonical link: https://commits.webkit.org/{}'),
+        identifier_template=is_webkit_filter(IdentifierTrailer(name='Canonical link', value_template='https://commits.webkit.org/{}', aliases=('Canonical-link',))),
         subversion=is_webkit_filter('https://svn.webkit.org/repository/webkit'),
         hooks=os.path.join(_script_dir, 'hooks'),
         classifier=is_webkit_filter(classifier()),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -34,6 +34,7 @@ from unittest.mock import patch
 from webkitcorepy import OutputCapture, StringIO, decorators, mocks, string_utils
 
 from webkitscmpy import Commit, Contributor, local
+from webkitscmpy.program.canonicalize import IdentifierTrailer
 from webkitscmpy.program.canonicalize.committer import main as committer_main
 from webkitscmpy.program.canonicalize.message import main as message_main
 
@@ -492,7 +493,7 @@ nothing to commit, working tree clean
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.filter_branch(
                     args[-1],
-                    identifier_template=args[-2].split("'")[-2] if args[-3] == '--msg-filter' else None,
+                    identifier_trailer=IdentifierTrailer.from_json(kwargs['env'].get('WEBKITSCMPY_CANONICALIZE_IDENTIFIER_TRAILER')),
                     environment_shell=args[4] if args[3] == '--env-filter' and args[4] else None,
                 )
             ), mocks.Subprocess.Route(
@@ -1018,7 +1019,7 @@ nothing to commit, working tree clean
             self.detached = something not in self.commits.keys()
         return True if commit else False
 
-    def filter_branch(self, range, identifier_template=None, environment_shell=None, sed=None, autostash=False):
+    def filter_branch(self, range, identifier_trailer=None, environment_shell=None, sed=None, autostash=False):
         if not autostash and (self.modified or self.staged):
             return mocks.ProcessCompletion(returncode=128)
 
@@ -1064,12 +1065,12 @@ nothing to commit, working tree clean
                         total=len(commits_to_edit),
                     ))
 
-                if identifier_template:
+                if identifier_trailer:
                     messagefile = StringIO()
                     messagefile.write(commit.message)
                     messagefile.seek(0)
                     with OutputCapture() as captured:
-                        message_main(messagefile, identifier_template)
+                        message_main(messagefile, identifier_trailer)
                     lines = captured.stdout.getvalue().splitlines()
                     if lines[-1].startswith('git-svn-id: https://svn'):
                         lines.pop(-1)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -30,7 +30,7 @@ import traceback
 from .apply import Apply
 from .blame import Blame
 from .branch import Branch
-from .canonicalize import Canonicalize
+from .canonicalize import Canonicalize, IdentifierTrailer
 from .cherry_pick import CherryPick
 from .clean import Clean, DeletePRBranches
 from .clone import Clone
@@ -171,6 +171,8 @@ def main(
         repository.classifier = classifier(repository) or repository.classifier
     if callable(identifier_template):
         identifier_template = identifier_template(repository) if repository else None
+    if isinstance(identifier_template, str):
+        identifier_template = IdentifierTrailer.from_template(identifier_template)
     if callable(subversion):
         subversion = subversion(repository) if repository else None
     if callable(hooks):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py
@@ -20,15 +20,40 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
 import logging
 import os
 import tempfile
 import subprocess
 import sys
+from dataclasses import asdict, dataclass
 
 from webkitcorepy import arguments, run, string_utils
 from webkitscmpy import log
 from ..command import Command
+
+
+@dataclass(frozen=True)
+class IdentifierTrailer:
+    name: str
+    value_template: str
+    aliases: tuple[str, ...] = ()
+
+    @classmethod
+    def from_template(cls, template):
+        name, value = template.split(':', 1)
+        return cls(name=name, value_template=value.lstrip())
+
+    @classmethod
+    def from_json(cls, s):
+        if s is None:
+            return None
+        data = json.loads(s)
+        data['aliases'] = tuple(data['aliases'])
+        return cls(**data)
+
+    def to_json(self):
+        return json.dumps(asdict(self))
 
 
 class Canonicalize(Command):
@@ -75,6 +100,9 @@ class Canonicalize(Command):
             sys.stderr.write('Failed to determine current branch\n')
             return -1
 
+        if identifier_template is None:
+            identifier_template = IdentifierTrailer(name='Identifier', value_template='{}')
+
         num_commits_to_canonicalize = args.number
         if not num_commits_to_canonicalize:
             result = run([
@@ -102,10 +130,9 @@ class Canonicalize(Command):
 
             message_filter = [
                 '--msg-filter',
-                "{} {} '{}'".format(
+                '{} {}'.format(
                     sys.executable,
                     os.path.join(os.path.dirname(__file__), 'message.py'),
-                    identifier_template or 'Identifier: {}',
                 ),
             ] if args.identifier else []
 
@@ -147,7 +174,11 @@ fi'''.format(
                     ),
                 ] + message_filter + ['{}...{}'.format(branch, base.hash)],
                     cwd=repository.root_path,
-                    env={'FILTER_BRANCH_SQUELCH_WARNING': '1', 'PYTHONPATH': ':'.join(sys.path)},
+                    env={
+                        'FILTER_BRANCH_SQUELCH_WARNING': '1',
+                        'PYTHONPATH': ':'.join(sys.path),
+                        **({'WEBKITSCMPY_CANONICALIZE_IDENTIFIER_TRAILER': identifier_template.to_json()} if args.identifier else {}),
+                    },
                     stdout=devnull if log.level > logging.WARNING else None,
                     stderr=devnull if log.level > logging.WARNING else None,
                 )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py
@@ -28,9 +28,10 @@ from typing import IO
 
 from webkitscmpy.local import Git
 from webkitscmpy import Commit
+from webkitscmpy.program.canonicalize import IdentifierTrailer
 
 
-def main(inputfile, identifier_template):
+def main(inputfile, identifier_trailer):
     REPOSITORY_PATH = os.environ.get('OLDPWD')
     GIT_COMMIT = os.environ.get('GIT_COMMIT')
 
@@ -50,21 +51,27 @@ def main(inputfile, identifier_template):
         sys.stderr.write("Failed to compute the identifier for '{}'".format(GIT_COMMIT))
         return -1
 
-    rewrite_message(inputfile, sys.stdout, commit, identifier_template)
+    rewrite_message(inputfile, sys.stdout, commit, identifier_trailer)
 
 
-def rewrite_message(inputfile: IO[str], outputfile: IO[str], commit: Commit, identifier_template: str) -> None:
+def rewrite_message(inputfile: IO[str], outputfile: IO[str], commit: Commit, identifier_trailer: IdentifierTrailer) -> None:
     lines = []
     for line in inputfile.readlines():
         lines.append(line.rstrip())
 
-    identifier_template_key = identifier_template.format('').split(':', maxsplit=1)[0]
+    identifier_keys = {identifier_trailer.name, *identifier_trailer.aliases}
+    new_trailer = '{}: {}'.format(identifier_trailer.name, identifier_trailer.value_template.format(commit))
+
+    def is_identifier_trailer(line: str) -> bool:
+        key, sep, _ = line.partition(':')
+        return bool(sep) and key in identifier_keys
 
     identifier_index = len(lines)
     if identifier_index and Git.GIT_SVN_REVISION.match(lines[-1]):
         identifier_index -= 1
 
-    # We're trying to cover cases where there is a space between link and git-svn-id:
+    # We're trying to cover cases where there is a space between the identifier
+    # trailer (Canonical link, Canonical-link, Identifier, etc.) and git-svn-id:
     #     <commit message content>
     #
     #     Canonical link: ...
@@ -74,18 +81,18 @@ def rewrite_message(inputfile: IO[str], outputfile: IO[str], commit: Commit, ide
     #     Canonical link: ...
     #
     #     git-svn-id: ...
-    if identifier_index and lines[identifier_index - 1].startswith(identifier_template_key):
-        lines[identifier_index - 1] = identifier_template.format(commit)
+    if identifier_index and is_identifier_trailer(lines[identifier_index - 1]):
+        lines[identifier_index - 1] = new_trailer
         identifier_index = identifier_index - 2
     else:
         for index in [2, 3]:
-            if identifier_index - index > 0 and lines[identifier_index - index].startswith(identifier_template_key):
+            if identifier_index - index > 0 and is_identifier_trailer(lines[identifier_index - index]):
                 del lines[identifier_index - index]
-                lines.insert(identifier_index - 1, identifier_template.format(commit))
+                lines.insert(identifier_index - 1, new_trailer)
                 identifier_index = identifier_index - 2
                 break
         else:
-            lines.insert(identifier_index, identifier_template.format(commit))
+            lines.insert(identifier_index, new_trailer)
             identifier_index = identifier_index - 1
 
     while identifier_index >= 0 and lines[identifier_index]:
@@ -109,4 +116,5 @@ def rewrite_message(inputfile: IO[str], outputfile: IO[str], commit: Commit, ide
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.stdin, sys.argv[1]))
+    trailer = IdentifierTrailer.from_json(os.environ['WEBKITSCMPY_CANONICALIZE_IDENTIFIER_TRAILER'])
+    sys.exit(main(sys.stdin, trailer))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py
@@ -370,7 +370,7 @@ class Land(Command):
             commit = repository.commit(branch=target, include_log=False)
 
         if identifier_template and commit.identifier:
-            land_message = 'Landed {} ({})!'.format(identifier_template.format(commit).split(': ')[-1], commit.hash[:Commit.HASH_LABEL_SIZE])
+            land_message = 'Landed {} ({})!'.format(identifier_template.value_template.format(commit), commit.hash[:Commit.HASH_LABEL_SIZE])
         else:
             land_message = 'Landed {}!'.format(commit.hash[:Commit.HASH_LABEL_SIZE])
         print(land_message)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import dataclasses
 import os
 import unittest
 from io import StringIO
@@ -27,6 +28,7 @@ from io import StringIO
 from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Time as MockTime
 from webkitscmpy import program, mocks, local, Commit, Contributor
+from webkitscmpy.program.canonicalize import IdentifierTrailer
 from webkitscmpy.program.canonicalize.message import rewrite_message
 
 
@@ -67,8 +69,8 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
     def test_formated_identifier(self):
         with OutputCapture() as captured, mocks.local.Git(self.path) as mock, mocks.local.Svn(), MockTime:
-            contirbutors = Contributor.Mapping()
-            contirbutors.create('\u017dan Dober\u0161ek', 'zdobersek@igalia.com')
+            contributors = Contributor.Mapping()
+            contributors.create('\u017dan Dober\u0161ek', 'zdobersek@igalia.com')
 
             mock.commits[mock.default_branch].append(Commit(
                 hash='38ea50d28ae394c9c8b80e13c3fb21f1c262871f',
@@ -82,12 +84,44 @@ class TestCanonicalizeProgam(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('canonicalize', '-v',),
                 path=self.path,
-                contributors=contirbutors,
+                contributors=contributors,
                 identifier_template='Canonical link: https://commits.webkit.org/{}',
             ))
 
             commit = local.Git(self.path).commit(branch=mock.default_branch)
-            self.assertEqual(commit.author, contirbutors['zdobersek@igalia.com'])
+            self.assertEqual(commit.author, contributors['zdobersek@igalia.com'])
+            self.assertEqual(commit.message, 'New commit\n\nCanonical link: https://commits.webkit.org/6@main')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Rewrite 38ea50d28ae394c9c8b80e13c3fb21f1c262871f (1/1) (--- seconds passed, remaining --- predicted)\n'
+            'Overwriting 38ea50d28ae394c9c8b80e13c3fb21f1c262871f\n'
+            '1 commit successfully canonicalized!\n',
+        )
+
+    def test_identifier_trailer_dataclass(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as mock, mocks.local.Svn(), MockTime:
+            contributors = Contributor.Mapping()
+            contributors.create('Žan Doberšek', 'zdobersek@igalia.com')
+
+            mock.commits[mock.default_branch].append(Commit(
+                hash='38ea50d28ae394c9c8b80e13c3fb21f1c262871f',
+                branch=mock.default_branch,
+                author=Contributor('Žan Doberšek', emails=['zdobersek@igalia.com']),
+                identifier=mock.commits[mock.default_branch][-1].identifier + 1,
+                timestamp=1601669000,
+                message='New commit\n',
+            ))
+
+            self.assertEqual(0, program.main(
+                args=('canonicalize', '-v',),
+                path=self.path,
+                contributors=contributors,
+                identifier_template=IdentifierTrailer(name='Canonical link', value_template='https://commits.webkit.org/{}'),
+            ))
+
+            commit = local.Git(self.path).commit(branch=mock.default_branch)
+            self.assertEqual(commit.author, contributors['zdobersek@igalia.com'])
             self.assertEqual(commit.message, 'New commit\n\nCanonical link: https://commits.webkit.org/6@main')
 
         self.assertEqual(
@@ -99,8 +133,8 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
     def test_existing_identifier(self):
         with OutputCapture() as captured, mocks.local.Git(self.path) as mock, mocks.local.Svn(), MockTime:
-            contirbutors = Contributor.Mapping()
-            contirbutors.create('Jonathan Bedard', 'jbedard@apple.com')
+            contributors = Contributor.Mapping()
+            contributors.create('Jonathan Bedard', 'jbedard@apple.com')
 
             mock.commits[mock.default_branch].append(Commit(
                 hash='38ea50d28ae394c9c8b80e13c3fb21f1c262871f',
@@ -117,12 +151,48 @@ class TestCanonicalizeProgam(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('canonicalize', '-v',),
                 path=self.path,
-                contributors=contirbutors,
+                contributors=contributors,
             ))
 
             commit = local.Git(self.path).commit(branch=mock.default_branch)
-            self.assertEqual(commit.author, contirbutors['jbedard@apple.com'])
+            self.assertEqual(commit.author, contributors['jbedard@apple.com'])
             self.assertEqual(commit.message, 'New commit\n\nIdentifier: 6@main')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            'Rewrite 38ea50d28ae394c9c8b80e13c3fb21f1c262871f (1/1) (--- seconds passed, remaining --- predicted)\n'
+            'Overwriting 38ea50d28ae394c9c8b80e13c3fb21f1c262871f\n'
+            '1 commit successfully canonicalized!\n',
+        )
+
+    def test_existing_canonical_link_alias(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as mock, mocks.local.Svn(), MockTime:
+            contributors = Contributor.Mapping()
+            contributors.create('Jonathan Bedard', 'jbedard@apple.com')
+
+            mock.commits[mock.default_branch].append(Commit(
+                hash='38ea50d28ae394c9c8b80e13c3fb21f1c262871f',
+                branch=mock.default_branch,
+                author=Contributor('Jonathan Bedard', emails=['jbedard@apple.com']),
+                identifier=mock.commits[mock.default_branch][-1].identifier + 1,
+                timestamp=1601668000,
+                message='New commit\n\nCanonical-link: https://commits.webkit.org/3@main',
+            ))
+
+            self.assertEqual(0, program.main(
+                args=('canonicalize', '-v',),
+                path=self.path,
+                contributors=contributors,
+                identifier_template=IdentifierTrailer(
+                    name='Canonical link',
+                    value_template='https://commits.webkit.org/{}',
+                    aliases=('Canonical-link',),
+                ),
+            ))
+
+            commit = local.Git(self.path).commit(branch=mock.default_branch)
+            self.assertEqual(commit.author, contributors['jbedard@apple.com'])
+            self.assertEqual(commit.message, 'New commit\n\nCanonical link: https://commits.webkit.org/6@main')
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -133,8 +203,8 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
     def test_git_svn(self):
         with OutputCapture() as captured, mocks.local.Git(self.path, git_svn=True) as mock, mocks.local.Svn(), MockTime:
-            contirbutors = Contributor.Mapping()
-            contirbutors.create('Jonathan Bedard', 'jbedard@apple.com')
+            contributors = Contributor.Mapping()
+            contributors.create('Jonathan Bedard', 'jbedard@apple.com')
 
             mock.commits[mock.default_branch].append(Commit(
                 hash='766609276fe201e7ce2c69994e113d979d2148ac',
@@ -149,11 +219,11 @@ class TestCanonicalizeProgam(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('canonicalize', '-vv'),
                 path=self.path,
-                contributors=contirbutors,
+                contributors=contributors,
             ))
 
             commit = local.Git(self.path).commit(branch=mock.default_branch)
-            self.assertEqual(commit.author, contirbutors['jbedard@apple.com'])
+            self.assertEqual(commit.author, contributors['jbedard@apple.com'])
             self.assertEqual(
                 commit.message,
                 'New commit\n\n'
@@ -174,8 +244,8 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
     def test_git_svn_existing(self):
         with OutputCapture() as captured, mocks.local.Git(self.path, git_svn=True) as mock, mocks.local.Svn(), MockTime:
-            contirbutors = Contributor.Mapping()
-            contirbutors.create('Jonathan Bedard', 'jbedard@apple.com')
+            contributors = Contributor.Mapping()
+            contributors.create('Jonathan Bedard', 'jbedard@apple.com')
 
             mock.commits[mock.default_branch].append(Commit(
                 hash='766609276fe201e7ce2c69994e113d979d2148ac',
@@ -190,11 +260,11 @@ class TestCanonicalizeProgam(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('canonicalize', '-vv'),
                 path=self.path,
-                contributors=contirbutors,
+                contributors=contributors,
             ))
 
             commit = local.Git(self.path).commit(branch=mock.default_branch)
-            self.assertEqual(commit.author, contirbutors['jbedard@apple.com'])
+            self.assertEqual(commit.author, contributors['jbedard@apple.com'])
             self.assertEqual(
                 commit.message,
                 'New commit\n\n'
@@ -215,8 +285,8 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
     def test_git_svn_existing_merge_queue(self):
         with OutputCapture() as captured, mocks.local.Git(self.path, git_svn=True) as mock, mocks.local.Svn(), MockTime:
-            contirbutors = Contributor.Mapping()
-            contirbutors.create('Jonathan Bedard', 'jbedard@apple.com')
+            contributors = Contributor.Mapping()
+            contributors.create('Jonathan Bedard', 'jbedard@apple.com')
 
             mock.commits[mock.default_branch].append(Commit(
                 hash='766609276fe201e7ce2c69994e113d979d2148ac',
@@ -231,11 +301,11 @@ class TestCanonicalizeProgam(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('canonicalize', '-vv'),
                 path=self.path,
-                contributors=contirbutors,
+                contributors=contributors,
             ))
 
             commit = local.Git(self.path).commit(branch=mock.default_branch)
-            self.assertEqual(commit.author, contirbutors['jbedard@apple.com'])
+            self.assertEqual(commit.author, contributors['jbedard@apple.com'])
 
             self.assertEqual(
                 commit.message,
@@ -257,8 +327,8 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
     def test_branch_commits(self):
         with OutputCapture() as captured, mocks.local.Git(self.path) as mock, mocks.local.Svn(), MockTime:
-            contirbutors = Contributor.Mapping()
-            contirbutors.create('Jonathan Bedard', 'jbedard@apple.com')
+            contributors = Contributor.Mapping()
+            contributors.create('Jonathan Bedard', 'jbedard@apple.com')
 
             local.Git(self.path).checkout('branch-a')
             mock.commits['branch-a'].append(Commit(
@@ -283,15 +353,15 @@ class TestCanonicalizeProgam(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('canonicalize', ),
                 path=self.path,
-                contributors=contirbutors,
+                contributors=contributors,
             ))
 
             commit_a = local.Git(self.path).commit(branch='branch-a~1')
-            self.assertEqual(commit_a.author, contirbutors['jbedard@apple.com'])
+            self.assertEqual(commit_a.author, contributors['jbedard@apple.com'])
             self.assertEqual(commit_a.message, 'New commit 1\n\nIdentifier: 2.3@branch-a')
 
             commit_b = local.Git(self.path).commit(branch='branch-a')
-            self.assertEqual(commit_b.author, contirbutors['jbedard@apple.com'])
+            self.assertEqual(commit_b.author, contributors['jbedard@apple.com'])
             self.assertEqual(commit_b.message, 'New commit 2\n\nIdentifier: 2.4@branch-a')
 
         self.assertEqual(
@@ -303,13 +373,13 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
     def test_number(self):
         with OutputCapture() as captured, mocks.local.Git(self.path), mocks.local.Svn(), MockTime:
-            contirbutors = Contributor.Mapping()
-            contirbutors.create('Jonathan Bedard', 'jbedard@apple.com')
+            contributors = Contributor.Mapping()
+            contributors.create('Jonathan Bedard', 'jbedard@apple.com')
 
             self.assertEqual(0, program.main(
                 args=('canonicalize', '--number', '3'),
                 path=self.path,
-                contributors=contirbutors,
+                contributors=contributors,
             ))
 
             self.assertEqual(local.Git(self.path).commit(identifier='5@main').message, 'Patch Series\n\nIdentifier: 5@main')
@@ -326,8 +396,8 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
     def test_alternate_trailer(self):
         with OutputCapture() as captured, mocks.local.Git(self.path) as mock, mocks.local.Svn(), MockTime:
-            contirbutors = Contributor.Mapping()
-            contirbutors.create('Jonathan Bedard', 'jbedard@apple.com')
+            contributors = Contributor.Mapping()
+            contributors.create('Jonathan Bedard', 'jbedard@apple.com')
 
             mock.commits[mock.default_branch].append(Commit(
                 hash='766609276fe201e7ce2c69994e113d979d2148ac',
@@ -341,11 +411,11 @@ class TestCanonicalizeProgam(testing.PathTestCase):
             self.assertEqual(0, program.main(
                 args=('canonicalize', '-vv'),
                 path=self.path,
-                contributors=contirbutors,
+                contributors=contributors,
             ))
 
             commit = local.Git(self.path).commit(branch=mock.default_branch)
-            self.assertEqual(commit.author, contirbutors['jbedard@apple.com'])
+            self.assertEqual(commit.author, contributors['jbedard@apple.com'])
             self.assertEqual(
                 commit.message,
                 'New commit\n\n'
@@ -366,9 +436,12 @@ class TestCanonicalizeProgam(testing.PathTestCase):
 
 
 class TestCanonicalizeMessage(unittest.TestCase):
-    def assert_canonicalized_commit_message(self, *, message, expected):
+    def assert_canonicalized_commit_message(self, *, message, expected, trailer=None):
         stdin = StringIO(message)
         stdout = StringIO()
+
+        if trailer is None:
+            trailer = IdentifierTrailer.from_template('Identifier: {}')
 
         commit = Commit(
             hash='38ea50d28ae394c9c8b80e13c3fb21f1c262871f',
@@ -379,9 +452,211 @@ class TestCanonicalizeMessage(unittest.TestCase):
             message=message,
         )
 
-        rewrite_message(stdin, stdout, commit, 'Identifier: {}')
+        rewrite_message(stdin, stdout, commit, trailer)
 
         self.assertEqual(stdout.getvalue(), expected)
+
+    def test_canonical_link_alias(self):
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Canonical link: https://commits.webkit.org/6@main\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Canonical link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical-link',),
+            ),
+        )
+
+    def test_canonical_link_alias_mirror(self):
+        # Space-form trailer is replaced with hyphen-form (the canonical name) at the new identifier.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical link: https://commits.webkit.org/3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/6@main\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Canonical-link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical link',),
+            ),
+        )
+
+    def test_canonical_link_both_spellings(self):
+        # When both spellings appear, only the trailing one is replaced; the earlier one is preserved.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                'Canonical link: https://commits.webkit.org/3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                'Canonical link: https://commits.webkit.org/6@main\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Canonical link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical-link',),
+            ),
+        )
+
+    def test_no_alias_match_appends_new_trailer(self):
+        # An unrecognised trailer passes through; a fresh Identifier line is appended after it.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical link: https://commits.webkit.org/3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Canonical link: https://commits.webkit.org/3@main\n'
+                'Identifier: 6@main\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Identifier',
+                value_template='{}',
+            ),
+        )
+
+    def test_three_existing_canonical_link_trailers(self):
+        # Three matching trailers across both spellings: only the trailing one is updated;
+        # the two earlier ones (one alias-form, one canonical-form) stay.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                'Canonical link: https://commits.webkit.org/3@main\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                'Canonical link: https://commits.webkit.org/3@main\n'
+                'Canonical link: https://commits.webkit.org/6@main\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Canonical link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical-link',),
+            ),
+        )
+
+    def test_canonical_link_alias_separated_by_other_trailer(self):
+        # An earlier alias-form trailer, an unrelated trailer, then a canonical-form trailer:
+        # only the trailing match is updated; the earlier alias-form stays.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                'Reviewed-by: Someone\n'
+                'Canonical link: https://commits.webkit.org/3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                'Reviewed-by: Someone\n'
+                'Canonical link: https://commits.webkit.org/6@main\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Canonical link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical-link',),
+            ),
+        )
+
+    def test_canonical_link_alias_followed_by_other_trailer(self):
+        # An alias-form trailer followed by an unrelated trailer (no git-svn-id):
+        # the index-2 fallback finds the alias-form line, deletes it, and inserts the new
+        # canonical-form trailer at the trailing position; the unrelated trailer shifts up.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                'Reviewed-by: Someone\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Reviewed-by: Someone\n'
+                'Canonical link: https://commits.webkit.org/6@main\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Canonical link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical-link',),
+            ),
+        )
+
+    def test_canonical_link_alias_with_git_svn_id(self):
+        # Alias-form trailer immediately followed by git-svn-id: the trailing-position check
+        # (offset by the svn-id line) finds the alias and replaces it with the canonical form.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                'git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Canonical link: https://commits.webkit.org/6@main\n'
+                'git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Canonical link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical-link',),
+            ),
+        )
+
+    def test_canonical_link_alias_blank_before_git_svn_id(self):
+        # Alias-form trailer separated from git-svn-id by a blank line: the index-2 fallback
+        # finds the alias-form line and replaces it with the canonical form adjacent to git-svn-id.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Canonical-link: https://commits.webkit.org/3@main\n'
+                '\n'
+                'git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Canonical link: https://commits.webkit.org/6@main\n'
+                'git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
+            ),
+            trailer=IdentifierTrailer(
+                name='Canonical link',
+                value_template='https://commits.webkit.org/{}',
+                aliases=('Canonical-link',),
+            ),
+        )
 
     def test_incomplete_line(self):
         # By POSIX, a line must end in new line character.
@@ -527,6 +802,101 @@ class TestCanonicalizeMessage(unittest.TestCase):
                 'Identifier: 6@main\n'
                 '\n'
                 'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_three_existing_identifier_trailers(self):
+        # Three same-key trailers: only the trailing one is updated; the two earlier ones stay.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Identifier: 3@main\n'
+                'Identifier: 3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Identifier: 3@main\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_identifier_trailer_separated_by_other_trailer(self):
+        # An earlier `Identifier:` line, an unrelated trailer, then another `Identifier:` line:
+        # only the trailing match is updated; the earlier `Identifier:` stays.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Reviewed-by: Someone\n'
+                'Identifier: 3@main\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Reviewed-by: Someone\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_identifier_trailer_followed_by_other_trailer(self):
+        # An `Identifier:` line followed by another trailer (no git-svn-id):
+        # the index-2 fallback finds the `Identifier:` line, deletes it, and inserts the new one
+        # at the trailing position; the unrelated trailer shifts up.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'Reviewed-by: Someone\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Reviewed-by: Someone\n'
+                'Identifier: 6@main\n'
+            ),
+        )
+
+    def test_identifier_with_git_svn_id(self):
+        # `Identifier:` immediately followed by git-svn-id: the trailing-position check
+        # (offset by the svn-id line) finds the trailer and replaces it.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                'git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                'git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
+            ),
+        )
+
+    def test_identifier_blank_before_git_svn_id(self):
+        # `Identifier:` separated from git-svn-id by a blank line: the index-2 fallback finds
+        # the trailer line and replaces it adjacent to git-svn-id, collapsing the blank.
+        self.assert_canonicalized_commit_message(
+            message=(
+                'New commit\n'
+                '\n'
+                'Identifier: 3@main\n'
+                '\n'
+                'git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
+            ),
+            expected=(
+                'New commit\n'
+                '\n'
+                'Identifier: 6@main\n'
+                'git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'
             ),
         )
 
@@ -1001,3 +1371,16 @@ class TestCanonicalizeMessage(unittest.TestCase):
                     'Identifier: 6@main\n'
                 ),
             )
+
+
+class TestIdentifierTrailer(unittest.TestCase):
+    def test_from_template_fields(self):
+        trailer = IdentifierTrailer.from_template('Foo: bar/{}')
+        self.assertEqual(trailer.name, 'Foo')
+        self.assertEqual(trailer.value_template, 'bar/{}')
+        self.assertEqual(trailer.aliases, ())
+
+    def test_frozen(self):
+        trailer = IdentifierTrailer.from_template('Foo: bar/{}')
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            trailer.name = 'X'

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -33,6 +33,7 @@ from webkitcorepy.mocks import Terminal as MockTerminal
 from webkitcorepy.mocks import Time as MockTime
 
 from webkitscmpy import Commit, Contributor, local, mocks, program
+from webkitscmpy.program.canonicalize import IdentifierTrailer
 
 
 def repository(path, has_oops=True, remote=None, remotes=None, git_svn=False, issue_url=None):
@@ -211,6 +212,32 @@ class TestLand(testing.PathTestCase):
             '1 commit successfully canonicalized!\n'
             'Landed https://commits.webkit.org/6@main (a5fe8afe9bf7)!\n'
             "Delete branch 'eng/example'? ([Yes]/No): \n",
+        )
+
+    def test_canonicalize_with_identifier_trailer(self):
+        with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False), mocks.local.Svn(), MockTerminal.input('n'):
+            self.assertEqual(0, program.main(
+                args=('land', '-v'),
+                path=self.path,
+                identifier_template=IdentifierTrailer(
+                    name='Canonical link',
+                    value_template='https://commits.webkit.org/{}',
+                    aliases=('Canonical-link',),
+                ),
+            ))
+
+            commit = local.Git(self.path).commit(branch='main')
+            self.assertEqual(str(commit), '6@main')
+            self.assertEqual(
+                commit.message,
+                'To Be Committed\n\n'
+                'Reviewed by Ricky Reviewer.\n\n'
+                'Canonical link: https://commits.webkit.org/6@main',
+            )
+
+        self.assertIn(
+            'Landed https://commits.webkit.org/6@main (a5fe8afe9bf7)!\n',
+            captured.stdout.getvalue(),
         )
 
     def test_no_svn_canonical_svn(self):


### PR DESCRIPTION
#### 761e61f4ad964e587d617b87afec33e7a3570a9e
<pre>
Support both Canonical-link and Canonical link while doing canonicalisation
<a href="https://bugs.webkit.org/show_bug.cgi?id=316952">https://bugs.webkit.org/show_bug.cgi?id=316952</a>
<a href="https://rdar.apple.com/179414185">rdar://179414185</a>

Reviewed by Elliott Williams.

To migrate from &quot;Canonical link&quot; to &quot;Canonical-link&quot;, the
canonicalisation script must handle both variants during the
transition; when we re-canonicalise following a merge we may end up
changing which form a given change has.

We introduce a IdentifierTrailer class with support for aliases,
allowing us to change which variant is canonical in the future.

Trailer configuration now passes through the
WEBKITSCMPY_CANONICALIZE_IDENTIFIER_TRAILER environment variable
instead of command-line arguments, avoiding the need to properly
escape structured data when passing between process invocations.

* Tools/Scripts/git-webkit:
Import and use IdentifierTrailer for identifier_template.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.filter_branch): Change signature to use identifier_trailer parameter, parse from environment variable.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
(main): Import IdentifierTrailer, convert string templates via from_template.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/__init__.py:
(IdentifierTrailer): Added.
(IdentifierTrailer.from_template): Added.
(IdentifierTrailer.from_json): Added.
(IdentifierTrailer.to_json): Added.
(Canonicalize.main): Updated to pass trailer via environment variable.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/canonicalize/message.py:
(main): Updated for IdentifierTrailer integration.
(rewrite_message): Refactored to accept IdentifierTrailer.
(rewrite_message.is_identifier_trailer): Added helper.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/land.py:
(Land.main): Updated for IdentifierTrailer integration.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/canonicalize_unittest.py:
(TestCanonicalizeProgam.test_formated_identifier): Drive-by: spelling.
(TestCanonicalizeProgam.test_identifier_trailer_dataclass): Added.
(TestCanonicalizeProgam.test_existing_identifier): Drive-by: spelling.
(TestCanonicalizeProgam.test_existing_canonical_link_alias): Added.
(TestCanonicalizeProgam.test_git_svn): Drive-by: spelling.
(TestCanonicalizeProgam.test_git_svn_existing): Drive-by: spelling.
(TestCanonicalizeProgam.test_git_svn_existing_merge_queue): Drive-by: spelling.
(TestCanonicalizeProgam.test_branch_commits): Drive-by: spelling.
(TestCanonicalizeProgam.test_number): Drive-by: spelling.
(TestCanonicalizeProgam.test_alternate_trailer): Drive-by: spelling.
(TestCanonicalizeMessage.assert_canonicalized_commit_message): Updated.
(TestCanonicalizeMessage.test_canonical_link_alias): Added.
(TestCanonicalizeMessage.test_canonical_link_alias_mirror): Added.
(TestCanonicalizeMessage.test_canonical_link_both_spellings): Added.
(TestCanonicalizeMessage.test_no_alias_match_appends_new_trailer): Added.
(TestCanonicalizeMessage.test_three_existing_canonical_link_trailers): Added.
(TestCanonicalizeMessage.test_canonical_link_alias_separated_by_other_trailer): Added.
(TestCanonicalizeMessage.test_canonical_link_alias_followed_by_other_trailer): Added.
(TestCanonicalizeMessage.test_canonical_link_alias_with_git_svn_id): Added.
(TestCanonicalizeMessage.test_canonical_link_alias_blank_before_git_svn_id): Added.
(TestCanonicalizeMessage.test_three_existing_identifier_trailers): Added.
(TestCanonicalizeMessage.test_identifier_trailer_separated_by_other_trailer): Added.
(TestCanonicalizeMessage.test_identifier_trailer_followed_by_other_trailer): Added.
(TestCanonicalizeMessage.test_identifier_with_git_svn_id): Added.
(TestCanonicalizeMessage.test_identifier_blank_before_git_svn_id): Added.
(TestIdentifierTrailer): Added.
(TestIdentifierTrailer.test_from_template_fields): Added.
(TestIdentifierTrailer.test_frozen): Added.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(TestLand.test_canonicalize_with_identifier_trailer): Added.

Canonical link: <a href="https://commits.webkit.org/319313@main">https://commits.webkit.org/319313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d613e3e8a2d6abbc64499fb16094b9bec9da6f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181105 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191322 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145428 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141320 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121771 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180429 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43658 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41938 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41598 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2479 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193254 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180506 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54716 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150708 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40340 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55404 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150423 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45014 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123217 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53921 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16594 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53303 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53368 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->