### PR TITLE
REGRESSION(309877@main): window.event not restored when a window.onerror handler throws

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-event-restored-after-throwing-onerror-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-event-restored-after-throwing-onerror-expected.txt
@@ -1,0 +1,3 @@
+
+PASS window.event is restored after a throwing window.onerror handler
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-event-restored-after-throwing-onerror.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/window-event-restored-after-throwing-onerror.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>window.event is restored after a throwing window.onerror handler</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+setup({ allow_uncaught_exception: true });
+
+test(t => {
+    let onerrorCalls = 0;
+    window.onerror = () => {
+        // Throw on the first invocation, leaving window.event set to the error event mid-dispatch.
+        // Only throw once so reporting the exception cannot recurse without bound.
+        if (++onerrorCalls === 1)
+            throw new Error("onerror throws");
+    };
+
+    let outerEvent;
+    window.addEventListener("outer", t.step_func(event => {
+        outerEvent = event;
+        assert_equals(window.event, outerEvent, "window.event is the outer event before the nested dispatch");
+
+        // Synchronously dispatch an error event whose onerror handler throws.
+        window.dispatchEvent(new ErrorEvent("error", { error: new Error("boom") }));
+
+        assert_equals(window.event, outerEvent,
+            "window.event must be restored to the outer event after a throwing onerror handler");
+    }));
+
+    window.dispatchEvent(new Event("outer"));
+}, "window.event is restored after a throwing window.onerror handler");
+</script>

--- a/Source/WebCore/bindings/js/JSErrorHandler.cpp
+++ b/Source/WebCore/bindings/js/JSErrorHandler.cpp
@@ -46,6 +46,7 @@
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/VMEntryScopeInlines.h>
 #include <wtf/Ref.h>
+#include <wtf/Scope.h>
 
 namespace WebCore {
 using namespace JSC;
@@ -97,6 +98,11 @@ void JSErrorHandler::handleEvent(ScriptExecutionContext& scriptExecutionContext,
                 jsFunctionWindow->setCurrentEvent(errorEvent);
         }
 
+        auto restoreCurrentEventOnExit = makeScopeExit([&] {
+            if (jsFunctionWindow)
+                jsFunctionWindow->setCurrentEvent(savedEvent.get());
+        });
+
         auto exception = ([&] -> NakedPtr<JSC::Exception> {
             VM& vm = globalObject->vm();
 
@@ -136,9 +142,6 @@ void JSErrorHandler::handleEvent(ScriptExecutionContext& scriptExecutionContext,
 
             if (returnValue.isTrue())
                 errorEvent->preventDefault();
-
-            if (jsFunctionWindow)
-                jsFunctionWindow->setCurrentEvent(savedEvent.get());
 
             return nullptr;
         }());


### PR DESCRIPTION
#### f03a38dfc461b3d9a0d119c7ed67796bb281daae
<pre>
REGRESSION(309877@main): window.event not restored when a window.onerror handler throws
<a href="https://bugs.webkit.org/show_bug.cgi?id=316968">https://bugs.webkit.org/show_bug.cgi?id=316968</a>

Reviewed by Anne van Kesteren.

JSErrorHandler::handleEvent saves the window&apos;s current event, sets it to the
error event for the duration of the onerror call, and is supposed to restore it
afterwards. 309877@main refactored this function into a lambda that returns
early when the handler throws (if (exception) return exception;), placing the
setCurrentEvent(savedEvent) restore on the success path only. As a result, when
a window.onerror handler throws, window.event is left pointing at the error
event instead of being restored to the previously current event.

Restore window.event with a makeScopeExit right after it is saved, so it runs on
both the normal and throwing paths, mirroring JSEventListener::handleEvent (which
has always done this and was not changed by 309877@main).

Test: imported/w3c/web-platform-tests/dom/events/window-event-restored-after-throwing-onerror.html

* LayoutTests/imported/w3c/web-platform-tests/dom/events/window-event-restored-after-throwing-onerror-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/window-event-restored-after-throwing-onerror.html: Added.
* Source/WebCore/bindings/js/JSErrorHandler.cpp:
(WebCore::JSErrorHandler::handleEvent):

Canonical link: <a href="https://commits.webkit.org/315106@main">https://commits.webkit.org/315106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/666c9525c73769c5a2e00c18806dc06424e4b63a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125735 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8801a52d-cb7e-4f17-8fcc-94eacf04dae3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130743 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44011d0e-0614-4ee7-8250-6dc8eadc300f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111260 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d197c833-a5ca-42ae-b766-92d6d0f3e60e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32197 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30902 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26040 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179937 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32689 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139168 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139048 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37457 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105600 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34338 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27375 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40803 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114055 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40200 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5474 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40451 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->