### PR TITLE
[JSC] Remove ucal_clone by reorganize ucal code

### DIFF
--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -34,6 +34,9 @@
 #include <wtf/DateMath.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/TinyLRUCache.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -84,31 +87,44 @@ static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> buildCalendarTemplate(
     return cal;
 }
 
-struct CalendarCacheEntry {
+struct CalendarCacheEntry final : public ThreadSafeRefCounted<CalendarCacheEntry> {
+    WTF_MAKE_TZONE_ALLOCATED(CalendarCacheEntry);
+public:
     Lock useLock;
     std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> cal;
 };
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CalendarCacheEntry);
 
-static CalendarCacheEntry& calendarCacheEntry(CalendarID calendarId)
+struct CalendarLRUCachePolicy {
+    static bool isKeyNull(const CalendarID&) { return false; }
+    static RefPtr<CalendarCacheEntry> createValueForNullKey() { return nullptr; }
+    static RefPtr<CalendarCacheEntry> createValueForKey(const CalendarID&) { return adoptRef(*new CalendarCacheEntry); }
+    static CalendarID createKeyForStorage(const CalendarID& id) { return id; }
+};
+
+static RefPtr<CalendarCacheEntry> calendarCacheEntry(CalendarID calendarId)
 {
-    static LazyNeverDestroyed<Vector<CalendarCacheEntry>> cache;
+    static Lock cacheLock;
+    static LazyNeverDestroyed<TinyLRUCache<CalendarID, RefPtr<CalendarCacheEntry>, 8, CalendarLRUCachePolicy>> cache;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        cache.construct(intlAvailableCalendars().size());
+        cache.construct();
     });
-    return cache.get()[calendarId];
+    Locker locker { cacheLock };
+    return cache.get().get(calendarId);
 }
 
 template<typename F>
 static auto withCalendar(CalendarID calendarId, F&& fn) -> decltype(fn(static_cast<UCalendar*>(nullptr)))
 {
-    CalendarCacheEntry& entry = calendarCacheEntry(calendarId);
-    Locker locker { entry.useLock };
-    if (!entry.cal)
-        entry.cal = buildCalendarTemplate(locker, calendarId);
-    if (entry.cal)
-        ucal_clear(entry.cal.get());
-    return fn(entry.cal.get());
+    auto entry = calendarCacheEntry(calendarId);
+    ASSERT(entry);
+    Locker locker { entry->useLock };
+    if (!entry->cal)
+        entry->cal = buildCalendarTemplate(locker, calendarId);
+    if (entry->cal)
+        ucal_clear(entry->cal.get());
+    return fn(entry->cal.get());
 }
 
 // lunarCalendarExtendedYearFor1972 — probes UCAL_EXTENDED_YEAR for the given lunisolar calendar
@@ -1103,7 +1119,27 @@ static std::optional<bool> surpassesMonths(
     auto trialMonthCode = getMonthCode(trialCal, calendarId);
     if (!trialMonthCode) [[unlikely]]
         return std::nullopt;
-    return nonISODateSurpasses(calendarId, sign, trialYear, *trialMonthCode, sourceDay, 0, targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
+
+    // Phase 1: lexicographic check (year, monthCode, day).
+    // Equivalent to nonISODateSurpasses with candidateYears=0, but inlined so we don't
+    // need resolveMonthCodeToOrdinal — that would re-enter withCalendar and deadlock with
+    // the cache lock the caller holds across the month iteration.
+    if (compareSurpassesLexicographic(sign, trialYear, *trialMonthCode, sourceDay, targetYear, targetMonthCode, targetDay))
+        return true;
+
+    // Phase 2: constrain source monthCode to year y0, compare ordinally.
+    // trialCal is at the trial position, so its ordinal month equals resolveMonthCodeToOrdinal(calendarId, trialMonthCode, trialYear).
+    // Read it directly. computeOrdinalMonth mutates trialCal (walks from year-start for lunisolar). save+restore epoch ms preserves
+    // the trial position for the next loop iteration.
+    double savedMs = ucal_getMillis(trialCal, &status);
+    if (U_FAILURE(status)) [[unlikely]]
+        return std::nullopt;
+    auto trialOrdinal = computeOrdinalMonth(trialCal, calendarId);
+    UErrorCode restoreStatus = U_ZERO_ERROR;
+    ucal_setMillis(trialCal, savedMs, &restoreStatus);
+    if (!trialOrdinal || U_FAILURE(restoreStatus)) [[unlikely]]
+        return std::nullopt;
+    return compareSurpassesOrdinally(sign, trialYear, *trialOrdinal, sourceDay, targetYear, targetOrdinalMonth, targetDay);
 }
 
 // setMonths — icu4x: SurpassesChecker::set_months (components/calendar/src/calendar_arithmetic.rs)
@@ -1233,31 +1269,12 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
     int32_t yearDiff = target.year - source.year;
     int32_t minYears = !yearDiff ? 0 : yearDiff - sign;
 
-    int32_t years = 0, months = 0, weeks = 0;
-
-    // 6. largestUnit is ~year~ or ~month~: use a cloned working calendar for the month/year loop.
-    //    The clone is obtained inside its own withCalendar call; all subsequent mutations happen
-    //    on the clone, which is not shared — no lock needed for the clone itself.
+    // 6. largestUnit is ~year~ or ~month~: count years (if any) using nonISODateSurpasses,
+    //    then run the month loop on the shared cached calendar.
     ASSERT(largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month);
-    // Obtain a clone of the shared calendar to use as our working state for the iteration.
-    auto workCalOrError = withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>> {
-        if (!cal) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        // Set to source (one) so the clone starts at the right position.
-        if (!setCalendarToISODate(cal, one)) [[unlikely]]
-            return makeUnexpected(rangeError(icuSetCalendarFailed));
-        UErrorCode cloneStatus = U_ZERO_ERROR;
-        auto cloned = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_clone(cal, &cloneStatus));
-        if (!cloned || U_FAILURE(cloneStatus)) [[unlikely]]
-            return makeUnexpected(rangeError(icuOpenCalendarFailed));
-        return cloned;
-    });
-    if (!workCalOrError)
-        return makeUnexpected(workCalOrError.error());
-    auto workCal = WTF::move(*workCalOrError);
-    UCalendar* cal = workCal.get();
 
-    UErrorCode status = U_ZERO_ERROR;
+    int32_t years = 0;
+    int32_t months = 0;
 
     //    a. If largestUnit is ~year~: count full years using nonISODateSurpasses fast-forward.
     if (largestUnit == TemporalUnit::Year) {
@@ -1269,24 +1286,30 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
             years = static_cast<int32_t>(candidateYears);
             candidateYears += sign;
         }
-        //       i. Set cal to (one + years) using calendarDateAdd (preserves month code).
-        if (years) {
-            ISO8601::Duration yearDur;
-            yearDur.setYears(static_cast<int64_t>(years));
-            auto advanced = calendarDateAdd(calendarId, one, yearDur, TemporalOverflow::Constrain);
-            if (!advanced) [[unlikely]]
-                return makeUnexpected(advanced.error());
-            // Set the working clone to the advanced date.
-            if (!setCalendarToISODate(cal, *advanced)) [[unlikely]]
-                return makeUnexpected(rangeError(icuSetCalendarFailed));
-        }
     }
 
-    //    b. Count full months from cal using surpassesMonths (day=1 to avoid clamping).
-    {
+    //    b. Compute the month-loop start: (one + years) via calendarDateAdd (preserves month code).
+    ISO8601::PlainDate monthLoopStart = one;
+    if (years) {
+        ISO8601::Duration yearDur;
+        yearDur.setYears(static_cast<int64_t>(years));
+        auto advanced = calendarDateAdd(calendarId, one, yearDur, TemporalOverflow::Constrain);
+        if (!advanced) [[unlikely]]
+            return makeUnexpected(advanced.error());
+        monthLoopStart = *advanced;
+    }
+
+    //    c. Month iteration on the cached calendar.
+    return withCalendar(calendarId, [&](UCalendar* cal) -> TemporalResult<ISO8601::Duration> {
+        if (!cal) [[unlikely]]
+            return makeUnexpected(rangeError(icuOpenCalendarFailed));
+        if (!setCalendarToISODate(cal, monthLoopStart)) [[unlikely]]
+            return makeUnexpected(rangeError(icuSetCalendarFailed));
+
+        UErrorCode status = U_ZERO_ERROR;
         // NOTE: lunisolar months per year vary; iterate one at a time (no min_months fast-forward).
         int32_t candidateMonths = sign;
-        //    c. Set cal to (one + years) with day=1 for clamping-free month advancement.
+        //    d. Set cal to (one + years) with day=1 for clamping-free month advancement.
         double startMs = ucal_getMillis(cal, &status);
         if (U_FAILURE(status)) [[unlikely]]
             return makeUnexpected(rangeError(icuReadCalendarFailed));
@@ -1316,29 +1339,29 @@ TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const
             if (U_FAILURE(status)) [[unlikely]]
                 return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
         }
-        //    c. Apply regulated day = min(sourceDay, end_of_month) via setMonths.
+        //    e. Apply regulated day = min(sourceDay, end_of_month) via setMonths.
         if (!setMonths(cal, source.day)) [[unlikely]]
             return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-        //    d. If largestUnit is ~month~, clear years (months were counted from one + years=0).
-        if (largestUnit == TemporalUnit::Month)
-            years = 0;
-    }
 
-    // 7. Compute remaining days from the epoch ms difference between cal and two.
-    const double msPerDay = 86'400'000.0; // nsPerDay / nsPerMillisecond
-    // 8. Return Duration { years, months, weeks, days }.
-    double finalMs1 = ucal_getMillis(cal, &status);
-    if (U_FAILURE(status)) [[unlikely]]
-        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
-    double daysDiff = std::trunc((target.epochMs - finalMs1) / msPerDay);
+        // 7. Compute remaining days from the epoch ms difference between cal and two.
+        const double msPerDay = 86'400'000.0; // nsPerDay / nsPerMillisecond
+        // 8. Return Duration { years, months, weeks, days }.
+        double finalMs1 = ucal_getMillis(cal, &status);
+        if (U_FAILURE(status)) [[unlikely]]
+            return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+        double daysDiff = std::trunc((target.epochMs - finalMs1) / msPerDay);
 
-    return ISO8601::Duration {
-        years,
-        months,
-        weeks,
-        static_cast<int64_t>(daysDiff),
-        0, 0, 0, 0, Int128(0), Int128(0)
-    };
+        //    f. If largestUnit is ~month~, clear years (months were counted from one + years=0).
+        int32_t resultYears = (largestUnit == TemporalUnit::Month) ? 0 : years;
+
+        return ISO8601::Duration {
+            resultYears,
+            months,
+            0,
+            static_cast<int64_t>(daysDiff),
+            0, 0, 0, 0, Int128(0), Int128(0)
+        };
+    });
 }
 
 

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -43,7 +43,7 @@
 namespace JSC {
 namespace TemporalCore {
 
-class TimeZoneCacheEntry : public ThreadSafeRefCounted<TimeZoneCacheEntry> {
+class TimeZoneCacheEntry final : public ThreadSafeRefCounted<TimeZoneCacheEntry> {
     WTF_MAKE_TZONE_ALLOCATED(TimeZoneCacheEntry);
 public:
     Lock useLock;


### PR DESCRIPTION
#### ba459bae8fa7fff9852a9017e3735ec9dc20844a
<pre>
[JSC] Remove ucal_clone by reorganize ucal code
<a href="https://bugs.webkit.org/show_bug.cgi?id=316970">https://bugs.webkit.org/show_bug.cgi?id=316970</a>
<a href="https://rdar.apple.com/179440479">rdar://179440479</a>

Reviewed by Yijia Huang.

Let&apos;s change the scope of withCalendar / withTimeZone so that we do not
need to call ucal_clone, which is significantly slower. Also we
introduce TinyLRUCache to Calendar cache too.

* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::CalendarLRUCachePolicy::isKeyNull):
(JSC::TemporalCore::CalendarLRUCachePolicy::createValueForNullKey):
(JSC::TemporalCore::CalendarLRUCachePolicy::createValueForKey):
(JSC::TemporalCore::CalendarLRUCachePolicy::createKeyForStorage):
(JSC::TemporalCore::calendarCacheEntry):
(JSC::TemporalCore::withCalendar):
(JSC::TemporalCore::surpassesMonths):
(JSC::TemporalCore::calendarDateUntil):
* Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp:

Canonical link: <a href="https://commits.webkit.org/315128@main">https://commits.webkit.org/315128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fede633733a03b8d4033deb67fd117ed8bec7441

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125737 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39a02cd9-c848-4ea9-9a7d-e49ccad3fb2a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130745 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e6f4936-80fd-41f3-a37d-b35e9b2b91b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111262 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df2d807a-62e6-4a13-8237-026e1973dde7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30904 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26042 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160662 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179939 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29290 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32691 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139170 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139050 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42301 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105603 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25603 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27376 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200722 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114057 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53917 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40202 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5475 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40453 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->