### PR TITLE
random() crashes when one of its arguments is invalid at computed-value time

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+PASS random() whose 'max' argument fails to resolve is invalid at computed-value time (falls back to initial 'auto')
+PASS random() whose 'min' argument fails to resolve is invalid at computed-value time (falls back to initial 'auto')
+PASS random() with resolvable arguments produces a value within [min, max]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values: random() with an argument that is invalid at computed-value time</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#random">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn">
+<meta name="assert" content="When an argument of random() cannot be resolved at computed-value time (here anchor-size() used on a non-out-of-flow element), the declaration is invalid at computed-value time and the property falls back to its initial value. random() with resolvable arguments still produces a value within [min, max].">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+/* The container fixes the containing block width, so a child whose 'width'
+   becomes invalid at computed-value time (falls back to the initial 'auto')
+   has a deterministic used width of 400px. */
+#container { width: 400px; }
+
+/* anchor-size() resolves to nothing on a statically-positioned element, so the
+   argument it appears in fails to evaluate, making the whole random() invalid
+   at computed-value time.
+
+   The earlier 'width: 50px' declaration disambiguates two outcomes that would
+   otherwise both produce the initial 'auto':
+     - If random() is supported and the argument fails at computed-value time,
+       the property is invalid at computed-value time and reverts to the initial
+       value 'auto' (400px in this container), NOT to the earlier 50px.
+     - If random() is not supported at all, its declaration is dropped at parse
+       time and the earlier 'width: 50px' wins. */
+#max-unresolvable { width: 50px; width: random(0px, anchor-size(width), 100px); }
+#min-unresolvable { width: 50px; width: random(anchor-size(width), 100px, 1px); }
+
+/* Control: all arguments resolve, so random() produces a value in [10px, 20px]. */
+#resolvable { width: random(10px, 20px); }
+</style>
+<div id="container">
+  <div id="max-unresolvable"></div>
+  <div id="min-unresolvable"></div>
+  <div id="resolvable"></div>
+</div>
+<script>
+function computedWidth(id) {
+  return getComputedStyle(document.getElementById(id)).width;
+}
+
+test(() => {
+  assert_equals(computedWidth('max-unresolvable'), '400px');
+}, "random() whose 'max' argument fails to resolve is invalid at computed-value time (falls back to initial 'auto')");
+
+test(() => {
+  assert_equals(computedWidth('min-unresolvable'), '400px');
+}, "random() whose 'min' argument fails to resolve is invalid at computed-value time (falls back to initial 'auto')");
+
+test(() => {
+  const width = parseFloat(computedWidth('resolvable'));
+  assert_greater_than_equal(width, 10, 'resolved width is >= min');
+  assert_less_than_equal(width, 20, 'resolved width is <= max');
+}, "random() with resolvable arguments produces a value within [min, max]");
+</script>

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -245,7 +245,7 @@ std::optional<double> evaluate(const IndirectNode<Random>& root, const Evaluatio
         return { };
 
     auto max = evaluate(root->max, options);
-    if (!min)
+    if (!max)
         return { };
 
     auto step = evaluate(root->step, options);


### PR DESCRIPTION
#### 1683eb4fed1d7082bf4c1da27d39200bd739b9b9
<pre>
random() crashes when one of its arguments is invalid at computed-value time
<a href="https://bugs.webkit.org/show_bug.cgi?id=316972">https://bugs.webkit.org/show_bug.cgi?id=316972</a>

Reviewed by Darin Adler.

The evaluator for random() in CSSCalcTree+Evaluation.cpp evaluated its `max`
argument but then re-checked `min` (already known to be engaged from the check
above) instead of `max`. As a result, a `max` argument that fails to evaluate at
computed-value time -- e.g. an anchor-size() used on a non-out-of-flow element,
which resolves to nothing -- was not caught, and the subsequent `*max` then
dereferenced a disengaged std::optional&lt;double&gt;. With hardened libc++ this traps
(SIGTRAP) and crashes the WebContent process; otherwise it reads uninitialized
memory and produces a garbage result.

Fix this by checking the result of evaluating `max`. When any argument fails to
resolve, random() correctly evaluates to nothing, making the declaration invalid
at computed-value time so the property falls back to its initial value.

Test: imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative.html: Added.
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
(WebCore::CSSCalc::evaluate):

Canonical link: <a href="https://commits.webkit.org/315177@main">https://commits.webkit.org/315177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0637b4680f708f18162b7e0e079b27c2dc9619b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177347 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125744 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9224cfd7-8a3d-4814-b576-3f80b7e4f400) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130751 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91895 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8dcc9a06-23fd-4c0d-a891-0bd98aa64e80) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecb807f1-3881-4744-bd72-b88519e30a47) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32206 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30911 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26049 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179946 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32698 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139176 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139056 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37504 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105615 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34345 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27381 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40812 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114064 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40209 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5480 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40354 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->