### PR TITLE
Deferred and module scripts execute before parser-blocking stylesheets finish loading

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-import-expected.txt
@@ -1,4 +1,4 @@
 FAILED (This TC requires JavaScript enabled)
 
-FAIL  scheduler: stylesheets blocking defer scripts assert_equals: expected "fixed" but got "static"
+PASS  scheduler: stylesheets blocking defer scripts
 Test

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-noimport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-noimport-expected.txt
@@ -1,4 +1,4 @@
 FAILED (This TC requires JavaScript enabled)
 
-FAIL  scheduler: stylesheets blocking defer scripts assert_equals: expected "fixed" but got "static"
+PASS  scheduler: stylesheets blocking defer scripts
 Test

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-import-expected.txt
@@ -1,4 +1,4 @@
 FAILED (This TC requires JavaScript enabled)
 
-FAIL  scheduler: stylesheets blocking external module scripts assert_equals: expected "fixed" but got "static"
+PASS  scheduler: stylesheets blocking external module scripts
 Test

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-noimport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-noimport-expected.txt
@@ -1,4 +1,4 @@
 FAILED (This TC requires JavaScript enabled)
 
-FAIL  scheduler: stylesheets blocking external module scripts assert_equals: expected "fixed" but got "static"
+PASS  scheduler: stylesheets blocking external module scripts
 Test

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-import-expected.txt
@@ -1,4 +1,4 @@
 FAILED (This TC requires JavaScript enabled)
 
-FAIL  scheduler: stylesheets blocking module scripts assert_equals: expected "fixed" but got "static"
+PASS  scheduler: stylesheets blocking module scripts
 Test

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-noimport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-noimport-expected.txt
@@ -1,4 +1,4 @@
 FAILED (This TC requires JavaScript enabled)
 
-FAIL  scheduler: stylesheets blocking module scripts assert_equals: expected "fixed" but got "static"
+PASS  scheduler: stylesheets blocking module scripts
 Test

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google, Inc. All rights reserved.
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -653,6 +653,12 @@ void HTMLDocumentParser::executeScriptsWaitingForStylesheets()
     // pumpTokenizer can cause this parser to be detached from the Document,
     // but we need to ensure it isn't deleted yet.
     Ref<HTMLDocumentParser> protectedThis(*this);
+
+    if (isStopping()) {
+        attemptToRunDeferredScriptsAndEnd();
+        return;
+    }
+
     m_scriptRunner->executeScriptsWaitingForStylesheets();
     if (!isWaitingForScripts())
         resumeParsingAfterScriptExecution();

--- a/Source/WebCore/html/parser/HTMLScriptRunner.cpp
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google, Inc. All rights reserved.
- * Copyright (C) 2010-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -201,6 +201,12 @@ bool HTMLScriptRunner::executeScriptsWaitingForParsing()
             watchForLoad(m_scriptsToExecuteAfterParsing.first());
             return false;
         }
+
+        if (!m_document)
+            return false;
+        m_hasScriptsWaitingForStylesheets = !m_document->haveStylesheetsLoaded();
+        if (m_hasScriptsWaitingForStylesheets)
+            return false;
         executePendingScriptAndDispatchEvent(m_scriptsToExecuteAfterParsing.takeFirst().get());
         // FIXME: What is this m_document check for?
         if (!m_document)


### PR DESCRIPTION
#### 33fd2a336d7e2e70deccdebdfc9c6a1dfd5a6993
<pre>
Deferred and module scripts execute before parser-blocking stylesheets finish loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=209261">https://bugs.webkit.org/show_bug.cgi?id=209261</a>
<a href="https://rdar.apple.com/122575084">rdar://122575084</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per the HTML &quot;stop parsing&quot; steps [1], a script in the &quot;list of scripts that
will execute when the document has finished parsing&quot; must not run until &quot;the
parser&apos;s Document has no style sheet that is blocking scripts.&quot; WebKit only
applied this to parser-blocking scripts (isPendingScriptReady), so deferred
scripts (classic defer and all module scripts) could run against stale,
unstyled layout and observe it via getComputedStyle().

Gate executeScriptsWaitingForParsing() on Document::haveStylesheetsLoaded(),
reusing m_hasScriptsWaitingForStylesheets so didRemoveAllPendingStylesheet()
resumes us once sheets load. When already stopping,
executeScriptsWaitingForStylesheets() routes to attemptToRunDeferredScriptsAndEnd().

[1] <a href="https://html.spec.whatwg.org/#stop-parsing">https://html.spec.whatwg.org/#stop-parsing</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-import-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-defer-noimport-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-import-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-external-module-noimport-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-import-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/106-module-noimport-expected.txt: Ditto
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::executeScriptsWaitingForStylesheets):
* Source/WebCore/html/parser/HTMLScriptRunner.cpp:
(WebCore::HTMLScriptRunner::executeScriptsWaitingForParsing):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33fd2a336d7e2e70deccdebdfc9c6a1dfd5a6993

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125753 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09276dc2-7f0f-4c92-a44d-906319eff884) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130760 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91899 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79258d03-b49e-4093-b8c3-33aaab31c812) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111277 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/674bde10-76a1-475d-8394-32fc9f277fe8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32216 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30921 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26058 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179955 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32707 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139185 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42317 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105632 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34356 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27389 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40821 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114073 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40218 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5488 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40469 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->