### PR TITLE
URL Pattern tokenizer emits a spurious zero-length Regexp token for empty regexp groups

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-empty-regexp-group-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-empty-regexp-group-expected.txt
@@ -1,0 +1,4 @@
+
+PASS URLPattern rejects an empty regexp group '()' with a TypeError
+PASS URLPattern accepts a non-empty regexp group '(a)'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-empty-regexp-group.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-empty-regexp-group.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_throws_js(TypeError, () => { new URLPattern({ pathname: '()' }); });
+}, `URLPattern rejects an empty regexp group '()' with a TypeError`);
+
+test(() => {
+  new URLPattern({ pathname: '(a)' });
+}, `URLPattern accepts a non-empty regexp group '(a)'`);
+</script>

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -257,8 +257,10 @@ ExceptionOr<Vector<Token>> Tokenizer::tokenize()
 
             auto regexLength = regexPosition - regexStart - 1;
 
-            if (!regexLength)
+            if (!regexLength) {
                 maybeException = processTokenizingError(regexStart, m_index, "Regex length is zero."_s);
+                continue;
+            }
 
             addToken(TokenType::Regexp, regexPosition, regexStart, regexLength);
             continue;


### PR DESCRIPTION
#### b43f1484e567625d0e1b124c405a8c6ba31461b4
<pre>
URL Pattern tokenizer emits a spurious zero-length Regexp token for empty regexp groups
<a href="https://bugs.webkit.org/show_bug.cgi?id=316976">https://bugs.webkit.org/show_bug.cgi?id=316976</a>
<a href="https://rdar.apple.com/179452346">rdar://179452346</a>

Reviewed by Rupin Mittal.

The &quot;regexp length is zero&quot; branch was missing the &quot;Continue&quot; of the spec&apos;s tokenize algorithm: it
recorded the tokenizing error but then fell through to add a zero-length Regexp token anyway. In
strict mode the required TypeError was dropped (the loop exits before the error is checked); in
lenient mode an extra bogus token was appended. Add the missing continue so the add-token step is
skipped, matching the other error branches.

Test: imported/w3c/web-platform-tests/urlpattern/urlpattern-empty-regexp-group.html

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-empty-regexp-group-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-empty-regexp-group.html: Added.
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
(WebCore::URLPatternUtilities::Tokenizer::tokenize):

Canonical link: <a href="https://commits.webkit.org/315289@main">https://commits.webkit.org/315289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a09d63925eef000e881168dc3776f23d6100bb0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126201 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6829d009-22be-4197-8045-14adfbdd55e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131152 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92244 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfaef96a-4155-40aa-bff8-c33da03a4330) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111663 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73e779e0-d9af-4b30-8c34-34d661e1ab8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32601 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31302 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26525 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142587 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180428 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139591 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42069 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35465 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139450 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106416 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27800 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41261 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114517 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40658 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5883 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->