### PR TITLE
PlaceholderModelPlayer::setPlaybackRate()/setPaused() do not call their completion handler on early return

### DIFF
--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -141,7 +141,7 @@ void PlaceholderModelPlayer::setLoop(bool loop)
 void PlaceholderModelPlayer::setPlaybackRate(double playbackRate, CompletionHandler<void(double effectivePlaybackRate)>&& completionHandler)
 {
     if (m_animationState.effectivePlaybackRate() == playbackRate)
-        return;
+        return completionHandler(playbackRate);
 
     m_animationState.setCurrentTime(m_animationState.currentTime(), MonotonicTime::now());
     m_animationState.setPlaybackRate(playbackRate);
@@ -162,7 +162,7 @@ bool PlaceholderModelPlayer::paused() const
 void PlaceholderModelPlayer::setPaused(bool paused, CompletionHandler<void(bool succeeded)>&& completionHandler)
 {
     if (m_animationState.paused() == paused)
-        return;
+        return completionHandler(true);
 
     m_animationState.setCurrentTime(m_animationState.currentTime(), MonotonicTime::now());
     m_animationState.setPaused(paused);


### PR DESCRIPTION
#### ae89c4e34f715bdf721db61e71c52bf49b9c171e
<pre>
PlaceholderModelPlayer::setPlaybackRate()/setPaused() do not call their completion handler on early return
<a href="https://bugs.webkit.org/show_bug.cgi?id=316978">https://bugs.webkit.org/show_bug.cgi?id=316978</a>
<a href="https://rdar.apple.com/179452630">rdar://179452630</a>

Reviewed by Mike Wyrzykowski.

Invoke the handler on the early-exit path, as the base ModelPlayer and the ModelProcess player do.

* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp:
(WebCore::PlaceholderModelPlayer::setPlaybackRate):
(WebCore::PlaceholderModelPlayer::setPaused):

Canonical link: <a href="https://commits.webkit.org/315679@main">https://commits.webkit.org/315679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/846d65f83a05e0e4d9336f7829793fa7446ccc80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177359 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125756 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d4b3067-829c-4d82-a201-216e1de89d45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130763 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91902 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c65cc5d2-4e7f-445d-9b61-acf7a084473e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111280 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8c6dfcb-df82-4eac-ad50-009ae1c7b23b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32228 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30922 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26061 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179958 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139188 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41632 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139068 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42320 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105635 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25857 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34353 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114076 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40824 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5492 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40221 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40472 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40366 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->