### PR TITLE
Refactor WebRTCVideoDecoder to store VideoInfo and color space override centrally

### DIFF
--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h
@@ -50,6 +50,17 @@ public:
     virtual void setFormat(std::span<const uint8_t>, uint16_t width, uint16_t height) = 0;
     virtual int32_t decodeFrame(int64_t timeStamp, std::span<const uint8_t>) = 0;
     virtual void setFrameSize(uint16_t width, uint16_t height) = 0;
+
+protected:
+    explicit WebRTCVideoDecoder(std::optional<PlatformVideoColorSpace>&& colorSpaceOverride)
+        : m_colorSpaceOverride(WTF::move(colorSpaceOverride))
+    {
+    }
+
+    const std::optional<PlatformVideoColorSpace>& colorSpaceOverride() const { return m_colorSpaceOverride; }
+
+private:
+    std::optional<PlatformVideoColorSpace> m_colorSpaceOverride;
 };
 
 }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.mm
@@ -45,8 +45,9 @@ namespace WebCore {
 class WebRTCLocalVideoDecoder final : public WebRTCVideoDecoder {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(WebRTCLocalVideoDecoder);
 public:
-    explicit WebRTCLocalVideoDecoder(webrtc::LocalDecoder decoder)
-        : m_decoder(decoder)
+    WebRTCLocalVideoDecoder(webrtc::LocalDecoder decoder, std::optional<PlatformVideoColorSpace>&& colorSpaceOverride)
+        : WebRTCVideoDecoder(WTF::move(colorSpaceOverride))
+        , m_decoder(decoder)
     {
     }
 
@@ -68,9 +69,9 @@ std::unique_ptr<WebRTCVideoDecoder> WebRTCVideoDecoder::create(VideoCodecType de
 {
     switch (decoderType) {
     case VideoCodecType::H264:
-        return makeUnique<WebRTCLocalVideoDecoder>(webrtc::createLocalH264Decoder(callback));
+        return makeUnique<WebRTCLocalVideoDecoder>(webrtc::createLocalH264Decoder(callback), WTF::move(colorSpaceOverride));
     case VideoCodecType::H265:
-        return makeUnique<WebRTCLocalVideoDecoder>(webrtc::createLocalH265Decoder(callback));
+        return makeUnique<WebRTCLocalVideoDecoder>(webrtc::createLocalH265Decoder(callback), WTF::move(colorSpaceOverride));
     case VideoCodecType::VP9:
         return makeUnique<WebRTCVideoDecoderVTBVP9>(callback, WTF::move(colorSpaceOverride));
     case VideoCodecType::AV1:

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.h
@@ -33,6 +33,7 @@
 
 namespace WebCore {
 
+class VideoInfo;
 class WebRTCVideoDecoderVTBQueue;
 
 class WebRTCVideoDecoderVTB : public WebRTCVideoDecoder {
@@ -40,10 +41,10 @@ public:
     ~WebRTCVideoDecoderVTB();
 
 protected:
-    explicit WebRTCVideoDecoderVTB(WebRTCVideoDecoderCallback);
+    WebRTCVideoDecoderVTB(WebRTCVideoDecoderCallback, std::optional<PlatformVideoColorSpace>&& colorSpaceOverride);
 
     int32_t decodeFrameInternal(int64_t timeStamp, std::span<const uint8_t> data);
-    void setVideoFormat(RetainPtr<CMVideoFormatDescriptionRef>&&, uint8_t reorderSize = 0);
+    void setVideoInfo(Ref<VideoInfo>&&, uint8_t reorderSize = 0);
 
     uint16_t width() const { return m_width; }
     uint16_t height() const { return m_height; }
@@ -53,7 +54,10 @@ private:
     void setFormat(std::span<const uint8_t>, uint16_t width, uint16_t height) override;
     void setFrameSize(uint16_t width, uint16_t height) final;
 
+    void updateFormat(const VideoInfo&);
+
     BlockPtr<void(CVPixelBufferRef, int64_t, int64_t, bool)> m_callback;
+    RefPtr<VideoInfo> m_videoInfo;
     RetainPtr<CMVideoFormatDescriptionRef> m_format;
     RefPtr<VideoDecoderVTB> m_decoder;
     RefPtr<WebRTCVideoDecoderVTBQueue> m_queue;

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm
@@ -108,8 +108,9 @@ private:
     MediaReorderQueue<Buffer, BufferComparator> m_queue WTF_GUARDED_BY_LOCK(m_lock);
 };
 
-WebRTCVideoDecoderVTB::WebRTCVideoDecoderVTB(WebRTCVideoDecoderCallback callback)
-    : m_callback(makeBlockPtr(callback))
+WebRTCVideoDecoderVTB::WebRTCVideoDecoderVTB(WebRTCVideoDecoderCallback callback, std::optional<PlatformVideoColorSpace>&& colorSpaceOverride)
+    : WebRTCVideoDecoder(WTF::move(colorSpaceOverride))
+    , m_callback(makeBlockPtr(callback))
 {
 }
 
@@ -163,12 +164,27 @@ int32_t WebRTCVideoDecoderVTB::decodeFrameInternal(int64_t timeStamp, std::span<
     return 0;
 }
 
-void WebRTCVideoDecoderVTB::setVideoFormat(RetainPtr<CMVideoFormatDescriptionRef>&& format, uint8_t reorderSize)
+void WebRTCVideoDecoderVTB::setVideoInfo(Ref<VideoInfo>&& videoInfo, uint8_t reorderSize)
 {
-    m_format = WTF::move(format);
+    updateFormat(videoInfo);
+    m_videoInfo = WTF::move(videoInfo);
     m_reorderSize = reorderSize;
     if (reorderSize && !m_queue)
         m_queue = WebRTCVideoDecoderVTBQueue::create(reorderSize);
+}
+
+void WebRTCVideoDecoderVTB::updateFormat(const VideoInfo& videoInfo)
+{
+    auto colorSpaceOverride = this->colorSpaceOverride();
+    if (!colorSpaceOverride) {
+        m_format = createFormatDescriptionFromTrackInfo(videoInfo);
+        return;
+    }
+
+    auto data = videoInfo.toVideoInfoData();
+    overrideVideoColorSpaceAsNeeded(data.second.colorSpace, colorSpaceOverride);
+    Ref updatedVideoInfo = VideoInfo::create(WTF::move(data));
+    m_format = createFormatDescriptionFromTrackInfo(updatedVideoInfo);
 }
 
 void WebRTCVideoDecoderVTB::flush()

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.h
@@ -38,12 +38,10 @@ class WebRTCVideoDecoderVTBAV1 final : public WebRTCVideoDecoderVTB {
     WTF_MAKE_TZONE_ALLOCATED(WebRTCVideoDecoderVTBAV1);
 public:
     explicit WebRTCVideoDecoderVTBAV1(WebRTCVideoDecoderCallback, std::optional<PlatformVideoColorSpace>&& colorSpaceOverride = std::nullopt);
-    ~WebRTCVideoDecoderVTBAV1() = default;
+    ~WebRTCVideoDecoderVTBAV1();
 
 private:
     int32_t decodeFrame(int64_t, std::span<const uint8_t>) final;
-
-    const std::optional<PlatformVideoColorSpace> m_colorSpaceOverride;
 };
 
 }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.mm
@@ -38,39 +38,17 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebRTCVideoDecoderVTBAV1);
 
-static RetainPtr<CMVideoFormatDescriptionRef> computeAV1InputFormat(std::span<const uint8_t> data, int32_t width, int32_t height, const std::optional<PlatformVideoColorSpace>& colorSpaceOverride)
-{
-#if ENABLE(AV1)
-    RefPtr videoInfo = createVideoInfoFromAV1Stream(data, std::nullopt, colorSpaceOverride);
-    if (!videoInfo)
-        return { };
-
-    if (width && videoInfo->size().width() != width)
-        return { };
-    if (height && videoInfo->size().height() != height)
-        return { };
-
-    return createFormatDescriptionFromTrackInfo(*videoInfo);
-#else
-    UNUSED_PARAM(data);
-    UNUSED_PARAM(width);
-    UNUSED_PARAM(height);
-    UNUSED_PARAM(colorSpaceOverride);
-    ASSERT_NOT_REACHED();
-    return { };
-#endif
-}
-
 WebRTCVideoDecoderVTBAV1::WebRTCVideoDecoderVTBAV1(WebRTCVideoDecoderCallback callback, std::optional<PlatformVideoColorSpace>&& colorSpaceOverride)
-    : WebRTCVideoDecoderVTB(callback)
-    , m_colorSpaceOverride(WTF::move(colorSpaceOverride))
+    : WebRTCVideoDecoderVTB(callback, WTF::move(colorSpaceOverride))
 {
 }
+
+WebRTCVideoDecoderVTBAV1::~WebRTCVideoDecoderVTBAV1() = default;
 
 int32_t WebRTCVideoDecoderVTBAV1::decodeFrame(int64_t timeStamp, std::span<const uint8_t> data)
 {
-    if (auto videoFormat = computeAV1InputFormat(data, width(), height(), m_colorSpaceOverride))
-        setVideoFormat(WTF::move(videoFormat));
+    if (RefPtr videoInfo = createVideoInfoFromAV1Stream(data, std::nullopt))
+        setVideoInfo(videoInfo.releaseNonNull());
 
     return decodeFrameInternal(timeStamp, data);
 }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.h
@@ -41,8 +41,6 @@ public:
 
 private:
     int32_t decodeFrame(int64_t, std::span<const uint8_t>) final;
-
-    const std::optional<PlatformVideoColorSpace> m_colorSpaceOverride;
 };
 
 }

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm
@@ -39,7 +39,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebRTCVideoDecoderVTBVP9);
 
-static RetainPtr<CMVideoFormatDescriptionRef> createVP9FormatDescriptionFromData(std::span<const uint8_t> data, int32_t width, int32_t height, const std::optional<PlatformVideoColorSpace>& colorSpaceOverride)
+static RefPtr<VideoInfo> createVP9VideoInfoFromData(std::span<const uint8_t> data, int32_t width, int32_t height)
 {
     auto parsedRecord = vpCodecConfigurationRecordFromVPXByteStream(VPXCodec::Vp9, data);
     if (!parsedRecord)
@@ -56,19 +56,18 @@ static RetainPtr<CMVideoFormatDescriptionRef> createVP9FormatDescriptionFromData
         parsedRecord->matrixCoefficients = VPConfigurationMatrixCoefficients::BT_709_6;
     }
 
-    return createVP9FormatDescriptionFromRecord(*parsedRecord, colorSpaceOverride);
+    return createVideoInfoFromVPCodecConfigurationRecord(*parsedRecord);
 }
 
 WebRTCVideoDecoderVTBVP9::WebRTCVideoDecoderVTBVP9(WebRTCVideoDecoderCallback callback, std::optional<PlatformVideoColorSpace>&& colorSpaceOverride)
-    : WebRTCVideoDecoderVTB(callback)
-    , m_colorSpaceOverride(WTF::move(colorSpaceOverride))
+    : WebRTCVideoDecoderVTB(callback, WTF::move(colorSpaceOverride))
 {
 }
 
 int32_t WebRTCVideoDecoderVTBVP9::decodeFrame(int64_t timeStamp, std::span<const uint8_t> data)
 {
-    if (auto videoFormat = createVP9FormatDescriptionFromData(data, width(), height(), m_colorSpaceOverride))
-        setVideoFormat(WTF::move(videoFormat));
+    if (RefPtr videoInfo = createVP9VideoInfoFromData(data, width(), height()))
+        setVideoInfo(videoInfo.releaseNonNull());
 
     return decodeFrameInternal(timeStamp, data);
 }


### PR DESCRIPTION
#### 437ffaac6c61c3b629437ae99bdafa7a446eb2d9
<pre>
Refactor WebRTCVideoDecoder to store VideoInfo and color space override centrally
<a href="https://rdar.apple.com/178529773">rdar://178529773</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316393">https://bugs.webkit.org/show_bug.cgi?id=316393</a>

Reviewed by Jean-Yves Avenard.

This is a preparatory refactoring that moves color-space-override state
from individual subclasses into the WebRTCVideoDecoder base class, and
replaces the raw CMVideoFormatDescriptionRef plumbing in WebRTCVideoDecoderVTB
with a VideoInfo-based approach. No external behavior changes.

- WebRTCVideoDecoder gains m_colorSpaceOverride with a protected accessor
  and a protected constructor that accepts an initial override value.

- WebRTCVideoDecoderVTB replaces setVideoFormat(CMVideoFormatDescriptionRef)
  with setVideoInfo(Ref&lt;VideoInfo&gt;) and stores m_videoInfo alongside m_format.
  A new private updateFormat(const VideoInfo&amp;) derives m_format from the
  supplied VideoInfo, applying the color space override when present and
  falling back to the in-band bitstream color space when not.

- WebRTCVideoDecoderVTBAV1 drops its own m_colorSpaceOverride (now inherited
  from the base). decodeFrame calls createVideoInfoFromAV1Stream without a
  color space argument and passes the result to setVideoInfo; updateFormat
  handles the override application centrally.

- WebRTCVideoDecoderVTBVP9 likewise drops m_colorSpaceOverride. The local
  createVP9VideoInfoFromData no longer takes a color space parameter; the
  override is applied in updateFormat.

* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h:
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.mm:
(WebCore::WebRTCLocalVideoDecoder::WebRTCLocalVideoDecoder):
(WebCore::WebRTCVideoDecoder::create):
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.h:
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTB.mm:
(WebCore::WebRTCVideoDecoderVTB::WebRTCVideoDecoderVTB):
(WebCore::WebRTCVideoDecoderVTB::setVideoInfo):
(WebCore::WebRTCVideoDecoderVTB::updateFormat):
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.h:
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBAV1.mm:
(WebCore::WebRTCVideoDecoderVTBAV1::WebRTCVideoDecoderVTBAV1):
(WebCore::WebRTCVideoDecoderVTBAV1::~WebRTCVideoDecoderVTBAV1):
(WebCore::WebRTCVideoDecoderVTBAV1::decodeFrame):
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.h:
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoderVTBVP9.mm:
(WebCore::createVP9VideoInfoFromData):
(WebCore::WebRTCVideoDecoderVTBVP9::WebRTCVideoDecoderVTBVP9):
(WebCore::WebRTCVideoDecoderVTBVP9::decodeFrame):

Canonical link: <a href="https://commits.webkit.org/315209@main">https://commits.webkit.org/315209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8aeecd0f7463f79065cfa107ef6e843a3e2a82a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126101 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b366227-c3d0-4154-893c-07e3c0b2c1ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131060 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/398bdf92-d4b6-4e86-9e84-23b3de1cefff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111571 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/caf53121-d2c4-429e-b0d0-7793939c7f03) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32512 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26424 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142498 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180328 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33052 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139495 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41969 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139359 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37525 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42657 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106249 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27711 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41161 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114417 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40558 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5796 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40809 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->