### PR TITLE
[CMake] Glob all Source/cmake/*.cmake files when deciding to remove CMakeCache.txt

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2711,19 +2711,15 @@ sub shouldRemoveCMakeCache(@)
     }
 
     my $cacheFileModifiedTime = stat($cmakeCache)->mtime;
-    my $platformConfiguration = File::Spec->catdir(sourceDir(), "Source", "cmake", "Options" . cmakeBasedPortName() . ".cmake");
-    if ($cacheFileModifiedTime < stat($platformConfiguration)->mtime) {
-        return 1;
-    }
 
-    my $globalConfiguration = File::Spec->catdir(sourceDir(), "Source", "cmake", "OptionsCommon.cmake");
-    if ($cacheFileModifiedTime < stat($globalConfiguration)->mtime) {
-        return 1;
-    }
-
-    my $compilerFlagsCMake = File::Spec->catdir(sourceDir(), "Source", "cmake", "WebKitCompilerFlags.cmake");
-    if ($cacheFileModifiedTime < stat($compilerFlagsCMake)->mtime) {
-        return 1;
+    # Any .cmake file under Source/cmake can influence the generated cache, so
+    # glob them all instead of enumerating by hand. Top level only; use
+    # File::Find if cmake modules ever move into subdirectories.
+    my $cmakeModuleDirectory = File::Spec->catdir(sourceDir(), "Source", "cmake");
+    for my $cmakeFile (bsd_glob(File::Spec->catfile($cmakeModuleDirectory, "*.cmake"))) {
+        if ($cacheFileModifiedTime < stat($cmakeFile)->mtime) {
+            return 1;
+        }
     }
 
     # FIXME: This probably does not work as expected, or the next block to
@@ -2737,13 +2733,6 @@ sub shouldRemoveCMakeCache(@)
     my $inspectorImageDirectory = File::Spec->catdir(sourceDir(), "Source", "WebInspectorUI", "UserInterface", "Images");
     if ($cacheFileModifiedTime < stat($inspectorImageDirectory)->mtime) {
         return 1;
-    }
-
-    if(isAnyWindows()) {
-        my $winConfiguration = File::Spec->catdir(sourceDir(), "Source", "cmake", "OptionsWin.cmake");
-        if ($cacheFileModifiedTime < stat($winConfiguration)->mtime) {
-            return 1;
-        }
     }
 
     # If a change on the JHBuild moduleset has been done, we need to clean the cache as well.


### PR DESCRIPTION
#### 7abc2361027ff0b9cd4f8d6c284f9ef89205eb5a
<pre>
[CMake] Glob all Source/cmake/*.cmake files when deciding to remove CMakeCache.txt

Reviewed by Carlos Alberto Lopez Perez.

shouldRemoveCMakeCache() only checked a hand-picked subset of cmake files
(the port Options file, OptionsCommon and WebKitCompilerFlags) against the
cache mtime, so edits to other configuration files that influence the
generated cache -- WebKitFeatures, VersioningUtils, did not trigger an
automatic reconfigure.

Replace the enumerated checks (and the redundant Windows-only OptionsWin
special case) with a glob over Source/cmake/*.cmake, so every current and
future module is covered automatically.

* Tools/Scripts/webkitdirs.pm:
(shouldRemoveCMakeCache):

Canonical link: <a href="https://commits.webkit.org/315086@main">https://commits.webkit.org/315086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cdc3afddfe4d53a616d7ad2717c4dea148159f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125784 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41603 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171050 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111304 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26089 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160709 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179986 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29337 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30459 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139092 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42348 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105683 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25584 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34381 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200769 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40852 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53935 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40249 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5515 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->