### PR TITLE
[GStreamer] Refactor pad probes in VideoFrameMetadata, getting rid of raw userData gpointer

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -165,17 +165,28 @@ void webkitGstTraceProcessingTimeForElement(GstElement* element)
 
     GST_DEBUG("Tracing processing time for %" GST_PTR_FORMAT, element);
 
+    // The pad probes life cycles are tied to their pad, they will be removed during the pad
+    // disposal. No need for PadProbeHandle here.
     static auto probeType = static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_BUFFER);
 
-    gst_pad_add_probe(sinkPad.get(), probeType, [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
+    gst_pad_add_probe(sinkPad.get(), probeType, [](GstPad* pad, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
+        auto element = adoptGRef(gst_pad_get_parent_element(pad));
+        if (!element) [[unlikely]]
+            return GST_PAD_PROBE_REMOVE;
+
         auto [modifiedBuffer, meta] = ensureVideoFrameMetadata(GRefPtr(GST_PAD_PROBE_INFO_BUFFER(info)));
         gst_pad_probe_info_set_buffer(info, modifiedBuffer.leakRef());
-        Locker locker { meta->priv->lock };
-        meta->priv->processingTimes.set(GST_ELEMENT_CAST(userData), std::make_pair(gst_util_get_timestamp(), GST_CLOCK_TIME_NONE));
-        return GST_PAD_PROBE_OK;
-    }, element, nullptr);
 
-    gst_pad_add_probe(srcPad.get(), probeType, [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
+        Locker locker { meta->priv->lock };
+        meta->priv->processingTimes.set(element.get(), std::make_pair(gst_util_get_timestamp(), GST_CLOCK_TIME_NONE));
+        return GST_PAD_PROBE_OK;
+    }, nullptr, nullptr);
+
+    gst_pad_add_probe(srcPad.get(), probeType, [](GstPad* pad, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
+        auto element = adoptGRef(gst_pad_get_parent_element(pad));
+        if (!element) [[unlikely]]
+            return GST_PAD_PROBE_REMOVE;
+
         auto* meta = getInternalVideoFrameMetadata(GST_PAD_PROBE_INFO_BUFFER(info));
         // Some decoders (such as theoradec) do not always copy the input meta to the output frame,
         // so we need to check the meta is valid here before accessing it.
@@ -183,11 +194,10 @@ void webkitGstTraceProcessingTimeForElement(GstElement* element)
             return GST_PAD_PROBE_OK;
 
         Locker locker { meta->priv->lock };
-        auto* key = GST_ELEMENT_CAST(userData);
-        auto [startTime, oldStopTime] = meta->priv->processingTimes.get(key);
-        meta->priv->processingTimes.set(key, std::make_pair(startTime, gst_util_get_timestamp()));
+        auto [startTime, oldStopTime] = meta->priv->processingTimes.get(element.get());
+        meta->priv->processingTimes.set(element.get(), std::make_pair(startTime, gst_util_get_timestamp()));
         return GST_PAD_PROBE_OK;
-    }, element, nullptr);
+    }, nullptr, nullptr);
 }
 
 VideoFrameMetadata webkitGstBufferGetVideoFrameMetadata(GstBuffer* buffer)


### PR DESCRIPTION
#### 464946d5f93b8da5c86f0047012a32240aad9c72
<pre>
[GStreamer] Refactor pad probes in VideoFrameMetadata, getting rid of raw userData gpointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=316986">https://bugs.webkit.org/show_bug.cgi?id=316986</a>

Reviewed by Xabier Rodriguez-Calvar.

After initial assessment there is no need for using PadProbeHandle for these two probes. As the
GstElement can easily be inferred from the probed pad, remove it from the gpointer passed to the
probe callbacks.

* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
(webkitGstTraceProcessingTimeForElement):

Canonical link: <a href="https://commits.webkit.org/315212@main">https://commits.webkit.org/315212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97a9e774fd59f065de0ea46b954dd5378e095ecf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130788 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91926 "1 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32250 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30955 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179987 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32739 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139218 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139093 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37527 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42349 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105684 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34382 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27422 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40853 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114105 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40250 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5516 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->