### PR TITLE
[GTK][WPE] ThreadedCompositor can composite a half-committed set of scrolling-tree layer positions

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFixedNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFixedNodeCoordinated.cpp
@@ -68,11 +68,7 @@ void ScrollingTreeFixedNodeCoordinated::applyLayerPositions()
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFixedNode " << scrollingNodeID() << " relatedNodeScrollPositionDidChange: viewportRectAtLastLayout " << m_constraints.viewportRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 
-    // Match the behavior of ScrollingTreeFrameScrollingNodeCoordinated::repositionScrollingLayers().
-    CoordinatedPlatformLayer::ForcePositionSync forceSync = ScrollingThread::isCurrentThread() && !scrollingTree()->isScrollingSynchronizedWithMainThread() ?
-        CoordinatedPlatformLayer::ForcePositionSync::Yes : CoordinatedPlatformLayer::ForcePositionSync::No;
-
-    m_layer->setTopLeftPositionForScrolling(layerPosition - m_constraints.alignmentOffset(), forceSync);
+    m_layer->setTopLeftPositionForScrolling(layerPosition - m_constraints.alignmentOffset());
 }
 
 void ScrollingTreeFixedNodeCoordinated::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
@@ -108,15 +108,8 @@ void ScrollingTreeFrameScrollingNodeCoordinated::repositionScrollingLayers()
     if (!scrollLayer)
         return;
 
-    // If we're committing on the scrolling thread, it means that ThreadedScrollingTree is in "desynchronized" mode.
-    // The main thread may already have set the same layer position, but here we need to trigger a scrolling thread composition
-    // to ensure that the scroll happens even when the main thread commit is taking a long time. So make sure the layer property
-    // changes when there has been a scroll position change.
-    CoordinatedPlatformLayer::ForcePositionSync forceSync = ScrollingThread::isCurrentThread() && !scrollingTree()->isScrollingSynchronizedWithMainThread() ?
-        CoordinatedPlatformLayer::ForcePositionSync::Yes : CoordinatedPlatformLayer::ForcePositionSync::No;
-
     auto scrollPosition = currentScrollPosition();
-    scrollLayer->setPositionForScrolling(-scrollPosition, forceSync);
+    scrollLayer->setPositionForScrolling(-scrollPosition);
 }
 
 void ScrollingTreeFrameScrollingNodeCoordinated::repositionRelatedLayers()

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreePositionedNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreePositionedNodeCoordinated.cpp
@@ -65,11 +65,7 @@ void ScrollingTreePositionedNodeCoordinated::applyLayerPositions()
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreePositionedNode " << scrollingNodeID() << " applyLayerPositions: overflow delta " << delta << " moving layer to " << layerPosition);
 
-    // Match the behavior of ScrollingTreeFrameScrollingNodeCoordinated::repositionScrollingLayers().
-    CoordinatedPlatformLayer::ForcePositionSync forceSync = ScrollingThread::isCurrentThread() && !scrollingTree()->isScrollingSynchronizedWithMainThread() ?
-        CoordinatedPlatformLayer::ForcePositionSync::Yes : CoordinatedPlatformLayer::ForcePositionSync::No;
-
-    m_layer->setTopLeftPositionForScrolling(layerPosition - m_constraints.alignmentOffset(), forceSync);
+    m_layer->setTopLeftPositionForScrolling(layerPosition - m_constraints.alignmentOffset());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp
@@ -66,11 +66,7 @@ void ScrollingTreeStickyNodeCoordinated::applyLayerPositions()
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeStickyNodeCoordinated " << scrollingNodeID() << " constrainingRectAtLastLayout " << m_constraints.constrainingRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 
-    // Match the behavior of ScrollingTreeFrameScrollingNodeCoordinated::repositionScrollingLayers().
-    CoordinatedPlatformLayer::ForcePositionSync forceSync = ScrollingThread::isCurrentThread() && !scrollingTree()->isScrollingSynchronizedWithMainThread() ?
-        CoordinatedPlatformLayer::ForcePositionSync::Yes : CoordinatedPlatformLayer::ForcePositionSync::No;
-
-    m_layer->setTopLeftPositionForScrolling(layerPosition - m_constraints.alignmentOffset(), forceSync);
+    m_layer->setTopLeftPositionForScrolling(layerPosition - m_constraints.alignmentOffset());
 }
 
 FloatPoint ScrollingTreeStickyNodeCoordinated::layerTopLeft() const

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -62,8 +62,20 @@ void SkiaBackingStore::update(const FloatSize& size, float scale, CoordinatedBac
     for (const auto& tileUpdate : update.tilesToUpdate()) {
         auto it = m_tiles.find(tileUpdate.tileID);
         ASSERT(it != m_tiles.end());
-        it->value.update(tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer);
+        it->value.scheduleUpdate(tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer);
+        m_hasPendingTileUpdates = true;
     }
+}
+
+void SkiaBackingStore::processPendingTileUpdates()
+{
+    if (!m_hasPendingTileUpdates)
+        return;
+
+    for (auto& tile : m_tiles.values())
+        tile.processPendingUpdateIfNeeded();
+
+    m_hasPendingTileUpdates = false;
 }
 
 static inline bool allTileEdgesExposed(const FloatRect& totalRect, const FloatRect& tileRect)
@@ -116,6 +128,18 @@ void SkiaBackingStore::drawDebugBorders(SkCanvas& canvas, const SkPaint& paint)
 {
     for (const auto& tile : m_tiles.values())
         canvas.drawRect(SkRect(tile.rect()), paint);
+}
+
+void SkiaBackingStore::Tile::scheduleUpdate(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer& buffer)
+{
+    m_pendingUpdates.append({ tileRect, dirtyRect, Ref { buffer } });
+}
+
+void SkiaBackingStore::Tile::processPendingUpdateIfNeeded()
+{
+    for (auto& pendingUpdate : m_pendingUpdates)
+        update(pendingUpdate.dirtyRect, pendingUpdate.tileRect, pendingUpdate.buffer.get());
+    m_pendingUpdates.clear();
 }
 
 void SkiaBackingStore::Tile::ensureTexture(const IntSize& size, CoordinatedTileBuffer& buffer)

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -46,8 +46,11 @@ public:
     ~SkiaBackingStore() = default;
 
     float scale() const { return m_scale; }
+    bool hasPendingTileUpdates() const { return m_hasPendingTileUpdates; }
 
     void update(const FloatSize&, float scale, CoordinatedBackingStoreProxy::Update&&);
+    void processPendingTileUpdates();
+
     void paintToCanvas(SkCanvas&, const SkPaint&);
     Vector<SkCanvas::ImageSetEntry> buildImageSet(size_t matrixIndex, float opacity, bool enableAntialias) const;
     void drawDebugBorders(SkCanvas&, const SkPaint&);
@@ -67,15 +70,25 @@ private:
 
         ~Tile() = default;
 
-        void update(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer&);
+        void scheduleUpdate(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer&);
+        void processPendingUpdateIfNeeded();
+
         const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
         sk_sp<SkImage> image() const;
 
     private:
         void ensureTexture(const IntSize&, CoordinatedTileBuffer&);
+        void update(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer&);
+
+        struct Update {
+            IntRect tileRect;
+            IntRect dirtyRect;
+            Ref<CoordinatedTileBuffer> buffer;
+        };
 
         float m_scale { 1. };
         FloatRect m_rect;
+        Vector<Update> m_pendingUpdates;
         sk_sp<SkSurface> m_surface;
         RefPtr<BitmapTexture> m_texture;
         mutable sk_sp<SkImage> m_cachedImage;
@@ -84,6 +97,7 @@ private:
     HashMap<uint32_t, Tile> m_tiles;
     FloatSize m_size;
     float m_scale { 1. };
+    bool m_hasPendingTileUpdates { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -174,6 +174,17 @@ void SkiaCompositingLayer::updateBackingStore(CoordinatedBackingStoreProxy::Upda
     m_backingStore->update(m_size, scale, WTF::move(update));
 }
 
+bool SkiaCompositingLayer::hasPendingBackingStoreTileUpdates() const
+{
+    return m_backingStore ? m_backingStore->hasPendingTileUpdates() : false;
+}
+
+void SkiaCompositingLayer::processPendingTileUpdates()
+{
+    if (m_backingStore)
+        m_backingStore->processPendingTileUpdates();
+}
+
 void SkiaCompositingLayer::setImageBackingStore(CoordinatedImageBackingStore* imageBackingStore)
 {
     m_imageBackingStore = imageBackingStore;

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -98,6 +98,8 @@ public:
 
     void setUseBackingStore(bool, CoordinatedAnimatedBackingStoreClient* = nullptr);
     void updateBackingStore(CoordinatedBackingStoreProxy::Update&&, float);
+    bool hasPendingBackingStoreTileUpdates() const;
+    void processPendingTileUpdates();
     void setImageBackingStore(CoordinatedImageBackingStore*);
     void setContentsBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&);
     CoordinatedPlatformLayerBuffer* contentsBuffer() const { return m_contentsBuffer.get(); }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -46,12 +46,18 @@ void CoordinatedBackingStore::updateTile(uint32_t id, const IntRect& sourceRect,
     auto it = m_tiles.find(id);
     ASSERT(it != m_tiles.end());
     it->value.addUpdate({ WTF::move(buffer), sourceRect, tileRect, offset });
+    m_hasPendingTileUpdates = true;
 }
 
 void CoordinatedBackingStore::processPendingUpdates()
 {
+    if (!m_hasPendingTileUpdates)
+        return;
+
     for (auto& tile : m_tiles.values())
         tile.processPendingUpdates();
+
+    m_hasPendingTileUpdates = false;
 }
 
 void CoordinatedBackingStore::resize(const FloatSize& size, float scale)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -44,6 +44,7 @@ public:
     void removeTile(uint32_t tileID);
     void updateTile(uint32_t tileID, const IntRect&, const IntRect&, Ref<CoordinatedTileBuffer>&&, const IntPoint&);
 
+    bool hasPendingUpdates() const { return m_hasPendingTileUpdates; }
     void processPendingUpdates();
 
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
@@ -56,6 +57,7 @@ private:
     HashMap<uint32_t, CoordinatedBackingStoreTile> m_tiles;
     FloatSize m_size;
     float m_scale { 1. };
+    bool m_hasPendingTileUpdates { false };
 };
 
 } // namespace WebKit

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -176,23 +176,13 @@ void CoordinatedPlatformLayer::notifyCompositionRequired()
 void CoordinatedPlatformLayer::setPosition(FloatPoint&& position)
 {
     ASSERT(m_lock.isHeld());
-    if (m_position == position)
-        return;
-
-    m_position = WTF::move(position);
-    m_pendingChanges.add(Change::Position);
-    notifyCompositionRequired();
+    m_pendingState.position = WTF::move(position);
 }
 
-void CoordinatedPlatformLayer::setPositionForScrolling(const FloatPoint& position, ForcePositionSync forceSync)
+void CoordinatedPlatformLayer::setPositionForScrolling(const FloatPoint& position)
 {
     Locker locker { m_lock };
-    if (m_position == position && forceSync == ForcePositionSync::No)
-        return;
-
-    m_position = position;
-    m_pendingChanges.add(Change::Position);
-    notifyCompositionRequired();
+    m_pendingState.positionForScrolling = position;
 }
 
 const FloatPoint& CoordinatedPlatformLayer::position() const
@@ -201,14 +191,14 @@ const FloatPoint& CoordinatedPlatformLayer::position() const
     return m_position;
 }
 
-void CoordinatedPlatformLayer::setTopLeftPositionForScrolling(const FloatPoint& position, ForcePositionSync forceSync)
+void CoordinatedPlatformLayer::setTopLeftPositionForScrolling(const FloatPoint& position)
 {
     FloatPoint newPosition;
     {
         Locker locker { m_lock };
         newPosition = { position.x() + m_anchorPoint.x() * m_size.width(), position.y() + m_anchorPoint.y() * m_size.height() };
     }
-    setPositionForScrolling(newPosition, forceSync);
+    setPositionForScrolling(newPosition);
 }
 
 FloatPoint CoordinatedPlatformLayer::topLeftPositionForScrolling()
@@ -220,23 +210,13 @@ FloatPoint CoordinatedPlatformLayer::topLeftPositionForScrolling()
 void CoordinatedPlatformLayer::setBoundsOrigin(const FloatPoint& origin)
 {
     ASSERT(m_lock.isHeld());
-    if (m_boundsOrigin == origin)
-        return;
-
-    m_boundsOrigin = origin;
-    m_pendingChanges.add(Change::BoundsOrigin);
-    notifyCompositionRequired();
+    m_pendingState.boundsOrigin = origin;
 }
 
 void CoordinatedPlatformLayer::setBoundsOriginForScrolling(const FloatPoint& origin)
 {
     Locker locker { m_lock };
-    if (m_boundsOrigin == origin)
-        return;
-
-    m_boundsOrigin = origin;
-    m_pendingChanges.add(Change::BoundsOrigin);
-    notifyCompositionRequired();
+    m_pendingState.boundsOriginForScrolling = origin;
 }
 
 const FloatPoint& CoordinatedPlatformLayer::boundsOrigin() const
@@ -974,6 +954,43 @@ void CoordinatedPlatformLayer::waitUntilPaintingComplete()
         m_backingStoreProxy->waitUntilPaintingComplete();
 }
 
+void CoordinatedPlatformLayer::flushPendingState()
+{
+    Locker locker { m_lock };
+    if (!m_pendingState.position && !m_pendingState.boundsOrigin && !m_pendingState.positionForScrolling && !m_pendingState.boundsOriginForScrolling)
+        return;
+
+    std::optional<FloatPoint> position;
+    if (m_pendingState.positionForScrolling) {
+        m_pendingState.position = std::nullopt;
+        position = *std::exchange(m_pendingState.positionForScrolling, std::nullopt);
+    } else if (m_pendingState.position)
+        position = *std::exchange(m_pendingState.position, std::nullopt);
+
+    std::optional<FloatPoint> boundsOrigin;
+    if (m_pendingState.boundsOriginForScrolling) {
+        m_pendingState.boundsOrigin = std::nullopt;
+        boundsOrigin = *std::exchange(m_pendingState.boundsOriginForScrolling, std::nullopt);
+    } else if (m_pendingState.boundsOrigin)
+        boundsOrigin = *std::exchange(m_pendingState.boundsOrigin, std::nullopt);
+
+    bool requireComposition = false;
+    if (position && m_position != *position) {
+        m_position = *position;
+        m_pendingChanges.add(Change::Position);
+        requireComposition = true;
+    }
+
+    if (boundsOrigin && m_boundsOrigin != boundsOrigin) {
+        m_boundsOrigin = *boundsOrigin;
+        m_pendingChanges.add(Change::BoundsOrigin);
+        requireComposition = true;
+    }
+
+    if (requireComposition)
+        notifyCompositionRequired();
+}
+
 void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<CompositionReason>& reasons, bool useSkiaTarget)
 {
     ASSERT(!isMainThread());
@@ -1170,8 +1187,6 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
                 m_backingStore->removeTile(tileID);
             for (const auto& tileUpdate : update.tilesToUpdate())
                 m_backingStore->updateTile(tileUpdate.tileID, tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer.copyRef(), { });
-
-            m_backingStore->processPendingUpdates();
         }
     }
 
@@ -1383,6 +1398,36 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
     }
 }
 #endif // USE(SKIA)
+
+bool CoordinatedPlatformLayer::hasPendingBackingStoreTileUpdates() const
+{
+    ASSERT(!isMainThread());
+
+#if USE(SKIA)
+    if (m_skiaTarget)
+        return m_skiaTarget->hasPendingBackingStoreTileUpdates();
+#endif
+
+    if (m_backingStore)
+        return m_backingStore->hasPendingUpdates();
+
+    return false;
+}
+
+void CoordinatedPlatformLayer::processPendingBackingStoreTileUpdates()
+{
+    ASSERT(!isMainThread());
+
+#if USE(SKIA)
+    if (m_skiaTarget) {
+        m_skiaTarget->processPendingTileUpdates();
+        return;
+    }
+#endif
+
+    if (m_backingStore)
+        m_backingStore->processPendingUpdates();
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -109,10 +109,9 @@ public:
 #endif
 
     void setPosition(FloatPoint&&);
-    enum class ForcePositionSync : bool { No, Yes };
-    void setPositionForScrolling(const FloatPoint&, ForcePositionSync = ForcePositionSync::No);
+    void setPositionForScrolling(const FloatPoint&);
     const FloatPoint& position() const;
-    void setTopLeftPositionForScrolling(const FloatPoint&, ForcePositionSync = ForcePositionSync::No);
+    void setTopLeftPositionForScrolling(const FloatPoint&);
     FloatPoint topLeftPositionForScrolling();
     void setBoundsOrigin(const FloatPoint&);
     void setBoundsOriginForScrolling(const FloatPoint&);
@@ -189,9 +188,12 @@ public:
     void updateContents(bool affectedByTransformAnimation);
     void updateBackingStore();
 
+    void flushPendingState();
     void flushCompositingState(const OptionSet<CompositionReason>&, bool = false);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
+    bool hasPendingBackingStoreTileUpdates() const;
+    void processPendingBackingStoreTileUpdates();
     bool isCompositionRequiredOrOngoing() const;
     void requestComposition(CompositionReason);
     RunLoop* compositingRunLoop() const;
@@ -344,6 +346,13 @@ private:
 #if ENABLE(SCROLLING_THREAD)
     Markable<ScrollingNodeID> m_scrollingNodeID WTF_GUARDED_BY_LOCK(m_lock);
 #endif
+
+    struct {
+        std::optional<FloatPoint> position;
+        std::optional<FloatPoint> positionForScrolling;
+        std::optional<FloatPoint> boundsOrigin;
+        std::optional<FloatPoint> boundsOriginForScrolling;
+    } m_pendingState WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
@@ -79,19 +79,27 @@ void CoordinatedSceneState::removeLayer(CoordinatedPlatformLayer& layer)
 bool CoordinatedSceneState::flush()
 {
     ASSERT(isMainRunLoop());
-    if (!m_didChangeLayers)
-        return false;
 
-    m_didChangeLayers = false;
+    bool didChangeLayers = m_didChangeLayers.exchange(false);
+    if (didChangeLayers) {
+        Locker pendingLayersLock { m_pendingLayersLock };
+        m_pendingLayers = m_layers;
+        if (m_pendingLayersToRemove.isEmpty())
+            m_pendingLayersToRemove = WTF::move(m_layersToRemove);
+        else
+            m_pendingLayersToRemove.addAll(std::exchange(m_layersToRemove, { }));
+    }
 
-    Locker pendingLayersLock { m_pendingLayersLock };
-    m_pendingLayers = m_layers;
-    if (m_pendingLayersToRemove.isEmpty())
-        m_pendingLayersToRemove = WTF::move(m_layersToRemove);
-    else
-        m_pendingLayersToRemove.addAll(std::exchange(m_layersToRemove, { }));
+    flushPendingState();
 
-    return true;
+    return didChangeLayers;
+}
+
+void CoordinatedSceneState::flushPendingState()
+{
+    Locker stateLock { m_stateLock };
+    for (auto& layer : m_layers)
+        layer->flushPendingState();
 }
 
 void CoordinatedSceneState::commitPendingLayers()
@@ -107,10 +115,24 @@ void CoordinatedSceneState::commitPendingLayers()
         m_committedLayers = WTF::move(m_pendingLayers);
 }
 
-const HashSet<Ref<CoordinatedPlatformLayer>>& CoordinatedSceneState::committedLayers()
+void CoordinatedSceneState::flushCompositingState(const OptionSet<CompositionReason>& reasons, bool useSkia)
 {
     commitPendingLayers();
-    return m_committedLayers;
+
+    // We update the tiles after flushing to release the state lock as early as possible.
+    Vector<Ref<CoordinatedPlatformLayer>, 16> layersWithPendingTileUpdates;
+    {
+        Locker stateLock { m_stateLock };
+        m_rootLayer->flushCompositingState(reasons, useSkia);
+        for (auto& layer : m_committedLayers) {
+            layer->flushCompositingState(reasons, useSkia);
+            if (layer->hasPendingBackingStoreTileUpdates())
+                layersWithPendingTileUpdates.append(Ref { layer });
+        }
+    }
+
+    for (auto& layer : layersWithPendingTileUpdates)
+        layer->processPendingBackingStoreTileUpdates();
 }
 
 void CoordinatedSceneState::invalidateCommittedLayers()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS)
+#include <WebCore/CoordinatedCompositionReason.h>
 #include <atomic>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
@@ -53,9 +54,10 @@ public:
     void removeLayer(WebCore::CoordinatedPlatformLayer&);
 
     bool flush();
+    void flushPendingState();
+    void flushCompositingState(const OptionSet<WebCore::CompositionReason>&, bool useSkia);
     void invalidate();
 
-    const HashSet<Ref<WebCore::CoordinatedPlatformLayer>>& committedLayers() LIFETIME_BOUND;
     void invalidateCommittedLayers();
 
     bool layersDidChange() const { return m_didChangeLayers; }
@@ -80,6 +82,7 @@ private:
     std::atomic<bool> m_didChangeLayers { false };
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_committedLayers;
     std::atomic<unsigned> m_pendingTiles { 0 };
+    Lock m_stateLock;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -352,6 +352,7 @@ void LayerTreeHost::requestComposition(CompositionReason reason)
 {
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {
+        m_sceneState->flushPendingState();
         if (!m_compositionRequiredInScrollingThread)
             return;
         m_compositionRequiredInScrollingThread = false;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -409,6 +409,7 @@ void LayerTreeHost::requestComposition(CompositionReason)
 {
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {
+        m_sceneState->flushPendingState();
         if (!m_compositionRequiredInScrollingThread)
             return;
         m_compositionRequiredInScrollingThread = false;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -298,9 +298,7 @@ void ThreadedCompositor::flushCompositingState(const OptionSet<CompositionReason
     }
 #endif
 
-    m_sceneState->rootLayer().flushCompositingState(reasons, m_useSkia);
-    for (auto& layer : m_sceneState->committedLayers())
-        layer->flushCompositingState(reasons, m_useSkia);
+    m_sceneState->flushCompositingState(reasons, m_useSkia);
 }
 
 void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size, const OptionSet<CompositionReason>& reasons)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
@@ -231,9 +231,7 @@ void ThreadedCompositor::updateSceneState()
         m_textureMapper = TextureMapper::create();
 
     auto reasons = OptionSet<CompositionReason>::all();
-    m_sceneState->rootLayer().flushCompositingState(reasons);
-    for (auto& layer : m_sceneState->committedLayers())
-        layer->flushCompositingState(reasons);
+    m_sceneState->flushCompositingState(reasons, false);
 }
 
 void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& matrix, const IntSize& size)


### PR DESCRIPTION
#### 1be44ed3b71a2438bb4ac84a49945d016fbf4684
<pre>
[GTK][WPE] ThreadedCompositor can composite a half-committed set of scrolling-tree layer positions
<a href="https://bugs.webkit.org/show_bug.cgi?id=315185">https://bugs.webkit.org/show_bug.cgi?id=315185</a>

Reviewed by Fujii Hironori.

Add pending values for CoordinatedPlatformLayer position, boundsOrigin
when updated directly or from scroling tree. The values from scrolling
always take precedence. Those pending values are later committed by a
flush that is called during the layer flush or by the scrolling tree.
The scene state now has a global lock that is taken before flusing
pending state for all layers in the tree and before flusing compositing
state before compositing. This ensures that those values are updated
atomically and with the scene lock held, preventing the compositor to
take partially updated trees. This is not needed for most of the other
layer properties, because for rendering updates we ensure that we can&apos;t
start a new layer flush until the composition for the previous one is
done.

* Source/WebCore/page/scrolling/coordinated/ScrollingTreeFixedNodeCoordinated.cpp:
(WebCore::ScrollingTreeFixedNodeCoordinated::applyLayerPositions):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp:
(WebCore::ScrollingTreeFrameScrollingNodeCoordinated::repositionScrollingLayers):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreePositionedNodeCoordinated.cpp:
(WebCore::ScrollingTreePositionedNodeCoordinated::applyLayerPositions):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp:
(WebCore::ScrollingTreeStickyNodeCoordinated::applyLayerPositions):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::update):
(WebCore::SkiaBackingStore::processPendingTileUpdates):
(WebCore::SkiaBackingStore::Tile::scheduleUpdate):
(WebCore::SkiaBackingStore::Tile::processPendingUpdateIfNeeded):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
(WebCore::SkiaBackingStore::hasPendingTileUpdates const):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::hasPendingBackingStoreTileUpdates const):
(WebCore::SkiaCompositingLayer::processPendingTileUpdates):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::updateTile):
(WebCore::CoordinatedBackingStore::processPendingUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setPosition):
(WebCore::CoordinatedPlatformLayer::setPositionForScrolling):
(WebCore::CoordinatedPlatformLayer::setTopLeftPositionForScrolling):
(WebCore::CoordinatedPlatformLayer::setBoundsOrigin):
(WebCore::CoordinatedPlatformLayer::setBoundsOriginForScrolling):
(WebCore::CoordinatedPlatformLayer::flushPendingState):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
(WebCore::CoordinatedPlatformLayer::hasPendingBackingStoreTileUpdates const):
(WebCore::CoordinatedPlatformLayer::processPendingBackingStoreTileUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp:
(WebKit::CoordinatedSceneState::flush):
(WebKit::CoordinatedSceneState::flushPendingState):
(WebKit::CoordinatedSceneState::flushCompositingState):
(WebKit::CoordinatedSceneState::committedLayers): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::requestComposition):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp:
(WebKit::LayerTreeHost::requestComposition):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::flushCompositingState):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp:
(WebKit::ThreadedCompositor::updateSceneState):

Canonical link: <a href="https://commits.webkit.org/315356@main">https://commits.webkit.org/315356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf2f7abf25e0d2fd6c93ed09b6425681b1ea3751

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131272 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92339 "6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31421 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180556 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33277 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35585 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139716 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42194 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139571 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42882 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106569 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34854 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114642 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41386 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6004 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40783 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->