### PR TITLE
Non-unified build fixes for June 12th, 2026

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -35,6 +35,7 @@
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "ContainerNodeInlines.h"
+#include "DocumentPage.h"
 #include "DocumentView.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameInlines.h"

--- a/Source/WebCore/editing/InsertNestedListCommand.cpp
+++ b/Source/WebCore/editing/InsertNestedListCommand.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "InsertNestedListCommand.h"
 
+#include "Document.h"
 #include "Editing.h"
 #include "HTMLLIElement.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/editing/ModifySelectionListLevel.cpp
+++ b/Source/WebCore/editing/ModifySelectionListLevel.cpp
@@ -35,7 +35,7 @@
 #include "HTMLUListElement.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
-#include "RenderObject.h"
+#include "RenderObjectNode.h"
 #include "SimpleRange.h"
 
 namespace WebCore {

--- a/Source/WebCore/editing/RemoveFormatCommand.cpp
+++ b/Source/WebCore/editing/RemoveFormatCommand.cpp
@@ -28,6 +28,7 @@
 #include "RemoveFormatCommand.h"
 
 #include "ApplyStyleCommand.h"
+#include "Document.h"
 #include "EditingStyle.h"
 #include "Element.h"
 #include "FrameSelection.h"

--- a/Source/WebCore/editing/SimplifyMarkupCommand.cpp
+++ b/Source/WebCore/editing/SimplifyMarkupCommand.cpp
@@ -27,6 +27,7 @@
 #include "SimplifyMarkupCommand.h"
 
 #include "ContainerNodeInlines.h"
+#include "HTMLElement.h"
 #include "HTMLNames.h"
 #include "NodeRenderStyle.h"
 #include "NodeTraversal.h"

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -37,6 +37,7 @@
 #include "ScriptDisallowedScope.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "StyleComputedStyleBase+GettersInlines.h"
 #include "UserAgentParts.h"
 #include "UserAgentStyleSheets.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -36,6 +36,7 @@
 #include "Event.h"
 #include "EventListener.h"
 #include "EventNames.h"
+#include "FrameDestructionObserverInlines.h"
 #include "FrameInlines.h"
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustom.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustom.cpp
@@ -26,6 +26,7 @@
 #include "StyleComputedStyleProperties+GettersCustomInlines.h"
 
 #include "RenderTheme.h"
+#include "StyleComputedStyle+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/values/images/StyleObjectViewBox.cpp
+++ b/Source/WebCore/style/values/images/StyleObjectViewBox.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSBasicShapeValue.h"
 #include "CSSKeywordValue.h"
+#include "CSSValuePool.h"
 #include "StyleBasicShape.h"
 #include "StyleBuilderState.h"
 #include "StyleComputedStyle.h"

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SharedWorkerScriptLoader.h"
 
+#include "ContentSecurityPolicy.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "InspectorInstrumentation.h"


### PR DESCRIPTION
#### a8884b8e05e683e3e5022a2034cc4ff5bf98ccc1
<pre>
Non-unified build fixes for June 12th, 2026
<a href="https://bugs.webkit.org/show_bug.cgi?id=316987">https://bugs.webkit.org/show_bug.cgi?id=316987</a>

Unreviewed build fixes.

* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
* Source/WebCore/editing/InsertNestedListCommand.cpp:
* Source/WebCore/editing/ModifySelectionListLevel.cpp:
* Source/WebCore/editing/RemoveFormatCommand.cpp:
* Source/WebCore/editing/SimplifyMarkupCommand.cpp:
* Source/WebCore/html/HTMLMeterElement.cpp:
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustom.cpp:
* Source/WebCore/style/values/images/StyleObjectViewBox.cpp:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:

Canonical link: <a href="https://commits.webkit.org/315092@main">https://commits.webkit.org/315092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc486e3fc2db124df9d2178ce50800c4711a149b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177430 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41614 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171061 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111313 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26126 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180028 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/30474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41671 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139100 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42359 "Built successfully") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/105710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34391 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40863 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114120 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40260 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5526 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->