### PR TITLE
[WPE][cross-toolchain-helper] Allow detached tmux/screen sessions, set logind KillUserProcesses=no

### DIFF
--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -714,16 +714,19 @@ diff --git a/sources/meta-webkit/conf/distro/webkitdevci.conf b/sources/meta-web
 index 1f952c2..d299d1f 100644
 --- a/sources/meta-webkit/conf/distro/webkitdevci.conf
 +++ b/sources/meta-webkit/conf/distro/webkitdevci.conf
-@@ -48,5 +48,14 @@ PACKAGECONFIG:append:pn-php = " apache2"
+@@ -47,6 +47,17 @@ PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
+ PACKAGECONFIG:append:pn-php = " apache2"
  # Disable mysql support as we don't need to build mysql/mariadb
  PACKAGECONFIG:remove:pn-php = "mysql"
- 
++# Do not kill detached screen(1)/tmux(1) sessions on logout
++PACKAGECONFIG:remove:pn-systemd-conf = "kill-user-processes"
++
 +# Disable the following services by default
 +# - Apache2: the service is not needed for the tests, the
 +#   layout test runner takes care of starting/stopping it.
 +INHERIT += "systemd-auto-enable-policy"
 +SYSTEMD_AUTOSTART_DISABLE = "apache2"
-+
+ 
  # Whitelist license from some deps.
  LICENSE_FLAGS_ACCEPTED:append = " commercial synaptics-killswitch"
 +
@@ -799,3 +802,36 @@ index bdd7fea..7005240 100644
      rm -rf ${D}${nonarch_libdir}/clang/${MAJOR_VER}/include/orc/
  }
  
+diff --git a/sources/poky/meta/recipes-core/systemd/systemd-conf/logind.conf b/sources/poky/meta/recipes-core/systemd/systemd-conf/logind.conf
+index bf7f692..25f01f3 100644
+--- a/sources/poky/meta/recipes-core/systemd/systemd-conf/logind.conf
++++ b/sources/poky/meta/recipes-core/systemd/systemd-conf/logind.conf
+@@ -1,2 +1,2 @@
+ [Login]
+-KillUserProcesses=yes
++KillUserProcesses=@KILL_USER_PROCESSES@
+diff --git a/sources/poky/meta/recipes-core/systemd/systemd-conf_1.0.bb b/sources/poky/meta/recipes-core/systemd/systemd-conf_1.0.bb
+index 2355936..0820dd9 100644
+--- a/sources/poky/meta/recipes-core/systemd/systemd-conf_1.0.bb
++++ b/sources/poky/meta/recipes-core/systemd/systemd-conf_1.0.bb
+@@ -10,8 +10,9 @@ REQUIRED_DISTRO_FEATURES += "usrmerge"
+ 
+ PE = "1"
+ 
+-PACKAGECONFIG ??= "dhcp-ethernet"
++PACKAGECONFIG ??= "dhcp-ethernet kill-user-processes"
+ PACKAGECONFIG[dhcp-ethernet] = ""
++PACKAGECONFIG[kill-user-processes] = ""
+ 
+ SRC_URI = "\
+     file://journald.conf \
+@@ -26,6 +27,9 @@ do_install() {
+        install -D -m0644 ${WORKDIR}/logind.conf ${D}${systemd_unitdir}/logind.conf.d/00-${PN}.conf
+        install -D -m0644 ${WORKDIR}/system.conf ${D}${systemd_unitdir}/system.conf.d/00-${PN}.conf
+ 
++        KILL_USER_PROCESSES="${@bb.utils.contains('PACKAGECONFIG', 'kill-user-processes', 'yes', 'no', d)}"
++        sed -i "s/@KILL_USER_PROCESSES@/${KILL_USER_PROCESSES}/" ${D}${systemd_unitdir}/logind.conf.d/00-${PN}.conf
++
+         if ${@bb.utils.contains('PACKAGECONFIG', 'dhcp-ethernet', 'true', 'false', d)}; then
+                install -D -m0644 ${WORKDIR}/wired.network ${D}${systemd_unitdir}/network/80-wired.network
+         fi


### PR DESCRIPTION
#### 06d7373045cefd2ef7022e719365cbfcbf23d114
<pre>
[WPE][cross-toolchain-helper] Allow detached tmux/screen sessions, set logind KillUserProcesses=no
<a href="https://bugs.webkit.org/show_bug.cgi?id=316989">https://bugs.webkit.org/show_bug.cgi?id=316989</a>

Reviewed by Nikolas Zimmermann.

Configure the image with KillUserProcesses=no for logind, so it is possible
to run detached screen or tmux sessions in the background. This is a general
useful thing for development and matches the behaviour expected on login
sessions from most desktop distributions.

* Tools/yocto/meta-openembedded_and_meta-webkit.patch:

Canonical link: <a href="https://commits.webkit.org/315103@main">https://commits.webkit.org/315103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7da523bc064905e847266a197427ac3f19b9422e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125807 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130803 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33278 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111315 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30962 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142249 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180032 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139231 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139103 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42363 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105717 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25592 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34396 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40867 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40264 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5534 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40409 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->