### PR TITLE
Increase memory limit for immersive models

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -697,7 +697,11 @@ void HTMLModelElement::createModelPlayer()
 
     // FIXME: We need to tell the player if the size changes as well, so passing this
     // in with load probably doesn't make sense.
-    modelPlayer->load(*model, contentSize());
+    bool isForImmersive = false;
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    isForImmersive = m_detachedForImmersive;
+#endif
+    modelPlayer->load(*model, contentSize(), isForImmersive);
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     if (m_environmentMapData)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -70,7 +70,7 @@ public:
     virtual bool NODELETE isPlaceholder() const;
 
     // Loading.
-    virtual void load(Model&, LayoutSize) = 0;
+    virtual void load(Model&, LayoutSize, bool) = 0;
     virtual void NODELETE reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&);
 
     // Graphics.

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp
@@ -79,7 +79,7 @@ std::optional<std::unique_ptr<ModelPlayerTransformState>> PlaceholderModelPlayer
     return m_transformState->clone();
 }
 
-void PlaceholderModelPlayer::load(Model&, LayoutSize)
+void PlaceholderModelPlayer::load(Model&, LayoutSize, bool)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h
@@ -44,7 +44,7 @@ private:
     bool isPlaceholder() const final { return true; }
     std::optional<ModelPlayerAnimationState> currentAnimationState() const final;
     std::optional<std::unique_ptr<ModelPlayerTransformState>> currentTransformState() const final;
-    void NODELETE load(Model&, LayoutSize) final;
+    void NODELETE load(Model&, LayoutSize, bool) final;
     void NODELETE reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&) final;
 
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp
@@ -46,7 +46,7 @@ DummyModelPlayer::DummyModelPlayer(ModelPlayerClient& client)
 
 DummyModelPlayer::~DummyModelPlayer() = default;
 
-void DummyModelPlayer::load(Model& model, LayoutSize)
+void DummyModelPlayer::load(Model& model, LayoutSize, bool)
 {
     if (RefPtr client = m_client)
         client->didFailLoading(*this, ResourceError { errorDomainWebKitInternal, 0, model.url(), "Trying to load model via DummyModelPlayer"_s });

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h
@@ -45,7 +45,7 @@ private:
 
     // ModelPlayer overrides.
     ModelPlayerIdentifier identifier() const final { return m_id; }
-    void load(Model&, LayoutSize) override;
+    void load(Model&, LayoutSize, bool) override;
     void NODELETE configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) override;
     void NODELETE sizeDidChange(LayoutSize) override;
     void NODELETE enterFullscreen() override;

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -234,6 +234,11 @@ std::optional<int> ModelConnectionToWebProcess::debugEntityMemoryLimit() const
     return m_modelProcess->debugEntityMemoryLimit();
 }
 
+std::optional<int> ModelConnectionToWebProcess::debugImmersiveEntityMemoryLimit() const
+{
+    return m_modelProcess->debugImmersiveEntityMemoryLimit();
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -107,6 +107,7 @@ public:
 
     const std::optional<String> attributionTaskID() const { return m_attributionTaskID; };
     std::optional<int> debugEntityMemoryLimit() const;
+    std::optional<int> debugImmersiveEntityMemoryLimit() const;
 
 private:
     ModelConnectionToWebProcess(ModelProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, ModelProcessConnectionParameters&&, const std::optional<String>&);

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -207,6 +207,7 @@ void ModelProcess::initializeModelProcess(ModelProcessCreationParameters&& param
     CompletionHandlerCallingScope callCompletionHandler(WTF::move(completionHandler));
 
     m_debugEntityMemoryLimit = parameters.debugEntityMemoryLimit;
+    m_debugImmersiveEntityMemoryLimit = parameters.debugImmersiveEntityMemoryLimit;
 #if HAVE(CORE_RE)
     WKREEngine::enableRestrictiveRenderingMode(parameters.restrictiveRenderingMode);
 #endif

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -82,6 +82,7 @@ public:
     void requestSharedSimulationConnection(WebCore::ProcessIdentifier, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&&);
 #endif
     std::optional<int> debugEntityMemoryLimit() const { return m_debugEntityMemoryLimit; }
+    std::optional<int> debugImmersiveEntityMemoryLimit() const { return m_debugImmersiveEntityMemoryLimit; }
 
     void webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&&);
     void modelPlayerCountForTesting(CompletionHandler<void(uint64_t)>&&);
@@ -123,6 +124,7 @@ private:
     WebCore::Timer m_idleExitTimer;
     String m_applicationVisibleName;
     std::optional<int> m_debugEntityMemoryLimit;
+    std::optional<int> m_debugImmersiveEntityMemoryLimit;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
@@ -38,6 +38,7 @@ struct ModelProcessCreationParameters {
     String applicationVisibleName;
     bool restrictiveRenderingMode { false };
     std::optional<int> debugEntityMemoryLimit;
+    std::optional<int> debugImmersiveEntityMemoryLimit;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
@@ -30,6 +30,7 @@ headers: "ModelProcessCreationParameters.h" "AuxiliaryProcessCreationParameters.
     String applicationVisibleName;
     bool restrictiveRenderingMode;
     std::optional<int> debugEntityMemoryLimit;
+    std::optional<int> debugImmersiveEntityMemoryLimit;
 };
 
 #endif

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -71,7 +71,7 @@ void ModelProcessModelPlayerManagerProxy::createModelPlayer(WebCore::ModelPlayer
     ASSERT(m_modelConnectionToWebProcess);
     MESSAGE_CHECK(!m_proxies.contains(identifier));
 
-    auto proxy = ModelProcessModelPlayerProxy::create(*this, identifier, protect(m_modelConnectionToWebProcess->connection()), m_modelConnectionToWebProcess->attributionTaskID(), m_modelConnectionToWebProcess->debugEntityMemoryLimit());
+    auto proxy = ModelProcessModelPlayerProxy::create(*this, identifier, protect(m_modelConnectionToWebProcess->connection()), m_modelConnectionToWebProcess->attributionTaskID(), m_modelConnectionToWebProcess->debugEntityMemoryLimit(), m_modelConnectionToWebProcess->debugImmersiveEntityMemoryLimit());
     m_proxies.add(identifier, WTF::move(proxy));
 }
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -103,7 +103,7 @@ class ModelProcessModelPlayerProxy final
     , private IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(ModelProcessModelPlayerProxy);
 public:
-    static Ref<ModelProcessModelPlayerProxy> create(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&, std::optional<int> debugEntityMemoryLimit);
+    static Ref<ModelProcessModelPlayerProxy> create(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&, std::optional<int>, std::optional<int>);
     ~ModelProcessModelPlayerProxy();
 
     void ref() const final { WebCore::ModelPlayer::ref(); }
@@ -123,7 +123,7 @@ public:
 
     // Messages
     void createLayer();
-    void loadModel(Ref<WebCore::Model>&&, WebCore::LayoutSize);
+    void loadModel(Ref<WebCore::Model>&&, WebCore::LayoutSize, bool);
     void reloadModel(Ref<WebCore::Model>&&, WebCore::LayoutSize, std::optional<WebCore::TransformationMatrix> transformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore);
     void modelVisibilityDidChange(bool isVisible);
 
@@ -133,7 +133,7 @@ public:
 
     // WebCore::ModelPlayer overrides.
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
-    void load(WebCore::Model&, WebCore::LayoutSize) final;
+    void load(WebCore::Model&, WebCore::LayoutSize, bool) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
     void setEntityTransform(WebCore::TransformationMatrix) final;
@@ -183,7 +183,7 @@ public:
     static uint64_t objectCountForTesting() { return gObjectCountForTesting; }
 
 private:
-    ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&, std::optional<int> debugEntityMemoryLimit);
+    ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&, std::optional<int>, std::optional<int>);
 
     RESRT modelStandardizedTransformSRT(RESRT originalSRT);
     RESRT modelLocalizedTransformSRT(RESRT originalSRT);
@@ -197,6 +197,7 @@ private:
     void applyDefaultIBL();
     void updateForCurrentStageMode();
     std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier();
+    int entityMemoryLimit(bool) const;
 
     WebCore::ModelPlayerIdentifier m_id;
     bool m_isVisible { true };
@@ -236,6 +237,7 @@ private:
 
     std::optional<String> m_attributionTaskID;
     std::optional<int> m_debugEntityMemoryLimit;
+    std::optional<int> m_debugImmersiveEntityMemoryLimit;
     std::optional<WebCore::TransformationMatrix> m_entityTransformToRestore;
     std::optional<WebCore::ModelPlayerAnimationState> m_animationStateToRestore;
     RunLoop::Timer m_unloadModelTimer;
@@ -247,11 +249,16 @@ private:
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     bool m_immersivePresentation { false };
     WebCore::LayoutSize m_layoutSize { };
+    RefPtr<WebCore::Model> m_currentModel;
+    RefPtr<WebCore::SharedBuffer> m_persistedEnvironmentMapData;
+    std::optional<int> m_loadedEntityMemoryLimit;
     Vector<CompletionHandler<void(bool)>> m_modelLoadedCallbacks;
 
     void triggerModelLoadedCallbacks(bool);
     void ensureModelLoaded(CompletionHandler<void(bool)>&&);
     void setImmersivePresentation(bool);
+    void teardownEntity();
+    void captureStateForReload();
 #endif
 };
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -35,7 +35,7 @@ messages -> ModelProcessModelPlayerProxy {
     [EnabledBy=AllowTestOnlyIPC] DisableUnloadDelayForTesting()
     
     # WebCore::ModelPlayer
-    LoadModel(Ref<WebCore::Model> url, WebCore::LayoutSize layoutSize)
+    LoadModel(Ref<WebCore::Model> url, WebCore::LayoutSize layoutSize, bool isForImmersive)
     SizeDidChange(WebCore::LayoutSize layoutSize)
     SetEntityTransform(WebCore::TransformationMatrix transform)
     SetAutoplay(bool autoplay)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -293,17 +293,18 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelProcessModelPlayerProxy);
 
 uint64_t ModelProcessModelPlayerProxy::gObjectCountForTesting = 0;
 
-Ref<ModelProcessModelPlayerProxy> ModelProcessModelPlayerProxy::create(ModelProcessModelPlayerManagerProxy& manager, WebCore::ModelPlayerIdentifier identifier, Ref<IPC::Connection>&& connection, const std::optional<String>& attributionTaskID, std::optional<int> debugEntityMemoryLimit)
+Ref<ModelProcessModelPlayerProxy> ModelProcessModelPlayerProxy::create(ModelProcessModelPlayerManagerProxy& manager, WebCore::ModelPlayerIdentifier identifier, Ref<IPC::Connection>&& connection, const std::optional<String>& attributionTaskID, std::optional<int> debugEntityMemoryLimit, std::optional<int> debugImmersiveEntityMemoryLimit)
 {
-    return adoptRef(*new ModelProcessModelPlayerProxy(manager, identifier, WTF::move(connection), attributionTaskID, debugEntityMemoryLimit));
+    return adoptRef(*new ModelProcessModelPlayerProxy(manager, identifier, WTF::move(connection), attributionTaskID, debugEntityMemoryLimit, debugImmersiveEntityMemoryLimit));
 }
 
-ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy& manager, WebCore::ModelPlayerIdentifier identifier, Ref<IPC::Connection>&& connection, const std::optional<String>& attributionTaskID, std::optional<int> debugEntityMemoryLimit)
+ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy& manager, WebCore::ModelPlayerIdentifier identifier, Ref<IPC::Connection>&& connection, const std::optional<String>& attributionTaskID, std::optional<int> debugEntityMemoryLimit, std::optional<int> debugImmersiveEntityMemoryLimit)
     : m_id(identifier)
     , m_webProcessConnection(WTF::move(connection))
     , m_manager(manager)
     , m_attributionTaskID(attributionTaskID)
     , m_debugEntityMemoryLimit(debugEntityMemoryLimit)
+    , m_debugImmersiveEntityMemoryLimit(debugImmersiveEntityMemoryLimit)
     , m_unloadModelTimer(RunLoop::mainSingleton(), "ModelProcessModelPlayerProxy::UnloadModelTimer"_s, this, &ModelProcessModelPlayerProxy::unloadModelTimerFired)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy initialized id=%" PRIu64, this, identifier.toUInt64());
@@ -385,7 +386,7 @@ void ModelProcessModelPlayerProxy::createLayer()
         send(Messages::ModelProcessModelPlayer::DidCreateLayer(contextID.value()));
 }
 
-void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize)
+void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, bool isForImmersive)
 {
 #if HAVE(CORE_RE)
     if (model->mimeType() != usdzMIMEType) {
@@ -399,7 +400,7 @@ void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCor
             send(Messages::ModelProcessModelPlayer::DidConvertModelData(convertedBuffer.copyRef(), usdzMIMEType));
 
             auto convertedModel = WebCore::Model::create(WTF::move(convertedBuffer), usdzMIMEType, model->url());
-            load(convertedModel, layoutSize);
+            load(convertedModel, layoutSize, isForImmersive);
             return;
         }
 
@@ -408,7 +409,7 @@ void ModelProcessModelPlayerProxy::loadModel(Ref<WebCore::Model>&& model, WebCor
 #endif
 
     // FIXME: Change the IPC message to land on load() directly
-    load(model, layoutSize);
+    load(model, layoutSize, isForImmersive);
 }
 
 void ModelProcessModelPlayerProxy::reloadModel(Ref<WebCore::Model>&& model, WebCore::LayoutSize layoutSize, std::optional<WebCore::TransformationMatrix> entityTransformToRestore, std::optional<WebCore::ModelPlayerAnimationState> animationStateToRestore)
@@ -422,7 +423,11 @@ void ModelProcessModelPlayerProxy::reloadModel(Ref<WebCore::Model>&& model, WebC
             m_playbackRate = *playbackRate;
     }
 
-    load(model, layoutSize);
+    bool isForImmersive = false;
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    isForImmersive = m_immersivePresentation;
+#endif
+    load(model, layoutSize, isForImmersive);
 }
 
 void ModelProcessModelPlayerProxy::modelVisibilityDidChange(bool isVisible)
@@ -765,7 +770,19 @@ void ModelProcessModelPlayerProxy::didFailLoading(WebCore::REModelLoader& loader
 
 // MARK: - WebCore::ModelPlayer
 
-static int defaultEntityMemoryLimit = 100; // MB
+static const int defaultEntityMemoryLimit = 100; // MB
+static const int defaultImmersiveEntityMemoryLimit = 500; // MB
+
+int ModelProcessModelPlayerProxy::entityMemoryLimit(bool isForImmersive) const
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    if (isForImmersive)
+        return m_debugImmersiveEntityMemoryLimit.value_or(defaultImmersiveEntityMemoryLimit);
+#else
+    UNUSED_PARAM(isForImmersive);
+#endif
+    return m_debugEntityMemoryLimit.value_or(defaultEntityMemoryLimit);
+}
 
 class SimpleModelLoader final : public WebCore::REModelLoader {
 public:
@@ -788,18 +805,29 @@ private:
 };
 #endif
 
-void ModelProcessModelPlayerProxy::load(WebCore::Model& model, WebCore::LayoutSize layoutSize)
+void ModelProcessModelPlayerProxy::load(WebCore::Model& model, WebCore::LayoutSize layoutSize, bool isForImmersive)
 {
     dispatch_assert_queue(mainDispatchQueueSingleton());
 
-    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::load size=%zu id=%" PRIu64, this, model.data()->size(), m_id.toUInt64());
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    m_currentModel = &model;
+#endif
+
+    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::load size=%zu isForImmersive=%d id=%" PRIu64, this, model.data()->size(), isForImmersive, m_id.toUInt64());
     sizeDidChange(layoutSize);
 
+#if HAVE(CORE_RE) || ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    auto memoryLimit = entityMemoryLimit(isForImmersive);
+#endif
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    m_loadedEntityMemoryLimit = memoryLimit;
+#endif
+
 #if HAVE(CORE_RE)
-    WKREEngine::singleton().runWithSharedScene([this, protectedThis = protect(*this), model = protect(model)] (RESceneRef scene) {
+    WKREEngine::singleton().runWithSharedScene([this, protectedThis = protect(*this), model = protect(model), memoryLimit] (RESceneRef scene) {
         m_scene = scene;
         if ([getWKRKEntityClassSingleton() isLoadFromDataAvailable])
-            m_loader = RKUSDModelLoadScheduler::singleton().scheduleModelLoad(model.get(), m_attributionTaskID, m_debugEntityMemoryLimit ? *m_debugEntityMemoryLimit : defaultEntityMemoryLimit, *this);
+            m_loader = RKUSDModelLoadScheduler::singleton().scheduleModelLoad(model.get(), m_attributionTaskID, memoryLimit, *this);
         else
             m_loader = WebCore::loadREModel(model.get(), *this);
     });
@@ -988,6 +1016,9 @@ void ModelProcessModelPlayerProxy::setCurrentTime(Seconds currentTime, Completio
 
 void ModelProcessModelPlayerProxy::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)
 {
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    m_persistedEnvironmentMapData = data.copyRef();
+#endif
     m_transientEnvironmentMapData = WTF::move(data);
     if (m_modelRKEntity)
         applyEnvironmentMapDataAndRelease([] { });
@@ -1172,9 +1203,57 @@ void ModelProcessModelPlayerProxy::applyDefaultIBL()
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
 
+void ModelProcessModelPlayerProxy::teardownEntity()
+{
+    if (m_loader) {
+        m_loader->cancel();
+        m_loader = nullptr;
+    }
+#if HAVE(CORE_RE)
+    if (m_hostingEntity.get())
+        REEntityRemoveFromSceneOrParent(m_hostingEntity.get());
+    m_hostingEntity = nullptr;
+    [m_stageModeInteractionDriver removeInteractionContainerFromSceneOrParent];
+    m_stageModeInteractionDriver = nil;
+#endif
+    m_modelRKEntity = nil;
+    m_originalBoundingBoxExtents = simd_make_float3(0, 0, 0);
+    m_originalBoundingBoxCenter = simd_make_float3(0, 0, 0);
+    m_originalEntityScale = simd_make_float3(1, 1, 1);
+    m_loadedEntityMemoryLimit = std::nullopt;
+}
+
+void ModelProcessModelPlayerProxy::captureStateForReload()
+{
+    if (m_modelRKEntity) {
+        m_animationStateToRestore = WebCore::ModelPlayerAnimationState(m_autoplay, m_loop, paused(), Seconds(duration()),
+            std::optional<double> { m_playbackRate }, std::optional<Seconds> { Seconds(currentTime()) }, std::optional<MonotonicTime> { MonotonicTime::now() });
+    }
+
+    // Re-stage the env map for the post-reload entity. Entity transform is intentionally NOT captured:
+    // the immersive/non-immersive coordinate spaces differ (see modelStandardizedTransformSRT), so a
+    // captured matrix would be in the wrong space after the boundary. didFinishLoading recomputes
+    // transform via computeTransform(true) for the new presentation mode.
+    if (m_persistedEnvironmentMapData)
+        m_transientEnvironmentMapData = m_persistedEnvironmentMapData;
+}
+
 void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler<void(std::optional<WebCore::LayerHostingContextIdentifier>)>&& completion)
 {
+    int targetLimit = entityMemoryLimit(true);
+    bool atTargetLimit = m_loadedEntityMemoryLimit && *m_loadedEntityMemoryLimit == targetLimit;
+
+    if (m_modelRKEntity && !atTargetLimit)
+        captureStateForReload();
+
     setImmersivePresentation(true);
+
+    if (m_currentModel && (m_modelRKEntity || m_loader) && !atTargetLimit) {
+        RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::ensureImmersivePresentation: reloading at %dMB id=%" PRIu64, this, targetLimit, m_id.toUInt64());
+        teardownEntity();
+        load(*m_currentModel, m_layoutSize, true);
+    }
+
     ensureModelLoaded([weakThis = WeakPtr { *this }, completion = WTF::move(completion)] (bool loaded) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -1191,7 +1270,24 @@ void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler
 
 void ModelProcessModelPlayerProxy::exitImmersivePresentation(CompletionHandler<void()>&& completion)
 {
+    int targetLimit = entityMemoryLimit(false);
+    bool atTargetLimit = m_loadedEntityMemoryLimit && *m_loadedEntityMemoryLimit == targetLimit;
+
+    if (m_modelRKEntity && !atTargetLimit)
+        captureStateForReload();
+
     setImmersivePresentation(false);
+
+    if (m_currentModel && (m_modelRKEntity || m_loader) && !atTargetLimit) {
+        RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy::exitImmersivePresentation: reloading at %dMB id=%" PRIu64, this, targetLimit, m_id.toUInt64());
+        teardownEntity();
+        load(*m_currentModel, m_layoutSize, false);
+        ensureModelLoaded([completion = WTF::move(completion)] (bool) mutable {
+            completion();
+        });
+        return;
+    }
+
     completion();
 }
 

--- a/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
@@ -57,6 +57,11 @@ void ModelProcessProxy::updateModelProcessCreationParameters(ModelProcessCreatio
     value = [NSUserDefaults.standardUserDefaults objectForKey:memoryLimitFlag];
     if ([value isKindOfClass:NSNumber.class])
         parameters.debugEntityMemoryLimit = [value integerValue];
+
+    NSString * const immersiveMemoryLimitFlag = @"WebKitDebugModelImmersiveEntityMemoryLimit";
+    value = [NSUserDefaults.standardUserDefaults objectForKey:immersiveMemoryLimitFlag];
+    if ([value isKindOfClass:NSNumber.class])
+        parameters.debugImmersiveEntityMemoryLimit = [value integerValue];
 }
 
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS) && ENABLE(MODEL_PROCESS) && HAVE(CORE_RE)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -174,7 +174,7 @@ std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> ModelProcessM
     return ModelProcessModelPlayerTransformState::create(m_entityTransform, m_boundingBoxCenter, m_boundingBoxExtents, m_hasPortal, m_stageModeOperation);
 }
 
-void ModelProcessModelPlayer::load(WebCore::Model& model, WebCore::LayoutSize size)
+void ModelProcessModelPlayer::load(WebCore::Model& model, WebCore::LayoutSize size, bool isForImmersive)
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer load model id=%" PRIu64, this, m_id.toUInt64());
 
@@ -184,7 +184,7 @@ void ModelProcessModelPlayer::load(WebCore::Model& model, WebCore::LayoutSize si
             client->logWarning(*this, makeString("Unexpected USDZ MIME type \""_s, model.mimeType(), "\" in <model> element. Expected \"model/vnd.usdz+zip\". Some features of <model> may not work properly. The model may fail to render in a future release."_s));
     }
 
-    send(Messages::ModelProcessModelPlayerProxy::LoadModel(model, size));
+    send(Messages::ModelProcessModelPlayerProxy::LoadModel(model, size, isForImmersive));
 }
 
 void ModelProcessModelPlayer::didUnload()

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -84,7 +84,7 @@ private:
     WebCore::ModelPlayerIdentifier identifier() const final { return m_id; }
     std::optional<WebCore::ModelPlayerAnimationState> currentAnimationState() const final;
     std::optional<std::unique_ptr<WebCore::ModelPlayerTransformState>> currentTransformState() const final;
-    void load(WebCore::Model&, WebCore::LayoutSize) final;
+    void load(WebCore::Model&, WebCore::LayoutSize, bool) final;
     void reload(WebCore::Model&, WebCore::LayoutSize, WebCore::ModelPlayerAnimationState&, std::unique_ptr<WebCore::ModelPlayerTransformState>&&) final;
     void visibilityStateDidChange() final;
     void sizeDidChange(WebCore::LayoutSize) final;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -77,7 +77,7 @@ private:
     void updateScene();
 
     // ModelPlayer finals.
-    void load(WebCore::Model&, WebCore::LayoutSize) final;
+    void load(WebCore::Model&, WebCore::LayoutSize, bool) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
     void enterFullscreen() final;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -197,7 +197,7 @@ static WebCore::ContentsFormat contentsFormatForDynamicRange(bool isStandard)
 
 // MARK: - ModelPlayer overrides.
 
-void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
+void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size, bool)
 {
     RefPtr corePage = m_page.get();
     if (!corePage)


### PR DESCRIPTION
#### 0ff66663ddfcbc432925828ff2cd0522a22fb5de
<pre>
Increase memory limit for immersive models
<a href="https://bugs.webkit.org/show_bug.cgi?id=316994">https://bugs.webkit.org/show_bug.cgi?id=316994</a>
<a href="https://rdar.apple.com/171065710">rdar://171065710</a>

Reviewed by Mike Wyrzykowski.

Reload the entity at a higher memory limit when entering immersive
presentation, and back at the standard limit on exit.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.cpp:
* Source/WebCore/Modules/model-element/PlaceholderModelPlayer.h:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.cpp:
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
Plumb the signal that informs the model process of the initial immersive
presentation state for the first load of the model.

* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp:
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
* Source/WebKit/ModelProcess/ModelProcess.cpp:
* Source/WebKit/ModelProcess/ModelProcess.h:
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.h:
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in:
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp:
* Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm:
Add the debug default for the immersive memory limit.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
Add the logic that unloads and reloads the entity with the right
memory limit if needed.

Canonical link: <a href="https://commits.webkit.org/315139@main">https://commits.webkit.org/315139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9ccf2ededbca3183f2b6ed9d552dd55c11ef97c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130821 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32286 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30982 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26152 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142271 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180056 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32779 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139253 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139124 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37483 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42385 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105741 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27455 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40889 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114145 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40286 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5551 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->