### PR TITLE
[Site Isolation] Report cross-origin frame url/securityOrigin in Page.getResourceTree

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe-expected.txt
@@ -12,4 +12,6 @@ PASS: Child frame should have a non-empty id.
 PASS: Child frame id should differ from main frame id.
 PASS: Child frame's parentId should match main frame's id.
 PASS: Child frame's name attribute should be reported.
+PASS: Child frame URL should point at the iframe document.
+PASS: Child frame should have a different (cross-origin) security origin from the main frame.
 

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe.html
@@ -21,19 +21,34 @@ function test() {
         description: "getResourceTree should return the main frame plus a cross-origin child frame with parentId/name/origin populated.",
         async test() {
             let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
-            // Add the cross-origin iframe from within the test so we can await the
-            // frame target it spawns in a separate WebContent process. The child
-            // commits in its own process, so the inspectedPage's WebFrameProxy never
-            // observes its didCommitLoadForFrame; the frame target appearing is the
-            // reliable signal that the cross-process frame exists.
-            await InspectorTest.evaluateInPage("addCrossOriginIFrame()");
-            await targetAddedPromise;
+            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+            let targetEvent = await targetAddedPromise;
+            let frameTarget = targetEvent.data.target;
 
-            // Under Site Isolation, use the multiplexing backendTarget because
-            // its PageAgent is the UIProcess proxy that sees every WebContent
-            // process. The per-page target's PageAgent (== window.PageAgent)
-            // would only return the local frame's view.
-            let { frameTree } = await WI.backendTarget.PageAgent.getResourceTree();
+            // Under Site Isolation, use the multiplexing backendTarget because its PageAgent is the
+            // UIProcess proxy that sees every WebContent process. The per-page target's PageAgent
+            // (== window.PageAgent) would only return the local frame's view.
+            //
+            // The cross-origin child loads provisionally in its own process and commits with
+            // CommitTiming::WaitForLoad. Its committed url/origin only reach the proxy via the
+            // Page.frameNavigated event (which fires at commit and populates the proxy's per-frame
+            // cache). Drive/await the frame target's execution context (created right after commit)
+            // and poll getResourceTree until the child's committed url is reported.
+            let frameTree;
+            let child;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                if (!frameTarget.executionContext) {
+                    await Promise.race([
+                        frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                        new Promise((resolve) => setTimeout(resolve, 100)),
+                    ]);
+                }
+                ({ frameTree } = await WI.backendTarget.PageAgent.getResourceTree());
+                child = frameTree.childFrames?.[0];
+                if (child && child.frame.url.endsWith("/resource-tree-frame.html"))
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
 
             InspectorTest.expectThat(!!frameTree.frame.id, "Main frame should have a non-empty id.");
             InspectorTest.expectEqual(frameTree.frame.parentId, undefined, "Main frame should have no parentId.");
@@ -42,17 +57,12 @@ function test() {
 
             InspectorTest.expectEqual(frameTree.childFrames?.length, 1, "Should have exactly one child frame in the tree.");
 
-            let child = frameTree.childFrames[0];
             InspectorTest.expectThat(!!child.frame.id, "Child frame should have a non-empty id.");
             InspectorTest.expectThat(child.frame.id !== frameTree.frame.id, "Child frame id should differ from main frame id.");
             InspectorTest.expectEqual(child.frame.parentId, frameTree.frame.id, "Child frame's parentId should match main frame's id.");
             InspectorTest.expectEqual(child.frame.name, "child-frame", "Child frame's name attribute should be reported.");
-            // FIXME: <https://webkit.org/b/308896> The inspectedPage's WebFrameProxy never
-            // observes the cross-origin child's didCommitLoadForFrame, so its url() and
-            // documentSecurityOriginData() remain stale. Re-enable these once cross-process
-            // WebFrameProxy state propagation lands.
-            // InspectorTest.expectThat(child.frame.url.endsWith("/resource-tree-frame.html"), "Child frame URL should point at the iframe document.");
-            // InspectorTest.expectThat(child.frame.securityOrigin !== frameTree.frame.securityOrigin, "Child frame should have a different (cross-origin) security origin from the main frame.");
+            InspectorTest.expectThat(child.frame.url.endsWith("/resource-tree-frame.html"), "Child frame URL should point at the iframe document.");
+            InspectorTest.expectThat(child.frame.securityOrigin !== frameTree.frame.securityOrigin, "Child frame should have a different (cross-origin) security origin from the main frame.");
         }
     });
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -392,6 +392,7 @@ struct WebPageCreationParameters {
     WebCore::AccessibilityMode accessibilityMode { };
     bool shouldForceSiteIsolationAlwaysOnForTesting { false };
     bool shouldEnableNetworkInstrumentation { false };
+    bool shouldEnablePageInstrumentation { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -307,6 +307,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     WebCore::AccessibilityMode accessibilityMode;
     bool shouldForceSiteIsolationAlwaysOnForTesting;
     bool shouldEnableNetworkInstrumentation;
+    bool shouldEnablePageInstrumentation;
 }
 
 [Nested] struct WebKit::RemotePageParameters {

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -92,6 +92,10 @@ static String protocolFrameIdForFrameID(FrameIdentifier frameID)
 
 void ProxyingPageAgent::frameNavigated(FrameIdentifier frameID, const URL& url, const String& mimeType, SecurityOriginData&& securityOrigin, std::optional<FrameIdentifier> parentFrameID, const String& name)
 {
+    // Cache the committing frame's real document info for cross-origin children, whose
+    // commit the inspectedPage's WebFrameProxy never observes. See webkit.org/b/308896.
+    m_cachedFrameDocumentInfo.set(frameID, CachedFrameDocumentInfo { url, mimeType, securityOrigin });
+
     auto frameObject = Protocol::Page::Frame::create()
         .setId(protocolFrameIdForFrameID(frameID))
         .setLoaderId(String()) // FIXME: <https://webkit.org/b/308895> get loaderId from document identifier
@@ -120,6 +124,7 @@ void ProxyingPageAgent::loadEventFired(double timestamp)
 
 void ProxyingPageAgent::frameDetached(FrameIdentifier frameID)
 {
+    m_cachedFrameDocumentInfo.remove(frameID);
     m_frontendDispatcher->frameDetached(protocolFrameIdForFrameID(frameID));
 }
 
@@ -201,6 +206,7 @@ CommandResult<void> ProxyingPageAgent::disable()
         return { };
 
     m_enabled = false;
+    m_cachedFrameDocumentInfo.clear();
 
     // Force-teardown: disable all processes unconditionally, bypassing the
     // refcount discipline in disableInstrumentationForProcess(). This is
@@ -237,18 +243,26 @@ Ref<Protocol::Page::FrameResourceTree> ProxyingPageAgent::buildFrameTree(const W
     // walking it yields the full structure (frame ids, parent linkage, name)
     // regardless of which process hosts each frame.
     //
-    // FIXME: <https://webkit.org/b/308896> url()/documentSecurityOriginData() are
-    // still stale for cross-origin children because the inspectedPage's
-    // WebFrameProxy never observes their owning process's didCommitLoadForFrame.
-    // WebFrameProxy state propagation across processes is the remaining follow-up.
+    // For url/origin/mimeType, prefer the cached document info populated from the live
+    // cross-process frameNavigated events: the inspectedPage's WebFrameProxy never
+    // observes a cross-origin child's commit, so its url() stays about:blank and its
+    // securityOrigin inherits the parent. Fall back to the WebFrameProxy state when no
+    // event has arrived yet (e.g. same-origin frames before their first navigation).
+    URL url = frame.url();
     SecurityOriginData securityOrigin = frame.documentSecurityOriginData();
     String mimeType = frame.mimeType();
+    if (auto it = m_cachedFrameDocumentInfo.find(frame.frameID()); it != m_cachedFrameDocumentInfo.end()) {
+        url = it->value.url;
+        securityOrigin = it->value.securityOrigin;
+        if (!it->value.mimeType.isEmpty())
+            mimeType = it->value.mimeType;
+    }
     String name = frame.frameName();
 
     auto frameObject = Protocol::Page::Frame::create()
         .setId(protocolId)
         .setLoaderId(emptyString()) // FIXME: <https://webkit.org/b/308895> get loaderId from document identifier
-        .setUrl(frame.url().string())
+        .setUrl(url.string())
         .setMimeType(mimeType.isEmpty() ? "text/html"_s : mimeType)
         .setSecurityOrigin(securityOrigin.toString())
         .release();

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
@@ -123,6 +123,17 @@ private:
     // map that has already gone away. The receiver's m_messageReceiverMapCount
     // then stays nonzero and ~MessageReceiver fires its debug ASSERT.
     HashMap<WebCore::ProcessIdentifier, Ref<WebKit::WebProcessProxy>> m_pinnedInstrumentedProcesses;
+
+    // Per-frame committed document info, cached from the cross-process frameNavigated
+    // events. buildFrameTree() prefers this over the inspectedPage's WebFrameProxy state,
+    // which is stale for cross-origin children whose commit the UIProcess never observes.
+    // See webkit.org/b/308896.
+    struct CachedFrameDocumentInfo {
+        URL url;
+        String mimeType;
+        WebCore::SecurityOriginData securityOrigin;
+    };
+    HashMap<WebCore::FrameIdentifier, CachedFrameDocumentInfo> m_cachedFrameDocumentInfo;
 };
 
 } // namespace Inspector

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -402,6 +402,16 @@ void WebPageInspectorController::didCreateProvisionalFrame(ProvisionalFrameProxy
 
     constexpr bool isProvisional = true;
     addTarget(makeUnique<FrameInspectorTargetProxy>(protect(provisionalFrame.frame())->frameID(), protect(provisionalFrame.process()), isProvisional));
+
+    // Register page instrumentation for the provisional frame's (possibly brand-new, cross-origin)
+    // process *before* it commits, so the UIProcess ProxyingPageAgent has a message receiver ready
+    // when the child's initial frameNavigated fires. didCommitProvisionalFrame is too late: the
+    // child commits (and emits frameNavigated) in its own process before then. See webkit.org/b/308896.
+    RefPtr pageAgent = m_pageAgent;
+    Ref process = provisionalFrame.process();
+    auto pageID = protect(m_inspectedPage)->webPageIDInProcess(process);
+    if (pageAgent && pageAgent->isEnabled())
+        pageAgent->enableInstrumentationForProcess(process, pageID);
 }
 
 void WebPageInspectorController::willDestroyProvisionalFrame(const ProvisionalFrameProxy& provisionalFrame)
@@ -417,6 +427,16 @@ void WebPageInspectorController::willDestroyProvisionalFrame(const ProvisionalFr
             target->resume();
     }
     removeTarget(targetId);
+
+    // Balance the enableInstrumentationForProcess() done in didCreateProvisionalFrame for a
+    // provisional frame that is being discarded WITHOUT committing. (On commit, this destructor
+    // early-returns because takeFrameProcess() already nulled m_frameProcess, and the registration
+    // is instead carried forward by didCommitProvisionalFrame.) See webkit.org/b/308896.
+    RefPtr pageAgent = m_pageAgent;
+    Ref process = provisionalFrame.process();
+    auto pageID = protect(m_inspectedPage)->webPageIDInProcess(process);
+    if (pageAgent && pageAgent->isEnabled())
+        pageAgent->disableInstrumentationForProcess(process, pageID);
 }
 
 void WebPageInspectorController::didCommitProvisionalFrame(WebFrameProxy& frame, WebCore::ProcessIdentifier oldProcessID, std::optional<WebCore::PageIdentifier> oldPageID, WebCore::ProcessIdentifier newProcessID)
@@ -455,8 +475,10 @@ void WebPageInspectorController::didCommitProvisionalFrame(WebFrameProxy& frame,
     if (pageAgent && pageAgent->isEnabled()) {
         if (oldProcess && oldPageID)
             pageAgent->disableInstrumentationForProcess(*oldProcess, *oldPageID);
-        if (auto pageID = frame.webPageIDInCurrentProcess())
-            pageAgent->enableInstrumentationForProcess(process, *pageID);
+        // Unlike the network agent, the page agent already registered the new (committing)
+        // process in didCreateProvisionalFrame -- so the frame's initial Page.frameNavigated
+        // is delivered. Re-registering here would double-count the receiver, so we only
+        // release the old process. See webkit.org/b/308896.
     }
 }
 
@@ -518,6 +540,11 @@ bool WebPageInspectorController::shouldManageFrameTargets() const
 bool WebPageInspectorController::isNetworkInstrumentationEnabled() const
 {
     return m_networkAgent && m_networkAgent->isEnabled();
+}
+
+bool WebPageInspectorController::isPageInstrumentationEnabled() const
+{
+    return m_pageAgent && m_pageAgent->isEnabled();
 }
 
 void WebPageInspectorController::setEnabledBrowserAgent(InspectorBrowserAgent* agent)

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -98,6 +98,7 @@ public:
     void browserExtensionsDisabled(HashSet<String>&&);
 
     bool isNetworkInstrumentationEnabled() const;
+    bool isPageInstrumentationEnabled() const;
 
 private:
     WebPageAgentContext NODELETE webPageAgentContext();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13852,6 +13852,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.accessibilityMode = m_accessibilityMode;
     parameters.shouldForceSiteIsolationAlwaysOnForTesting = WebPreferences::forcedSiteIsolationAlwaysOnForTesting();
     parameters.shouldEnableNetworkInstrumentation = inspectorController().isNetworkInstrumentationEnabled();
+    parameters.shouldEnablePageInstrumentation = inspectorController().isPageInstrumentationEnabled();
 
     return parameters;
 }

--- a/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
@@ -64,7 +64,13 @@ PageAgentProxy::PageAgentProxy(WebAgentContext& context, WebPage& page)
 {
 }
 
-PageAgentProxy::~PageAgentProxy() = default;
+PageAgentProxy::~PageAgentProxy()
+{
+    // Clear the enabledPageProxy slot on our InstrumentingAgents so a later frame commit
+    // doesn't dereference this freed proxy from InspectorInstrumentation. Mirrors
+    // FrameNetworkAgentProxy::~FrameNetworkAgentProxy().
+    disable();
+}
 
 void PageAgentProxy::didCreateFrontendAndBackend()
 {

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -313,6 +313,12 @@ void WebInspectorBackend::updateDockingAvailability()
 
 void WebInspectorBackend::ensureInstrumentationForFrame(LocalFrame& frame)
 {
+    ensureNetworkInstrumentationForFrame(frame);
+    ensurePageInstrumentationForFrame(frame);
+}
+
+void WebInspectorBackend::ensureNetworkInstrumentationForFrame(LocalFrame& frame)
+{
     if (!m_networkInstrumentationEnabled)
         return;
 
@@ -364,7 +370,7 @@ void WebInspectorBackend::enableNetworkInstrumentation()
     }
 
     corePage->forEachLocalFrame([&](LocalFrame& frame) {
-        ensureInstrumentationForFrame(frame);
+        ensureNetworkInstrumentationForFrame(frame);
     });
 }
 
@@ -386,6 +392,7 @@ void WebInspectorBackend::disableNetworkInstrumentation()
 void WebInspectorBackend::removeInstrumentationForFrame(FrameIdentifier frameID)
 {
     m_frameNetworkAgentProxies.remove(frameID);
+    m_framePageAgentProxies.remove(frameID);
 }
 
 void WebInspectorBackend::getResponseBody(ResourceLoaderIdentifier resourceID, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&& completionHandler)
@@ -399,6 +406,50 @@ void WebInspectorBackend::getResponseBody(ResourceLoaderIdentifier resourceID, C
         completionHandler(String(), false, result.error());
 }
 
+void WebInspectorBackend::ensurePageInstrumentationForFrame(LocalFrame& frame)
+{
+    if (!m_pageInstrumentationEnabled)
+        return;
+
+    auto frameID = frame.frameID();
+    if (m_framePageAgentProxies.contains(frameID))
+        return;
+
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    RefPtr corePage = page->corePage();
+    if (!corePage)
+        return;
+
+    // Register the PageAgentProxy on the frame's OWN InstrumentingAgents (mirroring
+    // FrameNetworkAgentProxy in ensureNetworkInstrumentationForFrame), rather than the page's.
+    // The frame's first commit dispatches frameNavigated via instrumentingAgents(frame),
+    // which resolves the frame's own InstrumentingAgents; setting the slot there fires
+    // the proxy directly without depending on the frame->page fallback. Under Site
+    // Isolation a cross-origin child loads in a brand-new process whose page-level slot
+    // is set up too late / via a fallback that doesn't fire, so the page-level + fallback
+    // model never delivered the child's initial frameNavigated. See webkit.org/b/308896.
+    auto& pageInspectorController = corePage->inspectorController();
+    auto& frameController = frame.inspectorController();
+    Inspector::AgentContext baseContext = {
+        frameController,
+        pageInspectorController.injectedScriptManager(),
+        pageInspectorController.frontendRouter(),
+        pageInspectorController.backendDispatcher()
+    };
+    Ref instrumentingAgents = frameController.instrumentingAgents();
+    WebAgentContext webContext = {
+        baseContext,
+        instrumentingAgents.get()
+    };
+
+    auto proxy = makeUnique<PageAgentProxy>(webContext, *page);
+    proxy->enable();
+    m_framePageAgentProxies.add(frameID, WTF::move(proxy));
+}
+
 void WebInspectorBackend::enablePageInstrumentation()
 {
     if (!m_page || !m_page->corePage())
@@ -409,26 +460,12 @@ void WebInspectorBackend::enablePageInstrumentation()
 
     m_pageInstrumentationEnabled = true;
 
-    RefPtr page = m_page.get();
-    RefPtr corePage = page->corePage();
+    RefPtr corePage = m_page->corePage();
     corePage->settings().setDeveloperExtrasEnabled(true);
 
-    auto& pageInspectorController = corePage->inspectorController();
-    Inspector::AgentContext baseContext = {
-        pageInspectorController,
-        pageInspectorController.injectedScriptManager(),
-        pageInspectorController.frontendRouter(),
-        pageInspectorController.backendDispatcher()
-    };
-    Ref instrumentingAgents = pageInspectorController.instrumentingAgents();
-    WebAgentContext webContext = {
-        baseContext,
-        instrumentingAgents.get()
-    };
-
-    m_pageAgentProxy = makeUnique<PageAgentProxy>(webContext, *page);
-    CheckedRef pageAgentProxy { *m_pageAgentProxy };
-    pageAgentProxy->enable();
+    corePage->forEachLocalFrame([&](LocalFrame& frame) {
+        ensurePageInstrumentationForFrame(frame);
+    });
 }
 
 void WebInspectorBackend::disablePageInstrumentation()
@@ -436,13 +473,12 @@ void WebInspectorBackend::disablePageInstrumentation()
     if (!m_pageInstrumentationEnabled)
         return;
 
-    // disable() clears the enabledPageProxy slot in the page's InstrumentingAgents. Without it,
-    // destroying m_pageAgentProxy below would leave a dangling pointer there, and the next frame
-    // commit in this process would crash dereferencing it from InspectorInstrumentation. The page
-    // is still alive here (this is an explicit DisablePageInstrumentation IPC, not process teardown).
-    if (CheckedPtr pageAgentProxy = m_pageAgentProxy.get())
-        pageAgentProxy->disable();
-    m_pageAgentProxy = nullptr;
+    // Clearing the map destroys each PageAgentProxy, whose destructor (via disable())
+    // clears the enabledPageProxy slot on its frame's InstrumentingAgents. Without that,
+    // a later frame commit in this process would dereference a freed pointer from
+    // InspectorInstrumentation. The page is still alive here (this is an explicit
+    // DisablePageInstrumentation IPC, not process teardown).
+    m_framePageAgentProxies.clear();
     m_pageInstrumentationEnabled = false;
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -93,11 +93,15 @@ public:
     void enableNetworkInstrumentation();
     void disableNetworkInstrumentation();
     void getResponseBody(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&&);
-    void ensureInstrumentationForFrame(WebCore::LocalFrame&);
-    void removeInstrumentationForFrame(WebCore::FrameIdentifier);
 
     void enablePageInstrumentation();
     void disablePageInstrumentation();
+
+    // Set up / tear down every per-frame instrumentation agent for a frame. Callers
+    // don't need to know which agents are frame-scoped; each helper no-ops unless its
+    // domain is enabled.
+    void ensureInstrumentationForFrame(WebCore::LocalFrame&);
+    void removeInstrumentationForFrame(WebCore::FrameIdentifier);
 
     void setFrontendConnection(IPC::Connection::Handle&&);
 
@@ -118,6 +122,9 @@ private:
 
     void whenFrontendConnectionEstablished(Function<void(IPC::Connection&)>&&);
 
+    void ensureNetworkInstrumentationForFrame(WebCore::LocalFrame&);
+    void ensurePageInstrumentationForFrame(WebCore::LocalFrame&);
+
     WeakPtr<WebPage> m_page;
 
     RefPtr<IPC::Connection> m_frontendConnection;
@@ -130,7 +137,7 @@ private:
     UniqueRef<BackendResourceDataStore> m_resourceDataStore;
     bool m_networkInstrumentationEnabled { false };
 
-    std::unique_ptr<PageAgentProxy> m_pageAgentProxy;
+    HashMap<WebCore::FrameIdentifier, std::unique_ptr<PageAgentProxy>> m_framePageAgentProxies;
     bool m_pageInstrumentationEnabled { false };
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -484,10 +484,14 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
     if (!localFrame->isMainFrame())
         protect(localFrame->document())->setURL(URL { aboutBlankURL() });
 
-    // If network instrumentation was enabled via WebPageCreationParameters (before
-    // this frame existed), create the FrameNetworkAgentProxy for it now.
+    // If network/page instrumentation was enabled via WebPageCreationParameters (before
+    // this frame existed), create the per-frame proxies for it now. Under Site Isolation
+    // a cross-origin child provisional-loads in a brand-new process; registering the
+    // PageAgentProxy on this frame's own InstrumentingAgents here guarantees its initial
+    // frameNavigated reaches the UIProcess ProxyingPageAgent. See webkit.org/b/308896.
     if (RefPtr page = m_page.get()) {
-        if (RefPtr backend = page->inspector(WebPage::LazyCreationPolicy::UseExistingOnly))
+        RefPtr backend = page->inspector(WebPage::LazyCreationPolicy::UseExistingOnly);
+        if (backend)
             backend->ensureInstrumentationForFrame(localFrame.get());
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -971,6 +971,16 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
             backend->enableNetworkInstrumentation();
     }
 
+    if (parameters.shouldEnablePageInstrumentation) {
+        // Mirror network: enable page instrumentation before the frontend connects so the
+        // PageAgentProxy is live before this (possibly cross-origin, freshly-spawned) process's
+        // first frame commit. This sets the gate so ensurePageInstrumentationForFrame() registers
+        // a per-frame proxy when the provisional LocalFrame is created (WebFrame::createProvisionalFrame),
+        // delivering the child's initial frameNavigated to the UIProcess ProxyingPageAgent.
+        if (RefPtr backend = inspector(LazyCreationPolicy::CreateIfNeeded))
+            backend->enablePageInstrumentation();
+    }
+
 #if PLATFORM(IOS_FAMILY) || ENABLE(ROUTING_ARBITRATION)
     DeprecatedGlobalSettings::setShouldManageAudioSessionCategory(true);
 #endif


### PR DESCRIPTION
#### a26da26bbd793760c4f032c2be7f3fa74af9bcc8
<pre>
[Site Isolation] Report cross-origin frame url/securityOrigin in Page.getResourceTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=316665">https://bugs.webkit.org/show_bug.cgi?id=316665</a>
<a href="https://rdar.apple.com/179117295">rdar://179117295</a>

Reviewed by BJ Burg.

Under Site Isolation, Page.getResourceTree returned the cross-origin frame tree&apos;s
structure (ids, parent linkage, names) but reported a stale url/securityOrigin for
cross-origin children: the inspectedPage&apos;s WebFrameProxy never observes a cross-origin
child&apos;s commit (which happens in another WebContent process), so its url() stays
about:blank and its securityOrigin inherits the parent.

The only source of the child&apos;s committed url/origin is its own process&apos;s
Page.frameNavigated event (re-enabled by the previous change). Two things prevented it
from reaching the UIProcess ProxyingPageAgent for a cross-origin child:

1. Page instrumentation was page-level: a single PageAgentProxy on the page&apos;s
   InstrumentingAgents, with the committing frame relying on the frame-&gt;page fallback.
   In a freshly-spawned cross-origin process that fallback did not fire for the
   provisional frame&apos;s first commit. Mirror the network agent&apos;s per-frame model instead:
   register a PageAgentProxy on the committing frame&apos;s OWN InstrumentingAgents, where
   InspectorInstrumentation::didCommitLoadImpl resolves enabledPageProxy().

2. The child commits (with CommitTiming::WaitForLoad) and emits frameNavigated in its own
   process BEFORE the UIProcess processed didCommitProvisionalFrame, which is where the
   ProxyingPageAgent message receiver for that process used to be registered. With no
   receiver yet, the event was dropped. Register the receiver in didCreateProvisionalFrame
   (before commit) instead.

ProxyingPageAgent now caches each frame&apos;s committed {url, mimeType, securityOrigin} from
frameNavigated and buildFrameTree prefers that cache over the stale WebFrameProxy state.

* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::ensurePageInstrumentationForFrame):
(WebKit::WebInspectorBackend::enablePageInstrumentation):
(WebKit::WebInspectorBackend::disablePageInstrumentation):
(WebKit::WebInspectorBackend::removePageInstrumentationForFrame):
Replace the single page-level m_pageAgentProxy with a per-frame
m_framePageAgentProxies map. ensurePageInstrumentationForFrame registers a PageAgentProxy
on the frame&apos;s own InstrumentingAgents (mirroring ensureInstrumentationForFrame for the
network proxy). enablePageInstrumentation sets the gate and instruments existing local
frames; disablePageInstrumentation clears the map (each proxy&apos;s destructor clears its
slot).

* Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp:
(WebKit::PageAgentProxy::~PageAgentProxy):
disable() on destruction to clear the enabledPageProxy slot, matching
~FrameNetworkAgentProxy, so a later commit can&apos;t dereference a freed proxy.

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::createProvisionalFrame):
Call ensurePageInstrumentationForFrame beside ensureInstrumentationForFrame so the
proxy is live on the frame&apos;s own InstrumentingAgents before its first commit.

* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::detachedFromParent2):
Remove the per-frame page proxy when the frame detaches.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::WebPage):
Honor WebPageCreationParameters::shouldEnablePageInstrumentation so a newly-spawned
cross-origin process self-enables page instrumentation before its first commit.

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
Add shouldEnablePageInstrumentation (mirrors shouldEnableNetworkInstrumentation).

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
Set shouldEnablePageInstrumentation from isPageInstrumentationEnabled(); shared by the
remote-page creation path, so cross-origin processes receive it.

* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::isPageInstrumentationEnabled):
(WebKit::WebPageInspectorController::didCreateProvisionalFrame):
(WebKit::WebPageInspectorController::willDestroyProvisionalFrame):
(WebKit::WebPageInspectorController::didCommitProvisionalFrame):
Register the ProxyingPageAgent receiver for the provisional frame&apos;s process before it
commits, balanced in willDestroyProvisionalFrame (discard path); didCommitProvisionalFrame
no longer re-registers the page agent (it would double-count).

* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp:
(Inspector::ProxyingPageAgent::frameNavigated):
(Inspector::ProxyingPageAgent::frameDetached):
(Inspector::ProxyingPageAgent::enableInstrumentationForProcess):
(Inspector::ProxyingPageAgent::disable):
(Inspector::ProxyingPageAgent::buildFrameTree):
Cache committed {url, mimeType, securityOrigin} per frame from frameNavigated; prefer it
over the stale WebFrameProxy state in buildFrameTree; clear on frameDetached/disable.

* LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe.html:
* LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-cross-origin-iframe-expected.txt:
Wait for the child frame target&apos;s execution context (committed-and-ready) and poll
getResourceTree until the committed url is reported; rebaseline the two now-passing lines.

Canonical link: <a href="https://commits.webkit.org/315292@main">https://commits.webkit.org/315292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/622be3dd0b427737c19b7653e42b5d82607cd0ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126335 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29b35865-7198-42ba-96a5-0354f2e946ec) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131276 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa1d09a5-0597-4bfe-8554-afe5f1635dcc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151549 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111787 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c1c8ee2-d2c0-43c2-be29-4e865ff6cf42) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31425 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26655 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180562 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139721 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37579 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42887 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106585 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34858 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114647 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41391 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6009 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41039 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40933 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->