### PR TITLE
[Site Isolation] Web Inspector: Use FrameCSSAgent in the frontend

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/css/css-frontend-routing-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/css-frontend-routing-frame-target-expected.txt
@@ -1,0 +1,32 @@
+Test that the Web Inspector frontend routes CSS commands and events to a cross-origin iframe's FrameCSSAgent under site isolation.
+
+
+
+== Running test suite: SiteIsolation.CSS.FrontendRouting.FrameTarget
+-- Running test case: SiteIsolation.CSS.FrontendRouting.FrameTarget.Setup
+PASS: Should find a child frame target.
+PASS: Should find the target paragraph node.
+PASS: Target node's owningTarget should be the child frame target.
+
+-- Running test case: SiteIsolation.CSS.FrontendRouting.FrameTarget.StyleSheetsTrackedPerTarget
+PASS: Child frame should contribute at least one tracked stylesheet to WI.cssManager.
+
+-- Running test case: SiteIsolation.CSS.FrontendRouting.FrameTarget.StyleSheetIdentifierIsScoped
+PASS: Sheets from different targets must be distinct WI.CSSStyleSheet instances.
+PASS: Page-target sheet should not be tagged as owned by the child frame target.
+PASS: Frame-target sheet's owningTarget should be the child frame target.
+PASS: Page-target sheet's id getter should return the raw protocol id.
+PASS: Frame-target sheet's id getter should return the raw protocol id.
+
+-- Running test case: SiteIsolation.CSS.FrontendRouting.FrameTarget.StylesForNodeRoutesToFrameTarget
+PASS: Should have matched CSS rules from the frame target.
+PASS: Should have a rule matching .test-class from the frame target's stylesheet.
+PASS: Matched rule's ownerStyleSheet.owningTarget should be the child frame target (verifies styleSheetForIdentifier lookup with target).
+PASS: .test-class rule should have a color property.
+PASS: Initial color value should be 'red'.
+
+-- Running test case: SiteIsolation.CSS.FrontendRouting.FrameTarget.ChangeStyleTextRoutesToFrameTarget
+PASS: Should still have the .test-class rule.
+PASS: Frame target should still have the .test-class rule.
+PASS: Color value on the frame target should be 'blue' after the frontend edit.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/css/css-frontend-routing-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/css/css-frontend-routing-frame-target.html
@@ -1,0 +1,120 @@
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+    function test() {
+        let suite = InspectorTest.createAsyncSuite("SiteIsolation.CSS.FrontendRouting.FrameTarget");
+
+        let mainFrameTarget;
+        let childFrameTarget;
+        let targetNode;
+
+        // FIXME: Simplify this by using DOM.querySelector once it's implemented for frame targets.
+        async function findParagraphInFrame(target) {
+            let frameDoc = WI.domManager.frameTargetDocumentForTarget(target);
+            if (!frameDoc) {
+                let event = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = event.data.document;
+            }
+            await target.DOMAgent.requestChildNodes(frameDoc.backendNodeId, -1);
+            let body = frameDoc.children[0].children[1]; // html > body
+            return body.children.find((node) => node.nodeName() === "P");
+        }
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.FrontendRouting.FrameTarget.Setup",
+            description: "Find the child frame target and a paragraph node inside it.",
+            async test() {
+                let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+                let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+                mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+                childFrameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+                InspectorTest.expectNotNull(childFrameTarget, "Should find a child frame target.");
+
+                targetNode = await findParagraphInFrame(childFrameTarget);
+                InspectorTest.expectNotNull(targetNode, "Should find the target paragraph node.");
+                InspectorTest.expectEqual(targetNode.owningTarget, childFrameTarget, "Target node's owningTarget should be the child frame target.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.FrontendRouting.FrameTarget.StyleSheetsTrackedPerTarget",
+            description: "WI.cssManager should track stylesheets from the child frame target with owningTarget set.",
+            async test() {
+                let frameSheets = WI.cssManager.styleSheets.filter((s) => s.owningTarget === childFrameTarget);
+                InspectorTest.expectGreaterThanOrEqual(frameSheets.length, 1, "Child frame should contribute at least one tracked stylesheet to WI.cssManager.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.FrontendRouting.FrameTarget.StyleSheetIdentifierIsScoped",
+            description: "styleSheetForIdentifier with different targets should return distinct WI.CSSStyleSheet instances even for the same raw id.",
+            async test() {
+                let { styleSheetId: pageStylesheetId } = await mainFrameTarget.CSSAgent.createStyleSheet(WI.networkManager.mainFrame.id);
+                let { styleSheetId: frameStylesheetId } = await childFrameTarget.CSSAgent.createStyleSheet("");
+
+                let pageSheet = WI.cssManager.styleSheetForIdentifier(pageStylesheetId, null);
+                let frameSheet = WI.cssManager.styleSheetForIdentifier(frameStylesheetId, childFrameTarget);
+                InspectorTest.expectNotEqual(pageSheet, frameSheet, "Sheets from different targets must be distinct WI.CSSStyleSheet instances.");
+                InspectorTest.expectNotEqual(pageSheet.owningTarget, childFrameTarget, "Page-target sheet should not be tagged as owned by the child frame target.");
+                InspectorTest.expectEqual(frameSheet.owningTarget, childFrameTarget, "Frame-target sheet's owningTarget should be the child frame target.");
+                InspectorTest.expectEqual(pageSheet.id, pageStylesheetId, "Page-target sheet's id getter should return the raw protocol id.");
+                InspectorTest.expectEqual(frameSheet.id, frameStylesheetId, "Frame-target sheet's id getter should return the raw protocol id.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.FrontendRouting.FrameTarget.StylesForNodeRoutesToFrameTarget",
+            description: "WI.cssManager.stylesForNode(nodeInFrame).refresh() should route through the frame target's CSSAgent and tag rules with the right owning target.",
+            async test() {
+                let nodeStyles = WI.cssManager.stylesForNode(targetNode);
+                await nodeStyles.refresh();
+
+                let matchedRules = nodeStyles.matchedRules;
+                InspectorTest.expectGreaterThan(matchedRules.length, 0, "Should have matched CSS rules from the frame target.");
+
+                let testClassRule = matchedRules.find((rule) => rule.selectors.some((sel) => sel.text === ".test-class"));
+                InspectorTest.expectNotNull(testClassRule, "Should have a rule matching .test-class from the frame target's stylesheet.");
+
+                InspectorTest.expectEqual(testClassRule.ownerStyleSheet.owningTarget, childFrameTarget, "Matched rule's ownerStyleSheet.owningTarget should be the child frame target (verifies styleSheetForIdentifier lookup with target).");
+
+                let colorProperty = testClassRule.style.properties.find((p) => p.name === "color");
+                InspectorTest.expectNotNull(colorProperty, ".test-class rule should have a color property.");
+                InspectorTest.expectEqual(colorProperty.value, "red", "Initial color value should be 'red'.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.CSS.FrontendRouting.FrameTarget.ChangeStyleTextRoutesToFrameTarget",
+            description: "Editing a style declaration via WI.DOMNodeStyles.changeStyleText should land on the frame target's stylesheet.",
+            async test() {
+                let nodeStyles = WI.cssManager.stylesForNode(targetNode);
+                let testClassRule = nodeStyles.matchedRules.find((rule) => rule.selectors.some((sel) => sel.text === ".test-class"));
+                InspectorTest.expectNotNull(testClassRule, "Should still have the .test-class rule.");
+
+                await new Promise((resolve, reject) => {
+                    nodeStyles.changeStyleText(testClassRule.style, "color: blue; font-size: 16px;", (error) => {
+                        if (error)
+                            reject(error);
+                        else
+                            resolve();
+                    });
+                });
+
+                // Re-fetch matched styles directly from the frame agent to confirm the edit landed on the frame target's backend.
+                let { matchedCSSRules } = await childFrameTarget.CSSAgent.getMatchedStylesForNode(targetNode.backendNodeId);
+                let testClassFromAgent = matchedCSSRules.find((m) => m.rule.selectorList.selectors.some((s) => s.text === ".test-class"));
+                InspectorTest.expectNotNull(testClassFromAgent, "Frame target should still have the .test-class rule.");
+
+                let colorProperty = testClassFromAgent.rule.style.cssProperties.find((p) => p.name === "color");
+                InspectorTest.expectEqual(colorProperty.value, "blue", "Color value on the frame target should be 'blue' after the frontend edit.");
+            }
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()">
+    <p>Test that the Web Inspector frontend routes CSS commands and events to a cross-origin iframe's FrameCSSAgent under site isolation.</p>
+    <iframe src="http://localhost:8000/site-isolation/inspector/css/resources/frame-with-stylesheet.html"></iframe>
+</body>

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// FIXME: CSSManager lacks advanced multi-target support. (Stylesheets per-target)
-
 WI.CSSManager = class CSSManager extends WI.Object
 {
     constructor()
@@ -39,6 +37,8 @@ WI.CSSManager = class CSSManager extends WI.Object
         WI.DOMNode.addEventListener(WI.DOMNode.Event.AttributeModified, this._nodeAttributesDidChange, this);
         WI.DOMNode.addEventListener(WI.DOMNode.Event.AttributeRemoved, this._nodeAttributesDidChange, this);
         WI.DOMNode.addEventListener(WI.DOMNode.Event.EnabledPseudoClassesChanged, this._nodePseudoClassesDidChange, this);
+
+        WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, this._handleTargetRemoved, this);
 
         this._colorFormatSetting = new WI.Setting("default-color-format", WI.Color.Format.Original);
 
@@ -446,14 +446,15 @@ WI.CSSManager = class CSSManager extends WI.Object
         return match[1];
     }
 
-    styleSheetForIdentifier(id)
+    styleSheetForIdentifier(id, target)
     {
-        let styleSheet = this._styleSheetIdentifierMap.get(id);
+        let key = CSSManager.keyForStyleSheet(id, target);
+        let styleSheet = this._styleSheetIdentifierMap.get(key);
         if (styleSheet)
             return styleSheet;
 
-        styleSheet = new WI.CSSStyleSheet(id);
-        this._styleSheetIdentifierMap.set(id, styleSheet);
+        styleSheet = new WI.CSSStyleSheet(id, target);
+        this._styleSheetIdentifierMap.set(key, styleSheet);
         return styleSheet;
     }
 
@@ -472,7 +473,7 @@ WI.CSSManager = class CSSManager extends WI.Object
         return this.styleSheets.filter((styleSheet) => styleSheet.isInspectorStyleSheet() && styleSheet.parentFrame === frame);
     }
 
-    preferredInspectorStyleSheetForFrame(frame, callback)
+    preferredInspectorStyleSheetForFrame(frame, callback, target)
     {
         var inspectorStyleSheets = this.inspectorStyleSheetsForFrame(frame);
         for (let styleSheet of inspectorStyleSheets) {
@@ -482,15 +483,15 @@ WI.CSSManager = class CSSManager extends WI.Object
             }
         }
 
-        let target = WI.assumingMainTarget();
-        target.CSSAgent.createStyleSheet(frame.id, function(error, styleSheetId) {
+        let agentTarget = target || WI.assumingMainTarget();
+        agentTarget.CSSAgent.createStyleSheet(frame.id, function(error, styleSheetId) {
             if (error || !styleSheetId) {
                 WI.reportInternalError(error || styleSheetId);
                 return;
             }
 
             const url = null;
-            let styleSheet = WI.cssManager.styleSheetForIdentifier(styleSheetId);
+            let styleSheet = WI.cssManager.styleSheetForIdentifier(styleSheetId, target);
             styleSheet.updateInfo(url, frame, styleSheet.origin, styleSheet.isInlineStyleTag(), styleSheet.startLineNumber, styleSheet.startColumnNumber);
             styleSheet[WI.CSSManager.PreferredInspectorStyleSheetSymbol] = true;
             callback(styleSheet);
@@ -573,9 +574,9 @@ WI.CSSManager = class CSSManager extends WI.Object
             this._nodeStylesMap[key].mediaQueryResultDidChange();
     }
 
-    styleSheetChanged(styleSheetIdentifier)
+    styleSheetChanged(styleSheetIdentifier, target)
     {
-        var styleSheet = this.styleSheetForIdentifier(styleSheetIdentifier);
+        var styleSheet = this.styleSheetForIdentifier(styleSheetIdentifier, target);
         console.assert(styleSheet);
 
         // Do not observe inline styles
@@ -588,15 +589,13 @@ WI.CSSManager = class CSSManager extends WI.Object
         this._updateResourceContent(styleSheet);
     }
 
-    styleSheetAdded(styleSheetInfo)
+    styleSheetAdded(styleSheetInfo, target)
     {
-        // FIXME <https://webkit.org/b/310164>: Under Site Isolation, different targets independently generate
-        // stylesheet IDs starting from "1", causing collisions. Skip duplicates to avoid overwriting an existing
-        // stylesheet with data from a different target. This will be resolved by deterministic process-qualified IDs.
-        if (this._styleSheetIdentifierMap.has(styleSheetInfo.styleSheetId))
+        let key = CSSManager.keyForStyleSheet(styleSheetInfo.styleSheetId, target);
+        if (this._styleSheetIdentifierMap.has(key))
             return;
 
-        let styleSheet = this.styleSheetForIdentifier(styleSheetInfo.styleSheetId);
+        let styleSheet = this.styleSheetForIdentifier(styleSheetInfo.styleSheetId, target);
         let parentFrame = WI.networkManager.frameForIdentifier(styleSheetInfo.frameId);
         let origin = WI.CSSManager.protocolStyleSheetOriginToEnum(styleSheetInfo.origin);
         styleSheet.updateInfo(styleSheetInfo.sourceURL, parentFrame, origin, styleSheetInfo.isInline, styleSheetInfo.startLine, styleSheetInfo.startColumn);
@@ -604,19 +603,46 @@ WI.CSSManager = class CSSManager extends WI.Object
         this.dispatchEventToListeners(WI.CSSManager.Event.StyleSheetAdded, {styleSheet});
     }
 
-    styleSheetRemoved(styleSheetIdentifier)
+    styleSheetRemoved(styleSheetIdentifier, target)
     {
-        let styleSheet = this._styleSheetIdentifierMap.get(styleSheetIdentifier);
+        let key = CSSManager.keyForStyleSheet(styleSheetIdentifier, target);
+        let styleSheet = this._styleSheetIdentifierMap.get(key);
         console.assert(styleSheet, "Attempted to remove a CSSStyleSheet that was not tracked");
         if (!styleSheet)
             return;
 
-        this._styleSheetIdentifierMap.delete(styleSheetIdentifier);
+        this._styleSheetIdentifierMap.delete(key);
 
         this.dispatchEventToListeners(WI.CSSManager.Event.StyleSheetRemoved, {styleSheet});
     }
 
     // Private
+
+    static keyForStyleSheet(rawId, target)
+    {
+        if (target instanceof WI.FrameTarget)
+            return `${target.identifier}:${rawId}`;
+        return rawId;
+    }
+
+    _handleTargetRemoved(event)
+    {
+        let {target} = event.data;
+        if (!(target instanceof WI.FrameTarget))
+            return;
+
+        let prefix = target.identifier + ":";
+        let removedKeys = [];
+        for (let key of this._styleSheetIdentifierMap.keys()) {
+            if (typeof key === "string" && key.startsWith(prefix))
+                removedKeys.push(key);
+        }
+        for (let key of removedKeys) {
+            let styleSheet = this._styleSheetIdentifierMap.get(key);
+            this._styleSheetIdentifierMap.delete(key);
+            this.dispatchEventToListeners(WI.CSSManager.Event.StyleSheetRemoved, {styleSheet});
+        }
+    }
 
     _nodePseudoClassesDidChange(event)
     {

--- a/Source/WebInspectorUI/UserInterface/Models/CSSGrouping.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSGrouping.js
@@ -78,7 +78,8 @@ WI.CSSGrouping = class CSSGrouping extends WI.Object
 
         this._nodeStyles.ignoreNextContentDidChangeForStyleSheet = this._ownerStyleSheet;
 
-        let target = WI.assumingMainTarget();
+        let owningTarget = this._nodeStyles.node.owningTarget;
+        let target = owningTarget || WI.assumingMainTarget();
         let {grouping: groupingPayload} = await target.CSSAgent.setGroupingHeaderText(this._id, newText);
 
         WI.domUndoCoordinator.markUndoableState(target);
@@ -100,7 +101,7 @@ WI.CSSGrouping = class CSSGrouping extends WI.Object
         }
 
         let groupingSourceCodeLocation = WI.DOMNodeStyles.createSourceCodeLocation(groupingPayload.sourceURL, location);
-        this._sourceCodeLocation = WI.cssManager.styleSheetForIdentifier(this._id.styleSheetId).offsetSourceCodeLocation(groupingSourceCodeLocation);
+        this._sourceCodeLocation = WI.cssManager.styleSheetForIdentifier(this._id.styleSheetId, owningTarget).offsetSourceCodeLocation(groupingSourceCodeLocation);
 
         this.dispatchEventToListeners(WI.CSSGrouping.Event.TextChanged);
     }

--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js
@@ -25,13 +25,14 @@
 
 WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
 {
-    constructor(id)
+    constructor(id, owningTarget)
     {
         super();
 
         console.assert(id);
 
         this._id = id || null;
+        this._owningTarget = owningTarget || null;
         this._parentFrame = null;
         this._origin = null;
         this._startLineNumber = 0;
@@ -55,6 +56,11 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
     get id()
     {
         return this._id;
+    }
+
+    get owningTarget()
+    {
+        return this._owningTarget;
     }
 
     get parentFrame()
@@ -173,7 +179,7 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
         if (!this._id)
             return;
 
-        let target = WI.assumingMainTarget();
+        let target = this._owningTarget || WI.assumingMainTarget();
 
         function contentDidChange(error)
         {
@@ -202,7 +208,7 @@ WI.CSSStyleSheet = class CSSStyleSheet extends WI.SourceCode
             return Promise.reject(new Error("There is no identifier to request content with."));
         }
 
-        let target = WI.assumingMainTarget();
+        let target = this._owningTarget || WI.assumingMainTarget();
         return target.CSSAgent.getStyleSheetText(this._id);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -232,7 +232,7 @@ WI.DOMNode = class DOMNode extends WI.Object
     // Public
 
     get destroyed() { return this._destroyed; }
-    get frame() { return this._frame; }
+    get frame() { return this._frame || this.parentNode?.frame || null; }
     get owningTarget() { return this._owningTarget || this.parentNode?.owningTarget || null; }
     get backendNodeId() { return this._rawNodeId ?? this.id; }
     get nextSibling() { return this._nextSibling; }
@@ -1313,18 +1313,14 @@ WI.DOMNode = class DOMNode extends WI.Object
             pseudoClasses.remove(pseudoClass);
         }
 
-        // FIXME: <https://webkit.org/b/298980> Forcing pseudo classes on cross-origin frame nodes is not yet supported.
-        if (this.owningTarget)
-            return;
-
         function changed(error)
         {
             if (!error)
                 this.dispatchEventToListeners(WI.DOMNode.Event.EnabledPseudoClassesChanged);
         }
 
-        let target = WI.assumingMainTarget();
-        target.CSSAgent.forcePseudoState(this.id, pseudoClasses, changed.bind(this));
+        let target = this.owningTarget || WI.assumingMainTarget();
+        target.CSSAgent.forcePseudoState(this.backendNodeId, pseudoClasses, changed.bind(this));
     }
 
     _markUndoableState()

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -174,10 +174,6 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
 
         this._needsRefresh = false;
 
-        // FIXME: <https://webkit.org/b/298980> CSS inspection for cross-origin frame nodes requires FrameCSSAgent.
-        if (this._node.owningTarget)
-            return Promise.resolve(this);
-
         let fetchedMatchedStylesPromise = Promise.withResolvers();
         let fetchedInlineStylesPromise = Promise.withResolvers();
         let fetchedComputedStylesPromise = Promise.withResolvers();
@@ -350,14 +346,15 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
             fetchedFontDataPromise.resolve();
         }
 
-        let target = WI.assumingMainTarget();
-        target.CSSAgent.getMatchedStylesForNode.invoke({nodeId: this._node.id, includePseudo: true, includeInherited: true}, wrap.call(this, fetchedMatchedStyles, fetchedMatchedStylesPromise));
-        target.CSSAgent.getInlineStylesForNode.invoke({nodeId: this._node.id}, wrap.call(this, fetchedInlineStyles, fetchedInlineStylesPromise));
-        target.CSSAgent.getComputedStyleForNode.invoke({nodeId: this._node.id}, wrap.call(this, fetchedComputedStyle, fetchedComputedStylesPromise));
+        let target = this._node.owningTarget || WI.assumingMainTarget();
+        let nodeId = this._node.backendNodeId;
+        target.CSSAgent.getMatchedStylesForNode.invoke({nodeId, includePseudo: true, includeInherited: true}, wrap.call(this, fetchedMatchedStyles, fetchedMatchedStylesPromise));
+        target.CSSAgent.getInlineStylesForNode.invoke({nodeId}, wrap.call(this, fetchedInlineStyles, fetchedInlineStylesPromise));
+        target.CSSAgent.getComputedStyleForNode.invoke({nodeId}, wrap.call(this, fetchedComputedStyle, fetchedComputedStylesPromise));
 
         // COMPATIBILITY (iOS 14.0): `CSS.getFontDataForNode` did not exist yet.
         if (InspectorBackend.hasCommand("CSS.getFontDataForNode"))
-            target.CSSAgent.getFontDataForNode.invoke({nodeId: this._node.id}, wrap.call(this, fetchedFontData, fetchedFontDataPromise));
+            target.CSSAgent.getFontDataForNode.invoke({nodeId}, wrap.call(this, fetchedFontData, fetchedFontDataPromise));
         else
             fetchedFontDataPromise.resolve();
 
@@ -378,7 +375,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         selector = selector || this._node.appropriateSelectorFor(true);
 
         let result = Promise.withResolvers();
-        let target = WI.assumingMainTarget();
+        let target = this._node.owningTarget || WI.assumingMainTarget();
 
         function completed()
         {
@@ -427,9 +424,9 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         }
 
         if (styleSheetId)
-            inspectorStyleSheetAvailable.call(this, WI.cssManager.styleSheetForIdentifier(styleSheetId));
+            inspectorStyleSheetAvailable.call(this, WI.cssManager.styleSheetForIdentifier(styleSheetId, this._node.owningTarget));
         else
-            WI.cssManager.preferredInspectorStyleSheetForFrame(this._node.frame, inspectorStyleSheetAvailable.bind(this));
+            WI.cssManager.preferredInspectorStyleSheetForFrame(this._node.frame, inspectorStyleSheetAvailable.bind(this), this._node.owningTarget);
 
         return result.promise;
     }
@@ -466,7 +463,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
     {
         selector = selector || "";
         let result = Promise.withResolvers();
-        let target = WI.assumingMainTarget();
+        let target = this._node.owningTarget || WI.assumingMainTarget();
 
         function ruleSelectorChanged(error, rulePayload)
         {
@@ -515,7 +512,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
             this.refresh();
         };
 
-        let target = WI.assumingMainTarget();
+        let target = this._node.owningTarget || WI.assumingMainTarget();
         target.CSSAgent.setStyleText(style.id, text, didSetStyleText);
     }
 
@@ -659,7 +656,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         if (!matchesNode)
             return null;
 
-        var styleSheet = id ? WI.cssManager.styleSheetForIdentifier(id.styleSheetId) : null;
+        var styleSheet = id ? WI.cssManager.styleSheetForIdentifier(id.styleSheetId, this._node.owningTarget) : null;
         if (styleSheet) {
             if (type === WI.CSSStyleDeclaration.Type.Inline)
                 styleSheet.markAsInlineStyleAttributeStyleSheet();
@@ -709,7 +706,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         if (!style)
             return null;
 
-        var styleSheet = id ? WI.cssManager.styleSheetForIdentifier(id.styleSheetId) : null;
+        var styleSheet = id ? WI.cssManager.styleSheetForIdentifier(id.styleSheetId, this._node.owningTarget) : null;
 
         var selectorText = payload.selectorList.text;
         let selectors = DOMNodeStyles.parseSelectorListPayload(payload.selectorList);
@@ -766,7 +763,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
             // The style sheet may be different from the style rule's style sheet, since groupings are computed beyond
             // `@import` boundaries, and an `@import` statement from another style sheet may have been wrapped in
             // another `@` rule.
-            let groupingStyleSheet = ruleId ? WI.cssManager.styleSheetForIdentifier(ruleId.styleSheetId) : null;
+            let groupingStyleSheet = ruleId ? WI.cssManager.styleSheetForIdentifier(ruleId.styleSheetId, this._node.owningTarget) : null;
 
             let groupingSourceCodeLocation = WI.DOMNodeStyles.createSourceCodeLocation(grouping.sourceURL, location);
             let offsetGroupingSourceCodeLocation = styleSheet?.offsetSourceCodeLocation(groupingSourceCodeLocation) ?? groupingSourceCodeLocation;

--- a/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
@@ -29,38 +29,22 @@ WI.CSSObserver = class CSSObserver extends InspectorBackend.Dispatcher
 
     mediaQueryResultChanged()
     {
-        // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
-        if (this._target instanceof WI.FrameTarget)
-            return;
-
         WI.cssManager.mediaQueryResultChanged();
     }
 
     styleSheetChanged(styleSheetId)
     {
-        // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
-        if (this._target instanceof WI.FrameTarget)
-            return;
-
-        WI.cssManager.styleSheetChanged(styleSheetId);
+        WI.cssManager.styleSheetChanged(styleSheetId, this._target);
     }
 
     styleSheetAdded(styleSheetInfo)
     {
-        // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
-        if (this._target instanceof WI.FrameTarget)
-            return;
-
-        WI.cssManager.styleSheetAdded(styleSheetInfo);
+        WI.cssManager.styleSheetAdded(styleSheetInfo, this._target);
     }
 
     styleSheetRemoved(id)
     {
-        // FIXME <https://webkit.org/b/314148> Use FrameCSSAgent in the frontend.
-        if (this._target instanceof WI.FrameTarget)
-            return;
-
-        WI.cssManager.styleSheetRemoved(id);
+        WI.cssManager.styleSheetRemoved(id, this._target);
     }
 
     nodeLayoutFlagsChanged(nodeId, layoutFlags)


### PR DESCRIPTION
#### d12d6366d4fc3beb9af4d609cb4b01d0e4d43883
<pre>
[Site Isolation] Web Inspector: Use FrameCSSAgent in the frontend
<a href="https://bugs.webkit.org/show_bug.cgi?id=314148">https://bugs.webkit.org/show_bug.cgi?id=314148</a>

Reviewed by BJ Burg.

Route CSS commands and events through FrameCSSAgent for cross-origin
iframes, mirroring how FrameDOMAgent is already used in the frontend
for the DOM domain&apos;s commands and events. Cross-origin iframes now
go from no CSS support to partial support, while the main frame and
same-origin iframes continue to be handled by the page-target
InspectorCSSAgent unchanged, with full support.

Routing decisions key based on the existing `owningTarget` getter on
DOMNode, introduced for FrameDOMAgent. When a DOMNode&apos;s owningTarget is
a FrameTarget, CSS commands for that node go to the frame&apos;s new
CSSAgent; otherwise they fall back to the page target via
WI.assumingMainTarget(). The same predicate is used to decide whether a
styleSheetAdded event came from a frame target&apos;s CSSObserver, in which
case the style sheet is recorded with `target.identifier + &quot;:&quot; + rawId`
as its map key to disambiguate from page-target identifiers.

Most of the changes are mechanical owningTarget-based routing across
CSSObserver, CSSManager, CSSStyleSheet, CSSGrouping, DOMNodeStyles,
and DOMNode. The DOMNode `frame` getter now walks the parentNode chan:
after the iframe document is spliced into the page tree, the walk
reaches the iframe element which does have its frame resolved,
in a similar fashion to finding the owning target.

Out of scope and tracked separately as follow-ups:

- CSSObserver still drops nodeLayoutFlagsChanged and
  nodeLayoutContextTypeChanged for FrameTargets, since those commands&apos;
  ownership needs to be reworked. (webkit.org/b/316844)

- Style sheet entries for the main frame are duplicated in
  WI.cssManager.styleSheets: the page target observes them via the
  shared process, and the main frame&apos;s FrameCSSAgent observes them
  again. With cross-origin-only routing, the main-frame FrameTarget&apos;s
  entries waste memory and nothing reads them. A future cleanup can
  either silence the duplicate observation in the backend or filter it
  on the frontend, if not done as part of the page target&apos;s deprecation.
  (webkit.org/b/317762)

- Editing a CSS resource through the Sources tab is currently blocked
  by Network/Page domain limitations: under SI, cross-origin iframe
  resources cannot be loaded by the page target&apos;s NetworkAgent /
  PageAgent. The CSS-side routing for setStyleSheetText is implemented
  (CSSStyleSheet.handleCurrentRevisionContentChange uses the owning
  target), but the path is unreachable end-to-end through the Sources
  tab UI until more support on the networking side of cross-origin
  inspection completes. (webkit.org/b/317760)

Test: http/tests/site-isolation/inspector/css/css-frontend-routing-frame-target.html

- Cover routing distinctions that tests in css-editing-commands-frame-target.html
  can&apos;t verify.

* LayoutTests/http/tests/site-isolation/inspector/css/css-frontend-routing-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/css/css-frontend-routing-frame-target.html: Added.
* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager):
(WI.CSSManager.prototype.styleSheetForIdentifier):
(WI.CSSManager.prototype.preferredInspectorStyleSheetForFrame):
(WI.CSSManager.prototype.styleSheetChanged):
(WI.CSSManager.prototype.styleSheetAdded):
(WI.CSSManager.prototype.styleSheetRemoved):
(WI.CSSManager.prototype._styleSheetKey):
(WI.CSSManager.prototype._handleTargetRemoved):
* Source/WebInspectorUI/UserInterface/Models/CSSGrouping.js:
(WI.CSSGrouping.prototype.async setText):
* Source/WebInspectorUI/UserInterface/Models/CSSStyleSheet.js:
(WI.CSSStyleSheet):
(WI.CSSStyleSheet.prototype.get owningTarget):
(WI.CSSStyleSheet.prototype.requestContentFromBackend):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.get frame):
(WI.DOMNode.prototype.setPseudoClassEnabled):
(WI.DOMNode.prototype._markUndoableState):
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.prototype.refresh):
(WI.DOMNodeStyles.prototype.addRule):
(WI.DOMNodeStyles.prototype.changeStyleText):
(WI.DOMNodeStyles.prototype._parseStyleDeclarationPayload):
(WI.DOMNodeStyles.prototype._parseRulePayload):
* Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js:
(WI.CSSObserver.prototype.mediaQueryResultChanged):
(WI.CSSObserver.prototype.styleSheetChanged):
(WI.CSSObserver.prototype.styleSheetAdded):
(WI.CSSObserver.prototype.styleSheetRemoved):

Canonical link: <a href="https://commits.webkit.org/315775@main">https://commits.webkit.org/315775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b74cec2637c7d37f5f3a91a30145d3b1c53ac5a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170051 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/43974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/179413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bc40c5e-1a01-4890-963f-119bc29213c9) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43606 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/179413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d886f589-038c-4cb2-a979-dd457e432c0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173010 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/45202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/37387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/179413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef6a7256-8568-4a48-9bdf-cb9adf221591) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/28109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/37387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/45202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36855 "Build is in progress. Recent messages:") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/182010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/43629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/37387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/44318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25913 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/44318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/116200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/42829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/37387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/42221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/42476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/42364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->