### PR TITLE
Update rec2020 transfer functions to use 2.4 gamma

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color.html
@@ -841,8 +841,8 @@
   fuzzy_test_computed_color(`color(from color(srgb 0.25 0.5 0.75) a98-rgb r g b)`, `color(a98-rgb 0.346741 0.496104 0.736143)`, 0.001);
   fuzzy_test_computed_color(`color(from color(prophoto-rgb 0.25 0.5 0.75) srgb r g b)`, `color(srgb -0.510555 0.612317 0.825249)`, 0.001);
   fuzzy_test_computed_color(`color(from color(srgb 0.25 0.5 0.75) prophoto-rgb r g b)`, `color(prophoto-rgb 0.374928 0.416497 0.663803)`, 0.001);
-  fuzzy_test_computed_color(`color(from color(rec2020 0.25 0.5 0.75) srgb r g b)`, `color(srgb -0.280036 0.565528 0.79951)`, 0.001);
-  fuzzy_test_computed_color(`color(from color(srgb 0.25 0.5 0.75) rec2020 r g b)`, `color(rec2020 0.331998 0.440976 0.696422)`, 0.001);
+  fuzzy_test_computed_color(`color(from color(rec2020 0.25 0.5 0.75) srgb r g b)`, `color(srgb -0.32868637 0.49120129 0.76185175)`, 0.001);
+  fuzzy_test_computed_color(`color(from color(srgb 0.25 0.5 0.75) rec2020 r g b)`, `color(rec2020 0.42049303 0.51802421 0.74138103)`, 0.001);
   fuzzy_test_computed_color(`color(from color(xyz-d50 0.25 0.5 0.75) srgb r g b)`, `color(srgb -0.660025 0.874825 0.981099)`, 0.001);
   fuzzy_test_computed_color(`color(from color(srgb 0.25 0.5 0.75) xyz-d50 x y z)`, `color(xyz-d50 0.179385 0.196438 0.39462)`, 0.001);
   fuzzy_test_computed_color(`color(from color(xyz-d65 0.25 0.5 0.75) srgb r g b)`, `color(srgb -0.611728 0.868673 0.856817)`, 0.001);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/predefined-011.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/predefined-011.html
@@ -8,7 +8,7 @@
 <style>
     .test { background-color: red; width: 12em; height: 6em; margin-top:0}
     .ref { background-color: #009900; width: 12em; height: 6em; margin-bottom: 0}
-    .test {background-color: color(rec2020 0.299218 0.533327 0.120785)}
+    .test {background-color: color(rec2020 0.39081936 0.59952875 0.22553675)}
 </style>
 <body>
     <p>Test passes if you see a green square, and no red.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/predefined-012.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/predefined-012.html
@@ -8,7 +8,7 @@
 <style>
     .test { background-color: red; width: 12em; height: 6em; margin-top:0}
     .ref { background-color: #009900; width: 12em; height: 6em; margin-bottom: 0}
-    .test {background-color: color(rec2020 29.9218% 53.3327% 12.0785%)}
+    .test {background-color: color(rec2020 39.081936% 59.952875% 22.553675%)}
 </style>
 <body>
     <p>Test passes if you see a green square, and no red.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/rec2020-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/rec2020-001.html
@@ -7,7 +7,7 @@
 <meta name="assert" content="rec2020 with no alpha">
 <style>
     .test { background-color: red; width: 12em; height: 12em; }
-    .test { background-color: color(rec2020 0.235202 0.431704 0.085432); } /* green (sRGB #008000) converted to rec2020 */
+    .test { background-color: color(rec2020 0.33232223 0.50979237 0.19177882); } /* green (sRGB #008000) converted to rec2020 */
 </style>
 <body>
     <p>Test passes if you see a green square, and no red.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/relative-currentcolor-rec2020-02-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/relative-currentcolor-rec2020-02-expected.html
@@ -7,8 +7,8 @@ div {
   height: 100px;
 }
 div div {
-  background-color: color(rec2020 0.23072 0.46956 0.08); /* rgb(-16.284% 54.0356% -5.7344%) */
-  /* https://colorjs.io/apps/convert/?color=color(prophoto-rgb%200.23%200.43%200.13)&precision=6 */
+  background-color: color(rec2020 0.32819588 0.54335203 0.18654218); /* rgb(-16.284% 54.0356% -5.7344%) */
+  /* https://apps.colorjs.io/convert/?color=color(prophoto-rgb%200.23%200.43%200.13)&precision=8 */
 }
 </style>
 <div>

--- a/Source/WebCore/platform/graphics/ColorTransferFunctions.h
+++ b/Source/WebCore/platform/graphics/ColorTransferFunctions.h
@@ -124,33 +124,20 @@ template<typename T, TransferFunctionMode mode> T ProPhotoRGBTransferFunction<T,
 
 template<typename T, TransferFunctionMode mode> T Rec2020TransferFunction<T, mode>::toGammaEncoded(T c)
 {
-    if constexpr (mode == TransferFunctionMode::Clamped) {
-        if (c <= beta)
-            return 4.5f * c;
-
-        return clampTo<T>(alpha * std::pow(c, gamma) - (alpha - 1.0f), 0, 1);
-    } else {
-        if (std::abs(c) <= beta)
-            return 4.5f * c;
-
-        float sign = std::signbit(c) ? -1.0 : 1.0;
-        return (alpha * std::pow(c, gamma) - (alpha - 1.0)) * sign;
-    }
+    auto sign = std::signbit(c) ? -1.0f : 1.0f;
+    auto result = std::pow(std::abs(c), 1.0f / 2.4f) * sign;
+    if constexpr (mode == TransferFunctionMode::Clamped)
+        return clampTo<T>(result, 0, 1);
+    return result;
 }
 
 template<typename T, TransferFunctionMode mode> T Rec2020TransferFunction<T, mode>::toLinear(T c)
 {
-    if constexpr (mode == TransferFunctionMode::Clamped) {
-        if (c < beta * 4.5f)
-            return c / 4.5f;
-        return clampTo<T>(std::pow((c + alpha - 1.0) / alpha, 1.0 / gamma), 0, 1);
-    } else {
-        if (std::abs(c) < beta * 4.5f)
-            return c / 4.5f;
-
-        float sign = std::signbit(c) ? -1.0 : 1.0;
-        return std::pow((c + alpha - 1.0) / alpha, 1.0 / gamma) * sign;
-    }
+    auto sign = std::signbit(c) ? -1.0f : 1.0f;
+    auto result = std::pow(std::abs(c), 2.4f) * sign;
+    if constexpr (mode == TransferFunctionMode::Clamped)
+        return clampTo<T>(result, 0, 1);
+    return result;
 }
 
 // MARK: SRGBTransferFunction.

--- a/Source/WebCore/platform/graphics/ColorTransferFunctions.h
+++ b/Source/WebCore/platform/graphics/ColorTransferFunctions.h
@@ -52,10 +52,6 @@ struct ProPhotoRGBTransferFunction {
 
 template<typename T, TransferFunctionMode mode>
 struct Rec2020TransferFunction {
-    static constexpr T alpha = 1.09929682680944;
-    static constexpr T beta = 0.018053968510807;
-    static constexpr T gamma = 0.45;
-
     static T toGammaEncoded(T);
     static T toLinear(T);
 };


### PR DESCRIPTION
#### bae8b96209306e93933212df771f93593a2ac66a
<pre>
Update rec2020 transfer functions to use 2.4 gamma
<a href="https://bugs.webkit.org/show_bug.cgi?id=316997">https://bugs.webkit.org/show_bug.cgi?id=316997</a>

Reviewed by NOBODY (OOPS!).

The css-color-4 specification was updated and uses new transfer functions for rec2020.
<a href="https://github.com/w3c/csswg-drafts/issues/12574">https://github.com/w3c/csswg-drafts/issues/12574</a>

No new tests (OOPS!).

* Source/WebCore/platform/graphics/ColorTransferFunctions.h:
(WebCore::mode&gt;::toGammaEncoded):
(WebCore::mode&gt;::toLinear):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56dc8b5ab38e940f786e0fb00851104aa77c7b5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177655 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131001 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92098 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111513 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32455 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142441 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180255 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32979 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30681 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139438 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-images/gradient/gradient-eval-predefined-color-spaces.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139301 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150754 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106099 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27652 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114344 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40485 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5737 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->