### PR TITLE
webkitpy should share autoinstalled packages with primary checkout in workspace clones

### DIFF
--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -41,29 +41,50 @@ os.environ['SYSTEM_VERSION_COMPAT'] = '0'
 
 
 def _get_main_repo_autoinstall_path():
-    """If running in a git worktree, return the main repo's autoinstalled path.
-
-    This allows worktrees to share autoinstalled third-party packages with
-    the main repo, avoiding redundant downloads. Development libraries
-    (webkitcorepy, webkitscmpy, etc.) still come from the worktree itself.
-    """
+    """If running in a git worktree, return the main repo's autoinstalled path."""
     try:
-        # Get the common git directory (same for main repo and all worktrees)
         git_common_dir = subprocess.check_output(
             ['git', 'rev-parse', '--git-common-dir'],
             stderr=subprocess.DEVNULL,
             cwd=os.path.dirname(__file__)
         ).decode().strip()
 
-        # If we're in a worktree, git_common_dir points to main_repo/.git
-        # The main repo root is the parent of .git
         if git_common_dir and os.path.isdir(git_common_dir):
             main_repo_root = os.path.dirname(os.path.abspath(git_common_dir))
             main_autoinstall = os.path.join(main_repo_root, 'Tools', 'Scripts', 'libraries', 'autoinstalled')
-            # Only use if it exists and is writable
             if os.path.isdir(main_autoinstall) and os.access(main_autoinstall, os.W_OK):
                 return main_autoinstall
     except (subprocess.CalledProcessError, OSError, UnicodeDecodeError):
+        pass
+    return None
+
+
+def _get_workspace_clone_autoinstall_path():
+    """If running in a `git safari workspace create --clone` clone, return
+    the primary checkout's autoinstalled path."""
+    try:
+        import json as _json
+
+        scripts_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        this_root = os.path.dirname(os.path.dirname(scripts_dir))
+        this_name = os.path.basename(this_root)
+        parent_dir = os.path.dirname(this_root)
+
+        workspace_meta = os.path.join(parent_dir, '.workspace.json')
+        if not os.path.isfile(workspace_meta):
+            return None
+
+        with open(workspace_meta) as f:
+            meta = _json.load(f)
+        if meta.get('mode') != 'clone' or this_name not in meta.get('repos', {}):
+            return None
+
+        volume_root = os.path.dirname(os.path.dirname(parent_dir))
+        primary_autoinstall = os.path.join(
+            volume_root, this_name, 'Tools', 'Scripts', 'libraries', 'autoinstalled')
+        if os.path.isdir(primary_autoinstall) and os.access(primary_autoinstall, os.W_OK):
+            return primary_autoinstall
+    except (OSError, ValueError, KeyError, IOError):
         pass
     return None
 
@@ -84,8 +105,10 @@ if sys.platform == 'darwin':
 
 from webkitcorepy import AutoInstall, Package, Version
 
-# If in a git worktree, share autoinstalled packages with main repo
-autoinstall_base = _get_main_repo_autoinstall_path() or os.path.join(libraries, 'autoinstalled')
+# If in a git worktree or a `git safari workspace --clone` clone, share
+# autoinstalled packages with the main/primary checkout instead of
+# re-downloading them; otherwise fall back to this checkout's own directory.
+autoinstall_base = _get_main_repo_autoinstall_path() or _get_workspace_clone_autoinstall_path() or os.path.join(libraries, 'autoinstalled')
 AutoInstall.set_directory(os.path.join(autoinstall_base, 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
 
 AutoInstall.register(Package('pylint', Version(2, 13, 9)))


### PR DESCRIPTION
#### c3a0970edcc46f488786dc64ce8e29d05cbcb0fb
<pre>
webkitpy should share autoinstalled packages with primary checkout in workspace clones
<a href="https://bugs.webkit.org/show_bug.cgi?id=317003">https://bugs.webkit.org/show_bug.cgi?id=317003</a>
<a href="https://rdar.apple.com/179502211">rdar://179502211</a>

Reviewed by NOBODY (OOPS!).

When running from a `git safari workspace create --clone` APFS clone,
webkitpy redundantly downloads autoinstalled packages instead of sharing
them with the primary checkout. Add _get_workspace_clone_autoinstall_path()
which reads .workspace.json metadata to locate the primary repo&apos;s
autoinstalled directory.

* Tools/Scripts/webkitpy/__init__.py:
(_get_main_repo_autoinstall_path):
(_get_workspace_clone_autoinstall_path):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3a0970edcc46f488786dc64ce8e29d05cbcb0fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125847 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b69117e-28ce-47e5-9178-2178ed763e54) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130841 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91967 "3 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9be62489-d759-4a4b-ab9b-01e96cdbc693) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111353 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3046e9c7-4dba-48be-9b5d-148bed655c7e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/167467 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32303 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31002 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26170 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142289 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180074 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139276 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/167546 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139142 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42403 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105766 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27476 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40907 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40304 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5572 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->