### PR TITLE
MediaSource text-track removal loop always processes the last track

### DIFF
--- a/LayoutTests/media/media-source/media-source-detach-removes-all-text-tracks-expected.txt
+++ b/LayoutTests/media/media-source/media-source-detach-removes-all-text-tracks-expected.txt
@@ -1,0 +1,10 @@
+
+EXPECTED (source.detachable == 'true') OK
+RUN(video.srcObject = source)
+EVENT(sourceopen)
+EVENT(updateend)
+EXPECTED (video.textTracks.length == '2') OK
+RUN(video.srcObject = null)
+EXPECTED (removetrackCount == '2') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-detach-removes-all-text-tracks.html
+++ b/LayoutTests/media/media-source/media-source-detach-removes-all-text-tracks.html
@@ -1,0 +1,46 @@
+<!-- webkit-test-runner [ DetachableMediaSourceEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var removetrackCount = 0;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    async function runTest() {
+        findMediaElement();
+
+        source = new MediaSource({ detachable: true });
+        testExpected('source.detachable', true);
+
+        run('video.srcObject = source');
+        await waitFor(source, 'sourceopen');
+
+        let sourceBuffer = source.addSourceBuffer('video/mock; codecs=mock');
+        sourceBuffer.appendBuffer(makeAInit(8, [
+            makeATrack(1, 'mock', TRACK_KIND.VIDEO),
+            makeATrack(2, 'mock', TRACK_KIND.TEXT),
+            makeATrack(3, 'mock', TRACK_KIND.TEXT),
+        ]));
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('video.textTracks.length', 2);
+
+        video.textTracks.addEventListener('removetrack', () => { ++removetrackCount; });
+        run('video.srcObject = null');
+
+        for (let i = 0; i < 20 && removetrackCount < 2; ++i)
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+        testExpected('removetrackCount', 2);
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest().catch(failTest)">
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1098,7 +1098,7 @@ void MediaSource::removeSourceBufferWithOptionalDestruction(SourceBuffer& buffer
 
             // 9.3 For each TextTrack object in the SourceBuffer textTracks list, run the following steps:
             for (ssize_t index = textTracks->length() - 1; index >= 0; index--) {
-                Ref track = *textTracks->lastItem();
+                Ref track = *textTracks->item(index);
 
                 if (withDestruction) {
                     // 9.3.1 Set the sourceBuffer attribute on the TextTrack object to null.


### PR DESCRIPTION
#### 1be54df8bbe887e9faaaf4a9bfe18565f48af0e2
<pre>
MediaSource text-track removal loop always processes the last track
<a href="https://bugs.webkit.org/show_bug.cgi?id=317015">https://bugs.webkit.org/show_bug.cgi?id=317015</a>
<a href="https://rdar.apple.com/179508398">rdar://179508398</a>

Reviewed by Eric Carlson.

The text-track loop read &quot;*textTracks-&gt;lastItem()&quot; instead of indexing with the loop variable like
the audio and video loops (&quot;item(index)&quot;). On the detach path (withDestruction == false) the list is
never shrunk, so lastItem() returns the same final track on every iteration Index by the loop
variable.

Test: media/media-source/media-source-detach-removes-all-text-tracks.html

* LayoutTests/media/media-source/media-source-detach-removes-all-text-tracks-expected.txt: Added.
* LayoutTests/media/media-source/media-source-detach-removes-all-text-tracks.html: Added.
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::removeSourceBufferWithOptionalDestruction):

Canonical link: <a href="https://commits.webkit.org/315310@main">https://commits.webkit.org/315310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dacf5cd184daacd44517aec3dcf092dd232ece86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168154 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41701 "Hash dacf5cd1 for PR 67082 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125855 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96462406-a546-4d5c-8321-33f604d3115c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130848 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91973 "1 flakes 5 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b87cf18a-998c-4b48-a5eb-928207793b23) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111360 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76f90ce5-25d6-42c6-873b-5c19858fe752) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32307 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31009 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180082 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32805 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35168 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139283 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139149 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42411 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27488 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105774 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25689 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34439 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114171 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40915 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5584 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40312 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40563 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->