### PR TITLE
[Automatic Password Upgrades] Web process sometimes crashes when mapping stale node ID to JS handle

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1589,22 +1589,28 @@ String WebFrame::frameTextForTesting(bool includeSubframes)
     return builder.toString();
 }
 
-static Ref<WebKitJSHandle> createJSHandle(Node& node)
+static RefPtr<WebKitJSHandle> createJSHandle(Node& node)
 {
     Ref document = node.document();
     auto* lexicalGlobalObject = document->globalObject();
+    if (!lexicalGlobalObject)
+        return { };
+
     RELEASE_ASSERT(lexicalGlobalObject->template inherits<JSDOMGlobalObject>());
     auto* domGlobalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
     JSC::JSLockHolder locker { lexicalGlobalObject };
     return WebKitJSHandle::create(toJS(lexicalGlobalObject, domGlobalObject, node).toObject(lexicalGlobalObject));
 }
 
-std::pair<Ref<WebKitJSHandle>, JSHandleInfo> WebFrame::createAndPrepareToSendJSHandle(Node& node) const
+std::optional<std::pair<Ref<WebKitJSHandle>, JSHandleInfo>> WebFrame::createAndPrepareToSendJSHandle(Node& node) const
 {
-    Ref handle = createJSHandle(node);
+    RefPtr handle = createJSHandle(node);
+    if (!handle)
+        return std::nullopt;
+
     WebKitJSHandle::jsHandleSentToAnotherProcess(handle->identifier());
     JSHandleInfo handleInfo { handle->identifier(), pageContentWorldIdentifier(), info(), handle->windowFrameIdentifier() };
-    return { WTF::move(handle), WTF::move(handleInfo) };
+    return { { handle.releaseNonNull(), WTF::move(handleInfo) } };
 }
 
 WebFrame* WebFrame::webFrame(std::optional<WebCore::FrameIdentifier> frameID)
@@ -1811,8 +1817,11 @@ void WebFrame::requestJSHandleForExtractedText(TextExtraction::ExtractedText&& e
     if (!element)
         return completion({ });
 
-    auto [handle, info] = createAndPrepareToSendJSHandle(*element);
-    completion({ WTF::move(info) });
+    auto handleAndInfo = createAndPrepareToSendJSHandle(*element);
+    if (!handleAndInfo)
+        return completion({ });
+
+    completion({ WTF::move(handleAndInfo->second) });
 }
 
 void WebFrame::requestContainerJSHandleForExtractedText(TextExtraction::ExtractedText&& extractedText, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&& completion)
@@ -1825,8 +1834,11 @@ void WebFrame::requestContainerJSHandleForExtractedText(TextExtraction::Extracte
     if (!element)
         return completion({ });
 
-    auto [handle, info] = createAndPrepareToSendJSHandle(*element);
-    completion({ WTF::move(info) });
+    auto handleAndInfo = createAndPrepareToSendJSHandle(*element);
+    if (!handleAndInfo)
+        return completion({ });
+
+    completion({ WTF::move(handleAndInfo->second) });
 }
 
 void WebFrame::requestContainerJSHandleForSearchTexts(Vector<String>&& searchTexts, std::optional<NodeIdentifier>&& targetNodeIdentifier, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&& completion)
@@ -1839,8 +1851,11 @@ void WebFrame::requestContainerJSHandleForSearchTexts(Vector<String>&& searchTex
     if (!element)
         return completion({ });
 
-    auto [handle, info] = createAndPrepareToSendJSHandle(*element);
-    completion({ WTF::move(info) });
+    auto handleAndInfo = createAndPrepareToSendJSHandle(*element);
+    if (!handleAndInfo)
+        return completion({ });
+
+    completion({ WTF::move(handleAndInfo->second) });
 }
 
 void WebFrame::getSelectorPathsForNode(JSHandleInfo&& handle, CompletionHandler<void(Vector<HashSet<String>>&&)>&& completion)
@@ -1870,8 +1885,11 @@ void WebFrame::getNodeForSelectorPaths(Vector<HashSet<String>>&& selectors, Comp
     if (!element)
         return completion({ });
 
-    auto [handle, info] = createAndPrepareToSendJSHandle(*element);
-    completion({ WTF::move(info) });
+    auto handleAndInfo = createAndPrepareToSendJSHandle(*element);
+    if (!handleAndInfo)
+        return completion({ });
+
+    completion({ WTF::move(handleAndInfo->second) });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -271,7 +271,7 @@ public:
 
     String frameTextForTesting(bool);
 
-    std::pair<Ref<WebCore::WebKitJSHandle>, JSHandleInfo> createAndPrepareToSendJSHandle(WebCore::Node&) const;
+    std::optional<std::pair<Ref<WebCore::WebKitJSHandle>, JSHandleInfo>> createAndPrepareToSendJSHandle(WebCore::Node&) const;
 
     void markAsRemovedInAnotherProcess() { m_wasRemovedInAnotherProcess = true; }
     bool wasRemovedInAnotherProcess() const { return m_wasRemovedInAnotherProcess; }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10422,8 +10422,11 @@ void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoi
     if (!nodeWebFrame)
         return completionHandler({ });
 
-    auto [handle, info] = nodeWebFrame->createAndPrepareToSendJSHandle(*node);
-    completionHandler({ WTF::move(info) });
+    auto handleAndInfo = nodeWebFrame->createAndPrepareToSendJSHandle(*node);
+    if (!handleAndInfo)
+        return completionHandler({ });
+
+    completionHandler({ WTF::move(handleAndInfo->second) });
 }
 
 void WebPage::adjustVisibilityForTargetedElements(Vector<TargetedElementAdjustment>&& adjustments, CompletionHandler<void(bool)>&& completion)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -950,6 +950,48 @@ TEST(TextExtractionTests, RequestContainerJSHandleForSearchTextsFallsBackToBodyW
     EXPECT_FALSE([debugText containsString:@"Customer Reviews"]);
 }
 
+TEST(TextExtractionTests, RequestJSHandleForNodeInDetachedSubframe)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    __block RetainPtr subframes = adoptNS([NSMutableArray new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate setDidCommitLoadWithRequestInFrame:^(WKWebView *, NSURLRequest *, WKFrameInfo *frame) {
+        if (!frame.mainFrame && ![frame.request.URL.scheme isEqualToString:@"about"])
+            [subframes addObject:frame];
+    }];
+    [webView setNavigationDelegate:navigationDelegate];
+
+    [webView loadHTMLString:@"<h1>Subframe</h1> <iframe id='child' srcdoc=\"<button id='target'>subframe target</p>\"></iframe>" baseURL:nil];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    Util::waitForConditionWithLogging([webView] {
+        return [[webView objectByEvaluatingJavaScript:@"!!document.getElementById('child').contentDocument && document.getElementById('child').contentDocument.readyState === 'complete'"] boolValue];
+    }, 3, @"Expected subframe to finish loading.");
+
+    RetainPtr extractionResult = [webView synchronouslyExtractDebugTextResult:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setAdditionalFrames:subframes];
+        return configuration.autorelease();
+    }()];
+
+    RetainPtr buttonIdentifier = extractNodeIdentifier([extractionResult textContent], @"subframe target");
+    EXPECT_NOT_NULL(buttonIdentifier);
+
+    [webView objectByEvaluatingJavaScript:@"document.querySelector('iframe').remove()"];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr buttonHandle = [extractionResult jsHandleForNodeIdentifier:buttonIdentifier searchText:nil];
+    EXPECT_NULL(buttonHandle);
+
+    RetainPtr headingText = [webView stringByEvaluatingJavaScript:@"document.querySelector('h1').textContent"];
+    EXPECT_WK_STREQ(@"Subframe", headingText);
+}
+
 TEST(TextExtractionTests, ResolveTargetNodeFromSelectorData)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 67f1900d8045336f14fcfa70940ea97fbb22b6f1
<pre>
[Automatic Password Upgrades] Web process sometimes crashes when mapping stale node ID to JS handle
<a href="https://bugs.webkit.org/show_bug.cgi?id=317014">https://bugs.webkit.org/show_bug.cgi?id=317014</a>
<a href="https://rdar.apple.com/179507309">rdar://179507309</a>

Reviewed by Abrar Rahman Protyasha.

Add a missing null check for the document&apos;s `globalObject`, before attempting to resolve it to a
node handle.

Test: TextExtractionTests.RequestJSHandleForNodeInDetachedSubframe

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::createJSHandle):
(WebKit::WebFrame::createAndPrepareToSendJSHandle const):
(WebKit::WebFrame::requestJSHandleForExtractedText):
(WebKit::WebFrame::requestContainerJSHandleForExtractedText):
(WebKit::WebFrame::requestContainerJSHandleForSearchTexts):
(WebKit::WebFrame::getNodeForSelectorPaths):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hitTestAtPoint):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::RequestJSHandleForNodeInDetachedSubframe)):

Canonical link: <a href="https://commits.webkit.org/315150@main">https://commits.webkit.org/315150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2377ee33d177323ed6629c2ff68371afc6e30211

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41726 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35292 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125872 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95806581-397e-4787-adae-480ba3401c38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130864 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23d9b513-bf2b-4b4c-9406-a0760b5a016b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111376 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f21afb1-dd7c-4f6d-be49-0326e94a558a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32319 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31022 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26195 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142305 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180099 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139301 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41740 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139165 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37489 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42428 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105802 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34453 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27499 "Unexpected infrastructure issue, retrying build") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40329 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5595 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40474 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->