### PR TITLE
isValidVideoFrameBufferInit() tests displayWidth/Height presence against itself

### DIFF
--- a/LayoutTests/fast/webcodecs/video-frame-zero-display-size-expected.txt
+++ b/LayoutTests/fast/webcodecs/video-frame-zero-display-size-expected.txt
@@ -1,0 +1,12 @@
+Tests that VideoFrame construction rejects a zero displayWidth or displayHeight with a TypeError.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS new VideoFrame(data, makeInit({ displayWidth: 0, displayHeight: 2 })) threw exception TypeError: buffer init is not valid.
+PASS new VideoFrame(data, makeInit({ displayWidth: 2, displayHeight: 0 })) threw exception TypeError: buffer init is not valid.
+PASS new VideoFrame(data, makeInit({ displayWidth: 2, displayHeight: 2 })).close() did not throw exception.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webcodecs/video-frame-zero-display-size.html
+++ b/LayoutTests/fast/webcodecs/video-frame-zero-display-size.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that VideoFrame construction rejects a zero displayWidth or displayHeight with a TypeError.");
+
+const data = new Uint8Array(6);
+function makeInit(extra)
+{
+    return Object.assign({ format: "I420", codedWidth: 2, codedHeight: 2, timestamp: 0 }, extra);
+}
+
+shouldThrowErrorName("new VideoFrame(data, makeInit({ displayWidth: 0, displayHeight: 2 }))", "TypeError");
+shouldThrowErrorName("new VideoFrame(data, makeInit({ displayWidth: 2, displayHeight: 0 }))", "TypeError");
+
+shouldNotThrow("new VideoFrame(data, makeInit({ displayWidth: 2, displayHeight: 2 })).close()");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
@@ -54,9 +54,9 @@ bool isValidVideoFrameBufferInit(const WebCodecsVideoFrame::BufferInit& init)
             return false;
     }
 
-    if (init.displayWidth && !init.displayWidth)
+    if (init.displayWidth && !*init.displayWidth)
         return false;
-    if (init.displayHeight && !init.displayHeight)
+    if (init.displayHeight && !*init.displayHeight)
         return false;
     return true;
 }


### PR DESCRIPTION
#### 25570b9123de10c7a7035d9aa7a1b584abb25fc6
<pre>
isValidVideoFrameBufferInit() tests displayWidth/Height presence against itself
<a href="https://bugs.webkit.org/show_bug.cgi?id=317028">https://bugs.webkit.org/show_bug.cgi?id=317028</a>
<a href="https://rdar.apple.com/179514279">rdar://179514279</a>

Reviewed by Jean-Yves Avenard.

&quot;init.displayWidth &amp;&amp; !init.displayWidth&quot; is has_value() &amp;&amp; !has_value(), always false, so the
zero-dimension rejection was dead code. Dereference the optional (&quot;!*init.displayWidth&quot;) to reject
a zero displayWidth/displayHeight, matching validateVideoFrameInit and the spec&apos;s
valid-VideoFrameBufferInit check.

Test: fast/webcodecs/video-frame-zero-display-size.html
* LayoutTests/fast/webcodecs/video-frame-zero-display-size-expected.txt: Added.
* LayoutTests/fast/webcodecs/video-frame-zero-display-size.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp:
(WebCore::isValidVideoFrameBufferInit):

Canonical link: <a href="https://commits.webkit.org/315401@main">https://commits.webkit.org/315401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e1897330802053d3e5a159bc20b4ff595f679b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41731 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35318 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125877 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26dbc727-ee17-4e62-90a5-fba58a5f5114) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130867 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91988 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40c01008-4051-4426-8423-182f94e8520b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111379 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e042b303-1f9d-49c6-857f-9ce484348fb7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32320 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31027 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26200 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180104 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32827 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35186 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139304 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139167 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42433 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27515 "Unexpected infrastructure issue, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105807 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34454 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114193 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40937 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5611 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40334 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->