### PR TITLE
[macOS Golden Gate] Add pull-to-refresh functionality in MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -27,6 +27,9 @@
 
 #import "AppDelegate.h"
 #import "SettingsController.h"
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 270000
+#import <AppKit/NSRefreshController.h>
+#endif
 #import <PDFKit/PDFDocument.h>
 #import <QuartzCore/CATextLayer.h>
 #import <SecurityInterface/SFCertificateTrustPanel.h>
@@ -118,6 +121,10 @@ static const int testFooterBannerHeight = 58;
     BOOL _usingFindDelegate;
 
     CATextLayer *_pointerLockBanner;
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 270000
+    NSRefreshController *_refreshController;
+#endif
 }
 
 - (void)awakeFromNib
@@ -163,6 +170,13 @@ static const int testFooterBannerHeight = 58;
     _webView._usePlatformFindUI = NO;
 
     _zoomTextOnly = NO;
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 270000
+    _refreshController = [[NSRefreshController alloc] init];
+    _refreshController.target = self;
+    _refreshController.action = @selector(_refreshControllerActivated:);
+    _webView.refreshController = _refreshController;
+#endif
 }
 
 - (id)windowWillReturnFieldEditor:(NSWindow *)sender toObject:(id)client
@@ -386,6 +400,14 @@ static BOOL areEssentiallyEqual(double a, double b)
 {
     [_webView reload];
 }
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 270000
+- (void)_refreshControllerActivated:(NSRefreshController *)refreshController
+{
+    [_webView reload];
+    [refreshController performSelector:@selector(endRefreshing) withObject:nil afterDelay:2.5];
+}
+#endif
 
 - (IBAction)showCertificate:(id)sender
 {
@@ -966,6 +988,9 @@ static BOOL isJavaScriptURL(NSURL *url)
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
     LOG(@"didFinishNavigation: %@", navigation);
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 270000
+    [_refreshController endRefreshing];
+#endif
 }
 
 - (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *__nullable credential))completionHandler


### PR DESCRIPTION
#### ea32ddc204f955300c0e2bb6cb8d4c728c0f71ea
<pre>
[macOS Golden Gate] Add pull-to-refresh functionality in MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=317016">https://bugs.webkit.org/show_bug.cgi?id=317016</a>
<a href="https://rdar.apple.com/179508777">rdar://179508777</a>

Reviewed by Lily Spiniolas, Megan Gardner, and Zak Ridouh.

This patch is a primitive adoption of NSRefreshController in MiniBrowser.

* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController awakeFromNib]):
(-[WK2BrowserWindowController _refreshControllerActivated:]):
(-[WK2BrowserWindowController webView:didFinishNavigation:]):

Canonical link: <a href="https://commits.webkit.org/315650@main">https://commits.webkit.org/315650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f0aa74c963ed0779133e733e89f451de0071366

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169651 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127363 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f860dd4-18f0-49f1-aab2-6fee612c5f25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171517 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43202 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a5e0b21-e82b-4b50-89cc-f7346f2ebebd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172610 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112702 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d780fd2e-f0b4-479a-9af7-25f9456e692c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27707 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/985 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181609 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36503 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43229 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140484 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43918 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108152 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25847 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35749 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42428 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42076 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41964 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->