### PR TITLE
Use default member initializers for legacy SVG renderer data members

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -52,8 +52,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyRenderSVGImage);
 
 LegacyRenderSVGImage::LegacyRenderSVGImage(SVGImageElement& element, Style::ComputedStyle&& style)
     : LegacyRenderSVGModelObject(Type::LegacySVGImage, element, WTF::move(style), SVGModelObjectFlag::UsesBoundaryCaching)
-    , m_needsBoundariesUpdate(true)
-    , m_needsTransformUpdate(true)
     , m_imageResource(makeUniqueRef<RenderImageResource>())
 {
     imageResource().initialize(*this);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -85,8 +85,8 @@ private:
 
     AffineTransform localTransform() const override { return m_localTransform; }
 
-    bool m_needsBoundariesUpdate : 1;
-    bool m_needsTransformUpdate : 1;
+    bool m_needsBoundariesUpdate : 1 { true };
+    bool m_needsTransformUpdate : 1 { true };
     AffineTransform m_localTransform;
     FloatRect m_objectBoundingBox;
     FloatRect m_repaintBoundingBox;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -59,9 +59,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyRenderSVGShape);
 
 LegacyRenderSVGShape::LegacyRenderSVGShape(Type type, SVGGraphicsElement& element, Style::ComputedStyle&& style)
     : LegacyRenderSVGModelObject(type, element, WTF::move(style), { SVGModelObjectFlag::IsShape, SVGModelObjectFlag::UsesBoundaryCaching })
-    , m_needsBoundariesUpdate(false) // Default is false, the cached rects are empty from the beginning.
-    , m_needsShapeUpdate(true) // Default is true, so we grab a Path object once from SVGGraphicsElement.
-    , m_needsTransformUpdate(true) // Default is true, so we grab a AffineTransform object once from SVGGraphicsElement.
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -152,9 +152,9 @@ protected:
 private:
     FloatRect m_repaintBoundingBox;
 
-    bool m_needsBoundariesUpdate : 1;
-    bool m_needsShapeUpdate : 1;
-    bool m_needsTransformUpdate : 1;
+    bool m_needsBoundariesUpdate : 1 { false }; // Default is false, the cached rects are empty from the beginning.
+    bool m_needsShapeUpdate : 1 { true }; // Default is true, so we grab a Path object once from SVGGraphicsElement.
+    bool m_needsTransformUpdate : 1 { true }; // Default is true, so we grab a AffineTransform object once from SVGGraphicsElement.
     bool m_fillRequiresClip : 1 { true };
 protected:
     ShapeType m_shapeType : 3 { ShapeType::Empty };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -36,8 +36,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyRenderSVGTransformableContainer);
 
 LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer(SVGGraphicsElement& element, Style::ComputedStyle&& style)
     : LegacyRenderSVGContainer(Type::LegacySVGTransformableContainer, element, WTF::move(style))
-    , m_needsTransformUpdate(true)
-    , m_didTransformToRootUpdate(false)
 {
     ASSERT(isLegacyRenderSVGTransformableContainer());
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
@@ -47,8 +47,8 @@ private:
     bool calculateLocalTransform() override;
     AffineTransform localTransform() const override { return m_localTransform; }
 
-    bool m_needsTransformUpdate : 1;
-    bool m_didTransformToRootUpdate : 1;
+    bool m_needsTransformUpdate : 1 { true };
+    bool m_didTransformToRootUpdate : 1 { false };
     AffineTransform m_localTransform;
     FloatSize m_additionalTranslation;
     FloatRect m_lastTransformReferenceBoxRect;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
@@ -36,9 +36,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyRenderSVGViewportContainer);
 
 LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer(SVGSVGElement& element, Style::ComputedStyle&& style)
     : LegacyRenderSVGContainer(Type::LegacySVGViewportContainer, element, WTF::move(style))
-    , m_didTransformToRootUpdate(false)
-    , m_isLayoutSizeChanged(false)
-    , m_needsTransformUpdate(true)
 {
     ASSERT(isLegacyRenderSVGViewportContainer());
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
@@ -61,9 +61,9 @@ private:
     void applyViewportClip(PaintInfo&) override;
     bool pointIsInsideViewportClip(const FloatPoint& pointInParent) override;
 
-    bool m_didTransformToRootUpdate : 1;
-    bool m_isLayoutSizeChanged : 1;
-    bool m_needsTransformUpdate : 1;
+    bool m_didTransformToRootUpdate : 1 { false };
+    bool m_isLayoutSizeChanged : 1 { false };
+    bool m_needsTransformUpdate : 1 { true };
 
     FloatRect m_viewport;
     mutable AffineTransform m_localToParentTransform;


### PR DESCRIPTION
#### 8d6bcd2e959985063417002d39e007ffe5746d65
<pre>
Use default member initializers for legacy SVG renderer data members
<a href="https://bugs.webkit.org/show_bug.cgi?id=317029">https://bugs.webkit.org/show_bug.cgi?id=317029</a>
<a href="https://rdar.apple.com/179514435">rdar://179514435</a>

Reviewed by Dan Glastonbury.

Move the constant-literal member initializers for the bitfield flags in the
legacy SVG renderers out of the constructor initializer lists and into header
default member initializers, following the pattern of the recent Table Layout,
RenderFrameSet, RenderLayoutState, and RenderEmbeddedObject cleanups. The
initial values are unchanged; this is a no-behavior-change refactor.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::LegacyRenderSVGImage):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::LegacyRenderSVGShape):
(WebCore::m_needsTransformUpdate): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp:
(WebCore::LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h:

Canonical link: <a href="https://commits.webkit.org/315194@main">https://commits.webkit.org/315194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9815585514263b13e0baf99833c9b07d557bcc8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125879 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d18b5e3-cabb-4a46-8360-28d2dbc215a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130869 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91987 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6867ab61-05d2-4fae-9bad-4544050890b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111381 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f466950-2ab4-408d-bb14-420c024bb5f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32322 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31028 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26202 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142308 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180106 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139307 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41747 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35187 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139170 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37517 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42435 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105809 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34457 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27503 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114195 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40336 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5599 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40587 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40481 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->