### PR TITLE
Web Inspector: `Network.setExtraHTTPHeaders` does not affect `WebSocket`

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/echo-headers_wsh.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/echo-headers_wsh.py
@@ -1,0 +1,12 @@
+from pywebsocket3 import msgutil
+
+
+def web_socket_do_extra_handshake(request):
+    pass  # Always accept.
+
+
+def web_socket_transfer_data(request):
+    # Echo the value of a header named by the client back to it.
+    header_name = msgutil.receive_message(request)
+    header_value = request.headers_in.get(header_name, "")
+    msgutil.send_message(request, header_value)

--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/set-extra-http-headers-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/set-extra-http-headers-expected.txt
@@ -1,0 +1,9 @@
+Tests for Network.setExtraHTTPHeaders.
+
+
+== Running test suite: Network.setExtraHTTPHeaders
+-- Running test case: Network.setExtraHTTPHeaders.WebSocket.Request
+PASS: Resource should be a WebSocket.
+PASS: Resource request headers should include "X-WebKit-Test-Extra-Header: TestValue123".
+PASS: Server should have received header "X-WebKit-Test-Extra-Header" with value "TestValue123".
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/set-extra-http-headers.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/set-extra-http-headers.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../../../inspector/resources/inspector-test.js"></script>
+<script>
+function createWebSocketConnection()
+{
+    let webSocket = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/inspector/echo-headers");
+    webSocket.addEventListener("open", () => {
+        webSocket.send("X-WebKit-Test-Extra-Header");
+    });
+    webSocket.addEventListener("message", (event) => {
+        TestPage.dispatchEventToFrontend("InspectedPage_WebSocket_Message", event.data);
+        webSocket.close();
+    });
+}
+
+function test()
+{
+    const headerName = "X-WebKit-Test-Extra-Header";
+    const headerValue = "TestValue123";
+
+    let suite = InspectorTest.createAsyncSuite("Network.setExtraHTTPHeaders");
+
+    suite.addTestCase({
+        name: "Network.setExtraHTTPHeaders.WebSocket.Request",
+        description: "Headers set via Network.setExtraHTTPHeaders should be included in the WebSocket handshake request.",
+        async test() {
+            await NetworkAgent.setExtraHTTPHeaders({[headerName]: headerValue});
+
+            let [resourceWasAddedEvent, inspectedPageWebSocketMessageEvent] = await Promise.all([
+                WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded),
+                InspectorTest.awaitEvent("InspectedPage_WebSocket_Message"),
+                InspectorTest.evaluateInPage(`createWebSocketConnection()`),
+            ]);
+
+            let webSocketResource = resourceWasAddedEvent.data.resource;
+            InspectorTest.expectThat(webSocketResource instanceof WI.WebSocketResource, "Resource should be a WebSocket.");
+            InspectorTest.expectEqual(webSocketResource.requestHeaders.valueForCaseInsensitiveKey(headerName), headerValue, `Resource request headers should include "${headerName}: ${headerValue}".`);
+
+            let echoedHeaderValue = inspectedPageWebSocketMessageEvent.data;
+            InspectorTest.expectEqual(echoedHeaderValue, headerValue, `Server should have received header "${headerName}" with value "${headerValue}".`);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for Network.setExtraHTTPHeaders.</p>
+</body>
+</html>

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp
@@ -48,10 +48,16 @@ void WebSocketChannelInspector::didCreateWebSocket(const URL& url) const
         InspectorInstrumentation::didCreateWebSocket(document.get(), m_progressIdentifier, url);
 }
 
-void WebSocketChannelInspector::willSendWebSocketHandshakeRequest(const ResourceRequest& request) const
+void WebSocketChannelInspector::willSendWebSocketHandshakeRequest(ResourceRequest& request) const
 {
     if (RefPtr document = m_document.get())
         InspectorInstrumentation::willSendWebSocketHandshakeRequest(document.get(), m_progressIdentifier, request);
+}
+
+void WebSocketChannelInspector::didSendWebSocketHandshakeRequest(const ResourceRequest& request) const
+{
+    if (RefPtr document = m_document.get())
+        InspectorInstrumentation::didSendWebSocketHandshakeRequest(document.get(), m_progressIdentifier, request);
 }
 
 void WebSocketChannelInspector::didReceiveWebSocketHandshakeResponse(const ResourceResponse& response) const

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
@@ -47,7 +47,8 @@ public:
     ~WebSocketChannelInspector();
 
     void didCreateWebSocket(const URL&) const;
-    void willSendWebSocketHandshakeRequest(const ResourceRequest&) const;
+    void willSendWebSocketHandshakeRequest(ResourceRequest&) const;
+    void didSendWebSocketHandshakeRequest(const ResourceRequest&) const;
     void didReceiveWebSocketHandshakeResponse(const ResourceResponse&) const;
     void didCloseWebSocket() const;
     void didReceiveWebSocketFrame(const WebSocketFrame&) const;

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -56,6 +56,7 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/ParsingUtilities.h>
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/WTFString.h>
@@ -162,6 +163,41 @@ String WebSocketHandshake::clientLocation() const
     return makeString(m_secure ? "wss"_s : "ws"_s, "://"_s, hostName(m_url, m_secure), resourceName(m_url));
 }
 
+static bool isStandardWebSocketHandshakeRequestHeader(HTTPHeaderName name)
+{
+    switch (name) {
+    case HTTPHeaderName::Upgrade:
+    case HTTPHeaderName::Connection:
+    case HTTPHeaderName::Host:
+    case HTTPHeaderName::Origin:
+    case HTTPHeaderName::SecWebSocketProtocol:
+    case HTTPHeaderName::SecWebSocketKey:
+    case HTTPHeaderName::SecWebSocketVersion:
+    case HTTPHeaderName::SecWebSocketExtensions:
+    case HTTPHeaderName::Pragma:
+    case HTTPHeaderName::CacheControl:
+    case HTTPHeaderName::UserAgent:
+    case HTTPHeaderName::Cookie:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void WebSocketHandshake::setClientHandshakeRequestHeaders(const HTTPHeaderMap& headers)
+{
+    HTTPHeaderMap filtered;
+    for (const auto& header : headers) {
+        if (auto httpHeaderName = header.keyAsHTTPHeaderName) {
+            if (isStandardWebSocketHandshakeRequestHeader(*httpHeaderName))
+                continue;
+            filtered.set(*httpHeaderName, header.value);
+        } else
+            filtered.setUncommonHeader(header.key, header.value);
+    }
+    m_clientHandshakeRequestHeaders = WTF::move(filtered);
+}
+
 CString WebSocketHandshake::clientHandshakeMessage() const
 {
     // Keep the following consistent with clientHandshakeRequest just below.
@@ -172,6 +208,10 @@ CString WebSocketHandshake::clientHandshakeMessage() const
     // Add no-cache headers to avoid a compatibility issue. There are some proxies that
     // rewrite "Connection: upgrade" to "Connection: close" in the response if a request
     // doesn't contain these headers.
+
+    StringBuilder extraHeaders;
+    for (const auto& header : m_clientHandshakeRequestHeaders)
+        extraHeaders.append(header.key, ": "_s, header.value, "\r\n"_s);
 
     auto extensions = m_extensionDispatcher.createHeaderValue();
     return makeString("GET "_s, resourceName(m_url), " HTTP/1.1\r\n"
@@ -185,7 +225,8 @@ CString WebSocketHandshake::clientHandshakeMessage() const
         "Sec-WebSocket-Key: "_s, m_secWebSocketKey, "\r\n"
         "Sec-WebSocket-Version: 13\r\n"_s,
         extensions.isEmpty() ? ""_s : "Sec-WebSocket-Extensions: "_s, extensions, extensions.isEmpty() ? ""_s : "\r\n"_s,
-        "User-Agent: "_s, m_userAgent, "\r\n"
+        "User-Agent: "_s, m_userAgent, "\r\n"_s,
+        extraHeaders.toString(),
         "\r\n"_s).utf8();
 }
 
@@ -213,6 +254,12 @@ ResourceRequest WebSocketHandshake::clientHandshakeRequest(NOESCAPE const Functi
         request.setHTTPHeaderField(HTTPHeaderName::SecWebSocketExtensions, extensions);
     request.setHTTPUserAgent(m_userAgent);
     request.setIsAppInitiated(m_isAppInitiated);
+    for (const auto& header : m_clientHandshakeRequestHeaders) {
+        if (auto httpHeaderName = header.keyAsHTTPHeaderName)
+            request.setHTTPHeaderField(*httpHeaderName, header.value);
+        else
+            request.setHTTPHeaderField(header.key, header.value);
+    }
     return request;
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.h
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <WebCore/CookieRequestHeaderFieldProxy.h>
+#include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/WebSocketExtensionDispatcher.h>
 #include <WebCore/WebSocketExtensionProcessor.h>
@@ -68,6 +69,8 @@ public:
 
     WEBCORE_EXPORT CString clientHandshakeMessage() const;
     WEBCORE_EXPORT ResourceRequest clientHandshakeRequest(NOESCAPE const Function<String(const URL&)>& cookieRequestHeaderFieldValue) const;
+
+    WEBCORE_EXPORT void setClientHandshakeRequestHeaders(const HTTPHeaderMap&);
 
     WEBCORE_EXPORT void reset();
 
@@ -106,6 +109,8 @@ private:
     String m_clientOrigin;
     bool m_allowCookies;
     bool m_isAppInitiated;
+
+    HTTPHeaderMap m_clientHandshakeRequestHeaders;
 
     ResourceResponse m_serverHandshakeResponse;
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1166,10 +1166,16 @@ void InspectorInstrumentation::didCreateWebSocketImpl(InstrumentingAgents& instr
         networkAgent->didCreateWebSocket(identifier, requestURL);
 }
 
-void InspectorInstrumentation::willSendWebSocketHandshakeRequestImpl(InstrumentingAgents& instrumentingAgents, WebSocketChannelIdentifier identifier, const ResourceRequest& request)
+void InspectorInstrumentation::willSendWebSocketHandshakeRequestImpl(InstrumentingAgents& instrumentingAgents, WebSocketChannelIdentifier identifier, ResourceRequest& request)
 {
     if (CheckedPtr networkAgent = instrumentingAgents.enabledNetworkAgent())
         networkAgent->willSendWebSocketHandshakeRequest(identifier, request);
+}
+
+void InspectorInstrumentation::didSendWebSocketHandshakeRequestImpl(InstrumentingAgents& instrumentingAgents, WebSocketChannelIdentifier identifier, const ResourceRequest& request)
+{
+    if (CheckedPtr networkAgent = instrumentingAgents.enabledNetworkAgent())
+        networkAgent->didSendWebSocketHandshakeRequest(identifier, request);
 }
 
 void InspectorInstrumentation::didReceiveWebSocketHandshakeResponseImpl(InstrumentingAgents& instrumentingAgents, WebSocketChannelIdentifier identifier, const ResourceResponse& response)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -302,7 +302,8 @@ public:
     static void workerTerminated(WorkerInspectorProxy&);
 
     static void didCreateWebSocket(Document*, WebSocketChannelIdentifier, const URL& requestURL);
-    static void willSendWebSocketHandshakeRequest(Document*, WebSocketChannelIdentifier, const ResourceRequest&);
+    static void willSendWebSocketHandshakeRequest(Document*, WebSocketChannelIdentifier, ResourceRequest&);
+    static void didSendWebSocketHandshakeRequest(Document*, WebSocketChannelIdentifier, const ResourceRequest&);
     static void didReceiveWebSocketHandshakeResponse(Document*, WebSocketChannelIdentifier, const ResourceResponse&);
     static void didCloseWebSocket(Document*, WebSocketChannelIdentifier);
     static void didReceiveWebSocketFrame(Document*, WebSocketChannelIdentifier, const WebSocketFrame&);
@@ -507,7 +508,8 @@ private:
     static void workerTerminatedImpl(InstrumentingAgents&, WorkerInspectorProxy&);
 
     static void didCreateWebSocketImpl(InstrumentingAgents&, WebSocketChannelIdentifier, const URL& requestURL);
-    static void willSendWebSocketHandshakeRequestImpl(InstrumentingAgents&, WebSocketChannelIdentifier, const ResourceRequest&);
+    static void willSendWebSocketHandshakeRequestImpl(InstrumentingAgents&, WebSocketChannelIdentifier, ResourceRequest&);
+    static void didSendWebSocketHandshakeRequestImpl(InstrumentingAgents&, WebSocketChannelIdentifier, const ResourceRequest&);
     static void didReceiveWebSocketHandshakeResponseImpl(InstrumentingAgents&, WebSocketChannelIdentifier, const ResourceResponse&);
     static void didCloseWebSocketImpl(InstrumentingAgents&, WebSocketChannelIdentifier);
     static void didReceiveWebSocketFrameImpl(InstrumentingAgents&, WebSocketChannelIdentifier, const WebSocketFrame&);
@@ -1373,11 +1375,18 @@ inline void InspectorInstrumentation::didCreateWebSocket(Document* document, Web
         didCreateWebSocketImpl(*agents, identifier, requestURL);
 }
 
-inline void InspectorInstrumentation::willSendWebSocketHandshakeRequest(Document* document, WebSocketChannelIdentifier identifier, const ResourceRequest& request)
+inline void InspectorInstrumentation::willSendWebSocketHandshakeRequest(Document* document, WebSocketChannelIdentifier identifier, ResourceRequest& request)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (RefPtr agents = instrumentingAgents(document))
         willSendWebSocketHandshakeRequestImpl(*agents, identifier, request);
+}
+
+inline void InspectorInstrumentation::didSendWebSocketHandshakeRequest(Document* document, WebSocketChannelIdentifier identifier, const ResourceRequest& request)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (RefPtr agents = instrumentingAgents(document))
+        didSendWebSocketHandshakeRequestImpl(*agents, identifier, request);
 }
 
 inline void InspectorInstrumentation::didReceiveWebSocketHandshakeResponse(Document* document, WebSocketChannelIdentifier identifier, const ResourceResponse& response)

--- a/Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.cpp
@@ -40,9 +40,14 @@ void LegacyWebSocketInspectorInstrumentation::didCreateWebSocket(Document* docum
     InspectorInstrumentation::didCreateWebSocket(document, identifier, requestURL);
 }
 
-void LegacyWebSocketInspectorInstrumentation::willSendWebSocketHandshakeRequest(Document* document, WebSocketChannelIdentifier identifier, const ResourceRequest& request)
+void LegacyWebSocketInspectorInstrumentation::willSendWebSocketHandshakeRequest(Document* document, WebSocketChannelIdentifier identifier, ResourceRequest& request)
 {
     InspectorInstrumentation::willSendWebSocketHandshakeRequest(document, identifier, request);
+}
+
+void LegacyWebSocketInspectorInstrumentation::didSendWebSocketHandshakeRequest(Document* document, WebSocketChannelIdentifier identifier, const ResourceRequest& request)
+{
+    InspectorInstrumentation::didSendWebSocketHandshakeRequest(document, identifier, request);
 }
 
 void LegacyWebSocketInspectorInstrumentation::didReceiveWebSocketHandshakeResponse(Document* document, WebSocketChannelIdentifier identifier, const ResourceResponse& response)

--- a/Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h
+++ b/Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h
@@ -40,7 +40,8 @@ class WEBCORE_EXPORT LegacyWebSocketInspectorInstrumentation {
 public:
     static bool NODELETE hasFrontends();
     static void didCreateWebSocket(Document*, WebSocketChannelIdentifier, const URL& requestURL);
-    static void willSendWebSocketHandshakeRequest(Document*, WebSocketChannelIdentifier, const ResourceRequest&);
+    static void willSendWebSocketHandshakeRequest(Document*, WebSocketChannelIdentifier, ResourceRequest&);
+    static void didSendWebSocketHandshakeRequest(Document*, WebSocketChannelIdentifier, const ResourceRequest&);
     static void didReceiveWebSocketHandshakeResponse(Document*, WebSocketChannelIdentifier, const ResourceResponse&);
     static void didCloseWebSocket(Document*, WebSocketChannelIdentifier);
     static void didReceiveWebSocketFrame(Document*, WebSocketChannelIdentifier, const WebSocketFrame&);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -766,7 +766,13 @@ void InspectorNetworkAgent::didCreateWebSocket(WebSocketChannelIdentifier identi
     m_frontendDispatcher->webSocketCreated(IdentifiersFactory::requestId(identifier.toUInt64()), requestURL.string());
 }
 
-void InspectorNetworkAgent::willSendWebSocketHandshakeRequest(WebSocketChannelIdentifier identifier, const ResourceRequest& request)
+void InspectorNetworkAgent::willSendWebSocketHandshakeRequest(WebSocketChannelIdentifier, ResourceRequest& request)
+{
+    for (auto& entry : m_extraRequestHeaders)
+        request.setHTTPHeaderField(entry.key, entry.value);
+}
+
+void InspectorNetworkAgent::didSendWebSocketHandshakeRequest(WebSocketChannelIdentifier identifier, const ResourceRequest& request)
 {
     auto requestObject = Inspector::Protocol::Network::WebSocketRequest::create()
         .setHeaders(buildObjectForHeaders(request.httpHeaderFields()))
@@ -826,7 +832,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::enable()
                     return { };
                 return document->page()->cookieJar().cookieRequestHeaderFieldValue(*document, url);
             };
-            willSendWebSocketHandshakeRequest(identifier, channel->clientHandshakeRequest(WTF::move(cookieRequestHeaderFieldValue)));
+            didSendWebSocketHandshakeRequest(identifier, channel->clientHandshakeRequest(WTF::move(cookieRequestHeaderFieldValue)));
 
             if (channel->isConnected())
                 didReceiveWebSocketHandshakeResponse(identifier, channel->serverHandshakeResponse());

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.h
@@ -123,7 +123,8 @@ public:
     void didReceiveScriptResponse(ResourceLoaderIdentifier) override;
     void willDestroyCachedResource(CachedResource&) override;
     void didCreateWebSocket(WebSocketChannelIdentifier, const URL& requestURL);
-    void willSendWebSocketHandshakeRequest(WebSocketChannelIdentifier, const ResourceRequest&);
+    void willSendWebSocketHandshakeRequest(WebSocketChannelIdentifier, ResourceRequest&);
+    void didSendWebSocketHandshakeRequest(WebSocketChannelIdentifier, const ResourceRequest&);
     void didReceiveWebSocketHandshakeResponse(WebSocketChannelIdentifier, const ResourceResponse&);
     void didCloseWebSocket(WebSocketChannelIdentifier);
     void didReceiveWebSocketFrame(WebSocketChannelIdentifier, const WebSocketFrame&);

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -125,6 +125,7 @@ void WebSocketTask::didOpen(WebCore::CurlStreamID)
     m_handshake = makeUnique<WebCore::WebSocketHandshake>(m_request.url(), m_protocol, m_request.httpUserAgent(), m_request.httpHeaderField(WebCore::HTTPHeaderName::Origin), m_request.allowCookies(), false);
     m_handshake->reset();
     m_handshake->addExtensionProcessor(m_deflateFramer.createExtensionProcessor());
+    m_handshake->setClientHandshakeRequestHeaders(m_request.httpHeaderFields());
 
     String cookieHeaderField;
     if (m_request.allowCookies()) {

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -164,6 +164,7 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& url, const 
 
     m_inspector.didCreateWebSocket(url);
     m_url = request->url();
+    m_inspector.willSendWebSocketHandshakeRequest(*request);
     Ref mainFrame = frame->mainFrame();
 
     Ref policySourceFrame = [&] -> Ref<Frame> {
@@ -378,7 +379,7 @@ void WebSocketChannel::resume()
 
 void WebSocketChannel::didSendHandshakeRequest(ResourceRequest&& request)
 {
-    m_inspector.willSendWebSocketHandshakeRequest(request);
+    m_inspector.didSendWebSocketHandshakeRequest(request);
     m_handshakeRequest = WTF::move(request);
 }
 

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -268,7 +268,10 @@ void WebSocketChannel::didOpenSocketStream(SocketStreamHandle& handle)
                 return { };
             return document->page()->cookieJar().cookieRequestHeaderFieldValue(*document, url);
         };
-        LegacyWebSocketInspectorInstrumentation::willSendWebSocketHandshakeRequest(m_document.get(), m_progressIdentifier, m_handshake->clientHandshakeRequest(WTF::move(cookieRequestHeaderFieldValue)));
+        auto request = m_handshake->clientHandshakeRequest(WTF::move(cookieRequestHeaderFieldValue));
+        LegacyWebSocketInspectorInstrumentation::willSendWebSocketHandshakeRequest(m_document.get(), m_progressIdentifier, request);
+        m_handshake->setClientHandshakeRequestHeaders(request.httpHeaderFields());
+        LegacyWebSocketInspectorInstrumentation::didSendWebSocketHandshakeRequest(m_document.get(), m_progressIdentifier, request);
     }
     auto handshakeMessage = m_handshake->clientHandshakeMessage();
     std::optional<CookieRequestHeaderFieldProxy> cookieRequestHeaderFieldProxy;


### PR DESCRIPTION
#### 1e9d5a1b06504bb26ef17b263ff55dd0e47a53f2
<pre>
Web Inspector: `Network.setExtraHTTPHeaders` does not affect `WebSocket`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317001">https://bugs.webkit.org/show_bug.cgi?id=317001</a>

Reviewed by Youenn Fablet.

Test: http/tests/websocket/tests/hybi/inspector/set-extra-http-headers.html

* Source/WebCore/Modules/websockets/WebSocketHandshake.h:
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::isStandardWebSocketHandshakeRequestHeader): Added.
(WebCore::WebSocketHandshake::setClientHandshakeRequestHeaders): Added.
(WebCore::WebSocketHandshake::clientHandshakeMessage const):
(WebCore::WebSocketHandshake::clientHandshakeRequest const):
Allow the caller to set additional headers that will be included in the handshake message/request.

* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::didOpen):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::didOpenSocketStream):
Make sure to forward any additional headers.

* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::connect):
(WebKit::WebSocketChannel::didSendHandshakeRequest):
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.h:
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp:
(WebCore::WebSocketChannelInspector::willSendWebSocketHandshakeRequest const):
(WebCore::WebSocketChannelInspector::didSendWebSocketHandshakeRequest const): Added.
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::willSendWebSocketHandshakeRequest):
(WebCore::InspectorInstrumentation::didSendWebSocketHandshakeRequest): Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::willSendWebSocketHandshakeRequestImpl):
(WebCore::InspectorInstrumentation::didSendWebSocketHandshakeRequestImpl): Added.
* Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.h:
* Source/WebCore/inspector/LegacyWebSocketInspectorInstrumentation.cpp:
(WebCore::LegacyWebSocketInspectorInstrumentation::willSendWebSocketHandshakeRequest):
(WebCore::LegacyWebSocketInspectorInstrumentation::didSendWebSocketHandshakeRequest): Added.
* Source/WebCore/inspector/agents/InspectorNetworkAgent.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::willSendWebSocketHandshakeRequest):
(WebCore::InspectorNetworkAgent::didSendWebSocketHandshakeRequest): Added.
(WebCore::InspectorNetworkAgent::enable):
Rename the existing `willSendWebSocketHandshakeRequest` to `didSendWebSocketHandshakeRequest` since it actually instrumented after the request was sent.
Add a new `willSendWebSocketHandshakeRequest` that allows Web Inspector to modify the request before it is sent.

* LayoutTests/http/tests/websocket/tests/hybi/inspector/echo-headers_wsh.py: Added.
* LayoutTests/http/tests/websocket/tests/hybi/inspector/set-extra-http-headers.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/inspector/set-extra-http-headers-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/315465@main">https://commits.webkit.org/315465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ceb66f532ec2a501a69e8ef12eeb8dc09bd0303

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41743 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35307 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125888 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130879 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91996 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32331 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31038 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180115 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32838 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35197 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139315 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41756 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150624 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139178 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37674 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42444 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27511 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105818 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34474 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114204 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40948 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5607 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->