### PR TITLE
Remove dumpResourceResponseMIMETypes from InjectedBundle/TestRunner.h

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -138,7 +138,6 @@ public:
     void dumpTitleChanges() { m_dumpTitleChanges = true; }
     void dumpFrameLoadCallbacks() { setShouldDumpFrameLoadCallbacks(true); }
     void dumpProgressFinishedCallback() { setShouldDumpProgressFinishedCallback(true); }
-    void dumpResourceResponseMIMETypes(String&& types) { m_resourceResponseMIMETypesToDump = WTF::move(types); }
     void dumpWillCacheResponse() { m_dumpWillCacheResponse = true; }
     void dumpApplicationCacheDelegateCallbacks() { m_dumpApplicationCacheDelegateCallbacks = true; }
     void dumpDOMAsWebArchive() { setWhatToDump(WhatToDump::DOMAsWebArchive); }
@@ -230,7 +229,6 @@ public:
     bool shouldDumpPixels() const;
     bool shouldDumpFrameLoadCallbacks();
     bool shouldDumpProgressFinishedCallback() const { return m_dumpProgressFinishedCallback; }
-    const String& resourceResponseMIMETypesToDump() const { return m_resourceResponseMIMETypesToDump; }
     bool shouldDumpWillCacheResponse() const { return m_dumpWillCacheResponse; }
     bool shouldDumpApplicationCacheDelegateCallbacks() const { return m_dumpApplicationCacheDelegateCallbacks; }
     bool shouldDumpSelectionRect() const { return m_dumpSelectionRect; }
@@ -523,7 +521,6 @@ private:
     bool m_dumpPixels { false };
     bool m_dumpSelectionRect { false };
     bool m_dumpProgressFinishedCallback { false };
-    String m_resourceResponseMIMETypesToDump;
     bool m_dumpWillCacheResponse { false };
     bool m_dumpApplicationCacheDelegateCallbacks { false };
 


### PR DESCRIPTION
#### eb5b87025b457ab132440561374b8e2508f0ae03
<pre>
Remove dumpResourceResponseMIMETypes from InjectedBundle/TestRunner.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=317032">https://bugs.webkit.org/show_bug.cgi?id=317032</a>
<a href="https://rdar.apple.com/179518087">rdar://179518087</a>

Reviewed by Per Arne Vollan.

`dumpResourceResponseMIMETypes` was removed from TestRunner.idl when `dumpResourceResponseMIMETypes` became a
webkit-test-runner directive instead of a JS testRunner API for Site Isolation support (314790@main); and
the `dumpResourceResponseMIMETypes` functions in TestRunner.h have become dead code.

* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::dumpProgressFinishedCallback):
(WTR::TestRunner::shouldDumpProgressFinishedCallback const):
(WTR::TestRunner::dumpResourceResponseMIMETypes): Deleted.
(WTR::TestRunner::resourceResponseMIMETypesToDump const): Deleted.

Canonical link: <a href="https://commits.webkit.org/315164@main">https://commits.webkit.org/315164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566a8d12b7bf74c38ebaaa24293741e507271551

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41747 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35322 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125892 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/913a760e-daa2-40b9-b4db-14ea16e7973a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130882 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fc542d8-f280-4cd7-8396-6c1c5251b1da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33350 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111394 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6107a763-d09e-40e1-9a95-8b868710a6d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32336 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31041 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26215 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142322 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180119 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139319 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41760 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35200 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37496 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42448 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105822 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34469 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27517 "Unexpected infrastructure issue, retrying build") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40952 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40349 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5613 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40600 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->