### PR TITLE
[Build Speed] Header hygiene: Include What You Use

### DIFF
--- a/Source/JavaScriptCore/API/JSCallbackObject.h
+++ b/Source/JavaScriptCore/API/JSCallbackObject.h
@@ -33,6 +33,7 @@
 #if defined(JSC_GLIB_API_ENABLED)
 #include "JSAPIWrapperGlobalObject.h"
 #endif
+#include "JSBase.h"
 #include "JSGlobalObject.h"
 #include "JSObject.h"
 #include "JSObjectRef.h"

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -48,6 +48,7 @@
 #include "WasmThunks.h"
 #include <bmalloc/BPlatform.h>
 #include <mutex>
+#include <wtf/Condition.h>
 #include <wtf/Threading.h>
 #include <wtf/threads/Signals.h>
 

--- a/Source/JavaScriptCore/runtime/VMManager.cpp
+++ b/Source/JavaScriptCore/runtime/VMManager.cpp
@@ -32,6 +32,7 @@
 #include "VMEntryScopeInlines.h"
 #include "VMThreadContext.h"
 #include "WasmDebugServerUtilities.h"
+#include <wtf/Condition.h>
 #include <wtf/RunLoop.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -42,6 +42,7 @@
 #include "VMTrapsInlines.h"
 #include "WaiterListManager.h"
 #include "Watchdog.h"
+#include <wtf/Condition.h>
 #include <wtf/ProcessID.h>
 #include <wtf/Scope.h>
 #include <wtf/ThreadMessage.h>

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/StackManager.h>
 #include <wtf/Box.h>
+#include <wtf/Condition.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
 #include <wtf/RefPtr.h>

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -27,6 +27,7 @@
 #include <wtf/WorkQueue.h>
 
 #include <wtf/BlockPtr.h>
+#include <wtf/Threading.h>
 #include <wtf/darwin/DispatchExtras.h>
 
 namespace WTF {

--- a/Source/WebKit/Shared/RTCPacketOptions.cpp
+++ b/Source/WebKit/Shared/RTCPacketOptions.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "RTCPacketOptions.h"
 
+#include <wtf/CheckedArithmetic.h>
+
 #if USE(LIBWEBRTC)
 
 

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/ApplePayShippingContactUpdate.h>
 #include <WebCore/ApplePayShippingMethodUpdate.h>
 #include <WebCore/LocalFrame.h>
+#include <WebCore/Page.h>
 #include <WebCore/PaymentCoordinator.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
@@ -31,6 +31,7 @@
 #include "GPUProcessConnection.h"
 #include "Logging.h"
 #include "RemoteAudioSourceProviderManager.h"
+#include "WebProcess.h"
 #include <WebCore/MediaPlayer.h>
 
 // Include after MediaPlayer.h: the generated header uses WebCore::MediaPlayer.

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
@@ -28,6 +28,7 @@
 
 #if USE(LIBWEBRTC)
 
+#include "Connection.h"
 #include "LibWebRTCResolver.h"
 #include "LibWebRTCSocketFactory.h"
 #include <WebCore/LibWebRTCProvider.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -46,6 +46,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/Document.h>
 #include <WebCore/DocumentLoader.h>
+#include <WebCore/ExceptionData.h>
 #include <WebCore/ExceptionOr.h>
 #include <WebCore/LoaderStrategy.h>
 #include <WebCore/LocalFrameInlines.h>


### PR DESCRIPTION
#### f2a866573ce590d22793c2a16af29b27558743e0
<pre>
[Build Speed] Header hygiene: Include What You Use
<a href="https://bugs.webkit.org/show_bug.cgi?id=317035">https://bugs.webkit.org/show_bug.cgi?id=317035</a>
<a href="https://rdar.apple.com/179518779">rdar://179518779</a>

Reviewed by Mike Wyrzykowski and Brandon Stewart.

This prevents surprising build failures when adding / move files, or when the
CMake adaptive unified build decides to build in &quot;no bundle&quot; mode.

Canonical link: <a href="https://commits.webkit.org/315160@main">https://commits.webkit.org/315160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aefef4ce71594fdb9185d7219350902b97ba5edd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41750 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35338 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125895 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c05971b-75e9-4875-b1c1-89c6fbd2705e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130889 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/790bafaf-f87c-4546-92af-7c1842a16f9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33355 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111401 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48ee6927-c485-4c30-8959-e70b2b9253a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32341 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31046 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26218 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160813 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142327 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180122 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29441 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32845 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139324 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41763 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139187 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42451 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105825 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25618 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34475 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27524 "Unexpected infrastructure issue, retrying build") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200872 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114211 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53960 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40352 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5618 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->