### PR TITLE
media/media-source/media-source-real-webm-fastseek.html is a flaky text diff on mac

### DIFF
--- a/LayoutTests/media/media-source/media-source-real-webm-fastseek.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-fastseek.html
@@ -53,21 +53,25 @@
 
         // Seek to 1 (exact)
         run('video.currentTime = 1');
+        await waitFor(video, 'seeking', true);
         await waitFor(video, 'seeked');
         testExpected('video.currentTime.toFixed(1)', 1);
 
         // fastSeek(5) should snap to sync frame at 4
         run('video.fastSeek(5)');
+        await waitFor(video, 'seeking', true);
         await waitFor(video, 'seeked');
         testExpected('video.currentTime.toFixed(1)', 4);
 
         // Seek to 3 (exact)
         run('video.currentTime = 3');
+        await waitFor(video, 'seeking', true);
         await waitFor(video, 'seeked');
         testExpected('video.currentTime.toFixed(1)', 3);
 
         // fastSeek(2) should snap to sync frame at 0
         run('video.fastSeek(2)');
+        await waitFor(video, 'seeking', true);
         await waitFor(video, 'seeked');
         testExpected('video.currentTime.toFixed(1)', 0);
     }

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2271,8 +2271,6 @@ webkit.org/b/308326 [ Debug ] imported/w3c/web-platform-tests/fetch/api/basic/er
 
 webkit.org/b/308586 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Pass Failure ]
 
-webkit.org/b/316539 media/media-source/media-source-real-webm-fastseek.html [ Pass Failure ]
-
 # REGRESSION(314534@main): [macOS] 2x media/media-source/media-source-real-webm-currenttime-progression.html are a flaky text diff 
 webkit.org/b/316578 media/media-source/media-source-real-webm-currenttime-progression.html [ Pass Failure ]
 webkit.org/b/316578 media/media-source/media-source-real-currenttime-progression.html [ Pass Failure ]


### PR DESCRIPTION
#### 24b452b78e69950e3b9192d9bb6647a906e859f4
<pre>
media/media-source/media-source-real-webm-fastseek.html is a flaky text diff on mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=317034">https://bugs.webkit.org/show_bug.cgi?id=317034</a>
<a href="https://rdar.apple.com/179012963">rdar://179012963</a>

Reviewed by Jer Noble.

Await the seeking event before awaiting seeked for each seek operation,
to ensure we aren&apos;t catching a stale seeked event from a prior operation.

* LayoutTests/media/media-source/media-source-real-webm-fastseek.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/315335@main">https://commits.webkit.org/315335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c2b3de4c61a407e146b0daf2dee73b13d38182a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126394 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07357101-e65f-4fe5-982a-ef801274453e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131332 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/025677ba-f513-49a6-bbf0-b9f5620dd6fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111836 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a7bca1b-048a-43eb-a2c4-842f0e3de257) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31483 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26713 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180619 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139775 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139624 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42947 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106674 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25697 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34903 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41450 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6065 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40847 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41101 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->