### PR TITLE
[EWS] Don't forward tester OS/SDK as builder properties when re-triggering parent build

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2981,9 +2981,10 @@ class Trigger(trigger.Trigger):
 
         properties_to_pass = {prop: properties.Property(prop) for prop in property_names}
         properties_to_pass['retry_count'] = properties.Property('retry_count', default=0)
-        properties_to_pass['os_version_builder'] = properties.Property('os_version', default='')
-        properties_to_pass['xcode_version_builder'] = properties.Property('xcode_version', default='')
-        properties_to_pass['deployment_target_builder'] = properties.Property('deployment_target')
+        if not self.triggers:
+            properties_to_pass['os_version_builder'] = properties.Property('os_version', default='')
+            properties_to_pass['xcode_version_builder'] = properties.Property('xcode_version', default='')
+            properties_to_pass['deployment_target_builder'] = properties.Property('deployment_target')
         properties_to_pass['parent_buildnumber'] = properties.Property('buildnumber')
         properties_to_pass['parent_builderid'] = properties.Property('builderid')
         properties_to_pass['rebuild_without_change_on_builder'] = properties.Property('rebuild_without_change_on_builder', default=False)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -11200,6 +11200,8 @@ class TestTrigger(BuildStepMixinAdditions, unittest.TestCase):
         self.assertIn('architecture', props)
         self.assertIn('codebase', props)
         self.assertIn('retry_count', props)
+        self.assertIn('os_version_builder', props)
+        self.assertIn('xcode_version_builder', props)
         self.assertIn('deployment_target_builder', props)
         self.assertIn('ews_revision', props)
         self.assertIn('parent_buildnumber', props)
@@ -11210,6 +11212,13 @@ class TestTrigger(BuildStepMixinAdditions, unittest.TestCase):
         self.assertNotIn('repository', props)
         self.assertFalse(step.updateSourceStamp)
         self.assertNotIn('triggers', props)
+
+    def test_builder_version_properties_excluded_when_re_triggering_parent(self):
+        step = Trigger(schedulerNames=['test-scheduler'], triggers=['tester-scheduler'])
+        props = step.propertiesToPassToTriggers()
+        self.assertNotIn('os_version_builder', props)
+        self.assertNotIn('xcode_version_builder', props)
+        self.assertNotIn('deployment_target_builder', props)
 
     def test_pull_request_properties_included_when_enabled(self):
         step = Trigger(schedulerNames=['test-scheduler'], pull_request=True)


### PR DESCRIPTION
#### 1286c5a040abcabc4ee93a846d81b3d5ded60649
<pre>
[EWS] Don&apos;t forward tester OS/SDK as builder properties when re-triggering parent build
<a href="https://bugs.webkit.org/show_bug.cgi?id=317036">https://bugs.webkit.org/show_bug.cgi?id=317036</a>
<a href="https://rdar.apple.com/problem/179521390">rdar://problem/179521390</a>

Reviewed by Aakash Jain.

When a tester re-triggers the parent archive build after an infrastructure issue,
propertiesToPassToTriggers was forwarding the tester&apos;s own os_version / xcode_version
/ deployment_target values. If the re-triggered parent landed on a worker with a different
OS (which is expected for back-deployed macOS versions), the ConfigureBuild step compared
the new builder&apos;s actual OS against the forwarded tester values and failed the build with
&quot;Error: OS/SDK version mismatch&quot;.

* Tools/CISupport/ews-build/steps.py:
(Trigger.propertiesToPassToTriggers): Skip passing those three properties when self.triggers
is set, which is only true on the tester-&gt;parent re-trigger path.
* Tools/CISupport/ews-build/steps_unittest.py: Add new unit test.

Canonical link: <a href="https://commits.webkit.org/315296@main">https://commits.webkit.org/315296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c73616f2b7b9630744baa5f7097926f7561e7297

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41759 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35342 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125904 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcfed5e0-1e87-4746-98a7-4a500aa0c586) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130890 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92002 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1cc4dee7-c91f-4b61-85c0-c8462ff0a890) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111402 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c58c733-c644-40b6-9ded-7bf3b2b57539) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32342 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31048 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26227 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142328 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180131 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139328 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/167603 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139191 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42460 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105834 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34478 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27526 "Unexpected infrastructure issue, retrying build") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40964 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40361 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5619 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->