### PR TITLE
AX: Isolated tree includes ::before/::after generated content in text marker strings and should not do so

### DIFF
--- a/LayoutTests/accessibility/mac/text-marker-string-excludes-checkmark-content-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-string-excludes-checkmark-content-expected.txt
@@ -1,0 +1,13 @@
+A base-appearance select's checked option renders a ::checkmark whose user-agent content is a check glyph (content: "\2713"). That generated content is not a valid DOM position, so it must be excluded from the option's text-marker string.
+
+PASS: select.isExpanded === true
+PASS: checkedItem.role.toLowerCase().includes('menuitem') === true
+Checked option's text-marker string: "Banana"
+PASS: markerString.includes('Banana') === true
+PASS: markerString.includes(String.fromCharCode(0x2713)) === false
+PASS: select.isExpanded === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-string-excludes-checkmark-content.html
+++ b/LayoutTests/accessibility/mac/text-marker-string-excludes-checkmark-content.html
@@ -1,0 +1,54 @@
+<!doctype html><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select">
+    <option>Apple</option>
+    <option selected>Banana</option>
+</select>
+
+<script>
+var output = "A base-appearance select's checked option renders a ::checkmark whose user-agent content is a check glyph (content: \"\\2713\"). That generated content is not a valid DOM position, so it must be excluded from the option's text-marker string.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+
+    setTimeout(async function() {
+        // The ::checkmark only renders once the picker is open, so expand it first.
+        select.press();
+        output += await expectAsync("select.isExpanded", "true");
+
+        window.menu = findBaseSelectMenu(select);
+        window.checkedItem = menu.selectedChildAtIndex(0);
+        output += expect("checkedItem.role.toLowerCase().includes('menuitem')", "true");
+
+        // The checked option's text-marker string must contain its label but not the ::checkmark glyph
+        // (U+2713), which is generated content with no DOM node.
+        window.range = checkedItem.textMarkerRangeForElement(checkedItem);
+        window.markerString = checkedItem.stringForTextMarkerRange(range) || "";
+        output += `Checked option's text-marker string: "${markerString}"\n`;
+        output += expect("markerString.includes('Banana')", "true");
+        output += expect("markerString.includes(String.fromCharCode(0x2713))", "false");
+
+        // Close the picker.
+        select.press();
+        output += await expectAsync("select.isExpanded", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-string-excludes-generated-content-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-string-excludes-generated-content-expected.txt
@@ -1,0 +1,10 @@
+::before / ::after generated content has no DOM node, so it must be excluded from the text-marker string of a containing range, matching the live tree (and TextIterator), which never emits generated content. Regression test for the isolated tree caching generated-content text runs.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.stringForTextMarkerRange(range) is 'middle'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+middle

--- a/LayoutTests/accessibility/mac/text-marker-string-excludes-generated-content.html
+++ b/LayoutTests/accessibility/mac/text-marker-string-excludes-generated-content.html
@@ -1,0 +1,27 @@
+<!doctype html><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false ] -->
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<style>
+    #target::before { content: "before-"; }
+    #target::after { content: "-after"; }
+</style>
+</head>
+<body>
+
+<p id="target">middle</p>
+
+<script>
+    description("::before / ::after generated content has no DOM node, so it must be excluded from the text-marker string of a containing range, matching the live tree (and TextIterator), which never emits generated content. Regression test for the isolated tree caching generated-content text runs.");
+
+    if (window.accessibilityController) {
+        var target = accessibilityController.accessibleElementById("target");
+        var range = target.textMarkerRangeForElement(target);
+        shouldBe("target.stringForTextMarkerRange(range)", "'middle'");
+    }
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1445,6 +1445,57 @@ CharacterRange AccessibilityRenderObject::selectedTextRange() const
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+// Returns true when the AX text runs for a RenderText parented by this pseudo-element type must be
+// excluded. Some pseudo-elements represent generated content as text with no backing DOM node. Such
+// content cannot be a valid text position nor be selected (with a mouse or otherwise), so emitting
+// text runs for it would make the isolated tree's text-marker strings diverge from what can actually
+// be represented on the main-thread.
+static bool shouldExcludeTextRunsForPseudoElement(std::optional<PseudoElementType> pseudoElementType)
+{
+    if (!pseudoElementType) {
+        // No pseudo type, so this function is not applicable.
+        return false;
+    }
+
+    switch (*pseudoElementType) {
+    case PseudoElementType::Before:
+    case PseudoElementType::After:
+    case PseudoElementType::Marker:
+    case PseudoElementType::Checkmark:
+    case PseudoElementType::PickerIcon:
+    case PseudoElementType::InternalWritingSuggestions:
+    // These pseudos are paint-time decorations and shouldn't generate text of their own.
+    case PseudoElementType::GrammarError:
+    case PseudoElementType::Highlight:
+    case PseudoElementType::Selection:
+    case PseudoElementType::SpellingError:
+    case PseudoElementType::TargetText:
+    // These generate a box / chrome / image that never hosts text.
+    case PseudoElementType::Backdrop:
+    case PseudoElementType::WebKitScrollbar:
+    case PseudoElementType::WebKitScrollbarThumb:
+    case PseudoElementType::WebKitScrollbarButton:
+    case PseudoElementType::WebKitScrollbarTrack:
+    case PseudoElementType::WebKitScrollbarTrackPiece:
+    case PseudoElementType::WebKitScrollbarCorner:
+    case PseudoElementType::WebKitResizer:
+    case PseudoElementType::ViewTransition:
+    case PseudoElementType::ViewTransitionGroup:
+    case PseudoElementType::ViewTransitionImagePair:
+    case PseudoElementType::ViewTransitionOld:
+    case PseudoElementType::ViewTransitionNew:
+    case PseudoElementType::UserAgentPartFallback:
+        return true;
+
+    // These relate to real, selectable DOM text, so we must not exclude their text runs.
+    case PseudoElementType::FirstLine:
+    case PseudoElementType::FirstLetter:
+        return false;
+    }
+    AX_ASSERT_NOT_REACHED();
+    return true;
+}
+
 AXTextRuns AccessibilityRenderObject::textRuns()
 {
     constexpr std::array<uint16_t, 2> lengthOneDomOffsets = { 0, 1 };
@@ -1499,6 +1550,11 @@ AXTextRuns AccessibilityRenderObject::textRuns()
     WeakPtr renderText = dynamicDowncast<RenderText>(renderer.get());
     if (!renderText)
         return { };
+
+    if (CheckedPtr parent = renderText->parent()) {
+        if (shouldExcludeTextRunsForPseudoElement(parent->style().pseudoElementType()))
+            return { };
+    }
 
     // FIXME: Need to handle PseudoElementType::FirstLetter. Right now, it will be chopped off from the other
     // other text in the line, and AccessibilityRenderObject::computeIsIgnored ignores the


### PR DESCRIPTION
#### e92b564759d82c4c5e14f37f875ccf6b8befbbfa
<pre>
AX: Isolated tree includes ::before/::after generated content in text marker strings and should not do so
<a href="https://bugs.webkit.org/show_bug.cgi?id=317039">https://bugs.webkit.org/show_bug.cgi?id=317039</a>
<a href="https://rdar.apple.com/179521442">rdar://179521442</a>

Reviewed by Chris Fleizach and Dominic Mazzoni.

AccessibilityRenderObject::textRuns() emitted a text run for ::before/::after generated
content, which the isolated tree caches and serves during text-marker stringification.
The live tree (TextIterator) and AccessibilityObject::simpleRange(), in contrast, do not
allow this, and in general CSS generated content cannot be selected or otherwise used in
DOM positions.

To match the live tree and accurately reflect the page text state, we should (and with this
commit, do) stop generating text runs for this content.

Beyond passing new test accessibility/mac/text-marker-string-excludes-generated-content.html,
this gets us closer to passing accessibility/mac/pseudo-element-text-markers.html with isolated
tree mode enabled.

* LayoutTests/accessibility/mac/text-marker-string-excludes-checkmark-content-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-string-excludes-checkmark-content.html: Added.
* LayoutTests/accessibility/mac/text-marker-string-excludes-generated-content-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-string-excludes-generated-content.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::shouldExcludeTextRunsForPseudoElement):
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/315282@main">https://commits.webkit.org/315282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66831833baea56a2aa185a9d9cc3bbcf1af3830d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177893 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126265 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7df23b68-e79f-43dc-8dbc-0272bf43bb7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131215 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8863b926-6eac-411f-af8d-b73d46ab2ee9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111726 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27e67b78-fe30-4eae-97d0-55908873d2f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32657 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31363 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26588 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142643 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180492 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139656 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139514 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37574 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106482 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27862 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41324 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114580 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40721 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5945 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40972 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->