### PR TITLE
MediaMetadata artwork "sizes" parsing reads the wrong substring for height

### DIFF
--- a/LayoutTests/media/media-session-artwork-sizes-selection-expected.txt
+++ b/LayoutTests/media/media-session-artwork-sizes-selection-expected.txt
@@ -1,0 +1,23 @@
+
+Tests that MediaMetadata selects the highest-scored artwork by parsing non-square "sizes" correctly.
+
+* Load a media file so a NowPlaying session can register.
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplaythrough)
+
+* Provide artwork with both square and non-square sizes.
+RUN(navigator.mediaSession.metadata = new MediaMetadata({title: "title", artwork: [{src: "content/abe.png", sizes: "130x130"}, {src: "content/greenbox.png", sizes: "1280x720"}]}))
+RUN(navigator.mediaSession.playbackState = "paused")
+RUN(navigator.mediaSession.positionState = {duration: video.duration, position: video.currentTime})
+
+* Start to play so NowPlaying becomes active.
+RUN(video.play())
+EVENT(playing)
+
+* The 1280x720 image has the higher score and must be the selected artwork.
+EXPECTED (internals.nowPlayingMetadata.artwork != 'null') OK
+EXPECTED (internals.nowPlayingMetadata.artwork.src.endsWith("greenbox.png") == 'true') OK
+EXPECTED (internals.nowPlayingMetadata.artwork.src.endsWith("abe.png") == 'false') OK
+
+END OF TEST
+

--- a/LayoutTests/media/media-session-artwork-sizes-selection.html
+++ b/LayoutTests/media/media-session-artwork-sizes-selection.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-session-artwork-sizes-selection</title>
+    <script src=video-test.js></script>
+    <script src=media-file.js></script>
+    <script>
+
+        async function runTest()
+        {
+            findMediaElement();
+
+            consoleWrite('<br>* Load a media file so a NowPlaying session can register.');
+            run('video.src = findMediaFile("video", "content/test")');
+            await waitFor(video, 'canplaythrough');
+
+            consoleWrite('<br>* Provide artwork with both square and non-square sizes.');
+            run('navigator.mediaSession.metadata = new MediaMetadata({title: "title", artwork: [{src: "content/abe.png", sizes: "130x130"}, {src: "content/greenbox.png", sizes: "1280x720"}]})');
+            run('navigator.mediaSession.playbackState = "paused"');
+            run('navigator.mediaSession.positionState = {duration: video.duration, position: video.currentTime}');
+
+            consoleWrite('<br>* Start to play so NowPlaying becomes active.');
+            runWithKeyDown(() => {
+                run('video.play()');
+            });
+            await waitFor(video, 'playing');
+
+            consoleWrite('<br>* The 1280x720 image has the higher score and must be the selected artwork.');
+            await testExpectedEventuallyIgnoringError('internals.nowPlayingMetadata.artwork', null, '!=', 10000);
+            testExpected('internals.nowPlayingMetadata.artwork.src.endsWith("greenbox.png")', true);
+            testExpected('internals.nowPlayingMetadata.artwork.src.endsWith("abe.png")', false);
+
+            consoleWrite('');
+        }
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        });
+    </script>
+</head>
+<body>
+    <video controls></video>
+    <br>
+    Tests that MediaMetadata selects the highest-scored artwork by parsing non-square "sizes" correctly.
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3463,6 +3463,7 @@ http/tests/media/now-playing-info-default-artwork-favicon.html [ Skip ]
 http/tests/media/now-playing-info-media-session-artwork-favicon.html [ Skip ]
 media/now-playing-info-media-session-private-browsing.html [ Skip ]
 media/now-playing-info-media-session-suspend-playback.html [ Skip ]
+media/media-session-artwork-sizes-selection.html [ Skip ]
 
 webkit.org/b/304995 [ Release ] imported/w3c/web-platform-tests/largest-contentful-paint/video-poster.html [ Pass Failure ]
 

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -241,7 +241,7 @@ void MediaMetadata::refreshArtworkImage()
                 if (posX == notFound || !posX)
                     return { };
                 std::optional<uint32_t> width = parseInteger<uint32_t>(element.left(posX));
-                std::optional<uint32_t> height = parseInteger<uint32_t>(element.right(posX));
+                std::optional<uint32_t> height = parseInteger<uint32_t>(element.substring(posX + 1));
                 if (!width || !height)
                     return { };
 


### PR DESCRIPTION
#### d262f2e6edc652e4d44bcd3fd3e6e706ff3aa7ef
<pre>
MediaMetadata artwork &quot;sizes&quot; parsing reads the wrong substring for height
<a href="https://bugs.webkit.org/show_bug.cgi?id=317041">https://bugs.webkit.org/show_bug.cgi?id=317041</a>
<a href="https://rdar.apple.com/179523057">rdar://179523057</a>

Reviewed by Jean-Yves Avenard.

For a &quot;WxH&quot; size token the height was parsed with element.right(posX) (the rightmost posX
characters) rather than element.substring(posX + 1) (everything after the &apos;x&apos;). The two coincide
only for square sizes; e.g. &quot;1280x720&quot; failed to parse and &quot;50x100&quot; yielded height 0. Use
substring(posX + 1).

Test: media/media-session-artwork-sizes-selection.html
* LayoutTests/media/media-session-artwork-sizes-selection-expected.txt: Added.
* LayoutTests/media/media-session-artwork-sizes-selection.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::MediaMetadata::refreshArtworkImage):

Canonical link: <a href="https://commits.webkit.org/315402@main">https://commits.webkit.org/315402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/837a635b43fc8055528e92ad433af7262a2c9313

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41764 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35346 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125909 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcfa2bb3-288a-4d26-b918-ee28ce52aafb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130895 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92007 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4124a346-eec4-43d4-bd64-4b7a7bbee8e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111407 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c08cafa-b9c9-48c1-97a3-03550bb9ddc7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32344 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31052 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26232 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180136 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32859 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35211 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139333 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139196 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42465 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27527 "Unexpected infrastructure issue, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105839 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34479 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114225 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40969 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5620 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40366 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40617 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->