### PR TITLE
Transforming the camera instead of the model leads to undesirable lighting effects

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -279,28 +279,6 @@ final class Renderer {
     func setBackgroundColor(_ color: simd_float3) {
         clearColor = MTLClearColor(red: Double(color.x), green: Double(color.y), blue: Double(color.z), alpha: 1.0)
     }
-
-    func setCameraTransformForModelTransform(_ modelTransform: simd_float4x4) {
-        // To keep the model stationary while achieving the same visual result as applying
-        // modelTransform to the model, derive the equivalent camera pose by composing the
-        // inverse model transform with the default camera matrix.
-        var defaultCameraMatrix = matrix_identity_float4x4
-        defaultCameraMatrix.columns.3 = [0, 0, Renderer.cameraDistance, 1]
-        let cameraMatrix = simd_inverse(modelTransform) * defaultCameraMatrix
-
-        let col0 = simd_float3(cameraMatrix.columns.0.x, cameraMatrix.columns.0.y, cameraMatrix.columns.0.z)
-        let col1 = simd_float3(cameraMatrix.columns.1.x, cameraMatrix.columns.1.y, cameraMatrix.columns.1.z)
-        let col2 = simd_float3(cameraMatrix.columns.2.x, cameraMatrix.columns.2.y, cameraMatrix.columns.2.z)
-        let scale = simd_float3(simd_length(col0), simd_length(col1), simd_length(col2))
-        let rotation = simd_quatf(simd_float3x3(col0 / scale.x, col1 / scale.y, col2 / scale.z))
-        let position = simd_float3(cameraMatrix.columns.3.x, cameraMatrix.columns.3.y, cameraMatrix.columns.3.z)
-        cameraPosition = position
-        cameraRotation = rotation
-        // Derive the near/far distance from the camera's world-space position.
-        // The model lives at its USD-space coordinates, so the camera can be far from
-        // origin for large or offset models; simd_length gives the actual view distance.
-        effectiveCameraDistance = max(simd_length(position), Self.cameraDistance)
-    }
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -590,6 +590,10 @@ extension WKBridgeReceiver {
     @nonobjc
     fileprivate var meshToMeshInstances: [WKBridgeTypedResourceId: [LowLevelMeshInstance]] = [:]
     @nonobjc
+    fileprivate var meshTransforms: [WKBridgeTypedResourceId: [simd_float4x4]] = [:]
+    @nonobjc
+    fileprivate var modelTransform: simd_float4x4 = matrix_identity_float4x4
+    @nonobjc
     fileprivate var rotationAngle: Float = 0
 
     @nonobjc
@@ -625,8 +629,6 @@ extension WKBridgeReceiver {
         enum UpdateType {
             // First time mesh update, should add mesh instances to the scene
             case newMesh
-            // Transform update on existing mesh, should only update the transform on relevant mesh instances
-            case transformUpdate([simd_float4x4])
         }
 
         let identifier: WKBridgeTypedResourceId
@@ -637,10 +639,6 @@ extension WKBridgeReceiver {
             self.identifier = identifier
             self.type = type
             self.updatedInstances = updatedInstances
-
-            if case .transformUpdate(let newTransforms) = type {
-                assert(newTransforms.count == updatedInstances.count)
-            }
         }
     }
 
@@ -717,6 +715,17 @@ extension WKBridgeReceiver {
 
     @objc(renderWithTexture:commandBuffer:)
     func render(with texture: any MTLTexture, commandBuffer: any MTLCommandBuffer) {
+        // Apply the latest model transform to every mesh instance, composed with
+        // each instance's original USD-space transform.
+        for (identifier, meshes) in meshToMeshInstances {
+            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+            // swift-format-ignore: NeverForceUnwrap
+            let originalTransforms = meshTransforms[identifier]!
+            for (index, meshInstance) in meshes.enumerated() {
+                meshInstance.transform = modelTransform * originalTransforms[index]
+            }
+        }
+
         // animate
         if !meshResourceToDeformationContext.isEmpty {
             let commandBuffer = self.commandQueue.makeCommandBuffer()!
@@ -936,6 +945,7 @@ extension WKBridgeReceiver {
                 if meshData.instanceTransformsCount > 0 {
                     if meshToMeshInstances[identifier] == nil {
                         meshToMeshInstances[identifier] = []
+                        meshTransforms[identifier] = []
 
                         var deferredMeshUpdate = DeferredMeshUpdate(identifier: identifier, type: .newMesh, updatedInstances: [])
 
@@ -992,6 +1002,9 @@ extension WKBridgeReceiver {
                                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                                 // swift-format-ignore: NeverForceUnwrap
                                 meshToMeshInstances[identifier]!.append(meshInstance)
+                                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
+                                // swift-format-ignore: NeverForceUnwrap
+                                meshTransforms[identifier]!.append(instanceTransform)
                                 deferredMeshUpdate.updatedInstances.append(meshInstance)
                             }
                         }
@@ -1001,26 +1014,14 @@ extension WKBridgeReceiver {
                         // Update transforms otherwise
                         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                         // swift-format-ignore: NeverForceUnwrap
-                        var newTransforms: [simd_float4x4] = []
-                        var updatedInstances: [LowLevelMeshInstance] = []
-
                         let partCount = meshToMeshInstances[identifier]!.count / meshData.instanceTransforms.count
                         for (instanceIndex, instanceTransform) in meshData.instanceTransforms.enumerated() {
                             for partIndex in 0..<partCount {
                                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                                 // swift-format-ignore: NeverForceUnwrap
-                                let meshInstance = meshToMeshInstances[identifier]![instanceIndex * meshData.parts.count + partIndex]
-                                updatedInstances.append(meshInstance)
-                                newTransforms.append(instanceTransform)
+                                meshTransforms[identifier]![instanceIndex * partCount + partIndex] = instanceTransform
                             }
                         }
-
-                        let deferredMeshUpdate = DeferredMeshUpdate(
-                            identifier: identifier,
-                            type: .transformUpdate(newTransforms),
-                            updatedInstances: updatedInstances
-                        )
-                        deferredMeshUpdates.append(deferredMeshUpdate)
                     }
                 }
 
@@ -1036,10 +1037,6 @@ extension WKBridgeReceiver {
                     for newMeshInstance in deferredUpdate.updatedInstances {
                         try meshInstancePool.add(newMeshInstance)
                     }
-                case .transformUpdate(let newTransforms):
-                    for (instanceIndex, meshInstance) in deferredUpdate.updatedInstances.enumerated() {
-                        meshInstance.transform = newTransforms[instanceIndex]
-                    }
                 }
             }
         } catch {
@@ -1049,7 +1046,7 @@ extension WKBridgeReceiver {
 
     @objc(setTransform:)
     func setTransform(_ transform: simd_float4x4) {
-        appRenderer.setCameraTransformForModelTransform(transform)
+        modelTransform = transform
     }
 
     func setFOV(_ fovY: Float) {


### PR DESCRIPTION
#### 3a451b677717137eaa41e5831f6372862213d766
<pre>
Transforming the camera instead of the model leads to undesirable lighting effects
<a href="https://bugs.webkit.org/show_bug.cgi?id=317040">https://bugs.webkit.org/show_bug.cgi?id=317040</a>
<a href="https://rdar.apple.com/179522538">rdar://179522538</a>

Unreviewed, revert of 312407@main

* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(ImplicitFragmentInPlace.setBackgroundColor(_:)):
(ImplicitFragmentInPlace.setCameraTransformForModelTransform(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(WKBridgeReceiver.meshTransforms):
(WKBridgeReceiver.modelTransform):
(render(with:commandBuffer:)):
(updateMesh(_:)):
(setTransform(_:)):

Canonical link: <a href="https://commits.webkit.org/315155@main">https://commits.webkit.org/315155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dc2953104f9670f189e36e6d2e69c9609672f0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177544 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57e33c1f-9c03-4e9f-a2bc-6dda464ce8b5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130902 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7789fc94-8daa-4960-82d5-140f562cb071) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33377 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111414 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c8630f6-d687-4dac-a3ea-f38fabe483b3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26240 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180144 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139338 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41785 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139201 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37492 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42473 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105847 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34490 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40977 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114233 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40374 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5630 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40625 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->