### PR TITLE
StabilityTracer: Crash in WebKit::RemoteAudioVideoRendererProxyManager::ref

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -143,6 +143,7 @@ public:
     // IPC::Connection::Client, WebCore::NowPlayingManagerClient.
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    using ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::controlBlock;
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
     const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const LIFETIME_BOUND { return m_sharedPreferencesForWebProcess; }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -121,12 +121,14 @@ void RemoteAudioVideoRendererProxyManager::deref() const
     m_gpuConnectionToWebProcess.get()->deref();
 }
 
+ThreadSafeWeakPtrControlBlock& RemoteAudioVideoRendererProxyManager::controlBlock() const
+{
+    return m_gpuConnectionToWebProcess.get()->controlBlock();
+}
+
 std::optional<SharedPreferencesForWebProcess> RemoteAudioVideoRendererProxyManager::sharedPreferencesForWebProcess() const
 {
-    if (RefPtr gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get())
-        return gpuConnectionToWebProcess->sharedPreferencesForWebProcess();
-
-    return std::nullopt;
+    return m_gpuConnectionToWebProcess.get()->sharedPreferencesForWebProcess();
 }
 
 void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdentifier identifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, CompletionHandler<void(std::optional<WebCore::SharedTimebaseHandle>)>&& completionHandler)
@@ -152,12 +154,12 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
         .sharedTimebase = WTF::move(sharedTimebase)
     };
 
-    context.renderer->notifyWhenErrorOccurs([weakThis = WeakPtr { *this }, identifier](PlatformMediaError error) {
+    context.renderer->notifyWhenErrorOccurs([weakThis = ThreadSafeWeakPtr { *this }, identifier](PlatformMediaError error) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::ErrorOccurred(error));
     });
 
-    context.renderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }, identifier] {
+    context.renderer->notifyFirstFrameAvailable([weakThis = ThreadSafeWeakPtr { *this }, identifier] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !protectedThis->m_renderers.contains(identifier))
             return;
@@ -167,22 +169,22 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
         protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::FirstFrameAvailable(protectedThis->stateFor(identifier)));
     });
 
-    context.renderer->notifyWhenRequiresFlushToResume([weakThis = WeakPtr { *this }, identifier] {
+    context.renderer->notifyWhenRequiresFlushToResume([weakThis = ThreadSafeWeakPtr { *this }, identifier] {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::RequiresFlushToResume(protectedThis->stateFor(identifier)));
     });
 
-    context.renderer->notifyRenderingModeChanged([weakThis = WeakPtr { *this }, identifier] {
+    context.renderer->notifyRenderingModeChanged([weakThis = ThreadSafeWeakPtr { *this }, identifier] {
         if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
             protectedThis->rendereringModeChanged(identifier);
     });
 
-    context.renderer->notifySizeChanged([weakThis = WeakPtr { *this }, identifier](const MediaTime& time, FloatSize size) {
+    context.renderer->notifySizeChanged([weakThis = ThreadSafeWeakPtr { *this }, identifier](const MediaTime& time, FloatSize size) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::SizeChanged(time, size, protectedThis->stateFor(identifier)));
     });
 
-    context.renderer->notifyEffectiveRateChanged([weakThis = WeakPtr { *this }, identifier](double) {
+    context.renderer->notifyEffectiveRateChanged([weakThis = ThreadSafeWeakPtr { *this }, identifier](double) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::EffectiveRateChanged(protectedThis->stateFor(identifier)));
     });
@@ -256,7 +258,7 @@ void RemoteAudioVideoRendererProxyManager::addTrack(RemoteAudioVideoRendererIden
         return;
     }
     if (auto trackIdentifier = renderer->addTrack(type)) {
-        renderer->notifyTrackNeedsReenqueuing(*trackIdentifier, [weakThis = WeakPtr { *this }, identifier](TrackIdentifier trackIdentifier, const MediaTime& time) {
+        renderer->notifyTrackNeedsReenqueuing(*trackIdentifier, [weakThis = ThreadSafeWeakPtr { *this }, identifier](TrackIdentifier trackIdentifier, const MediaTime& time) {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::TrackNeedsReenqueuing(trackIdentifier, time, protectedThis->stateFor(identifier)));
         });
@@ -278,7 +280,7 @@ void RemoteAudioVideoRendererProxyManager::requestMediaDataWhenReady(RemoteAudio
     RefPtr renderer = rendererFor(identifier);
     if (!renderer)
         return;
-    renderer->requestMediaDataWhenReady(trackIdentifier)->whenSettled(RunLoop::mainSingleton(), [identifier, trackIdentifier, weakThis = WeakPtr { *this }](auto result) {
+    renderer->requestMediaDataWhenReady(trackIdentifier)->whenSettled(RunLoop::mainSingleton(), [identifier, trackIdentifier, weakThis = ThreadSafeWeakPtr { *this }](auto result) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !result)
             return;
@@ -336,7 +338,7 @@ void RemoteAudioVideoRendererProxyManager::performTaskAtTime(RemoteAudioVideoRen
     RefPtr renderer = rendererFor(identifier);
     if (!renderer)
         return;
-    renderer->performTaskAtTime(time, [weakThis = WeakPtr { *this }, time, identifier](auto) {
+    renderer->performTaskAtTime(time, [weakThis = ThreadSafeWeakPtr { *this }, time, identifier](auto) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::TaskTimeReached(time, protectedThis->stateFor(identifier)));
     });
@@ -389,7 +391,7 @@ void RemoteAudioVideoRendererProxyManager::installTimeObserver(RemoteAudioVideoR
     if (iterator == m_renderers.end())
         return;
     auto& context = iterator->value;
-    context.renderer->setTimeObserver(interval, [weakThis = WeakPtr { *this }, identifier](const MediaTime&) {
+    context.renderer->setTimeObserver(interval, [weakThis = ThreadSafeWeakPtr { *this }, identifier](const MediaTime&) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -456,7 +458,7 @@ void RemoteAudioVideoRendererProxyManager::prepareToSeek(RemoteAudioVideoRendere
         completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
         return;
     }
-    renderer->prepareToSeek(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
+    renderer->prepareToSeek(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)));
         completionHandler(WTF::move(result));
@@ -470,7 +472,7 @@ void RemoteAudioVideoRendererProxyManager::finishSeek(RemoteAudioVideoRendererId
         completionHandler(makeUnexpected(GenericPromise::RejectValueType { }));
         return;
     }
-    renderer->finishSeek(time)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
+    renderer->finishSeek(time)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)));
         completionHandler(WTF::move(result));
@@ -549,7 +551,7 @@ void RemoteAudioVideoRendererProxyManager::notifyWhenHasAvailableVideoFrame(WebK
         renderer->notifyWhenHasAvailableVideoFrame({ });
         return;
     }
-    renderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }, identifier](auto presentationTime, auto clockTime) {
+    renderer->notifyWhenHasAvailableVideoFrame([weakThis = ThreadSafeWeakPtr { *this }, identifier](auto presentationTime, auto clockTime) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !protectedThis->m_renderers.contains(identifier))
             return;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -51,6 +51,7 @@
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 class AudioVideoRenderer;
@@ -73,6 +74,7 @@ public:
 
     void ref() const final;
     void deref() const final;
+    ThreadSafeWeakPtrControlBlock& controlBlock() const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -207,7 +209,7 @@ private:
     HashMap<RemoteAudioVideoRendererIdentifier, RendererContext> m_renderers;
     const Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
 
-    ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
+    ThreadSafeWeakRef<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
 #if !RELEASE_LOG_DISABLED
     uint64_t m_logIdentifier { 0 };
     const Ref<Logger> m_logger;


### PR DESCRIPTION
#### a7ea563d0fb8b73b316aefd556610de241ab8d62
<pre>
StabilityTracer: Crash in WebKit::RemoteAudioVideoRendererProxyManager::ref
<a href="https://bugs.webkit.org/show_bug.cgi?id=317038">https://bugs.webkit.org/show_bug.cgi?id=317038</a>
<a href="https://rdar.apple.com/167378009">rdar://167378009</a>

Reviewed by Chris Dumez.

It looks like RemoteAudioVideoRendererProxyManager::ref() crashes when
dereferencing the result of m_gpuConnectionToWebProcess.get() because it&apos;s null.

From the crash trace, this call to ref() comes from the lambda given to
setTimeObserver() in RemoteAudioVideoRendererProxyManager::installTimeObserver()
where we initialize protectedThis.

So somehow, at the point when this lambda is called, the ThreadSafeWeakPtr that
points to the GPUConnectionWebProcess has a ref-count of zero, but the
RemoteAudioVideoRendererProxyManager that it holds is still alive (we know this
because otherwise RefPtr protectedThis would have been constructed with nullptr
and would not have called ref() at all). Since RemoteAudioVideoRendererProxyManager
is a unique_ptr member of GPUConnectionWebProcess, this means that the
GPUConnectionWebProcess itself hasn&apos;t been destroyed yet.

What&apos;s happening is that this lambda is called in between the GPUConnectionWebProcess
hitting a ref-count of zero and it&apos;s destructor being called. The ref-count can
hit zero on any thread, but the destructor must run on the main thread. So if the
ref-count hits zero on a non-main thread, we must hop to the main thread to
destroy it. This is asynchronous, and so there&apos;s a gap in which other code can
execute--like this lambda.

There actually is a way for us to check in the lambda whether the ref-count has
dropped to zero. GPUConnectionWebProcess inherits from
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr, and as soon as the ref-count
drops to zero, the control block swaps its pointer to GPUConnectionWebProcess
to nullptr. So if you make a ThreadSafeWeakPtr&lt;GPUConnectionWebProcess&gt; weakThis
and then try weakThis.get() after the ref-count has dropped to zero, you get back
nullptr (even if ~GPUConnectionWebProcess() hasn&apos;t been called yet).

Given that RemoteAudioVideoRendererProxyManager&apos;s lifetime is meant to be tied
to the GPUConnectionWebProcess, we can add a controlBlock() function to
RemoteAudioVideoRendererProxyManager which simply returns the controlBlock of
GPUConnectionWebProcess. This way, we can make a ThreadSafeWeakPtr of the
RemoteAudioVideoRendererProxyManager which will return a nullptr on get() if the
GPUConnectionWebProcess has hit a ref-count of zero. We then update all of the
lambdas that were capturing weakThis to use this ThreadSafeWeakPtr. Now, if
the lambda is called in between the GPUConnectionWebProcess hitting a ref-count
of zero and actually being destroyed, weakThis.get() will see that m_object is
null and return nullptr without caling RemoteAudioVideoRendererProxyManager::ref()
at all.

Also, given that RemoteAudioVideoRendererProxyManager&apos;s lifetime is tied to that
of GPUConnectionWebProcess, we change m_gpuConnectionToWebProcess to be a
ThreadSafeWeakRef. Even though m_gpuConnectionToWebProcess was null in this case,
it should never be null after this fix.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::controlBlock const):
(WebKit::RemoteAudioVideoRendererProxyManager::sharedPreferencesForWebProcess const):
(WebKit::RemoteAudioVideoRendererProxyManager::create):
(WebKit::RemoteAudioVideoRendererProxyManager::addTrack):
(WebKit::RemoteAudioVideoRendererProxyManager::requestMediaDataWhenReady):
(WebKit::RemoteAudioVideoRendererProxyManager::performTaskAtTime):
(WebKit::RemoteAudioVideoRendererProxyManager::installTimeObserver):
(WebKit::RemoteAudioVideoRendererProxyManager::prepareToSeek):
(WebKit::RemoteAudioVideoRendererProxyManager::finishSeek):
(WebKit::RemoteAudioVideoRendererProxyManager::notifyWhenHasAvailableVideoFrame):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:

Canonical link: <a href="https://commits.webkit.org/315283@main">https://commits.webkit.org/315283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44427551105572b9fe731a113e0cf91527fc758c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126275 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1630e813-c854-4dee-a5aa-e22fbf67ea9c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131220 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c71a29a-4b28-4d11-8227-2504ac8ec65c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111731 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e278f2d-3f46-4dd7-8034-13081cb1c369) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32663 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31371 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26595 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180499 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139661 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42139 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139519 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42827 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27865 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106492 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25675 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34801 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114587 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41331 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5948 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40728 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40873 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->