### PR TITLE
Cherry-pick 314728@main (ce339f1f9454). https://bugs.webkit.org/show_bug.cgi?id=316523

### DIFF
--- a/LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash-expected.txt
+++ b/LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests that the WebContent process does not crash when window deactivation fires a change event on a focused form control whose onchange handler removes focus from that control.
+
+
+PASS - did not crash

--- a/LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash.html
+++ b/LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p id="description">
+This tests that the WebContent process does not crash when window deactivation
+fires a change event on a focused form control whose onchange handler removes
+focus from that control.
+</p>
+<input id="input" autofocus onchange="this.blur()">
+<div id="result"></div>
+<script>
+if (!window.testRunner || !window.eventSender)
+    document.getElementById("result").textContent = "This test requires testRunner and eventSender.";
+else {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const input = document.getElementById("input");
+    input.focus();
+
+    // Simulated keystroke marks the input as dirty.
+    eventSender.keyDown("a");
+
+    // Triggers FocusController::setActiveInternal(false) which
+    // leads to dispatchEventsOnWindowAndFocusedElement().
+    testRunner.setWindowIsKey(false);
+
+    setTimeout(() => {
+        document.getElementById("result").textContent = "PASS - did not crash";
+        testRunner.notifyDone();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WTF/wtf/LazyRef.h
+++ b/Source/WTF/wtf/LazyRef.h
@@ -88,7 +88,7 @@ public:
         return std::bit_cast<T*>(m_pointer);
     }
 
-    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { &get(owner); }
+    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
     T* ptr(const OwnerType& owner) const LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
 
     template<typename Func>

--- a/Source/WTF/wtf/LazyUniqueRef.h
+++ b/Source/WTF/wtf/LazyUniqueRef.h
@@ -88,7 +88,7 @@ public:
         return std::bit_cast<T*>(m_pointer);
     }
 
-    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { &get(owner); }
+    T* ptr(OwnerType& owner) LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
     T* ptr(const OwnerType& owner) const LIFETIME_BOUND RETURNS_NONNULL { return &get(owner); }
 
     template<typename Func>

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -423,7 +423,8 @@ static inline void dispatchEventsOnWindowAndFocusedElement(Document* document, b
             return;
         }
 
-        focusedElement->dispatchBlurEvent(nullptr);
+        if (RefPtr focusedElement = document->focusedElement())
+            focusedElement->dispatchBlurEvent(nullptr);
     }
 
     document->dispatchWindowEvent(Event::create(focused ? eventNames().focusEvent : eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No));

--- a/Source/WebCore/platform/graphics/AV1Utilities.cpp
+++ b/Source/WebCore/platform/graphics/AV1Utilities.cpp
@@ -1311,7 +1311,7 @@ static size_t readULEBSize(std::span<const uint8_t> data, size_t& index)
 
         uint8_t dataByte = data[index++];
         uint8_t decodedByte = dataByte & 0x7f;
-        value |= decodedByte << (7 * cptr);
+        value |= static_cast<size_t>(decodedByte) << (7 * cptr);
         if (value >= std::numeric_limits<uint32_t>::max())
             return 0;
         if (!(dataByte & 0x80))

--- a/Source/WebCore/platform/graphics/GraphicsLayerAnimation.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayerAnimation.cpp
@@ -64,7 +64,7 @@ bool GraphicsLayerAnimation::operator==(const GraphicsLayerAnimation& other) con
 
 TextStream& operator<<(TextStream& ts, const GraphicsLayerAnimation& animation)
 {
-    ts.dumpProperty("delay"_s, animation.iterationCount());
+    ts.dumpProperty("delay"_s, animation.delay());
     ts.dumpProperty("direction"_s, animation.direction());
     ts.dumpProperty("duration"_s, animation.duration());
     ts.dumpProperty("fill-mode"_s, animation.fillMode());

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -424,6 +424,8 @@ DestinationColorSpace Image::colorSpace()
 RefPtr<ShareableBitmap> Image::toShareableBitmap() const
 {
     RefPtr bitmap = ShareableBitmap::create({ IntSize(size()) });
+    if (!bitmap)
+        return nullptr;
     std::unique_ptr graphicsContext = bitmap->createGraphicsContext();
     if (!graphicsContext)
         return nullptr;

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -110,7 +110,7 @@ size_t TrackPrivateBase::addClient(TrackPrivateBaseClient::Dispatcher&& dispatch
 void TrackPrivateBase::removeClient(uint32_t index)
 {
     Locker locker { m_lock };
-    if (m_clients.size() > index)
+    if (m_clients.size() <= index)
         return;
     m_clients[index] = std::make_tuple<RefPtr<SharedDispatcher>, WeakPtr<TrackPrivateBaseClient>, bool>({ }, { }, false);
 }

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -128,14 +128,17 @@ void BackgroundFetchLoad::loadRequest(NetworkProcess& networkProcess, ResourceRe
 void BackgroundFetchLoad::willPerformHTTPRedirection(ResourceResponse&& redirectResponse, ResourceRequest&& request, RedirectCompletionHandler&& completionHandler)
 {
     m_networkLoadChecker->checkRedirection(ResourceRequest { }, WTF::move(request), WTF::move(redirectResponse), nullptr, [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (auto&& result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return completionHandler({ });
         if (!result.has_value()) {
-            weakThis->didFinish(result.error());
+            protectedThis->didFinish(result.error());
             completionHandler({ });
             return;
         }
         auto request = WTF::move(result->redirectRequest);
         if (!request.url().protocolIsInHTTPFamily()) {
-            weakThis->didFinish(ResourceError { String { }, 0, request.url(), "Redirection to URL with a scheme that is not HTTP(S)"_s, ResourceError::Type::AccessControl });
+            protectedThis->didFinish(ResourceError { String { }, 0, request.url(), "Redirection to URL with a scheme that is not HTTP(S)"_s, ResourceError::Type::AccessControl });
             completionHandler({ });
             return;
         }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1897,7 +1897,7 @@ void NetworkProcess::deleteWebsiteDataForOrigin(PAL::SessionID sessionID, Option
         if (CheckedPtr networkStorageSession = storageSession(sessionID))
             networkStorageSession->deleteCookies(origin, [clearTasksHandler] { });
     }
-    if (websiteDataTypes.contains(WebsiteDataType::DiskCache) && !sessionID.isEphemeral()) {
+    if (websiteDataTypes.contains(WebsiteDataType::DiskCache) && !sessionID.isEphemeral() && session) {
         if (RefPtr cache = session->cache()) {
             Vector<NetworkCache::Key> cacheKeysToDelete;
             String cachePartition = origin.clientOrigin == origin.topOrigin ? emptyString() : ResourceRequest::partitionName(origin.topOrigin.host());

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -290,7 +290,7 @@ void WebSWServerToContextConnection::workerTerminated(ServiceWorkerIdentifier se
 {
     SWServerToContextConnection::workerTerminated(serviceWorkerIdentifier);
 
-    if (--m_processingFunctionalEventCount)
+    if (!--m_processingFunctionalEventCount)
         protectedConnection()->networkProcess().protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8871,13 +8871,14 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
     MESSAGE_CHECK_URL_COMPLETION(process, request.url(), completionHandler({ }));
     MESSAGE_CHECK_URL_COMPLETION(process, response.url(), completionHandler({ }));
     RefPtr navigation = navigationID ? m_navigationState->navigation(*navigationID) : nullptr;
-    Ref navigationResponse = API::NavigationResponse::create(API::FrameInfo::create(WTF::move(frameInfo)).get(), request, response, canShowMIMEType, WTF::move(downloadAttribute), navigation.get());
 
     // COOP only applies to top-level browsing contexts.
     if (frameInfo.isMainFrame && coopValuesRequireBrowsingContextGroupSwitch(isShowingInitialAboutBlank, activeDocumentCOOPValue, frameInfo.securityOrigin.securityOrigin().get(), obtainCrossOriginOpenerPolicy(response).value, SecurityOrigin::create(response.url()).get())) {
         protectedMainFrame()->disownOpener();
         m_openedMainFrameName = { };
     }
+
+    Ref navigationResponse = API::NavigationResponse::create(API::FrameInfo::create(FrameInfoData { frameInfo }).get(), request, response, canShowMIMEType, WTF::move(downloadAttribute), navigation.get());
 
     auto expectSafeBrowsing = ShouldExpectSafeBrowsingResult::No;
     MonotonicTime requestStart;


### PR DESCRIPTION
#### 8ded39b7705d25a6dd1f8d395a9f57d960111c42
<pre>
Cherry-pick 314728@main (ce339f1f9454). <a href="https://bugs.webkit.org/show_bug.cgi?id=316523">https://bugs.webkit.org/show_bug.cgi?id=316523</a>

    Fix inverted condition in WebSWServerToContextConnection::workerTerminated
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316523">https://bugs.webkit.org/show_bug.cgi?id=316523</a>

    Reviewed by Youenn Fablet.

    The condition guarding the EndServiceWorkerBackgroundProcessing message
    was missing a `!`, so the message was sent on every decrement of
    m_processingFunctionalEventCount *except* when the count reached zero —
    the exact opposite of every other End-Background-Processing site in the
    same file (firePushEvent, fireNotificationEvent, fireBackgroundFetchEvent,
    fireBackgroundFetchClickEvent).

    As a result, the background-processing assertion held while terminating
    a service worker was never released for the last in-flight functional
    event, while spurious End messages were sent during normal counting.

    * Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
    (WebKit::WebSWServerToContextConnection::workerTerminated):

    Canonical link: <a href="https://commits.webkit.org/314728@main">https://commits.webkit.org/314728@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.749@webkitglib/2.52">https://commits.webkit.org/305877.749@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e441e8c5f6fd05d366de766c6b22816ae10604c1
<pre>
Cherry-pick 314764@main (3dffc69de57f). <a href="https://bugs.webkit.org/show_bug.cgi?id=316514">https://bugs.webkit.org/show_bug.cgi?id=316514</a>

    Use-after-move of frameInfo in WebPageProxy::decidePolicyForResponseShared()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316514">https://bugs.webkit.org/show_bug.cgi?id=316514</a>

    Reviewed by Rupin Mittal.

    decidePolicyForResponseShared() consumed `frameInfo` by passing
    WTF::move(frameInfo) to API::FrameInfo::create(), and then immediately
    read `frameInfo.securityOrigin.securityOrigin()` for the COOP
    browsing-context-group-switch check on the next line. API::FrameInfo&apos;s
    constructor stores the FrameInfoData by move (m_data(WTF::move(data))),
    so the SecurityOriginData&apos;s String members were left empty and the COOP
    comparison saw an empty origin — typically a false negative, meaning we
    failed to disown the opener and clear m_openedMainFrameName when COOP
    required it. The same moved-from `frameInfo` was then captured by
    WTF::move into the policy listener lambda, where it was further used
    (e.g. by FrameInfoData { frameInfo } on the safe-browsing failure path).

    Reorder the function so the COOP check runs first against a live
    `frameInfo`, pass a copy to API::FrameInfo::create(), and let the
    lambda&apos;s capture be the sole move.

    * Source/WebKit/UIProcess/WebPageProxy.cpp:
    (WebKit::WebPageProxy::decidePolicyForResponseShared):

    Canonical link: <a href="https://commits.webkit.org/314764@main">https://commits.webkit.org/314764@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.748@webkitglib/2.52">https://commits.webkit.org/305877.748@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 61de36e134bb34d2dc7aeb86cd0cbfbc13cc6e1d
<pre>
Cherry-pick 314767@main (6667782c52fa). <a href="https://bugs.webkit.org/show_bug.cgi?id=316510">https://bugs.webkit.org/show_bug.cgi?id=316510</a>

    Add missing return statements in LazyRef.h and LazyUniqueRef.h
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316510">https://bugs.webkit.org/show_bug.cgi?id=316510</a>

    Reviewed by Darin Adler.

    * Source/WTF/wtf/LazyRef.h:
    * Source/WTF/wtf/LazyUniqueRef.h:

    Canonical link: <a href="https://commits.webkit.org/314767@main">https://commits.webkit.org/314767@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.747@webkitglib/2.52">https://commits.webkit.org/305877.747@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### fd16d342f9b4f1e6d00ecc8fc0384f4941924e77
<pre>
Cherry-pick 314931@main (6fc2044df388). <a href="https://bugs.webkit.org/show_bug.cgi?id=316771">https://bugs.webkit.org/show_bug.cgi?id=316771</a>

    Possible null-deref in checkRedirection completion
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316771">https://bugs.webkit.org/show_bug.cgi?id=316771</a>
    <a href="https://rdar.apple.com/179220373">rdar://179220373</a>

    Reviewed by Pascoe.

    checkRedirection can complete asynchronously, so the BackgroundFetchLoad may have been torn down by
    the time the handler runs.

    * Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
    (WebKit::BackgroundFetchLoad::willPerformHTTPRedirection):

    Canonical link: <a href="https://commits.webkit.org/314931@main">https://commits.webkit.org/314931@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.746@webkitglib/2.52">https://commits.webkit.org/305877.746@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### cf79e3ff1cc063893fac2481466c9599af1b1ffd
<pre>
Cherry-pick 314933@main (c241847cce04). <a href="https://bugs.webkit.org/show_bug.cgi?id=316761">https://bugs.webkit.org/show_bug.cgi?id=316761</a>

    GraphicsLayerAnimation TextStream dump iterationCount under &quot;delay&quot;
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316761">https://bugs.webkit.org/show_bug.cgi?id=316761</a>
    <a href="https://rdar.apple.com/179208066">rdar://179208066</a>

    Reviewed by Pascoe.

    The &quot;delay&quot; property dumped animation.iterationCount() instead of animation.delay(), so the delay
    was never reported and the iteration count appeared twice. Dump delay().

    * Source/WebCore/platform/graphics/GraphicsLayerAnimation.cpp:
    (WebCore::operator&lt;&lt;):

    Canonical link: <a href="https://commits.webkit.org/314933@main">https://commits.webkit.org/314933@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.745@webkitglib/2.52">https://commits.webkit.org/305877.745@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ce0d174ed399031a1b804187c8eac99f722fa62f
<pre>
Cherry-pick 314934@main (82ef6d0843fe). <a href="https://bugs.webkit.org/show_bug.cgi?id=316770">https://bugs.webkit.org/show_bug.cgi?id=316770</a>

    Possible null-deref in NetworkProcess::deleteWebsiteDataForOrigin with ephemeral session
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316770">https://bugs.webkit.org/show_bug.cgi?id=316770</a>
    <a href="https://rdar.apple.com/179219807">rdar://179219807</a>

    Reviewed by Pascoe.

    networkSession(sessionID) returns null when no NetworkSession exists for the given sessionID. Every
    other branch in the same function and the sibling functions guard the sesion dereference. Add the
    same guard here.

    * Source/WebKit/NetworkProcess/NetworkProcess.cpp:
    (WebKit::NetworkProcess::deleteWebsiteDataForOrigin):

    Canonical link: <a href="https://commits.webkit.org/314934@main">https://commits.webkit.org/314934@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.744@webkitglib/2.52">https://commits.webkit.org/305877.744@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9cd327e6f60c9ff9757049760d34708a9c1464bf
<pre>
Cherry-pick 314937@main (6a12936c2791). <a href="https://bugs.webkit.org/show_bug.cgi?id=316767">https://bugs.webkit.org/show_bug.cgi?id=316767</a>

    Null deref in Image::toShareableBitmap when ShareableBitmap::create() fails
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316767">https://bugs.webkit.org/show_bug.cgi?id=316767</a>
    <a href="https://rdar.apple.com/179212122">rdar://179212122</a>

    Reviewed by Pascoe.

    ShareableBitmap::create() can return null, but the result was dereferenced without a check. Return
    nullptr when creation fails.

    * Source/WebCore/platform/graphics/Image.cpp:
    (WebCore::Image::toShareableBitmap const):

    Canonical link: <a href="https://commits.webkit.org/314937@main">https://commits.webkit.org/314937@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.743@webkitglib/2.52">https://commits.webkit.org/305877.743@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### db26f6947f9567221ddacbc08cb64bfd3ab3d8f4
<pre>
Cherry-pick 314942@main (d343d173217d). <a href="https://bugs.webkit.org/show_bug.cgi?id=316765">https://bugs.webkit.org/show_bug.cgi?id=316765</a>

    TrackPrivateBase::removeClient has an inverted bounds check
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316765">https://bugs.webkit.org/show_bug.cgi?id=316765</a>
    <a href="https://rdar.apple.com/179211106">rdar://179211106</a>

    Reviewed by Pascoe.

    removeClient() bailed out when m_clients.size() &gt; index -- i.e. for every valid index, and only
    reached the slot-clearing assignment when the index was out of bounds. Fix the bounds check.

    * Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
    (WebCore::TrackPrivateBase::removeClient):

    Canonical link: <a href="https://commits.webkit.org/314942@main">https://commits.webkit.org/314942@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.742@webkitglib/2.52">https://commits.webkit.org/305877.742@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8af2f1adc03a1ca55782edfde5d3e6237d9de953
<pre>
Cherry-pick 314944@main (74eb1295e28b). <a href="https://bugs.webkit.org/show_bug.cgi?id=316766">https://bugs.webkit.org/show_bug.cgi?id=316766</a>

    Undefined left-shift in AV1 readULEBSize()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316766">https://bugs.webkit.org/show_bug.cgi?id=316766</a>
    <a href="https://rdar.apple.com/179211459">rdar://179211459</a>

    Reviewed by Pascoe.

    decodedByte is a uint8_t that integer-promotes to a 32-bit int, so decodedByte &lt;&lt; (7 * cptr) is
    undefined behavior for any shift count &gt;= 32. Shift a size_t instead.

    * Source/WebCore/platform/graphics/AV1Utilities.cpp:
    (WebCore::readULEBSize):

    Canonical link: <a href="https://commits.webkit.org/314944@main">https://commits.webkit.org/314944@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.741@webkitglib/2.52">https://commits.webkit.org/305877.741@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 0d05dcbf7c29a56bdf660198c0ab4883cc1d1393
<pre>
Cherry-pick 315028@main (ab52a089ca02). <a href="https://bugs.webkit.org/show_bug.cgi?id=316860">https://bugs.webkit.org/show_bug.cgi?id=316860</a>

    StabilityTracer: com.apple.WebKit.WebContent at com.apple.WebCore: WebCore::dispatchEventsOnWindowAndFocusedElement
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316860">https://bugs.webkit.org/show_bug.cgi?id=316860</a>
    <a href="https://rdar.apple.com/179182828">rdar://179182828</a>

    Reviewed by Abrar Rahman Protyasha and Chris Dumez.

    On this line in dispatchEventsOnWindowAndFocusedElement, the focusedElement()
    may be nullptr, resulting a null dereference:

    document-&gt;focusedElement()-&gt;dispatchBlurEvent(nullptr);

    We can reproduce the crash in this scenario: There is an input element on the
    page which is focused and has an onchange handler that blurs it. We type a
    character in it, and then when we CMD+TAB to open and move to a new tab, the
    crash happens.

    When we move away from the this page, dispatchEventsOnWindowAndFocusedElement()
    is called, and since there is a HTMLFormControlElement on it, we call
    dispatchFormControlChangeEvent() on it. This calls Element::blur(), which sets
    Document::m_focusedElement to nullptr. Then we unconditionally dereference
    document-&gt;focusedElement() in the next line (the line shown above) and crash.
    This call to dispatchEventsOnWindowAndFocusedElement() was added in 308203@main.

    We fix this by null checking focusedElement before using it. We add a test that
    mirrors this scenario.

    Credit to Abrar Protyasha for finding the repro case.

    * LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash-expected.txt: Added.
    * LayoutTests/fast/events/window-deactivation-onchange-blurs-focused-element-should-not-crash.html: Added.
    * Source/WebCore/page/FocusController.cpp:
    (WebCore::dispatchEventsOnWindowAndFocusedElement):

    Canonical link: <a href="https://commits.webkit.org/315028@main">https://commits.webkit.org/315028@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.740@webkitglib/2.52">https://commits.webkit.org/305877.740@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a52df1767a06bd930bff1bc64e6648bc46a48b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168222 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/41778 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35344 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177550 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125923 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170088 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/42154 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41735 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125923 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171181 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/42154 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/35344 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111427 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/42154 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41735 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26246 "Built successfully") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160841 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/42154 "The change is no longer eligible for processing.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180150 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/29469 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32873 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35344 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139356 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/41791 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/41735 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139219 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/42479 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/35344 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/105853 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25630 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/42479 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35344 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200900 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/40983 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114239 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53967 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/40380 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/35344 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/40631 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/40525 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->