### PR TITLE
Add an additional regression test for the fix in 313814@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -396,6 +396,65 @@ TEST(WKBackForwardList, InteractionStateRestorationMultipleItems)
     EXPECT_STREQ([[list.get().backList.firstObject URL] absoluteString].UTF8String, url1.get().absoluteString.UTF8String);
 }
 
+TEST(WKBackForwardList, InteractionStateRestoreWithUserAttributionPreservesBackList)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/page1"_s, { "<title>Page 1</title>"_s } },
+        { "/page2"_s, { "<title>Page 2</title>"_s } },
+        { "/page3"_s, { "<title>Page 3</title>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr url1 = [NSURL URLWithString:@"https://webkit.org/page1"];
+    RetainPtr url2 = [NSURL URLWithString:@"https://example.com/page2"];
+    RetainPtr url3 = [NSURL URLWithString:@"https://apple.com/page3"];
+
+    auto userAttributedRequest = ^(NSURL *url) {
+        RetainPtr request = adoptNS([[NSMutableURLRequest alloc] initWithURL:url]);
+        [request setAttribution:NSURLRequestAttributionUser];
+        return request;
+    };
+
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    [processPoolConfiguration setProcessSwapsOnNavigation:YES];
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [configuration setProcessPool:processPool.get()];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    [webView loadRequest:userAttributedRequest(url1.get()).get()];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:userAttributedRequest(url2.get()).get()];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:userAttributedRequest(url3.get()).get()];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    id interactionState = [webView interactionState];
+
+    webView = nil;
+
+    RetainPtr restoredConfiguration = server.httpsProxyConfiguration();
+    [restoredConfiguration setProcessPool:processPool.get()];
+
+    RetainPtr restoredView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:restoredConfiguration.get()]);
+    restoredView.get().navigationDelegate = navigationDelegate.get();
+
+    [restoredView setInteractionState:interactionState];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_EQ([restoredView backForwardList].backList.count, 2U);
+    EXPECT_WK_STREQ([restoredView backForwardList].backList[0].URL.absoluteString, [url1 absoluteString]);
+    EXPECT_WK_STREQ([restoredView backForwardList].backList[1].URL.absoluteString, [url2 absoluteString]);
+    EXPECT_WK_STREQ([restoredView backForwardList].currentItem.URL.absoluteString, [url3 absoluteString]);
+}
+
 @interface WKBackForwardNavigationDelegate : NSObject <WKNavigationDelegatePrivate>
 - (void)waitForDidFinishNavigationOrDidSameDocumentNavigation;
 @end


### PR DESCRIPTION
#### ac384f185722c538db0e9667aa3731c62d53baf2
<pre>
Add an additional regression test for the fix in <a href="https://commits.webkit.org/313814@main">313814@main</a>
<a href="https://rdar.apple.com/179526259">rdar://179526259</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317047">https://bugs.webkit.org/show_bug.cgi?id=317047</a>

Reviewed by NOBODY (OOPS!).

Someone saw a bug on iOS 27.0 that we had fixed in <a href="https://commits.webkit.org/313814@main">313814@main</a>.

That change included a test, but we came up with an additional test that covers it a little
differently based on their report.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, InteractionStateRestoreWithUserAttributionPreservesBackList)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac384f185722c538db0e9667aa3731c62d53baf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125928 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a07dc56f-ce3b-413a-978c-0538379f0a9a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130913 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92021 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cb61e53-c137-40fd-8610-96ceb6c7e30e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3977dfc3-2dc1-4b90-8cb5-b8fd799cd093) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32366 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31070 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26251 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142352 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180155 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139350 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139213 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42484 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105858 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34500 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27578 "Found 2 new test failures: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40988 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40385 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5640 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40530 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->