### PR TITLE
WorkerStorageConnection::scopeClosed() leaves getEstimate() completion handlers uncalled

### DIFF
--- a/LayoutTests/storage/storagemanager/resources/worker-close-with-pending-estimate.js
+++ b/LayoutTests/storage/storagemanager/resources/worker-close-with-pending-estimate.js
@@ -1,0 +1,10 @@
+if (self.navigator && navigator.storage && navigator.storage.estimate) {
+    for (let i = 0; i < 5; ++i)
+        navigator.storage.estimate();
+
+    postMessage('started-estimate');
+
+    close();
+} else {
+    postMessage('no-storage-estimate');
+}

--- a/LayoutTests/storage/storagemanager/worker-close-with-pending-estimate-expected.txt
+++ b/LayoutTests/storage/storagemanager/worker-close-with-pending-estimate-expected.txt
@@ -1,0 +1,10 @@
+Closing a worker while a navigator.storage.estimate() request is still in flight must not leave the estimate completion handler uncalled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Worker closed with in-flight navigator.storage.estimate() requests without crashing the web process.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/storagemanager/worker-close-with-pending-estimate.html
+++ b/LayoutTests/storage/storagemanager/worker-close-with-pending-estimate.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Closing a worker while a navigator.storage.estimate() request is still in flight must not leave the estimate completion handler uncalled.");
+
+jsTestIsAsync = true;
+
+const worker = new Worker('resources/worker-close-with-pending-estimate.js');
+
+worker.onmessage = (event) => {
+    if (event.data === 'started-estimate')
+        testPassed('Worker closed with in-flight navigator.storage.estimate() requests without crashing the web process.');
+    else
+        testFailed('Unexpected message from worker: ' + event.data);
+
+    setTimeout(finishJSTest, 500);
+};
+
+worker.onerror = (event) => {
+    testFailed('Worker error: ' + (event.message || event));
+    finishJSTest();
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
@@ -58,6 +58,10 @@ void WorkerStorageConnection::scopeClosed()
     for (auto& callback : getDirectoryCallbacks.values())
         callback(Exception { ExceptionCode::InvalidStateError });
 
+    auto getEstimateCallbacks = std::exchange(m_getEstimateCallbacks, { });
+    for (auto& callback : getEstimateCallbacks.values())
+        callback(Exception { ExceptionCode::InvalidStateError });
+
     m_scope = nullptr;
 }
 


### PR DESCRIPTION
#### b0273bc189c1f6ddbfbb624d6cbe3b9f44e345d3
<pre>
WorkerStorageConnection::scopeClosed() leaves getEstimate() completion handlers uncalled
<a href="https://bugs.webkit.org/show_bug.cgi?id=317050">https://bugs.webkit.org/show_bug.cgi?id=317050</a>
<a href="https://rdar.apple.com/179531657">rdar://179531657</a>

Reviewed by Sihui Liu.

scopeClosed() drained m_getPersistedCallbacks and m_getDirectoryCallbacks but not
m_getEstimateCallbacks. An in-flight StorageManager.estimate() at worker teardown therefore
destroyed an unrun CompletionHandler. Drain the estimate callbacks with an InvalidStateError too.

Test: storage/storagemanager/worker-close-with-pending-estimate.html
* LayoutTests/storage/storagemanager/resources/worker-close-with-pending-estimate.js: Added.
* LayoutTests/storage/storagemanager/worker-close-with-pending-estimate-expected.txt: Added.
* LayoutTests/storage/storagemanager/worker-close-with-pending-estimate.html: Added.
* Source/WebCore/Modules/storage/WorkerStorageConnection.cpp:
(WebCore::WorkerStorageConnection::scopeClosed):

Canonical link: <a href="https://commits.webkit.org/315307@main">https://commits.webkit.org/315307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12779ac07614b7ab25b9e339a4def90b553527dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125936 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f7ad13c-a61a-4a7b-a148-d67457163be6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130919 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92023 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63fa16f5-3362-4544-bf14-0d669c5d895b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111431 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/666c0ddf-4889-4ac5-a736-de17a3d28f79) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32369 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31074 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26259 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180163 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32886 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139355 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139218 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42492 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105866 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25688 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34503 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114252 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40996 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5647 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40393 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40644 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40538 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->