### PR TITLE
[Site Isolation] Only inform WKNavigationDelegate when main frame process crashes

### DIFF
--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7181,6 +7181,11 @@ void Internals::terminateWebContentProcess()
     exit(0);
 }
 
+unsigned Internals::getpid() const
+{
+    return static_cast<unsigned>(getCurrentProcessID());
+}
+
 #if ENABLE(APPLE_PAY)
 ExceptionOr<Ref<MockPaymentCoordinator>> Internals::mockPaymentCoordinator(Document& document)
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1174,6 +1174,7 @@ public:
     void terminateServiceWorker(ServiceWorker&, DOMPromiseDeferred<void>&&);
     void whenServiceWorkerIsTerminated(ServiceWorker&, DOMPromiseDeferred<void>&&);
     NO_RETURN_DUE_TO_CRASH void terminateWebContentProcess();
+    unsigned getpid() const;
 
     void numberOfWebSocketChannelsInNetworkProcess(DOMPromiseDeferred<IDLUnsignedLong>&&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1319,6 +1319,7 @@ enum ContentsFormat {
     Promise<undefined> terminateServiceWorker(ServiceWorker worker);
     Promise<undefined> whenServiceWorkerIsTerminated(ServiceWorker worker);
     undefined terminateWebContentProcess();
+    unsigned long getpid();
 
     Promise<unsigned long> numberOfWebSocketChannelsInNetworkProcess();
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1296,6 +1296,9 @@ static _WKProcessTerminationReason wkProcessTerminationReason(ProcessTermination
 
 bool NavigationState::NavigationClient::processDidTerminate(WebPageProxy& page, ProcessTerminationReason reason)
 {
+    if (reason == ProcessTerminationReason::NonMainFrameWebContentProcessCrash)
+        return true;
+
     RefPtr navigationState = m_navigationState.get();
     if (!navigationState)
         return false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9720,4 +9720,33 @@ TEST(SiteIsolation, ScriptMessageHandlerDocumentIdentifierOnPageHide)
     EXPECT_NOT_NULL(message.frameInfo._documentIdentifier);
 }
 
+TEST(SiteIsolation, NonMainFrameProcessCrash)
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    enableSiteIsolation(configuration.get());
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    delegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        // Test passes if this delegate is not called for iframe process crashes.
+        EXPECT_FALSE(true);
+    };
+    [webView setNavigationDelegate:delegate.get()];
+
+    auto html = "<script>onload = () => {"
+    "var iframe = document.createElement('iframe');"
+    "document.body.appendChild(iframe);"
+    "iframe.src = 'http://localhost:' + window.location.port + '/iframe';"
+    "}</script>"_s;
+
+    HTTPServer server({
+        { "/"_s, { html } },
+        { "/iframe"_s, { "<script>alert(internals.getpid())</script>"_s } },
+    });
+
+    [webView loadRequest:server.request()];
+    NSString *iframeProcessPort = [webView _test_waitForAlert];
+    kill([iframeProcessPort intValue], 9);
+    Util::runFor(0.1_s);
+}
+
 }


### PR DESCRIPTION
#### 65f1020983d8e3aaba1454d3e1467f5b5fdab41f
<pre>
[Site Isolation] Only inform WKNavigationDelegate when main frame process crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=317053">https://bugs.webkit.org/show_bug.cgi?id=317053</a>
<a href="https://rdar.apple.com/177903694">rdar://177903694</a>

Reviewed by Ben Nham.

In 2024 we discussed what would be the best user experience when an iframe process
crashes with site isolation enabled, a condition that had naver been seen before.
We decided doing nothing would be the best user experience, but just continuing to
show the frames that had not crashed.  I even wrote some tests for it, for example
http/tests/site-isolation/iframe-process-termination.html.

In 285735@main I broke this in order to get more crash data from WebKitTestRunner.
It is useful to continue to get those crashes when using WKPageNavigationClient,
but when using WKNavigationDelegate it is best to do nothing.

Before this change, when an iframe process crashes the whole page is reloaded, and
when it happens multiple times Safari shows a banner that says an issue was hit
multiple times.  After this change, in that case we just lose the iframe content
but the rest of the page continues functioning normally.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getpid const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::processDidTerminate):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, NonMainFrameProcessCrash)):

Canonical link: <a href="https://commits.webkit.org/315183@main">https://commits.webkit.org/315183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73143b8e861a6a5ca8b6d48f878be4e96d550224

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125938 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0f7e9aa-a500-4fb1-8a61-d69d769c2250) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130922 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0f32b36-917e-4975-bab5-afcab2397d27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111434 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72e2fc36-1956-43d4-ba2b-093e4781cd29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32372 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31077 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26261 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142358 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180165 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32888 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139359 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41806 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35236 "Found 1 new test failure: http/tests/site-isolation/accessibility/focus-in-remote-frame.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139222 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42494 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105868 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34507 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27559 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-properties.html imported/w3c/web-platform-tests/css/css-images/tiled-radial-gradients.html imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114254 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40395 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5649 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40646 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40540 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->