### PR TITLE
[css-values] Math functions produce incorrect signed zero for subtraction, min/max/clamp, and mod()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed-expected.txt
@@ -1,14 +1,14 @@
 
 PASS round(10,10) should be used-value-equivalent to 10
 PASS mod(1,1) should be used-value-equivalent to 0
-FAIL mod(0,-2) should be used-value-equivalent to 0 assert_equals: mod(0,-2) and 0 serialize to the same thing in used values. expected "0" but got "-2"
-FAIL mod(2,-2) should be used-value-equivalent to 0 assert_equals: mod(2,-2) and 0 serialize to the same thing in used values. expected "0" but got "-2"
-FAIL mod(4,-2) should be used-value-equivalent to 0 assert_equals: mod(4,-2) and 0 serialize to the same thing in used values. expected "0" but got "-2"
+PASS mod(0,-2) should be used-value-equivalent to 0
+PASS mod(2,-2) should be used-value-equivalent to 0
+PASS mod(4,-2) should be used-value-equivalent to 0
 PASS mod(-2,-2) should be used-value-equivalent to 0
 PASS mod(-4,-2) should be used-value-equivalent to 0
 PASS mod(0, 2) should be used-value-equivalent to 0
 PASS mod(2, 2) should be used-value-equivalent to 0
-FAIL mod(-2, 2) should be used-value-equivalent to 0 assert_equals: mod(-2, 2) and 0 serialize to the same thing in used values. expected "0" but got "2"
+PASS mod(-2, 2) should be used-value-equivalent to 0
 PASS mod(1, 2) should be used-value-equivalent to 1
 PASS mod(3, 2) should be used-value-equivalent to 1
 PASS mod(-1, 2) should be used-value-equivalent to 1

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/signed-zero-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/signed-zero-expected.txt
@@ -30,7 +30,7 @@ PASS clamp(-1, 1 / sign(calc( 0 +  0)), 1) should be used-value-equivalent to 1
 PASS sign(calc(-0 - -0)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(calc(-0 - -0)), 1) should be used-value-equivalent to 1
 PASS sign(calc(-0 -  0)) should be used-value-equivalent to 0
-FAIL clamp(-1, 1 / sign(calc(-0 -  0)), 1) should be used-value-equivalent to -1 assert_equals: clamp(-1, 1 / sign(calc(-0 -  0)), 1) and -1 serialize to the same thing in used values. expected "-1" but got "1"
+PASS clamp(-1, 1 / sign(calc(-0 -  0)), 1) should be used-value-equivalent to -1
 PASS sign(calc( 0 - -0)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(calc( 0 - -0)), 1) should be used-value-equivalent to 1
 PASS sign(calc( 0 -  0)) should be used-value-equivalent to 0
@@ -38,9 +38,9 @@ PASS clamp(-1, 1 / sign(calc( 0 -  0)), 1) should be used-value-equivalent to 1
 PASS sign(min(-0,  0)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(min(-0,  0)), 1) should be used-value-equivalent to -1
 PASS sign(min( 0, -0)) should be used-value-equivalent to 0
-FAIL clamp(-1, 1 / sign(min( 0, -0)), 1) should be used-value-equivalent to -1 assert_equals: clamp(-1, 1 / sign(min( 0, -0)), 1) and -1 serialize to the same thing in used values. expected "-1" but got "1"
+PASS clamp(-1, 1 / sign(min( 0, -0)), 1) should be used-value-equivalent to -1
 PASS sign(max(-0,  0)) should be used-value-equivalent to 0
-FAIL clamp(-1, 1 / sign(max(-0,  0)), 1) should be used-value-equivalent to 1 assert_equals: clamp(-1, 1 / sign(max(-0,  0)), 1) and 1 serialize to the same thing in used values. expected "1" but got "-1"
+PASS clamp(-1, 1 / sign(max(-0,  0)), 1) should be used-value-equivalent to 1
 PASS sign(max( 0, -0)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(max( 0, -0)), 1) should be used-value-equivalent to 1
 PASS sign(clamp(-0, -1, -0)) should be used-value-equivalent to 0
@@ -56,9 +56,9 @@ PASS clamp(-1, 1 / sign(clamp(-0, -1, 0)), 1) should be used-value-equivalent to
 PASS sign(clamp(-0, -0, 0)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(clamp(-0, -0, 0)), 1) should be used-value-equivalent to -1
 PASS sign(clamp(-0,  0, 0)) should be used-value-equivalent to 0
-FAIL clamp(-1, 1 / sign(clamp(-0,  0, 0)), 1) should be used-value-equivalent to 1 assert_equals: clamp(-1, 1 / sign(clamp(-0,  0, 0)), 1) and 1 serialize to the same thing in used values. expected "1" but got "-1"
+PASS clamp(-1, 1 / sign(clamp(-0,  0, 0)), 1) should be used-value-equivalent to 1
 PASS sign(clamp(-0,  1, 0)) should be used-value-equivalent to 0
-FAIL clamp(-1, 1 / sign(clamp(-0,  1, 0)), 1) should be used-value-equivalent to 1 assert_equals: clamp(-1, 1 / sign(clamp(-0,  1, 0)), 1) and 1 serialize to the same thing in used values. expected "1" but got "-1"
+PASS clamp(-1, 1 / sign(clamp(-0,  1, 0)), 1) should be used-value-equivalent to 1
 PASS sign(clamp(0, -1, -0)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(clamp(0, -1, -0)), 1) should be used-value-equivalent to 1
 PASS sign(clamp(0, -0, -0)) should be used-value-equivalent to 0
@@ -89,9 +89,9 @@ PASS sign(round(down,  1, infinity)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(round(down,  1, infinity)), 1) should be used-value-equivalent to 1
 PASS sign(mod(-1, -1)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(mod(-1, -1)), 1) should be used-value-equivalent to -1
-FAIL sign(mod(-1,  1)) should be used-value-equivalent to 0 assert_equals: sign(mod(-1,  1)) and 0 serialize to the same thing in used values. expected "0" but got "1"
+PASS sign(mod(-1,  1)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(mod(-1,  1)), 1) should be used-value-equivalent to 1
-FAIL sign(mod( 1, -1)) should be used-value-equivalent to 0 assert_equals: sign(mod( 1, -1)) and 0 serialize to the same thing in used values. expected "0" but got "-1"
+PASS sign(mod( 1, -1)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(mod( 1, -1)), 1) should be used-value-equivalent to -1
 PASS sign(mod( 1,  1)) should be used-value-equivalent to 0
 PASS clamp(-1, 1 / sign(mod( 1,  1)), 1) should be used-value-equivalent to 1

--- a/Source/WebCore/css/calc/CSSCalcExecutor.h
+++ b/Source/WebCore/css/calc/CSSCalcExecutor.h
@@ -55,6 +55,23 @@ inline std::pair<double, double> getNearestMultiples(double a, double b)
     return { lower, upper };
 }
 
+// IEEE 754 / CSS signed-zero aware min and max. Unlike std::min / std::max, these
+// distinguish +0 from -0 when the values compare equal: minimum(+0, -0) is -0 and
+// maximum(+0, -0) is +0. See https://drafts.csswg.org/css-values-4/#calc-ieee
+template<std::floating_point T> inline T minWithSignedZero(T a, T b)
+{
+    if (a == b)
+        return std::signbit(a) ? a : b;
+    return std::min(a, b);
+}
+
+template<std::floating_point T> inline T maxWithSignedZero(T a, T b)
+{
+    if (a == b)
+        return std::signbit(a) ? b : a;
+    return std::max(a, b);
+}
+
 template<typename Range> concept FloatingPointRange = requires(Range range) {
     { *range.begin() } -> std::floating_point;
     { *range.end() } -> std::floating_point;
@@ -130,7 +147,7 @@ template<> struct OperatorExecutor<Operator::Min> {
             auto value = *it;
             if (std::isnan(value))
                 return value;
-            minimum = std::min(minimum, value);
+            minimum = minWithSignedZero(minimum, value);
         }
         return minimum;
     }
@@ -141,7 +158,7 @@ template<> struct OperatorExecutor<Operator::Min> {
             return val;
         if (std::isnan(min))
             return min;
-        return std::min(val, min);
+        return minWithSignedZero(val, min);
     }
 
     template<typename T, std::invocable<const T&> Functor> double operator()(const Vector<T>& range, Functor&& functor)
@@ -166,7 +183,7 @@ template<> struct OperatorExecutor<Operator::Max> {
             auto value = *it;
             if (std::isnan(value))
                 return value;
-            maximum = std::max(maximum, value);
+            maximum = maxWithSignedZero(maximum, value);
         }
         return maximum;
     }
@@ -177,7 +194,7 @@ template<> struct OperatorExecutor<Operator::Max> {
             return val;
         if (std::isnan(max))
             return max;
-        return std::max(val, max);
+        return maxWithSignedZero(val, max);
     }
 
     template<typename T, std::invocable<const T&> Functor> double operator()(const Vector<T>& range, Functor&& functor)
@@ -193,7 +210,7 @@ template<> struct OperatorExecutor<Operator::Clamp> {
     {
         if (std::isnan(min) || std::isnan(val) || std::isnan(max))
             return std::numeric_limits<T>::quiet_NaN();
-        return std::max(min, std::min(val, max));
+        return maxWithSignedZero(min, minWithSignedZero(val, max));
     }
 
     template<std::floating_point T> T operator()(Variant<T, CSS::Keyword::None> min, T val, Variant<T, CSS::Keyword::None> max)
@@ -290,9 +307,13 @@ template<> struct OperatorExecutor<Operator::Mod> {
         if (std::isinf(b) && std::signbit(a) != std::signbit(b))
             return std::numeric_limits<double>::quiet_NaN();
         auto result = std::fmod(a, b);
+        // A zero remainder takes the sign of B (the result is "on B's side of
+        // zero"), rather than the sign std::fmod inherits from A.
+        // https://drafts.csswg.org/css-values/#round-func
+        if (!result)
+            return std::signbit(b) ? -0.0 : +0.0;
         // If the result is on opposite side of zero from B,
         // put it between 0 and B.
-        // https://drafts.csswg.org/css-values/#round-func
         if (std::signbit(result) != std::signbit(b))
             result += b;
         return result;

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -907,8 +907,11 @@ std::optional<Child> simplify(Negate& root, const SimplificationOptions&)
 
     return WTF::switchOn(root.a,
         [&]<Numeric T>(T& a) -> std::optional<Child> {
-            // 6.1. If root’s child is a numeric value, return an equivalent numeric value, but with the value negated (0 - value).
-            return makeChildWithValueBasedOn(0.0 - a.value, a);
+            // 6.1. If root’s child is a numeric value, return an equivalent numeric value, but with the value negated.
+            // NOTE: We use unary negation rather than the spec's literal "0 - value" so that the sign of a zero is
+            // flipped (negating +0 yields -0), matching IEEE 754 and the runtime Negate executor.
+            // https://drafts.csswg.org/css-values-4/#calc-ieee
+            return makeChildWithValueBasedOn(-a.value, a);
         },
         [](IndirectNode<Negate>& a) -> std::optional<Child> {
             // 6.2. If root’s child is a Negate node, return the child’s child.

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -219,6 +219,10 @@ inline double Value::clampToPermittedRange(double value) const
     // it instead act as though the numeric part is 0.
     value = std::isnan(value) ? 0 : value;
 
+    // Signed zeros do not escape a top-level calculation; they are censored into the
+    // "unsigned" (positive) zero. https://drafts.csswg.org/css-values-4/#calc-ieee
+    value = value ? value : 0.0;
+
     // If an <angle> must be converted due to exceeding the implementation-defined range of supported values,
     // it must be clamped to the nearest supported multiple of 360deg.
     if (m_category == CSS::Category::Angle && std::isinf(value))


### PR DESCRIPTION
#### e809da70b870de6faae16df8bf00c39a27cc2575
<pre>
[css-values] Math functions produce incorrect signed zero for subtraction, min/max/clamp, and mod()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317056">https://bugs.webkit.org/show_bug.cgi?id=317056</a>
<a href="https://rdar.apple.com/179534440">rdar://179534440</a>

Reviewed by Sam Weinig.

Several CSS math operations did not follow the IEEE 754 signed-zero rules
required by <a href="https://drafts.csswg.org/css-values-4/#calc-ieee">https://drafts.csswg.org/css-values-4/#calc-ieee</a>, leading to
few test failures:

- Negate folded +0 to +0 via &quot;0 - value&quot;, so calc(-0 - 0) (i.e. 0⁻ - 0⁺)
  produced 0⁺ instead of 0⁻.
- min()/max()/clamp() used std::min/std::max, which ignore the sign of zero
  and return the first argument on ties, so min(0⁺, 0⁻), max(0⁺, 0⁻), and
  clamp(0⁺, 0⁻, ...) gave the wrong zero.
- mod() shifted a zero remainder by B, turning ±0 into B instead of a
  B-signed zero, so mod(-1, 1) returned 1 and mod(1, -1) returned -1.

Fix each to honor the spec: minimum(0⁺, 0⁻) is 0⁻, maximum(0⁺, 0⁻) is 0⁺,
0⁻ - 0⁺ is 0⁻, and a zero mod() result takes the sign of B. Also censor
signed zero into unsigned zero when a value escapes a top-level calculation.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/signed-zero-expected.txt: Ditto
* Source/WebCore/css/calc/CSSCalcExecutor.h:
(WebCore::CSSCalc::minWithSignedZero):
(WebCore::CSSCalc::maxWithSignedZero):
(WebCore::CSSCalc::OperatorExecutor&lt;Operator::Min&gt;::operator()):
(WebCore::CSSCalc::OperatorExecutor&lt;Operator::Max&gt;::operator()):
(WebCore::CSSCalc::OperatorExecutor&lt;Operator::Clamp&gt;::operator()):
(WebCore::CSSCalc::OperatorExecutor&lt;Operator::Mod&gt;::operator()):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::simplify):
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalc::Value::clampToPermittedRange const):

Canonical link: <a href="https://commits.webkit.org/315188@main">https://commits.webkit.org/315188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1a776ee2a02799196527729662c7632559c5caf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41796 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35410 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125940 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c51e48a-da80-4933-bcc3-dd6952c7e00a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130923 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92027 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32c2c881-e39a-410a-9c8b-a5826ff5efee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111435 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cce96549-6dc6-4935-bdee-9080d9421f89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32375 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31079 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26263 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142361 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180167 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139360 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41808 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35238 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37511 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42496 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105872 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27594 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41000 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40397 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5651 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40542 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->