### PR TITLE
[gardening]: [macOS release] imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html is flaky crash

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2439,3 +2439,5 @@ webkit.org/b/316036 [ Debug ] inspector/timeline/timeline-event-TimerFire.html [
 webkit.org/b/315982 [ Sequoia Release x86_64 ] webgl/pending/conformance/glsl/misc/swizzle-as-lvalue.html [ Pass Timeout ]
 
 webkit.org/b/316089 [ Sequoia Release ] inspector/css/setLayoutContextTypeChangedMode.html [ Pass Failure ]
+
+webkit.org/b/317031 [ Release ] imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html  [ Pass Crash ]


### PR DESCRIPTION
#### f31ccf8c850d1c0d2b1c85a8794bfe7303a0882a
<pre>
[Gardening]: [macOS release] imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html is flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=317031">https://bugs.webkit.org/show_bug.cgi?id=317031</a>
<a href="https://rdar.apple.com/179515644">rdar://179515644</a>

Unreviewed test gardening

* LayoutTests/platform/ios/TestExpectations:
</pre>