### PR TITLE
[JSC] Use UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE in getNamedTimeZoneEpochNanoseconds

### DIFF
--- a/JSTests/stress/temporal-zdt-apia-dateline-gap.js
+++ b/JSTests/stress/temporal-zdt-apia-dateline-gap.js
@@ -1,0 +1,90 @@
+//@ requireOptions("--useTemporal=1")
+
+// Pacific/Apia 2011-12-30 date-line skip: at 2011-12-30T10:00:00Z the offset jumped
+// from -10:00 to +14:00. All wall times 2011-12-30T00:00 .. 23:59:59 are nonexistent.
+// pre-gap offset (era right before): -10:00
+// post-gap offset:                    +14:00
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${String(expected)} but got ${String(actual)}`);
+}
+function shouldThrowRangeError(fn) {
+    try { fn(); throw new Error("expected RangeError but no exception thrown"); }
+    catch (e) { if (!(e instanceof RangeError)) throw new Error(`expected RangeError, got ${e}`); }
+}
+
+const tz = 'Pacific/Apia';
+// At/around the transition instant.
+const transitionEpochNs = 1325239200000000000n; // 2011-12-30T10:00:00Z
+
+// 1. PlainDateTime in the gap, all four disambiguations.
+{
+    const mid = Temporal.PlainDateTime.from('2011-12-30T00:00:00');
+
+    const e = mid.toZonedDateTime(tz, { disambiguation: 'earlier' });
+    shouldBe(e.offset, '-10:00');
+    shouldBe(e.epochNanoseconds, transitionEpochNs - 86400000000000n); // 24h before
+    // earlier epoch = naive(Dec 30 00:00 UTC) - afterOffset(+14h) = Dec 29 10:00 UTC.
+    // Local with offset -10:00 = Dec 29 00:00.
+    shouldBe(e.year, 2011); shouldBe(e.month, 12); shouldBe(e.day, 29);
+    shouldBe(e.hour, 0); shouldBe(e.minute, 0); shouldBe(e.second, 0);
+
+    // 'later' / 'compatible': bracketed by pre-gap offset (-10:00).
+    // naive = 2011-12-30T00:00 (as UTC) → epoch = naive + 10h = transition instant.
+    const l = mid.toZonedDateTime(tz, { disambiguation: 'later' });
+    shouldBe(l.offset, '+14:00');
+    shouldBe(l.epochNanoseconds, transitionEpochNs);
+
+    const c = mid.toZonedDateTime(tz, { disambiguation: 'compatible' });
+    shouldBe(c.epochNanoseconds, l.epochNanoseconds);
+
+    shouldThrowRangeError(() => mid.toZonedDateTime(tz, { disambiguation: 'reject' }));
+
+    // Mid-gap: 2011-12-30T12:00 → 'later' = naive + 10h = 2011-12-30T22:00Z
+    //                              'earlier' = naive - 14h = 2011-12-29T22:00Z
+    const noon = Temporal.PlainDateTime.from('2011-12-30T12:00:00');
+    const noonE = noon.toZonedDateTime(tz, { disambiguation: 'earlier' });
+    const noonL = noon.toZonedDateTime(tz, { disambiguation: 'later' });
+    shouldBe(noonE.epochNanoseconds, 1325196000000000000n); // 2011-12-29T22:00Z, -10:00
+    shouldBe(noonL.epochNanoseconds, 1325282400000000000n); // 2011-12-30T22:00Z, +14:00
+    shouldBe(noonL.epochNanoseconds - noonE.epochNanoseconds, 86400000000000n); // 24h apart
+}
+
+// 2. ZonedDateTime calendar arithmetic: subtract P1D over the date-line skip.
+//    'compatible' is the disambiguation used internally by AddZonedDateTime.
+{
+    // Day after the skip: 2011-12-31T00:00 +14 = transition instant.
+    const start = Temporal.ZonedDateTime.from('2011-12-31T00:00[Pacific/Apia]');
+    shouldBe(start.epochNanoseconds, transitionEpochNs);
+
+    // Subtracting 1 calendar day lands on 2011-12-30T00:00 wall (gap) → 'compatible' = transition.
+    const minusOne = start.subtract({ days: 1 });
+    shouldBe(minusOne.epochNanoseconds, transitionEpochNs);
+    shouldBe(minusOne.offset, '+14:00');
+
+    // Adding back 1 day lands on 2012-01-01T00:00.
+    const back = minusOne.add({ days: 1 });
+    shouldBe(back.year, 2012); shouldBe(back.month, 1); shouldBe(back.day, 1);
+    shouldBe(back.hour, 0); shouldBe(back.minute, 0);
+    shouldBe(back.offset, '+14:00');
+}
+
+// 3. ZonedDateTime.from with the bare gap wall time + each disambiguation.
+{
+    const fromE = Temporal.ZonedDateTime.from(
+        { year: 2011, month: 12, day: 30, hour: 0, minute: 0, timeZone: tz },
+        { disambiguation: 'earlier' });
+    shouldBe(fromE.offset, '-10:00');
+    shouldBe(fromE.epochNanoseconds, transitionEpochNs - 86400000000000n);
+
+    const fromL = Temporal.ZonedDateTime.from(
+        { year: 2011, month: 12, day: 30, hour: 0, minute: 0, timeZone: tz },
+        { disambiguation: 'later' });
+    shouldBe(fromL.offset, '+14:00');
+    shouldBe(fromL.epochNanoseconds, transitionEpochNs);
+
+    shouldThrowRangeError(() => Temporal.ZonedDateTime.from(
+        { year: 2011, month: 12, day: 30, hour: 12, minute: 0, timeZone: tz },
+        { disambiguation: 'reject' }));
+}

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -248,7 +248,9 @@ static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds
                     return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
 
                 UDate transitionMs = 0;
-                auto result = ucal_getTimeZoneTransitionDate(cal, UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &status);
+                // icuEpochMs can be the exact transition instant. UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE is including icuEpochMs's instant itself.
+                // We use it instead of UCAL_TZ_TRANSITION_PREVIOUS as it is not including icuEpochMs itself.
+                auto result = ucal_getTimeZoneTransitionDate(cal, UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE, &transitionMs, &status);
                 if (U_FAILURE(status)) [[unlikely]]
                     return makeUnexpected(rangeError(icuTimeZoneOffsetFailed));
 


### PR DESCRIPTION
#### 82b8665ef1c3c2c4ec385d1cab7132e3e71056e6
<pre>
[JSC] Use UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE in getNamedTimeZoneEpochNanoseconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=317058">https://bugs.webkit.org/show_bug.cgi?id=317058</a>
<a href="https://rdar.apple.com/179540818">rdar://179540818</a>

Reviewed by Yijia Huang.

When you ask Temporal to resolve a wall-clock datetime in a named time zone,
JSC asks ICU what UTC instant that local time corresponds to. ICU does this
through a calendar object: set the wall fields, read back ucal_getMillis.
Compute the offset at that instant. If icuEpochMs + offset == localMs, the
local time is valid (single candidate, normal case). If they don&apos;t match,
the local time does not exist, so it falls in a DST spring-forward gap
(so that time does not exist in the world!!!), and the spec says we need to
record the two bracket offsets (pre-gap beforeNs, post-gap afterNs) so
disambiguation later can pick which side to land on.

To obtain beforeNs, we need the offset of the era immediately before this gap.
The current code&apos;s strategy:

1. ucal_setMillis(cal, icuEpochMs) - point the calendar at the gap.
2. ucal_getTimeZoneTransitionDate(cal, UCAL_TZ_TRANSITION_PREVIOUS, ...) - find the transition that opened this gap.
3. Read the offset 1ms earlier (transitionMs - 1.0) — that&apos;s the pre-gap offset.

But UCAL_TZ_TRANSITION_PREVIOUS is strictly less than the calendar&apos;s current millis.
So if the current time is exact point of this boundary, we will not get
that time point.

This patch fixes a bug with UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE.

Test: JSTests/stress/temporal-zdt-apia-dateline-gap.js

* JSTests/stress/temporal-zdt-apia-dateline-gap.js: Added.
(shouldBe):
(shouldThrowRangeError):
* Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp:
(JSC::TemporalCore::getNamedTimeZoneEpochNanoseconds):

Canonical link: <a href="https://commits.webkit.org/315166@main">https://commits.webkit.org/315166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a37560219544ae7f513595c43bc42454fc09c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177578 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f4cc14a-211b-4367-a7da-cbb71d8823e8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130933 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/125951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca0ef671-2e64-4030-b333-29da1ea5e0b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33399 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111445 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07dae309-4a4d-40ec-9070-5fc467a64b8f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31086 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26274 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160869 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180178 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29497 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32901 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139369 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41819 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35245 "Build is in progress. Recent messages:") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139232 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42507 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105888 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34519 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200928 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41011 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114267 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40408 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5663 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40659 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40553 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->