### PR TITLE
[JSC] Make Liveness analysis faster

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -551,6 +551,7 @@
 		DD3DC96427A4BF8E007E5B61 /* CrossThreadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 515F794D1CFC9F4A00CCED93 /* CrossThreadTask.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC96527A4BF8E007E5B61 /* FixedVector.h in Headers */ = {isa = PBXBuildFile; fileRef = E3E0F04F26197157004640FC /* FixedVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC96627A4BF8E007E5B61 /* IndexSparseSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 2684D4351C000D400081D663 /* IndexSparseSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		08982C1A106045F4A68DF4F1 /* SparseBitVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 02F0B57890A842688F808D7C /* SparseBitVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC96727A4BF8E007E5B61 /* ListDump.h in Headers */ = {isa = PBXBuildFile; fileRef = A70DA0831799F04D00529A9B /* ListDump.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC96827A4BF8E007E5B61 /* MonotonicTime.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F66B2831DC97BAB004A1D3F /* MonotonicTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC9A027A5C0F0007E5B61 /* ReducedResolutionSeconds.h in Headers */ = {isa = PBXBuildFile; fileRef = DD3DC9A127A5C0F0007E5B61 /* ReducedResolutionSeconds.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1320,6 +1321,7 @@
 		26147B0815DDCCDC00DDB907 /* IntegerToStringConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntegerToStringConversion.h; sourceTree = "<group>"; };
 		26299B6D17A9E5B800ADEBE5 /* Ref.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ref.h; sourceTree = "<group>"; };
 		2684D4351C000D400081D663 /* IndexSparseSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndexSparseSet.h; sourceTree = "<group>"; };
+		02F0B57890A842688F808D7C /* SparseBitVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SparseBitVector.h; sourceTree = "<group>"; };
 		275DFB6B238BDF72001230E2 /* OptionSetHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OptionSetHash.h; sourceTree = "<group>"; };
 		27C793CE2C40909D000E1BE8 /* PlatformEnableWin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformEnableWin.h; sourceTree = "<group>"; };
 		2A0CF001302E77880086000A /* CFTypeTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFTypeTraits.h; sourceTree = "<group>"; };
@@ -2757,6 +2759,7 @@
 				A30D412D1F0DE13F00B71954 /* SoftLinking.h */,
 				93156C8D262C982200EAE27B /* SortedArrayMap.h */,
 				79038E05224B05A7004C0738 /* SpanningTree.h */,
+				02F0B57890A842688F808D7C /* SparseBitVector.h */,
 				A8A4730D151A825B004123FF /* Spectrum.h */,
 				A8A4730F151A825B004123CF /* StackAllocation.h */,
 				A8A4730E151A825B004123FF /* StackBounds.cpp */,
@@ -3921,6 +3924,7 @@
 				DD3DC91F27A4BF8E007E5B61 /* SortedArrayMap.h in Headers */,
 				466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */,
 				DD3DC8CD27A4BF8E007E5B61 /* SpanningTree.h in Headers */,
+				08982C1A106045F4A68DF4F1 /* SparseBitVector.h in Headers */,
 				DD3DC87727A4BF8E007E5B61 /* Spectrum.h in Headers */,
 				DD3DC97F27A4BF8E007E5BC1 /* StackAllocation.h in Headers */,
 				DD3DC97F27A4BF8E007E5B61 /* StackBounds.h in Headers */,

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -257,7 +257,7 @@ public:
         m_bitsOrPointer &= other.m_bitsOrPointer;
         ASSERT(isInline());
     }
-    
+
     void exclude(const BitVector& other)
     {
         if (!isInline() || !other.isInline()) {

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -325,6 +325,7 @@ set(WTF_PUBLIC_HEADERS
     SoftLinking.h
     SortedArrayMap.h
     SpanningTree.h
+    SparseBitVector.h
     Spectrum.h
     StackAllocation.h
     StackBounds.h

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -25,9 +25,11 @@
 
 #pragma once
 
+#include <algorithm>
 #include <ranges>
 #include <wtf/BitVector.h>
 #include <wtf/IndexSparseSet.h>
+#include <wtf/SparseBitVector.h>
 #include <wtf/StdLibExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -260,94 +262,229 @@ public:
 protected:
     void compute()
     {
+        uint64_t denseMatrixBits = static_cast<uint64_t>(m_cfg.numNodes()) * Adapter::numIndices();
+        constexpr uint64_t denseMatrixBitBudget = 32 * 1024 * 1024; // 4 MB per live-set matrix.
+        bool useSparse = denseMatrixBits > denseMatrixBitBudget;
+#if ASSERT_ENABLED
+        // Most JSC stress test functions are small enough that the dense path would always win.
+        // Force the sparse path on roughly half of them in debug builds so the sparse implementation
+        // gets meaningful coverage from the regular test suite.
+        if (!useSparse && (m_cfg.numNodes() & 1))
+            useSparse = true;
+#endif
+        if (useSparse)
+            computeSparse();
+        else
+            computeDense();
+    }
+
+    void computeDense()
+    {
         Adapter::prepareToCompute();
 
-        // The liveAtTail of each block automatically contains the LateUse's of the terminal.
-        BitVector dirtyBlocks;
+        unsigned numNodes = m_cfg.numNodes();
+        unsigned numIndices = Adapter::numIndices();
+
+        // Per-block live sets are stored as a flat bit-matrix: a single Vector<uint64_t> of
+        // numNodes * wordsPerSet words, where block b's set occupies the contiguous slice
+        // [b * wordsPerSet, (b + 1) * wordsPerSet). Keeping each set as a span of machine words lets
+        // the whole dataflow run as plain word loops, with one allocation per matrix (rather than
+        // one per block) and no inline/out-of-line special-casing. This is what makes liveness fast
+        // on the very large functions (e.g. SQLite's VDBE) that dominate its cost.
+        constexpr unsigned wordBits = 64;
+        size_t wordsPerSet = (numIndices + wordBits - 1) / wordBits;
+        size_t matrixWords = static_cast<size_t>(numNodes) * wordsPerSet;
+
+        Vector<uint64_t> liveInStore(matrixWords);
+        Vector<uint64_t> liveOutStore(matrixWords);
+        Vector<uint64_t> genStore(matrixWords);
+        Vector<uint64_t> killStore(matrixWords);
+        // Vector's sized constructor does not zero POD storage, and the dataflow ORs into these
+        // sets, so they must start empty.
+        std::ranges::fill(liveInStore, 0);
+        std::ranges::fill(liveOutStore, 0);
+        std::ranges::fill(genStore, 0);
+        std::ranges::fill(killStore, 0);
+        std::span<uint64_t> liveInMatrix = liveInStore.mutableSpan();
+        std::span<uint64_t> liveOutMatrix = liveOutStore.mutableSpan();
+        std::span<uint64_t> genMatrix = genStore.mutableSpan();
+        std::span<uint64_t> killMatrix = killStore.mutableSpan();
+
+        auto setFor = [&] (std::span<uint64_t> matrix, unsigned blockIndex) -> std::span<uint64_t> {
+            return matrix.subspan(static_cast<size_t>(blockIndex) * wordsPerSet, wordsPerSet);
+        };
+        auto setBit = [] (std::span<uint64_t> set, unsigned index) {
+            set[index / wordBits] |= static_cast<uint64_t>(1) << (index % wordBits);
+        };
+
+        BitVector dirtyBlocks(numNodes);
         Vector<unsigned, 64> worklist;
-        for (unsigned blockIndex = 0; blockIndex < m_cfg.numNodes(); ++blockIndex) {
-            typename CFG::Node block = m_cfg.node(blockIndex);
+        for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
+            auto block = m_cfg.node(blockIndex);
             if (!block)
                 continue;
 
-            IndexVector& liveAtTail = m_liveAtTail[block];
+            auto killSet = setFor(killMatrix, blockIndex);
+            auto genSet = setFor(genMatrix, blockIndex);
+            auto liveOutSet = setFor(liveOutMatrix, blockIndex);
 
-            Adapter::forEachUse(
-                block, Adapter::blockSize(block),
-                [&] (unsigned index) {
-                    liveAtTail.append(index);
+            // kill: every value defined anywhere in the block.
+            for (size_t boundary = 0; boundary <= Adapter::blockSize(block); ++boundary) {
+                Adapter::forEachDef(block, boundary, [&] (unsigned index) {
+                    setBit(killSet, index);
                 });
+            }
 
-            std::ranges::sort(liveAtTail);
-            removeRepeatedElements(liveAtTail);
-            dirtyBlocks.set(blockIndex);
+            // gen: the block's transfer function applied to an empty live-out, i.e. the uses that
+            // are exposed at the head. This is the only place we walk instructions; the fixpoint
+            // below works purely on gen/kill/liveOut.
+            m_workset.clear();
+            for (size_t instIndex = Adapter::blockSize(block); instIndex--;) {
+                Adapter::forEachDef(block, instIndex + 1, [&] (unsigned index) { m_workset.remove(index); });
+                Adapter::forEachUse(block, instIndex, [&] (unsigned index) { m_workset.add(index); });
+            }
+            Adapter::forEachDef(block, 0, [&] (unsigned index) { m_workset.remove(index); });
+            for (unsigned index : m_workset)
+                setBit(genSet, index);
+
+            // liveOut automatically contains the LateUse's of the terminal.
+            Adapter::forEachUse(block, Adapter::blockSize(block), [&] (unsigned index) {
+                setBit(liveOutSet, index);
+            });
+
+            dirtyBlocks.quickSet(blockIndex);
             worklist.append(blockIndex);
         }
-
-        IndexVector mergeBuffer;
 
         while (!worklist.isEmpty()) {
             unsigned blockIndex = worklist.takeLast();
             bool cleared = dirtyBlocks.quickClear(blockIndex);
             ASSERT_UNUSED(cleared, cleared);
 
-            typename CFG::Node block = m_cfg.node(blockIndex);
+            auto block = m_cfg.node(blockIndex);
             ASSERT(block);
 
-            LocalCalc localCalc(*this, block);
-            for (size_t instIndex = Adapter::blockSize(block); instIndex--;)
-                localCalc.execute(instIndex);
+            auto liveInSet = setFor(liveInMatrix, blockIndex);
+            auto liveOutSet = setFor(liveOutMatrix, blockIndex);
+            auto genSet = setFor(genMatrix, blockIndex);
+            auto killSet = setFor(killMatrix, blockIndex);
 
-            // Handle the early def's of the first instruction.
-            Adapter::forEachDef(
-                block, 0,
-                [&] (unsigned index) {
-                    m_workset.remove(index);
-                });
-
-            IndexVector& liveAtHead = m_liveAtHead[block];
-
-            // We only care about Tmps that were discovered in this iteration. It is impossible
-            // to remove a live value from the head.
-            // We remove all the values we already knew about so that we only have to deal with
-            // what is new in LiveAtHead.
-            if (m_workset.size() == liveAtHead.size())
-                m_workset.clear();
-            else {
-                for (unsigned liveIndexAtHead : liveAtHead)
-                    m_workset.remove(liveIndexAtHead);
+            // liveIn = gen | (liveOut & ~kill)
+            uint64_t changed = 0;
+            for (size_t i = 0; i < wordsPerSet; ++i) {
+                uint64_t newLiveIn = genSet[i] | (liveOutSet[i] & ~killSet[i]);
+                uint64_t oldLiveIn = liveInSet[i];
+                liveInSet[i] = newLiveIn;
+                changed |= newLiveIn ^ oldLiveIn;
             }
-
-            if (m_workset.isEmpty())
+            if (!changed)
                 continue;
 
-            liveAtHead.appendRange(m_workset.begin(), m_workset.end());
-
-            m_workset.sort();
-
-            for (typename CFG::Node predecessor : m_cfg.predecessors(block)) {
-                IndexVector& liveAtTail = m_liveAtTail[predecessor];
-
-                if (liveAtTail.isEmpty())
-                    liveAtTail = m_workset.values();
-                else {
-                    mergeBuffer.resize(liveAtTail.size() + m_workset.size());
-                    auto iter = mergeDeduplicatedSorted(
-                        liveAtTail.begin(), liveAtTail.end(),
-                        m_workset.begin(), m_workset.end(),
-                        mergeBuffer.begin());
-                    mergeBuffer.shrink(iter - mergeBuffer.begin());
-
-                    if (mergeBuffer.size() == liveAtTail.size())
-                        continue;
-
-                    RELEASE_ASSERT(mergeBuffer.size() > liveAtTail.size());
-                    std::swap(liveAtTail, mergeBuffer);
+            // Propagate this block's liveIn into each predecessor's liveOut, re-queuing a predecessor
+            // only when its liveOut actually grew.
+            for (auto predecessor : m_cfg.predecessors(block)) {
+                auto predLiveOut = setFor(liveOutMatrix, predecessor->index());
+                uint64_t predChanged = 0;
+                for (size_t i = 0; i < wordsPerSet; ++i) {
+                    uint64_t oldLiveOut = predLiveOut[i];
+                    uint64_t newLiveOut = oldLiveOut | liveInSet[i];
+                    predLiveOut[i] = newLiveOut;
+                    predChanged |= newLiveOut ^ oldLiveOut;
                 }
-
-                if (!dirtyBlocks.quickSet(predecessor->index()))
+                if (predChanged && !dirtyBlocks.quickSet(predecessor->index()))
                     worklist.append(predecessor->index());
             }
+        }
+
+        // Materialize the sorted IndexVector representation that the public API uses. WTF::forEachSetBit
+        // yields ascending indices, so the resulting vectors are already sorted.
+        for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
+            auto block = m_cfg.node(blockIndex);
+            if (!block)
+                continue;
+            WTF::forEachSetBit(std::span<const uint64_t> { setFor(liveInMatrix, blockIndex) }, [&] (size_t index) { m_liveAtHead[block].append(index); });
+            WTF::forEachSetBit(std::span<const uint64_t> { setFor(liveOutMatrix, blockIndex) }, [&] (size_t index) { m_liveAtTail[block].append(index); });
+        }
+    }
+
+    // Sparse fallback for functions whose dense matrices would be too large. Memory is proportional
+    // to live values, at the cost of working bit by bit (SparseBitVector has no bulk word ops).
+    void computeSparse()
+    {
+        Adapter::prepareToCompute();
+
+        unsigned numNodes = m_cfg.numNodes();
+
+        Vector<SparseBitVector<>> tailBits(numNodes);
+        Vector<SparseBitVector<>> headBits(numNodes);
+
+        BitVector dirtyBlocks(numNodes);
+        Vector<unsigned, 64> worklist;
+        for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
+            auto block = m_cfg.node(blockIndex);
+            if (!block)
+                continue;
+
+            // The liveAtTail of each block automatically contains the LateUse's of the terminal.
+            auto& liveAtTail = tailBits[blockIndex];
+            Adapter::forEachUse(
+                block, Adapter::blockSize(block),
+                [&] (unsigned index) {
+                    liveAtTail.set(index);
+                });
+
+            dirtyBlocks.quickSet(blockIndex);
+            worklist.append(blockIndex);
+        }
+
+        Vector<unsigned, 64> delta;
+        while (!worklist.isEmpty()) {
+            unsigned blockIndex = worklist.takeLast();
+            bool cleared = dirtyBlocks.quickClear(blockIndex);
+            ASSERT_UNUSED(cleared, cleared);
+
+            auto block = m_cfg.node(blockIndex);
+            ASSERT(block);
+
+            m_workset.clear();
+            tailBits[blockIndex].forEachSetBit(
+                [&] (size_t index) {
+                    m_workset.add(index);
+                });
+            for (size_t instIndex = Adapter::blockSize(block); instIndex--;) {
+                Adapter::forEachDef(block, instIndex + 1, [&] (unsigned index) { m_workset.remove(index); });
+                Adapter::forEachUse(block, instIndex, [&] (unsigned index) { m_workset.add(index); });
+            }
+            Adapter::forEachDef(block, 0, [&] (unsigned index) { m_workset.remove(index); });
+
+            auto& liveAtHead = headBits[blockIndex];
+            delta.shrink(0);
+            for (unsigned index : m_workset) {
+                if (liveAtHead.set(index))
+                    delta.append(index);
+            }
+
+            if (delta.isEmpty())
+                continue;
+
+            for (auto predecessor : m_cfg.predecessors(block)) {
+                auto& predTail = tailBits[predecessor->index()];
+                bool changed = false;
+                for (unsigned index : delta) {
+                    if (predTail.set(index))
+                        changed = true;
+                }
+                if (changed && !dirtyBlocks.quickSet(predecessor->index()))
+                    worklist.append(predecessor->index());
+            }
+        }
+
+        for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
+            auto block = m_cfg.node(blockIndex);
+            if (!block)
+                continue;
+            headBits[blockIndex].forEachSetBit([&] (size_t index) { m_liveAtHead[block].append(index); });
+            tailBits[blockIndex].forEachSetBit([&] (size_t index) { m_liveAtTail[block].append(index); });
         }
     }
 

--- a/Source/WTF/wtf/SparseBitVector.h
+++ b/Source/WTF/wtf/SparseBitVector.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <wtf/BitSet.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/Vector.h>
+
+namespace WTF {
+
+// A bit vector that only stores the chunks ("elements") that have set bits, so its memory is
+// proportional to the number of set bits rather than to the largest index. This is the right
+// representation when the universe of indices is large but only a small, clustered subset is set
+// at any time -- e.g. per-basic-block liveness sets over a function with many virtual registers,
+// where a dense BitVector would cost numBlocks x numIndices bits.
+template<unsigned elementBits = 128>
+class SparseBitVector {
+public:
+    SparseBitVector() = default;
+
+    void ensureSize(unsigned) { }
+
+    void clear()
+    {
+        m_elements.clear();
+        m_hint = 0;
+    }
+
+    bool isEmpty() const
+    {
+        ASSERT(allElementsNonEmpty());
+        return m_elements.isEmpty();
+    }
+
+    bool set(unsigned bit)
+    {
+        Element& element = findOrInsert(bit / elementBits);
+        return !element.bits.testAndSet(bit % elementBits);
+    }
+
+    bool reset(unsigned bit)
+    {
+        unsigned elementIndex = bit / elementBits;
+        unsigned position = (m_hint < m_elements.size() && m_elements[m_hint].index == elementIndex) ? m_hint : lowerBound(elementIndex);
+        if (position >= m_elements.size() || m_elements[position].index != elementIndex)
+            return false;
+
+        bool wasSet = m_elements[position].bits.testAndClear(bit % elementBits);
+        if (wasSet && m_elements[position].bits.isEmpty()) {
+            m_elements.removeAt(position);
+            m_hint = 0; // Positions shifted; invalidate the hint.
+        } else
+            m_hint = position;
+
+        return wasSet;
+    }
+
+    bool contains(unsigned bit) const
+    {
+        const Element* element = find(bit / elementBits);
+        return element && element->bits.get(bit % elementBits);
+    }
+
+    template<typename Func>
+    void forEachSetBit(const Func& func) const
+    {
+        for (const Element& element : m_elements) {
+            unsigned base = element.index * elementBits;
+            element.bits.forEachSetBit([&] (size_t bitInElement) {
+                func(base + static_cast<unsigned>(bitInElement));
+            });
+        }
+    }
+
+private:
+    struct Element {
+        unsigned index { 0 };
+        BitSet<elementBits> bits;
+    };
+
+#if ASSERT_ENABLED
+    bool allElementsNonEmpty() const
+    {
+        for (const Element& element : m_elements) {
+            if (element.bits.isEmpty())
+                return false;
+        }
+        return true;
+    }
+#endif
+
+    const Element* find(unsigned elementIndex) const
+    {
+        if (m_hint < m_elements.size() && m_elements[m_hint].index == elementIndex)
+            return &m_elements[m_hint];
+
+        unsigned position = lowerBound(elementIndex);
+        if (position < m_elements.size() && m_elements[position].index == elementIndex) {
+            m_hint = position;
+            return &m_elements[position];
+        }
+
+        return nullptr;
+    }
+
+    Element& findOrInsert(unsigned elementIndex)
+    {
+        if (m_hint < m_elements.size() && m_elements[m_hint].index == elementIndex)
+            return m_elements[m_hint];
+
+        unsigned position = lowerBound(elementIndex);
+        if (position < m_elements.size() && m_elements[position].index == elementIndex) {
+            m_hint = position;
+            return m_elements[position];
+        }
+
+        m_elements.insert(position, Element { elementIndex, { } });
+        m_hint = position;
+        return m_elements[position];
+    }
+
+    unsigned lowerBound(unsigned elementIndex) const
+    {
+        auto iterator = std::ranges::lower_bound(m_elements, elementIndex, { }, &Element::index);
+        return iterator - m_elements.begin();
+    }
+
+    Vector<Element> m_elements;
+    mutable unsigned m_hint { 0 };
+};
+
+} // namespace WTF
+
+using WTF::SparseBitVector;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -120,6 +120,7 @@ set(TestWTF_SOURCES
     Tests/WTF/SentinelLinkedList.cpp
     Tests/WTF/SetForScope.cpp
     Tests/WTF/Signals.cpp
+    Tests/WTF/SparseBitVector.cpp
     Tests/WTF/StackTraceTest.cpp
     Tests/WTF/StdLibExtrasTests.cpp
     Tests/WTF/StringBuilder.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1220,6 +1220,7 @@
 				WTF/Signals.cpp,
 				WTF/SmallSet.cpp,
 				WTF/SortedArrayMap.cpp,
+				WTF/SparseBitVector.cpp,
 				WTF/StackTraceTest.cpp,
 				WTF/StdLibExtrasTests.cpp,
 				WTF/StringBuilder.cpp,

--- a/Tools/TestWebKitAPI/Tests/WTF/SparseBitVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SparseBitVector.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Helpers/Test.h"
+#include <set>
+#include <wtf/SparseBitVector.h>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+template<unsigned elementBits>
+static Vector<unsigned> collect(const SparseBitVector<elementBits>& bits)
+{
+    Vector<unsigned> result;
+    bits.forEachSetBit([&] (unsigned index) {
+        result.append(index);
+    });
+    return result;
+}
+
+TEST(WTF_SparseBitVector, Empty)
+{
+    SparseBitVector<> bits;
+    EXPECT_TRUE(bits.isEmpty());
+    EXPECT_FALSE(bits.contains(0));
+    EXPECT_FALSE(bits.contains(42));
+    EXPECT_FALSE(bits.contains(1000000));
+    EXPECT_TRUE(collect(bits).isEmpty());
+}
+
+TEST(WTF_SparseBitVector, SetAndContains)
+{
+    SparseBitVector<> bits;
+
+    // set() returns true the first time and false afterwards.
+    EXPECT_TRUE(bits.set(42));
+    EXPECT_FALSE(bits.set(42));
+    EXPECT_FALSE(bits.isEmpty());
+    EXPECT_TRUE(bits.contains(42));
+    EXPECT_FALSE(bits.contains(41));
+    EXPECT_FALSE(bits.contains(43));
+
+    EXPECT_TRUE(bits.set(0));
+    EXPECT_TRUE(bits.set(1000000));
+    EXPECT_TRUE(bits.contains(0));
+    EXPECT_TRUE(bits.contains(1000000));
+    EXPECT_FALSE(bits.contains(999999));
+}
+
+TEST(WTF_SparseBitVector, ForEachSetBitIsAscending)
+{
+    SparseBitVector<> bits;
+    // Insert out of order and across many elements.
+    for (unsigned value : { 5000u, 3u, 4999u, 200u, 0u, 127u, 128u, 129u, 1u, 1000003u })
+        bits.set(value);
+
+    Vector<unsigned> expected { 0, 1, 3, 127, 128, 129, 200, 4999, 5000, 1000003 };
+    EXPECT_EQ(collect(bits), expected);
+}
+
+TEST(WTF_SparseBitVector, Clear)
+{
+    SparseBitVector<> bits;
+    bits.set(1);
+    bits.set(100000);
+    EXPECT_FALSE(bits.isEmpty());
+
+    bits.clear();
+    EXPECT_TRUE(bits.isEmpty());
+    EXPECT_FALSE(bits.contains(1));
+    EXPECT_FALSE(bits.contains(100000));
+    EXPECT_TRUE(collect(bits).isEmpty());
+
+    // Reusable after clear.
+    EXPECT_TRUE(bits.set(7));
+    EXPECT_TRUE(bits.contains(7));
+}
+
+TEST(WTF_SparseBitVector, ElementBoundaries)
+{
+    // With 128-bit elements, exercise the exact boundaries between words and elements.
+    SparseBitVector<128> bits;
+    for (unsigned value : { 0u, 63u, 64u, 127u, 128u, 191u, 192u, 255u })
+        EXPECT_TRUE(bits.set(value));
+    Vector<unsigned> expected { 0, 63, 64, 127, 128, 191, 192, 255 };
+    EXPECT_EQ(collect(bits), expected);
+    for (unsigned value : expected)
+        EXPECT_TRUE(bits.contains(value));
+    EXPECT_FALSE(bits.contains(62));
+    EXPECT_FALSE(bits.contains(193));
+}
+
+TEST(WTF_SparseBitVector, RandomizedAgainstReference)
+{
+    // Cross-check against std::set with a deterministic pseudo-random sequence.
+    SparseBitVector<> bits;
+    std::set<unsigned> reference;
+
+    uint64_t state = 0x123456789abcdef0ull;
+    auto next = [&] {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        return static_cast<unsigned>(state % 20000);
+    };
+
+    for (unsigned i = 0; i < 20000; ++i) {
+        unsigned value = next();
+        bool expectedNewlySet = !reference.contains(value);
+        EXPECT_EQ(bits.set(value), expectedNewlySet);
+        reference.insert(value);
+        EXPECT_TRUE(bits.contains(value));
+    }
+
+    EXPECT_EQ(bits.isEmpty(), reference.empty());
+
+    // Membership matches for the whole index range.
+    for (unsigned value = 0; value < 20000; ++value)
+        EXPECT_EQ(bits.contains(value), reference.contains(value));
+
+    // forEachSetBit yields exactly the reference set, in ascending order.
+    Vector<unsigned> collected = collect(bits);
+    Vector<unsigned> expected;
+    for (unsigned value : reference)
+        expected.append(value);
+    EXPECT_EQ(collected, expected);
+}
+
+TEST(WTF_SparseBitVector, SetAndReset)
+{
+    SparseBitVector<> bits;
+
+    // reset() returns true iff the bit was set.
+    EXPECT_FALSE(bits.reset(42));
+    EXPECT_TRUE(bits.set(42));
+    EXPECT_TRUE(bits.reset(42));
+    EXPECT_FALSE(bits.reset(42));
+    EXPECT_FALSE(bits.contains(42));
+
+    // Clearing the last bit of an element makes the vector empty again (the element is erased).
+    EXPECT_TRUE(bits.set(1000));
+    EXPECT_FALSE(bits.isEmpty());
+    EXPECT_TRUE(bits.reset(1000));
+    EXPECT_TRUE(bits.isEmpty());
+
+    // Clearing one bit while another in the same element remains stays non-empty.
+    bits.set(10);
+    bits.set(11);
+    EXPECT_TRUE(bits.reset(10));
+    EXPECT_FALSE(bits.isEmpty());
+    EXPECT_FALSE(bits.contains(10));
+    EXPECT_TRUE(bits.contains(11));
+    EXPECT_EQ(collect(bits), (Vector<unsigned> { 11 }));
+}
+
+TEST(WTF_SparseBitVector, RandomizedAddRemoveAgainstReference)
+{
+    SparseBitVector<> bits;
+    std::set<unsigned> reference;
+
+    uint64_t state = 0x0fedcba987654321ull;
+    auto next = [&] {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        return static_cast<unsigned>(state % 5000);
+    };
+
+    for (unsigned i = 0; i < 40000; ++i) {
+        unsigned value = next();
+        if (i & 1) {
+            bool expectedNewlySet = !reference.contains(value);
+            EXPECT_EQ(bits.set(value), expectedNewlySet);
+            reference.insert(value);
+        } else {
+            bool expectedWasSet = reference.contains(value);
+            EXPECT_EQ(bits.reset(value), expectedWasSet);
+            reference.erase(value);
+        }
+        EXPECT_EQ(bits.isEmpty(), reference.empty());
+    }
+
+    for (unsigned value = 0; value < 5000; ++value)
+        EXPECT_EQ(bits.contains(value), reference.contains(value));
+
+    Vector<unsigned> expected;
+    for (unsigned value : reference)
+        expected.append(value);
+    EXPECT_EQ(collect(bits), expected);
+}
+
+} // namespace TestWebKitAPI
+


### PR DESCRIPTION
#### 53209b2d1762797af5e7192311ee825092720436
<pre>
[JSC] Make Liveness analysis faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=317062">https://bugs.webkit.org/show_bug.cgi?id=317062</a>
<a href="https://rdar.apple.com/179544464">rdar://179544464</a>

Reviewed by Dan Hecht.

WTF::Liveness is slow in two cases,

1. Simply even in small graph, it is slow due to repeated sorting
2. In large graph, this is further slower

We should use BitVector, traditional textbook approach to liveness analysis.
But if graph is large (e.g. Air graph), it takes significant amount of
memory because these BitVector becomes sparse due to # of Air values.
Thus this patch adds SparseBitVector. This is managing Vector of BitSet,
maintaining sparse version of BitVector efficiently. It also has the
last accessed m_hint cache as similar to LLVM&apos;s SparseBitVector.

Liveness analysis code switches the underlying implementation based on
the graph size. If it is small, then we use (conceptually) BitVector,
otherwise using SparseBitVector.

To extremely optimize, we use Vector and doing word-level operations
directly instead of using BitVector.

Test: Tools/TestWebKitAPI/Tests/WTF/SparseBitVector.cpp

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::compute):
(WTF::Liveness::computeDense):
(WTF::Liveness::computeSparse):
* Source/WTF/wtf/SparseBitVector.h: Added.
(WTF::SparseBitVector::ensureSize):
(WTF::SparseBitVector::clear):
(WTF::SparseBitVector::isEmpty const):
(WTF::SparseBitVector::set):
(WTF::SparseBitVector::reset):
(WTF::SparseBitVector::contains const):
(WTF::SparseBitVector::forEachSetBit const):
(WTF::SparseBitVector::allElementsNonEmpty const):
(WTF::SparseBitVector::find const):
(WTF::SparseBitVector::findOrInsert):
(WTF::SparseBitVector::lowerBound const):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/SparseBitVector.cpp: Added.
(TestWebKitAPI::collect):
(TestWebKitAPI::TEST(WTF_SparseBitVector, Empty)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, SetAndContains)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, ForEachSetBitIsAscending)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, Clear)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, ElementBoundaries)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, RandomizedAgainstReference)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, SetAndReset)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, RandomizedAddRemoveAgainstReference)):

Canonical link: <a href="https://commits.webkit.org/315242@main">https://commits.webkit.org/315242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29c7ee8806091cc44fb0a3a07bc6a67cdbee2c91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168461 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126162 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fdc1bfdb-b398-4201-8c59-8172de350e14) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131116 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47b43b0d-1a95-4328-9aa2-132d59a1642d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111627 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e4f90cb-e3ac-43ae-a8e6-8a8f0decba35) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31271 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26485 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161080 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142555 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180389 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29708 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139557 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139416 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42718 "Built successfully") | | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106369 "Hash 29c7ee88 for PR 67125 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34709 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27769 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201139 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114478 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54024 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40619 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5852 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40870 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40764 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->