### PR TITLE
[Regression: 310995@main] overflow computed value is wrongly reset to visible on table rows

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2231,7 +2231,6 @@ imported/w3c/web-platform-tests/mathml/relations/css-styling/transform.html [ Im
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-lspace-rspace-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/display-with-overflow.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/relations/css-styling/overflow/computed-value-001.html [ Failure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/floating-inside-mathml-with-block-display.html [ ImageOnlyFailure ]
 mathml/non-core/mathvariant/mathvariant-basic-transforms-with-default-font.html [ ImageOnlyFailure ]
 mathml/non-core/mathvariant/mathvariant-double-struck-font-style-font-weight.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/overflow-computed-value-table-row-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/overflow-computed-value-table-row-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Computed value of overflow:scroll is preserved on a table row (trScroll)
+PASS Computed value of overflow:hidden is preserved on a table row (trHidden)
+PASS Computed value of overflow:auto is preserved on a table row (trAuto)
+PASS Computed value of overflow:clip is preserved on a table row (trClip)
+PASS Computed value of overflow:scroll is preserved on a table row (divRow)
+PASS overflow:scroll on a table row does not create a scroll container (used value is visible)
+scroll
+hidden
+auto
+clip
+display:table-row

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/overflow-computed-value-table-row.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/overflow-computed-value-table-row.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>overflow computed value on table rows</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visufx.html#overflow">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">
+<meta name="assert" content="The 'overflow' property does not apply to table rows, but its computed value is preserved (computed value: as specified). Only the used value is forced to visible so a table row never becomes a scroll container.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  .scroll { overflow: scroll; }
+  .hidden { overflow: hidden; }
+  .auto   { overflow: auto; }
+  .clip   { overflow: clip; }
+  .as-row { display: table-row; }
+</style>
+<div id="log"></div>
+
+<table>
+  <tbody>
+    <tr id="trScroll" class="scroll"><td>scroll</td></tr>
+    <tr id="trHidden" class="hidden"><td>hidden</td></tr>
+    <tr id="trAuto"   class="auto"><td>auto</td></tr>
+    <tr id="trClip"   class="clip"><td>clip</td></tr>
+  </tbody>
+</table>
+
+<!-- A non-table element forced to display:table-row must behave the same. -->
+<div id="divRow" class="as-row scroll"><span>display:table-row</span></div>
+
+<script>
+function checkComputedOverflow(id, expected) {
+  test(function () {
+    var element = document.getElementById(id);
+    var style = window.getComputedStyle(element);
+    assert_equals(style.display, "table-row", "precondition: element is a table row");
+    assert_equals(style.overflow, expected, "overflow");
+    assert_equals(style.overflowX, expected, "overflow-x");
+    assert_equals(style.overflowY, expected, "overflow-y");
+  }, "Computed value of overflow:" + expected + " is preserved on a table row (" + id + ")");
+}
+
+checkComputedOverflow("trScroll", "scroll");
+checkComputedOverflow("trHidden", "hidden");
+checkComputedOverflow("trAuto", "auto");
+checkComputedOverflow("trClip", "clip");
+checkComputedOverflow("divRow", "scroll");
+
+// The used value must remain "visible": a table row never establishes a
+// scroll container, so it must not have a scrollable area.
+test(function () {
+  var row = document.getElementById("trScroll");
+  assert_equals(row.scrollWidth, row.clientWidth,
+    "table row with overflow:scroll does not scroll horizontally");
+  assert_equals(row.scrollHeight, row.clientHeight,
+    "table row with overflow:scroll does not scroll vertically");
+}, "overflow:scroll on a table row does not create a scroll container (used value is visible)");
+</script>

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -99,11 +99,17 @@ inline bool RenderBox::scrollsOverflowY() const
 
 inline bool RenderBox::isScrollContainerX() const
 {
+    // The overflow property does not apply to table rows (CSS2 11.1.1), so they never scroll even
+    // though the computed value is preserved (see StyleAdjuster and RenderElement::effectiveOverflowX).
+    if (isRenderTableRow())
+        return false;
     return style().overflowX() == Overflow::Scroll || style().overflowX() == Overflow::Hidden || style().overflowX() == Overflow::Auto;
 }
 
 inline bool RenderBox::isScrollContainerY() const
 {
+    if (isRenderTableRow())
+        return false;
     return style().overflowY() == Overflow::Scroll || style().overflowY() == Overflow::Hidden || style().overflowY() == Overflow::Auto;
 }
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2702,6 +2702,10 @@ void RenderElement::setPseudoElementRenderer(PseudoElementType type, RenderBlock
 Overflow RenderElement::effectiveOverflowX() const
 {
     auto overflowX = style().overflowX();
+    // The overflow property does not apply to table row elements (CSS2 section 11.1.1), so they never
+    // become scroll containers, even though the computed value is preserved (see StyleAdjuster).
+    if (isRenderTableRow())
+        return Overflow::Visible;
     if (paintContainmentApplies() && overflowX == Overflow::Visible)
         return Overflow::Clip;
     return overflowX;
@@ -2710,6 +2714,8 @@ Overflow RenderElement::effectiveOverflowX() const
 Overflow RenderElement::effectiveOverflowY() const
 {
     auto overflowY = style().overflowY();
+    if (isRenderTableRow())
+        return Overflow::Visible;
     if (paintContainmentApplies() && overflowY == Overflow::Visible)
         return Overflow::Clip;
     return overflowY;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -635,11 +635,11 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 
     bool overflowIsClipOrVisible = isOverflowClipOrVisible(style.overflowY()) && isOverflowClipOrVisible(style.overflowX());
 
-    // The overflow property does not apply to table row elements (CSS2 section 11.1.1).
-    if (style.display() == DisplayType::TableRow) {
-        style.setOverflowX(ComputedStyle::initialOverflowX());
-        style.setOverflowY(ComputedStyle::initialOverflowY());
-    } else if (!overflowIsClipOrVisible && style.display().isTableBox()) {
+    // The overflow property does not apply to table row elements (CSS2 section 11.1.1), but this
+    // only affects the used value: rows never become scroll containers (see
+    // RenderElement::effectiveOverflowX/Y), while the computed value is preserved so getComputedStyle()
+    // reports it faithfully. This matches Blink, which does not special-case table rows here.
+    if (!overflowIsClipOrVisible && style.display().isTableBox()) {
         // Tables only support overflow:hidden and overflow:visible and ignore anything else,
         // see https://drafts.csswg.org/css2/#overflow. As a table is not a block
         // container box the rules for resolving conflicting x and y values in CSS Overflow Module


### PR DESCRIPTION
#### ec0594113754bd2ebd607102cf515d787009541b
<pre>
[Regression: <a href="https://commits.webkit.org/310995@main">310995@main</a>] overflow computed value is wrongly reset to visible on table rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=317063">https://bugs.webkit.org/show_bug.cgi?id=317063</a>
<a href="https://rdar.apple.com/179546444">rdar://179546444</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

getComputedStyle() reports &quot;visible&quot; for overflow on table rows even when the
author specified scroll/hidden/auto/clip. Per the spec [1] overflow applies to
block containers and its computed value is &quot;as specified&quot;; that overflow does
not apply to table rows only constrains the used value (a row never scrolls).
Blink and Gecko preserve the computed value; WebKit was the only engine
resetting it.

This is regression when we made RenderTableRow a RenderBlock and, to stop rows
from scrolling, reset overflow to initial in StyleAdjuster, clobbering the
computedv alue seen by script.

Keep the computed value and instead force the used value to visible:
- StyleAdjuster no longer resets overflow on table rows.
- RenderElement::effectiveOverflowX/Y() returns Visible for rows, so they still
  never scroll or clip.
- RenderBox::isScrollContainerX/Y() returns false for rows, which read style()
  directly and need the same guard.

[1] <a href="https://drafts.csswg.org/css2/#overflow-clipping">https://drafts.csswg.org/css2/#overflow-clipping</a>

Test: imported/w3c/web-platform-tests/css/css-tables/overflow-computed-value-table-row.html

* LayoutTests/TestExpectations: Undo [ Failure ] marked by <a href="https://commits.webkit.org/310995@main">310995@main</a>
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/overflow-computed-value-table-row-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/overflow-computed-value-table-row.html: Added.
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::isScrollContainerX const):
(WebCore::RenderBox::isScrollContainerY const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::effectiveOverflowX const):
(WebCore::RenderElement::effectiveOverflowY const):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec0594113754bd2ebd607102cf515d787009541b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126008 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/080e65df-dd96-4941-ab48-7fe16d3e626b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130982 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92079 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65a3de9c-755c-4821-9d26-a8553377085b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111494 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02fb7e71-a5af-43f1-8704-e6ef5feecd6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32434 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31137 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26331 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142420 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180235 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139419 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139282 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106046 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34571 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27631 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41068 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114324 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40465 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5715 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->