### PR TITLE
Scroll snapping selects a snap point that overshoots the destination instead of the closest one in the scroll direction

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/paged-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/paged-expected.txt
@@ -17,7 +17,7 @@ The last page
 
 FAIL Doesn't skip past small snappable content assert_array_equals: expected property 0 to be 2 but got 3 (expected array [2] got [3])
 FAIL Doesn't skip past large snappable content assert_array_equals: lengths differ, expected array [3] length 1, got [4, 5] length 2
-FAIL Scrolls multiple smaller items into view assert_array_equals: lengths differ, expected array [4, 5, 6] length 3, got [5, 6] length 2
-FAIL Scrolls past items currently in view assert_array_equals: expected property 0 to be 7 but got 8 (expected array [7] got [8])
+PASS Scrolls multiple smaller items into view
+PASS Scrolls past items currently in view
 PASS Scrolls more than a page if necessary
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002-expected.txt
@@ -1,6 +1,6 @@
 
 PASS The closest snap point is preferred than scroll-snap-stop: always where it's further than the destination (the closest one is closer to the scroll start position than the destination)
-FAIL The closest snap point is preferred than scroll-snap-stop: always where it's further than the destination (the closest one is further than the destination from the start position) assert_equals: expected 95 but got 120
+PASS The closest snap point is preferred than scroll-snap-stop: always where it's further than the destination (the closest one is further than the destination from the start position)
 PASS The scroll destination on a large element whose snap area covers the snapport entirely is a valid snap position
 PASS The scroll destination on a large element whose snap area covers the snapport entirely is a valid snap position (with two `scroll-snap-stop: always` snap points
 PASS `scroll-snap-stop: always` snap point is preferred even if the snap area entire snapport

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1763,7 +1763,6 @@ imported/w3c/web-platform-tests/css/css-scroll-snap/snap-fling-in-large-area.htm
 
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/common-to-both-axes-supercedes-first-in-tree-order.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-nested-containers.html [ Pass Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-on-reconstructing-frame.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element.html [ Skip ]
 
 webkit.org/b/170629  memory/memory-pressure-simulation.html [ Pass Failure Crash ]

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -239,11 +239,16 @@ static std::pair<LayoutType, std::optional<unsigned>> closestSnapOffsetWithInfoA
         // two screen-widths away, a naïve “always snap to nearest” selection algorithm might “trap” the
         //
         // For a directional scroll, we never snap back to the original scroll position or before it,
-        // always preferring the snap offset in the scroll direction.
+        // always preferring the snap offset in the scroll direction. Prefer the actual scroll
+        // direction (velocity) to decide which side to discard, since the predicted destination can
+        // collapse onto the original offset (e.g. when momentum prediction is disabled); only fall
+        // back to the destination for non-directional scrolls where velocity is 0.
         auto& originalOffset = *originalOffsetForDirectionalSnapping;
-        if (originalOffset < scrollDestinationOffset && previous && (*previous).first <= originalOffset)
+        bool scrollingForward = velocity ? velocity > 0 : scrollDestinationOffset > originalOffset;
+        bool scrollingBackward = velocity ? velocity < 0 : scrollDestinationOffset < originalOffset;
+        if (scrollingForward && previous && (*previous).first <= originalOffset)
             previous.reset();
-        if (originalOffset > scrollDestinationOffset && next && (*next).first >= originalOffset)
+        if (scrollingBackward && next && (*next).first >= originalOffset)
             next.reset();
     }
 
@@ -254,10 +259,16 @@ static std::pair<LayoutType, std::optional<unsigned>> closestSnapOffsetWithInfoA
     if (!next)
         return *previous;
 
-    // If this scroll isn't directional, then choose whatever snap point is closer, otherwise pick the offset in the scroll direction.
-    if (!std::abs(velocity))
-        return (scrollDestinationOffset - (*previous).first) <= ((*next).first - scrollDestinationOffset) ? *previous : *next;
-    return velocity < 0 ? *previous : *next;
+    // The directional filtering above has already discarded any snap offset that would trap the
+    // scroll (i.e. one at or behind the original offset), so both remaining candidates are valid
+    // targets in the scroll direction. Among them, prefer whichever is closest to the scroll
+    // destination, so a snap point between the origin and the destination is preferred over one that
+    // overshoots it. Only fall back to the scroll direction to break an exact tie.
+    auto distanceToPrevious = scrollDestinationOffset - (*previous).first;
+    auto distanceToNext = (*next).first - scrollDestinationOffset;
+    if (distanceToPrevious == distanceToNext)
+        return velocity < 0 ? *previous : *next;
+    return distanceToPrevious < distanceToNext ? *previous : *next;
 }
 
 static LayoutRect computeScrollSnapPortRect(const Style::ComputedStyle& style, const LayoutRect& rect)


### PR DESCRIPTION
#### d8f6ca541f56a048e8d292e862d5cc3249957ccd
<pre>
Scroll snapping selects a snap point that overshoots the destination instead of the closest one in the scroll direction
<a href="https://bugs.webkit.org/show_bug.cgi?id=317064">https://bugs.webkit.org/show_bug.cgi?id=317064</a>
<a href="https://rdar.apple.com/179549119">rdar://179549119</a>

Reviewed by Simon Fraser.

When two snap offsets bracket a scroll destination, closestSnapOffsetWithInfoAndAxis()
picked the one in the scroll direction unconditionally instead of the closest one, so a
snap point between the origin and the destination could be skipped in favor of one that
overshoots it (e.g. offsets 0/95/120, scrolling from 0 to 100, snapped to 120 instead of 95).

The fix is twofold. First, make the directional trap-escape filter decide which side to
discard from the actual scroll direction (velocity) rather than from the predicted
destination: the predicted destination can collapse onto the original offset (e.g. when
momentum scrolling prediction is disabled), in which case the strict origin-vs-destination
comparison failed to drop the candidate sitting at the origin. Only fall back to the
destination for non-directional scrolls where velocity is 0. With that filter now reliably
discarding any candidate at or behind the origin, both remaining candidates are valid
forward targets, so pick whichever is closest to the destination, using scroll direction
only to break an exact tie.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/paged-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-snap-stop-002-expected.txt: Ditto
* LayoutTests/platform/mac/TestExpectations: Unskip now passing test
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::closestSnapOffsetWithInfoAndAxis):

Canonical link: <a href="https://commits.webkit.org/315522@main">https://commits.webkit.org/315522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b3b3e9fda539aef48ca6156eee318ae18458b80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126906 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1eb00884-a6b4-4b6a-b78c-2ed483bc29d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131776 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fdbbd8e-4578-49bc-b4fb-840774752349) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172153 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112279 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c5e55b8-a8d4-4cb4-a36d-63d471e6c293) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31922 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27250 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181150 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140231 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37714 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43461 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107381 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35342 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115226 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41970 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6521 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41507 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->