### PR TITLE
[MSE] imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality.html is an intermittent timeout

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1540,50 +1540,13 @@ void MediaSource::updateBufferedIfNeeded(bool force)
     for (Ref sourceBuffer : m_activeSourceBuffers.get())
         sourceBuffer->setBufferedDirty(false);
 
-    PlatformTimeRanges buffered;
-    auto updatePrivate = makeScopeExit([&, protectedThis = Ref { *this }] {
-        if (buffered == msp->buffered())
-            return;
-        msp->bufferedChanged(buffered);
-        monitorSourceBuffers();
-    });
-
-    // Implements MediaSource algorithm for HTMLMediaElement.buffered.
-    // https://dvcs.w3.org/hg/html-media/raw-file/default/media-source/media-source.html#htmlmediaelement-extensions
-    Vector<PlatformTimeRanges> activeRanges = this->activeRanges();
-
-    // 1. If activeSourceBuffers.length equals 0 then return an empty TimeRanges object and abort these steps.
-    if (activeRanges.isEmpty())
+    // 10.2 HTMLMediaElement Extensions - HTMLMediaElement's buffered.
+    // https://w3c.github.io/media-source/#htmlmediaelement-extensions-buffered
+    auto buffered = MediaSourcePrivate::computeBufferedRanges(this->activeRanges(), readyState() == ReadyState::Ended);
+    if (msp->isBufferedEqual(buffered))
         return;
-
-    // 2. Let active ranges be the ranges returned by buffered for each SourceBuffer object in activeSourceBuffers.
-    // 3. Let highest end time be the largest range end time in the active ranges.
-    MediaTime highestEndTime = MediaTime::zeroTime();
-    for (auto& ranges : activeRanges) {
-        unsigned length = ranges.length();
-        if (length)
-            highestEndTime = std::max(highestEndTime, ranges.end(length - 1));
-    }
-
-    // Return an empty range if all ranges are empty.
-    if (!highestEndTime)
-        return;
-
-    // 4. Let intersection ranges equal a TimeRange object containing a single range from 0 to highest end time.
-    buffered.add(MediaTime::zeroTime(), highestEndTime);
-
-    // 5. For each SourceBuffer object in activeSourceBuffers run the following steps:
-    bool ended = readyState() == ReadyState::Ended;
-    for (auto& sourceRanges : activeRanges) {
-        // 5.1 Let source ranges equal the ranges returned by the buffered attribute on the current SourceBuffer.
-        // 5.2 If readyState is "ended", then set the end time on the last range in source ranges to highest end time.
-        if (ended && sourceRanges.length())
-            sourceRanges.add(sourceRanges.start(sourceRanges.length() - 1), highestEndTime);
-
-        // 5.3 Let new intersection ranges equal the intersection between the intersection ranges and the source ranges.
-        // 5.4 Replace the ranges in intersection ranges with the new intersection ranges.
-        buffered.intersectWith(sourceRanges);
-    }
+    msp->bufferedChanged(WTF::move(buffered));
+    monitorSourceBuffers();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1397,44 +1397,13 @@ void SourceBuffer::updateBuffered()
             protect(m_source)->monitorSourceBuffers();
     });
 
-    // 3.1 Attributes, buffered
-    // https://rawgit.com/w3c/media-source/45627646344eea0170dd1cbc5a3d508ca751abb8/media-source-respec.html#dom-sourcebuffer-buffered
-    // 2. Let highest end time be the largest track buffer ranges end time across all the track buffers managed by this SourceBuffer object.
-    MediaTime highestEndTime = MediaTime::negativeInfiniteTime();
-    for (auto& trackBuffer : m_trackBuffers) {
-        if (!trackBuffer.length())
-            continue;
-        highestEndTime = std::max(highestEndTime, trackBuffer.maximumBufferedTime());
-    }
+    // 5.1 Attributes - buffered
+    // https://w3c.github.io/media-source/#dom-sourcebuffer-buffered
+    auto intersectionRanges = SourceBufferPrivate::computeBufferedRanges(m_trackBuffers, m_mediaSourceEnded);
 
-    // NOTE: Short circuit the following if none of the TrackBuffers have buffered ranges to avoid generating
-    // a single range of {0, 0}.
-    if (highestEndTime.isNegativeInfinite()) {
-        m_buffered = TimeRanges::create();
-        return;
-    }
-
-    // 3. Let intersection ranges equal a TimeRange object containing a single range from 0 to highest end time.
-    PlatformTimeRanges intersectionRanges { MediaTime::zeroTime(), highestEndTime };
-
-    // 4. For each audio and video track buffer managed by this SourceBuffer, run the following steps:
-    for (auto& trackBuffer : m_trackBuffers) {
-        if (!trackBuffer.length())
-            continue;
-
-        // 4.1 Let track ranges equal the track buffer ranges for the current track buffer.
-        auto trackRanges = trackBuffer;
-
-        // 4.2 If readyState is "ended", then set the end time on the last range in track ranges to highest end time.
-        if (m_mediaSourceEnded)
-            trackRanges.add(trackRanges.maximumBufferedTime(), highestEndTime);
-
-        // 4.3 Let new intersection ranges equal the intersection between the intersection ranges and the track ranges.
-        // 4.4 Replace the ranges in intersection ranges with the new intersection ranges.
-        intersectionRanges.intersectWith(trackRanges);
-    }
-    // 5. If intersection ranges does not contain the exact same range information as the current value of this attribute,
-    //    then update the current value of this attribute to intersection ranges.
+    // 5. If intersection ranges does not contain the exact same range information
+    //    as the current value of this attribute, then update the current value
+    //    of this attribute to intersection ranges.
     if (oldRanges != intersectionRanges) {
         m_buffered = TimeRanges::create(intersectionRanges);
         LOG(Media, "SourceBuffer::updateBuffered(%p) - buffered = %s", this, toString(intersectionRanges).utf8().data());

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -226,11 +226,11 @@ void MediaSourcePrivate::durationChanged(const MediaTime& duration)
         sourceBuffer->setMediaSourceDuration(duration);
 }
 
-void MediaSourcePrivate::bufferedChanged(const PlatformTimeRanges& buffered)
+void MediaSourcePrivate::bufferedChanged(PlatformTimeRanges&& buffered)
 {
     Locker locker { m_lock };
 
-    m_buffered = buffered;
+    m_buffered = WTF::move(buffered);
 }
 
 void MediaSourcePrivate::trackBufferedChanged(SourceBufferPrivate& sourceBuffer, Vector<PlatformTimeRanges>&& ranges)
@@ -247,14 +247,73 @@ void MediaSourcePrivate::trackBufferedChanged(SourceBufferPrivate& sourceBuffer,
 
 void MediaSourcePrivate::updateBufferedRanges()
 {
-    assertIsCurrent(m_dispatcher);
+    assertIsCurrent(m_dispatcher.get());
 
-    PlatformTimeRanges intersectionRange { MediaTime::zeroTime(), MediaTime::positiveInfiniteTime() };
-    for (auto& ranges : m_bufferedRanges.values()) {
-        for (auto& range : ranges)
-            intersectionRange.intersectWith(range);
+    // Recompute each active SourceBuffer's aggregate from its per-track ranges,
+    // then run the HTMLMediaElement.buffered cross-buffer step on those.
+    const bool ended = m_readyState.load() == MediaSourceReadyState::Ended;
+    Vector<PlatformTimeRanges> activeRanges(m_activeSourceBuffers.size(), [&](size_t index) {
+        assertIsCurrent(m_dispatcher.get());
+        auto it = m_bufferedRanges.find(m_activeSourceBuffers[index]);
+        return it == m_bufferedRanges.end()
+            ? PlatformTimeRanges { }
+            : SourceBufferPrivate::computeBufferedRanges(it->value, ended);
+    });
+
+    auto newBuffered = MediaSourcePrivate::computeBufferedRanges(activeRanges, ended);
+    if (isBufferedEqual(newBuffered))
+        return;
+    bufferedChanged(WTF::move(newBuffered));
+}
+
+PlatformTimeRanges MediaSourcePrivate::computeBufferedRanges(const Vector<PlatformTimeRanges>& activeRanges, bool ended)
+{
+    // 10.2 HTMLMediaElement Extensions - HTMLMediaElement's buffered
+    // https://w3c.github.io/media-source/#htmlmediaelement-extensions-buffered
+
+    // 1. If activeSourceBuffers.length equals 0 then return an empty TimeRanges
+    //    object and abort these steps.
+    if (activeRanges.isEmpty())
+        return { };
+
+    // 2. Let active ranges be the ranges returned by buffered for each
+    //    SourceBuffer object in activeSourceBuffers.
+    // 3. Let highest end time be the largest range end time in the active ranges.
+    MediaTime highestEndTime = MediaTime::zeroTime();
+    for (auto& ranges : activeRanges) {
+        unsigned length = ranges.length();
+        if (length)
+            highestEndTime = std::max(highestEndTime, ranges.end(length - 1));
     }
-    bufferedChanged(intersectionRange);
+
+    // Return an empty range if all ranges are empty.
+    if (!highestEndTime)
+        return { };
+
+    // 4. Let intersection ranges equal a TimeRange object containing a single
+    //    range from 0 to highest end time.
+    PlatformTimeRanges buffered { MediaTime::zeroTime(), highestEndTime };
+
+    // 5. For each SourceBuffer object in activeSourceBuffers run the following
+    //    steps:
+    for (auto& sourceRanges : activeRanges) {
+        // 5.1 Let source ranges equal the ranges returned by the buffered
+        //     attribute on the current SourceBuffer.
+        // 5.2 If readyState is "ended", then set the end time on the last
+        //     range in source ranges to highest end time.
+        // 5.3 Let new intersection ranges equal the intersection between
+        //     the intersection ranges and the source ranges.
+        // 5.4 Replace the ranges in intersection ranges with the new
+        //     intersection ranges.
+        if (ended && sourceRanges.length()) {
+            auto adjusted = sourceRanges;
+            adjusted.add(adjusted.maximumBufferedTime(), highestEndTime);
+            buffered.intersectWith(adjusted);
+        } else
+            buffered.intersectWith(sourceRanges);
+    }
+
+    return buffered;
 }
 
 PlatformTimeRanges MediaSourcePrivate::buffered() const
@@ -269,6 +328,13 @@ bool MediaSourcePrivate::hasBufferedData() const
     Locker locker { m_lock };
 
     return m_buffered.length();
+}
+
+bool MediaSourcePrivate::isBufferedEqual(const PlatformTimeRanges& other) const
+{
+    Locker locker { m_lock };
+
+    return m_buffered == other;
 }
 
 MediaPlayer::ReadyState MediaSourcePrivate::mediaPlayerReadyState() const

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -89,8 +89,17 @@ public:
     void sourceBufferPrivateDidChangeActiveState(SourceBufferPrivate&, bool active);
     virtual void notifyActiveSourceBuffersChanged() = 0;
     virtual void durationChanged(const MediaTime&); // Base class method must be called in overrides. Must be thread-safe
-    virtual void bufferedChanged(const PlatformTimeRanges&); // Base class method must be called in overrides. Must be thread-safe.
+    virtual void bufferedChanged(PlatformTimeRanges&&); // Base class method must be called in overrides. Must be thread-safe.
     void trackBufferedChanged(SourceBufferPrivate&, Vector<PlatformTimeRanges>&&);
+
+    // Implements the HTMLMediaElement.buffered cross-buffer step:
+    // https://w3c.github.io/media-source/#htmlmediaelement-extensions-buffered
+    // Caller passes the per-active-SourceBuffer ranges (each itself the result
+    // of SourceBufferPrivate::computeBufferedRanges) and whether the
+    // MediaSource readyState is "ended". Used by both MediaSource (main) on
+    // readyState/dirty triggers and MediaSourcePrivate (dispatcher) when track
+    // ranges change so a single algorithm produces the value.
+    WEBCORE_EXPORT static PlatformTimeRanges computeBufferedRanges(const Vector<PlatformTimeRanges>& activeRanges, bool ended);
 
     MediaPlayer::ReadyState NODELETE mediaPlayerReadyState() const;
     virtual void setMediaPlayerReadyState(MediaPlayer::ReadyState);
@@ -114,6 +123,10 @@ public:
 
     MediaTime duration() const;
     PlatformTimeRanges buffered() const;
+    // Compares the argument against m_buffered under m_lock without copying
+    // m_buffered into the caller. Useful for short-circuit checks on the main
+    // thread which would otherwise pay a full PlatformTimeRanges copy via buffered().
+    bool isBufferedEqual(const PlatformTimeRanges&) const;
     PlatformTimeRanges seekable() const;
 
     bool hasBufferedData() const;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -219,6 +219,53 @@ Vector<PlatformTimeRanges> SourceBufferPrivate::trackBuffersRanges() const
     });
 }
 
+PlatformTimeRanges SourceBufferPrivate::computeBufferedRanges(const Vector<PlatformTimeRanges>& trackBufferedRanges, bool mediaSourceEnded)
+{
+    // 5.1 Attributes - buffered
+    // https://w3c.github.io/media-source/#dom-sourcebuffer-buffered
+    // When the attribute is read the following steps MUST occur:
+
+    // 2. Let highest end time be the largest track buffer ranges end time across
+    //    all the track buffers managed by this SourceBuffer object.
+    MediaTime highestEndTime = MediaTime::negativeInfiniteTime();
+    for (auto& trackRanges : trackBufferedRanges) {
+        if (!trackRanges.length())
+            continue;
+        highestEndTime = std::max(highestEndTime, trackRanges.maximumBufferedTime());
+    }
+
+    // NOTE: Short circuit the following if none of the TrackBuffers have buffered
+    // ranges to avoid generating a single range of {0, 0}.
+    if (highestEndTime.isNegativeInfinite())
+        return { };
+
+    // 3. Let intersection ranges equal a TimeRange object containing a single
+    //    range from 0 to highest end time.
+    PlatformTimeRanges intersectionRanges { MediaTime::zeroTime(), highestEndTime };
+
+    // 4. For each audio and video track buffer managed by this SourceBuffer,
+    //    run the following steps:
+    for (auto& trackRanges : trackBufferedRanges) {
+        if (!trackRanges.length())
+            continue;
+
+        // 4.1 Let track ranges equal the track buffer ranges for the current track buffer.
+        // 4.2 If readyState is "ended", then set the end time on the last range
+        //     in track ranges to highest end time.
+        // 4.3 Let new intersection ranges equal the intersection between the
+        //     intersection ranges and the track ranges.
+        // 4.4 Replace the ranges in intersection ranges with the new intersection ranges.
+        if (mediaSourceEnded) {
+            auto adjusted = trackRanges;
+            adjusted.add(adjusted.maximumBufferedTime(), highestEndTime);
+            intersectionRanges.intersectWith(adjusted);
+        } else
+            intersectionRanges.intersectWith(trackRanges);
+    }
+
+    return intersectionRanges;
+}
+
 bool SourceBufferPrivate::hasReceivedFirstInitializationSegment() const
 {
     assertIsCurrent(m_dispatcher.get());

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -134,6 +134,13 @@ public:
     WEBCORE_EXPORT SourceBufferEvictionData evictionData() const;
     WEBCORE_EXPORT Vector<PlatformTimeRanges> trackBuffersRanges() const;
 
+    // Implements the SourceBuffer.buffered getter algorithm:
+    // https://w3c.github.io/media-source/#dom-sourcebuffer-buffered
+    // Used by SourceBuffer::updateBuffered() and MediaSourcePrivate when it
+    // needs each active SourceBuffer's aggregate so the per-SourceBuffer
+    // buffered TimeRanges is computed by a single routine.
+    WEBCORE_EXPORT static PlatformTimeRanges computeBufferedRanges(const Vector<PlatformTimeRanges>& trackBufferedRanges, bool mediaSourceEnded);
+
     // Methods used by MediaSourcePrivate
     bool NODELETE hasReceivedFirstInitializationSegment() const;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -119,7 +119,7 @@ private:
 
     MediaTime currentTime() const final;
     bool timeIsProgressing() const final;
-    void bufferedChanged(const PlatformTimeRanges&) final;
+    void bufferedChanged(PlatformTimeRanges&&) final;
 
     WeakPtr<MediaPlayerPrivateMediaSourceAVFObjC> m_player WTF_GUARDED_BY_CAPABILITY(mainThread);
     ThreadSafeWeakPtr<SourceBufferPrivateAVFObjC> m_sourceBufferWithSelectedVideo WTF_GUARDED_BY_CAPABILITY(m_dispatcher.get());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -232,9 +232,9 @@ bool MediaSourcePrivateAVFObjC::needsVideoLayer() const
     });
 }
 
-void MediaSourcePrivateAVFObjC::bufferedChanged(const PlatformTimeRanges& buffered)
+void MediaSourcePrivateAVFObjC::bufferedChanged(PlatformTimeRanges&& buffered)
 {
-    MediaSourcePrivate::bufferedChanged(buffered);
+    MediaSourcePrivate::bufferedChanged(WTF::move(buffered));
     callOnMainThreadWithPlayer([](auto& player) {
         player.bufferedChanged();
     });

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -174,17 +174,19 @@ void MediaSourcePrivateRemote::durationChanged(const MediaTime& duration)
     });
 }
 
-void MediaSourcePrivateRemote::bufferedChanged(const PlatformTimeRanges& buffered)
+void MediaSourcePrivateRemote::bufferedChanged(PlatformTimeRanges&& buffered)
 {
     // Called from the MediaSource's dispatcher.
-    MediaSourcePrivate::bufferedChanged(buffered);
+    // Copy for the IPC capture before moving the value into the base.
+    auto bufferedForIPC = buffered;
+    MediaSourcePrivate::bufferedChanged(WTF::move(buffered));
     // Called from SourceBufferPrivateRemote
-    ensureOnDispatcher([protectedThis = Ref { *this }, this, buffered] {
+    ensureOnDispatcher([protectedThis = Ref { *this }, this, bufferedForIPC = WTF::move(bufferedForIPC)] {
         auto gpuProcessConnection = m_gpuProcessConnection.get();
         if (!isGPURunning() || !gpuProcessConnection)
             return;
 
-        gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::BufferedChanged(buffered), m_identifier);
+        gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::BufferedChanged(bufferedForIPC), m_identifier);
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -105,7 +105,7 @@ private:
     friend class MessageReceiver;
     MediaSourcePrivateRemote(GPUProcessConnection&, RemoteMediaSourceIdentifier, RemoteMediaPlayerMIMETypeCache&, const MediaPlayerPrivateRemote&, WebCore::MediaSourcePrivateClient&);
 
-    void bufferedChanged(const WebCore::PlatformTimeRanges&) final;
+    void bufferedChanged(WebCore::PlatformTimeRanges&&) final;
 
     bool isGPURunning() const { return !m_shutdown; }
 


### PR DESCRIPTION
#### 9a1b47f8701b3a06fa4fbe3bf7a43881fa5cfabe
<pre>
[MSE] imported/w3c/web-platform-tests/media-source/mediasource-getvideoplaybackquality.html is an intermittent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=316898">https://bugs.webkit.org/show_bug.cgi?id=316898</a>
<a href="https://rdar.apple.com/179339247">rdar://179339247</a>

Reviewed by Jer Noble.

MediaSourcePrivate::m_buffered was written by two independent paths running on
different threads, each implementing a different algorithm. JS-visible
mediaSource.buffered could end up with whichever value the loser of the race
published.

Path A — MediaSource::updateBufferedIfNeeded() — runs on the script execution
context (main thread). It is triggered when a SourceBuffer raises its
m_bufferedDirty flag (after track-buffer data changes propagated via
SourceBuffer::sourceBufferPrivateBufferedChanged), when MediaSource&apos;s readyState
transitions Open &lt;-&gt; Ended, and when the duration changes. It iterates the
active SourceBuffer set and runs the W3C MSE 10.2 HTMLMediaElement.buffered
algorithm: highest-end-time seed, ended-alignment per active SourceBuffer, then
cross-buffer intersection.

Path B — MediaSourcePrivate::updateBufferedRanges() — runs on
MediaSourcePrivate::m_dispatcher. It is triggered from
SourceBufferPrivate::updateBuffered() each time per-track ranges change. The
existing implementation simply intersected every entry in m_bufferedRanges
without distinguishing active from inactive SourceBuffers and without applying
the readyState-driven ended-alignment.

Both paths wrote m_buffered through MediaSourcePrivate::bufferedChanged() under
m_lock. There is no ordering between the two threads, so when track-buffer
changes arrived close to a readyState transition or to a setBufferedDirty
trigger, Path B could fire after Path A and overwrite the correct value with
the un-aligned, inactive sourceBuffer included intersection.

Fix: extract the two spec algorithms into static helpers shared by both paths.
SourceBufferPrivate::computeBufferedRanges implements MSE 5.1 SourceBuffer.buffered
and is used by SourceBuffer::updateBuffered and (indirectly) by the
MediaSourcePrivate dispatcher path when building per-SourceBuffer aggregates.
MediaSourcePrivate::computeBufferedRanges implements MSE 10.2 cross-buffer
intersection and is used by both MediaSource::updateBufferedIfNeeded (main) and
MediaSourcePrivate::updateBufferedRanges (dispatcher). Same algorithm + same
inputs =&gt; same value, so the remaining write race is benign.

Covered by existing tests.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::updateBufferedIfNeeded): Replace the inlined algorithm
with calls to the new MediaSourcePrivate::computeBufferedRanges helper, and use
MediaSourcePrivate::isBufferedEqual to skip notification when unchanged without
copying m_buffered out.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::updateBuffered): Replace the inlined algorithm with a
call to SourceBufferPrivate::computeBufferedRanges.

* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::computeBufferedRanges): New static helper
implementing MSE 5.1 SourceBuffer.buffered.

* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::computeBufferedRanges): New static helper
implementing MSE 10.2 HTMLMediaElement.buffered cross-buffer step.
(WebCore::MediaSourcePrivate::isBufferedEqual): New short-circuit comparison
helper that compares against m_buffered under m_lock without returning a copy.
(WebCore::MediaSourcePrivate::updateBufferedRanges): Build per-SourceBuffer
aggregates via SourceBufferPrivate::computeBufferedRanges, then call
MediaSourcePrivate::computeBufferedRanges for the cross-buffer step. Skip
notification when isBufferedEqual.
(WebCore::MediaSourcePrivate::bufferedChanged): Take Vector by rvalue so
m_buffered is move-assigned.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::bufferedChanged): Forward the rvalue to
the base via WTF::move.

* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::bufferedChanged): Take Vector by rvalue,
copy once for the IPC capture, move into the base.

Canonical link: <a href="https://commits.webkit.org/315265@main">https://commits.webkit.org/315265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7903f9e4f76de37fe94453c04d97ce0a36d9644f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125962 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d40f9083-f034-4dc8-b994-e7d948b81ea7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130943 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92038 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f79af61-35e9-4751-ba82-8cb6a2a101aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111455 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce9abb37-66ee-45de-9017-48994a709a07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32395 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31098 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26285 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142381 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180189 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32912 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139380 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41830 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35257 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139243 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37559 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42518 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105917 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34530 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27589 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114278 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40419 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5675 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40564 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->