### PR TITLE
Interrupting a smooth scroll with a new scrollTo() to a different target fires scrollend at the wrong position

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5610,7 +5610,6 @@ js/throw-large-string-oom.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-initial-layout/scroll-snap-writing-mode-000.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-on-oveflow-hidden-container.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-style-change-respects-scroll-behavior.html [ Pass Failure ]
 webkit.org/b/218325 imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-margin-001.html [ Pass ImageOnlyFailure ]
 

--- a/LayoutTests/fast/scrolling/mac/scrollend-event-retarget-smooth-scroll-main-frame-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-retarget-smooth-scroll-main-frame-expected.txt
@@ -1,0 +1,10 @@
+Interrupting a smooth scroll of the main frame with a new scrollTo() to a different target should retarget the running animation, so the scrollend event fires at the final destination rather than prematurely at the intermediate offset. useThreadedScrolling=false forces the main frame onto the main-thread ScrollAnimator, which is the path the fix touches.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scrollYAtScrollend is finalTarget
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/scrollend-event-retarget-smooth-scroll-main-frame.html
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-retarget-smooth-scroll-main-frame.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useThreadedScrolling=false ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+            margin: 0;
+            background-image: repeating-linear-gradient(transparent, silver 500px);
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        description('Interrupting a smooth scroll of the main frame with a new scrollTo() to a different target should retarget the running animation, so the scrollend event fires at the final destination rather than prematurely at the intermediate offset. useThreadedScrolling=false forces the main frame onto the main-thread ScrollAnimator, which is the path the fix touches.');
+
+        const firstTarget = 2000;
+        const finalTarget = 4000;
+
+        var scrollYAtScrollend = -1;
+
+        window.addEventListener('load', () => {
+            // Start a smooth scroll towards the first target.
+            window.scrollTo({ top: firstTarget, behavior: 'smooth' });
+
+            // Once the animation is actually in flight (first scroll event), retarget
+            // it to a different destination and capture where we are when scrollend fires.
+            window.addEventListener('scroll', function onScroll() {
+                if (window.scrollY <= 0 || window.scrollY >= firstTarget)
+                    return;
+                window.removeEventListener('scroll', onScroll);
+
+                window.addEventListener('scrollend', () => {
+                    // On the buggy code path, cancelling the in-flight animation fires a
+                    // premature scrollend here while still mid-way to finalTarget. After
+                    // the fix, the animation is retargeted and scrollend fires only once
+                    // we have reached finalTarget.
+                    scrollYAtScrollend = window.scrollY;
+                    shouldBe('scrollYAtScrollend', 'finalTarget');
+                    finishJSTest();
+                }, { once: true });
+
+                window.scrollTo({ top: finalTarget, behavior: 'smooth' });
+            }, false);
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-on-oveflow-hidden-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-on-oveflow-hidden-container-expected.txt
@@ -2,5 +2,5 @@
 2
 3
 
-FAIL resnap-on-oveflow-hidden-container assert_equals: Now the scroll position should be 1000px expected 1000 but got 20
+PASS resnap-on-oveflow-hidden-container
 

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -132,10 +132,10 @@ bool ScrollAnimator::scrollToPositionWithAnimation(const FloatPoint& position, S
     return m_scrollController.startAnimatedScrollToDestination(offsetFromPosition(m_currentPosition), offsetFromPosition(adjustedPosition));
 }
 
-void ScrollAnimator::retargetRunningAnimation(const FloatPoint& newPosition)
+bool ScrollAnimator::retargetRunningAnimation(const FloatPoint& newPosition)
 {
     ASSERT(scrollableArea().scrollAnimationStatus() == ScrollAnimationStatus::Animating);
-    m_scrollController.retargetAnimatedScroll(offsetFromPosition(newPosition));
+    return m_scrollController.retargetAnimatedScroll(offsetFromPosition(newPosition));
 }
 
 FloatPoint ScrollAnimator::offsetFromPosition(const FloatPoint& position) const

--- a/Source/WebCore/platform/ScrollAnimator.h
+++ b/Source/WebCore/platform/ScrollAnimator.h
@@ -80,7 +80,7 @@ public:
     WEBCORE_EXPORT bool scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
     WEBCORE_EXPORT bool scrollToPositionWithAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
 
-    void retargetRunningAnimation(const FloatPoint& newPosition);
+    bool retargetRunningAnimation(const FloatPoint& newPosition);
 
     virtual bool handleWheelEvent(const PlatformWheelEvent&);
     virtual bool processWheelEventForScrollSnap(const PlatformWheelEvent&) { return false; }

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -188,8 +188,16 @@ void ScrollableArea::scrollToPositionWithAnimation(const FloatPoint& position, c
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToPositionWithAnimation " << position);
 
-    if (scrollAnimationStatus() == ScrollAnimationStatus::Animating)
+    if (scrollAnimationStatus() == ScrollAnimationStatus::Animating) {
+        // If a smooth scroll animation is already running, retarget it to the new
+        // destination instead of cancelling it. Cancelling tears the animation down,
+        // which prematurely fires a scrollend event at the current intermediate position
+        // rather than running to the new destination. Fall back to cancellation when
+        // there is no active main-thread animation to retarget.
+        if (scrollAnimator().retargetRunningAnimation(position))
+            return;
         scrollAnimator().cancelAnimations();
+    }
 
     if (position == scrollPosition())
         return;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -311,18 +311,27 @@ void RenderLayerScrollableArea::stopAsyncAnimatedScroll()
 
 ScrollOffset RenderLayerScrollableArea::scrollToOffset(const ScrollOffset& scrollOffset, const ScrollPositionChangeOptions& options)
 {
+    ScrollOffset clampedScrollOffset = options.clamping == ScrollClamping::Clamped ? clampScrollOffset(scrollOffset) : scrollOffset;
+    ScrollOffset snappedOffset = ceiledIntPoint(scrollAnimator().scrollOffsetAdjustedForSnapping(clampedScrollOffset, options.snapPointSelectionMethod));
+    auto snappedPosition = scrollPositionFromOffset(snappedOffset);
+
     if (scrollAnimationStatus() == ScrollAnimationStatus::Animating) {
+        // If a smooth scroll animation is already running and the new request is also
+        // animated, retarget the running animation to the new destination instead of
+        // cancelling it. Cancelling tears the animation down, which prematurely fires a
+        // scrollend event at the current intermediate position rather than running to
+        // the new destination.
+        if (options.animated == ScrollIsAnimated::Yes && scrollAnimator().retargetRunningAnimation(snappedPosition))
+            return snappedOffset;
         scrollAnimator().cancelAnimations();
         stopAsyncAnimatedScroll();
     }
-    ScrollOffset clampedScrollOffset = options.clamping == ScrollClamping::Clamped ? clampScrollOffset(scrollOffset) : scrollOffset;
+
     if (clampedScrollOffset == this->scrollOffset())
         return clampedScrollOffset;
 
     auto scrollTypeScope = ScrollTypeScope(*this, options.type);
 
-    ScrollOffset snappedOffset = ceiledIntPoint(scrollAnimator().scrollOffsetAdjustedForSnapping(clampedScrollOffset, options.snapPointSelectionMethod));
-    auto snappedPosition = scrollPositionFromOffset(snappedOffset);
     if (options.animated == ScrollIsAnimated::Yes) {
         registerScrollableAreaForAnimatedScroll();
         ScrollableArea::scrollToPositionWithAnimation(snappedPosition, options);


### PR DESCRIPTION
#### ea4fe561d0dd64bdbd48e4f33f5401b1fb171aaa
<pre>
Interrupting a smooth scroll with a new scrollTo() to a different target fires scrollend at the wrong position
<a href="https://bugs.webkit.org/show_bug.cgi?id=317065">https://bugs.webkit.org/show_bug.cgi?id=317065</a>
<a href="https://rdar.apple.com/179551854">rdar://179551854</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When a programmatic smooth scroll was already running and a new animated
scrollTo() arrived for a different target, the in-flight animation was cancelled
before the new one started. Cancelling tears the animation down, which
prematurely fires a scrollend event at the current intermediate offset instead
of running on to the new destination.

This affected both scroller types:
- Overflow scrollers, via RenderLayerScrollableArea::scrollToOffset().
- The main frame, via ScrollableArea::scrollToPositionWithAnimation() (reached
through LocalFrameView::setScrollOffsetWithOptions()), which does not go
through the RenderLayerScrollableArea override.

Retarget the running animation to the new destination instead of cancelling it,
falling back to cancellation only for non-animated requests or when no active
main-thread animation exists. retargetRunningAnimation() now returns whether
retargeting succeeded so the caller can choose the fallback.

* LayoutTests/TestExpectations: Unskip Expectation
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/resnap-on-oveflow-hidden-container-expected.txt: Progression
* LayoutTests/fast/scrolling/mac/scrollend-event-retarget-smooth-scroll-main-frame-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/scrollend-event-retarget-smooth-scroll-main-frame.html: Added.
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::retargetRunningAnimation):
* Source/WebCore/platform/ScrollAnimator.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollToPositionWithAnimation):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollToOffset):

Canonical link: <a href="https://commits.webkit.org/315471@main">https://commits.webkit.org/315471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b8eaf7f1665bbf6467f1c901a0399b852d2ac17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126743 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aac77ff2-3ba3-446e-a246-693916a371e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131634 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2b1cdcf-91ca-40a7-bf84-01bcf2643e67) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112137 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8425918f-234a-4db9-9afd-61726264e941) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33078 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31783 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27087 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180986 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140083 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139925 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37678 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43298 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28284 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107141 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35205 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115063 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41807 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6372 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41201 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41456 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41344 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->