### PR TITLE
Re-snapping after layout moves away from a valid scroll position when the snap area is larger than the snapport

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align-nested-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align-nested-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Changing a large target's snap alignment shouldn't make the scroller resnap if the scroller is already in a valid snap position. assert_equals: expected 100 but got 200
+PASS Changing a large target's snap alignment shouldn't make the scroller resnap if the scroller is already in a valid snap position.
 PASS Changing the current (non-covering) target's snap alignment should make the scroller snap according to the new alignment.
 

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2020 Igalia S.L.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
@@ -48,6 +48,22 @@ static std::pair<UnitType, UnitType> NODELETE rangeForAxis(RectType rect, Scroll
     return axis == ScrollEventAxis::Horizontal ? std::make_pair(rect.x(), rect.maxX()) : std::make_pair(rect.y(), rect.maxY());
 }
 
+template <typename UnitType, typename RectType>
+bool ScrollSnapOffsetsInfo<UnitType, RectType>::snapOffsetCoversSnapport(const SnapOffset<UnitType>& snapOffset, ScrollEventAxis axis, UnitType axisOffset, UnitType viewportLength) const
+{
+    if (!snapOffset.hasSnapAreaLargerThanViewport)
+        return false;
+    for (auto areaIndex : snapOffset.snapAreaIndices) {
+        auto [areaMin, areaMax] = rangeForAxis<UnitType>(snapAreas[areaIndex], axis);
+        if (areaMin <= axisOffset && areaMax >= axisOffset + viewportLength)
+            return true;
+    }
+    return false;
+}
+
+template bool LayoutScrollSnapOffsetsInfo::snapOffsetCoversSnapport(const SnapOffset<LayoutUnit>&, ScrollEventAxis, LayoutUnit, LayoutUnit) const;
+template bool FloatScrollSnapOffsetsInfo::snapOffsetCoversSnapport(const SnapOffset<float>&, ScrollEventAxis, float, float) const;
+
 template <typename UnitType>
 struct PotentialSnapPointSearchResult {
     std::optional<std::pair<UnitType, unsigned>> previous;
@@ -75,15 +91,8 @@ static PotentialSnapPointSearchResult<UnitType> searchForPotentialSnapPoints(con
     };
 
     for (unsigned i = 0; i < snapOffsets.size(); i++) {
-        if (!landedInsideSnapAreaThatConsumesViewport && snapOffsets[i].hasSnapAreaLargerThanViewport) {
-            for (auto snapAreaIndices : snapOffsets[i].snapAreaIndices) {
-                auto [snapAreaMin, snapAreaMax] = rangeForAxis<UnitType>(info.snapAreas[snapAreaIndices], axis);
-                if (snapAreaMin <= destinationOffset && snapAreaMax >= (destinationOffset + viewportLength)) {
-                    landedInsideSnapAreaThatConsumesViewport = true;
-                    break;
-                }
-            }
-        }
+        if (!landedInsideSnapAreaThatConsumesViewport && info.snapOffsetCoversSnapport(snapOffsets[i], axis, destinationOffset, viewportLength))
+            landedInsideSnapAreaThatConsumesViewport = true;
 
         UnitType potentialSnapOffset = snapOffsets[i].offset;
         if (potentialSnapOffset == destinationOffset)

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,6 +77,12 @@ struct ScrollSnapOffsetsInfo {
     {
         return axis == ScrollEventAxis::Vertical ? verticalSnapOffsets : horizontalSnapOffsets;
     }
+
+    // From https://drafts.csswg.org/css-scroll-snap-1/#snap-overflow: if a snap area is larger than
+    // the snapport in an axis, then any scroll position in which the snap area covers the snapport is
+    // a valid snap position in that axis. Returns true if any of the snap offset's areas is larger
+    // than the snapport and covers it at the given offset.
+    bool snapOffsetCoversSnapport(const SnapOffset<UnitType>&, ScrollEventAxis, UnitType axisOffset, UnitType viewportLength) const;
 
     template<typename OutputType> OutputType convertUnits(float deviceScaleFactor = 0.0) const;
     template<typename SizeType, typename PointType>

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -658,14 +658,14 @@ void ScrollableArea::resnapAfterLayout()
     if (!horizontalScrollbar() || horizontalScrollbar()->pressedPart() == ScrollbarPart::NoPart) {
         const auto& horizontal = info->horizontalSnapOffsets;
         auto activeHorizontalIndex = currentHorizontalSnapPointIndex();
-        if (activeHorizontalIndex)
+        if (activeHorizontalIndex && !info->snapOffsetCoversSnapport(horizontal[*activeHorizontalIndex], ScrollEventAxis::Horizontal, currentOffset.x(), visibleWidth()))
             correctedOffset.setX(horizontal[*activeHorizontalIndex].offset.toInt());
     }
 
     if (!verticalScrollbar() || verticalScrollbar()->pressedPart() == ScrollbarPart::NoPart) {
         const auto& vertical = info->verticalSnapOffsets;
         auto activeVerticalIndex = currentVerticalSnapPointIndex();
-        if (activeVerticalIndex)
+        if (activeVerticalIndex && !info->snapOffsetCoversSnapport(vertical[*activeVerticalIndex], ScrollEventAxis::Vertical, currentOffset.y(), visibleHeight()))
             correctedOffset.setY(vertical[*activeVerticalIndex].offset.toInt());
     }
 


### PR DESCRIPTION
#### 905ad39d3aae96e94dd2b07a27a8f26aab5d0bdd
<pre>
Re-snapping after layout moves away from a valid scroll position when the snap area is larger than the snapport
<a href="https://bugs.webkit.org/show_bug.cgi?id=317067">https://bugs.webkit.org/show_bug.cgi?id=317067</a>
<a href="https://rdar.apple.com/179553122">rdar://179553122</a>

Reviewed by Simon Fraser.

ScrollableArea::resnapAfterLayout() always corrected the scroll offset to the
active snap offset&apos;s specified alignment. Per the snap-overflow spec
(<a href="https://drafts.csswg.org/css-scroll-snap-1/#snap-overflow)">https://drafts.csswg.org/css-scroll-snap-1/#snap-overflow)</a>, when a snap area is
larger than the snapport in an axis, any scroll position in which the area covers
the snapport is a valid snap position in that axis. So a current offset that
already covers the snapport is already snapped and should be preserved rather
than moved to the alignment offset.

Add ScrollSnapOffsetsInfo::snapOffsetCoversSnapport() to express this covering
test in one place, shared by the wheel/fling snap path (which uses it to compute
landedInsideSnapAreaThatConsumesViewport in searchForPotentialSnapPoints()) and
the post-layout resnap path. resnapAfterLayout() now skips the correction for an
axis when the active snap offset covers the snapport at the current offset.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/changing-scroll-snap-align-nested-expected.txt: Progression
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::RectType&gt;::snapOffsetCoversSnapport const):
(WebCore::searchForPotentialSnapPoints):
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::resnapAfterLayout):

Canonical link: <a href="https://commits.webkit.org/315291@main">https://commits.webkit.org/315291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/170abbb72e3083c5ae010c40eff07e0ffcfe4d04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126019 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56950149-057a-46d4-b88d-19ceae0fdc3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130993 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92090 "1 flakes 8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd25e82f-0262-4312-89f2-8d0fb45d141a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111505 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55f03f00-6a6b-4300-80aa-6036d89ad77d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32446 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31148 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26342 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142432 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180246 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32970 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139430 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37577 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42575 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106074 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34584 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27644 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114335 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40476 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5728 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->