### PR TITLE
[JSC][Temporal] Check `ucal_add` failure in `calendarDateFromFields` and remove dead `combineISODateAndTimeRecord`

### DIFF
--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -826,13 +826,6 @@ ISO8601::Duration TemporalDuration::subtract(JSGlobalObject* globalObject, JSVal
     RELEASE_AND_RETURN(scope, addDurations(globalObject, AddOrSubtract::Subtract, other, largestUnit));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-combinedateandtimerecord
-std::tuple<ISO8601::PlainDate, ISO8601::PlainTime> TemporalDuration::combineISODateAndTimeRecord(ISO8601::PlainDate isoDate, ISO8601::PlainTime isoTime)
-{
-    return { isoDate, isoTime };
-}
-
-
 // RoundDuration ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, increment, unit, roundingMode [ , relativeTo ] )
 // https://tc39.es/proposal-temporal/#sec-temporal-roundduration
 ISO8601::InternalDuration TemporalDuration::round(JSGlobalObject* globalObject, ISO8601::InternalDuration internalDuration, double increment, TemporalUnit unit, RoundingMode mode)

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -79,7 +79,6 @@ public:
     static ISO8601::Duration toISO8601Duration(JSGlobalObject*, JSValue);
 
     static ISO8601::InternalDuration round(JSGlobalObject*, ISO8601::InternalDuration, double increment, TemporalUnit, RoundingMode);
-    static std::tuple<ISO8601::PlainDate, ISO8601::PlainTime> combineISODateAndTimeRecord(ISO8601::PlainDate, ISO8601::PlainTime);
     static std::optional<ISO8601::PlainDate> regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow);
     static ISO8601::Duration toDateDurationRecordWithoutTime(JSGlobalObject*, const ISO8601::Duration&);
 private:

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -1731,8 +1731,11 @@ TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId,
                         return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
                     clampedDay = static_cast<uint8_t>(maxDay);
                 }
-                if (clampedDay > 1)
+                if (clampedDay > 1) {
                     ucal_add(cal, UCAL_DAY_OF_MONTH, clampedDay - 1, &status);
+                    if (U_FAILURE(status)) [[unlikely]]
+                        return makeUnexpected(rangeError(icuCalendarArithmeticFailed));
+                }
             } else if (calendarId == hebrewCalendarID()) [[unlikely]] {
                 // Hebrew non-lunisolar path — shouldn't reach here since Hebrew IS lunisolar.
                 ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 40fd5ae0d75b44b446d33fd2e13a9b6dede06a96
<pre>
[JSC][Temporal] Check `ucal_add` failure in `calendarDateFromFields` and remove dead `combineISODateAndTimeRecord`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317069">https://bugs.webkit.org/show_bug.cgi?id=317069</a>

Reviewed by Yijia Huang.

This patch cleans up two leftovers from recent Temporal refactorings:

1. The lunisolar monthCode path of calendarDateFromFields adjusts the day
   of month via ucal_add but never checks the resulting status. This was
   the only remaining unchecked status-taking ICU call in
   CalendarICUBridge.cpp / TimeZoneICUBridge.cpp after the ICU error
   handling was made strict. On the constrain path the status is not
   re-checked afterwards, so a failure would be silently swallowed and the
   first day of the resolved month would be returned. Add the same
   U_FAILURE check used by the surrounding ucal_add calls.

2. TemporalDuration::combineISODateAndTimeRecord became a dead one-line
   delegate (it just returns { isoDate, isoTime }) after the one-line
   TemporalCore delegate wrappers were removed; it has no callers left.
   Remove the definition and declaration.

* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::TemporalDuration::combineISODateAndTimeRecord): Deleted.
* Source/JavaScriptCore/runtime/TemporalDuration.h:
* Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp:
(JSC::TemporalCore::calendarDateFromFields):

Canonical link: <a href="https://commits.webkit.org/315456@main">https://commits.webkit.org/315456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03f58fdaa39ab82079ec7997fd740f094771e0aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125971 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130953 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92048 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111465 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31106 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26294 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160889 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180198 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29517 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139389 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41839 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139252 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37670 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42527 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105939 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34540 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114287 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200948 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41031 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5683 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53979 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->