### PR TITLE
U+2016 (DOUBLE VERTICAL LINE) is missing the symmetric property in the operator dictionary

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-symmetric-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-symmetric-001-expected.txt
@@ -1,10 +1,6 @@
 
-FAIL Operator dictionary chunk 1 - symmetric assert_approx_equals: Symmetric property for ‖ prefix should be 'true' expected 150 +/- 1 but got 100
+PASS Operator dictionary chunk 1 - symmetric
 PASS Operator dictionary chunk 2 - symmetric
 PASS Operator dictionary chunk 3 - symmetric
 PASS Operator dictionary chunk 4 - symmetric
-symmetric for "‖" (prefix):
-‖
- VS
-‖
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-symmetric-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-symmetric-006-expected.txt
@@ -1,10 +1,6 @@
 
-FAIL Operator dictionary chunk 1 - symmetric assert_approx_equals: Symmetric property for ‖ postfix should be 'true' expected 150 +/- 1 but got 100
+PASS Operator dictionary chunk 1 - symmetric
 PASS Operator dictionary chunk 2 - symmetric
 PASS Operator dictionary chunk 3 - symmetric
 PASS Operator dictionary chunk 4 - symmetric
-symmetric for "‖" (postfix):
-‖
- VS
-‖
 

--- a/LayoutTests/platform/glib/mathml/presentation/mo-stretch-expected.txt
+++ b/LayoutTests/platform/glib/mathml/presentation/mo-stretch-expected.txt
@@ -53,7 +53,7 @@ layer at (0,0) size 800x269
             RenderBlock (anonymous) at (0,0) size 4x16
               RenderText {#text} at (0,-45) size 4x106
                 text run at (0,-45) width 4: "|"
-          RenderMathMLOperator {mo} at (106,6) size 7x16
+          RenderMathMLOperator {mo} at (106,6) size 7x24
             RenderBlock (anonymous) at (0,0) size 6x16
               RenderText {#text} at (0,-45) size 6x106
                 text run at (0,-45) width 6: "\x{2016}"
@@ -113,7 +113,7 @@ layer at (0,0) size 800x269
             RenderBlock (anonymous) at (0,0) size 4x16
               RenderText {#text} at (0,-45) size 4x106
                 text run at (0,-45) width 4: "|"
-          RenderMathMLOperator {mo} at (146,0) size 8x76
+          RenderMathMLOperator {mo} at (146,0) size 8x142
             RenderBlock (anonymous) at (0,0) size 6x16
               RenderText {#text} at (0,-45) size 6x106
                 text run at (0,-45) width 6: "\x{2016}"
@@ -174,7 +174,7 @@ layer at (0,0) size 800x269
             RenderBlock (anonymous) at (0,0) size 4x16
               RenderText {#text} at (0,-45) size 4x106
                 text run at (0,-45) width 4: "|"
-          RenderMathMLOperator {mo} at (146,0) size 8x58
+          RenderMathMLOperator {mo} at (146,3) size 8x93
             RenderBlock (anonymous) at (0,0) size 6x16
               RenderText {#text} at (0,-45) size 6x106
                 text run at (0,-45) width 6: "\x{2016}"
@@ -235,7 +235,7 @@ layer at (0,0) size 800x269
             RenderBlock (anonymous) at (0,0) size 4x16
               RenderText {#text} at (0,-45) size 4x106
                 text run at (0,-45) width 4: "|"
-          RenderMathMLOperator {mo} at (120,0) size 7x25
+          RenderMathMLOperator {mo} at (120,1) size 7x34
             RenderBlock (anonymous) at (0,0) size 6x16
               RenderText {#text} at (0,-45) size 6x106
                 text run at (0,-45) width 6: "\x{2016}"
@@ -246,8 +246,8 @@ layer at (0,0) size 800x269
           RenderMathMLSpace {mspace} at (141,2) size 0x21
       RenderText {#text} at (0,0) size 0x0
       RenderBR {BR} at (487,97) size 1x17
-      RenderMathMLMath {math} at (0,178) size 185x75
-        RenderMathMLRoot {msqrt} at (0,0) size 185x75
+      RenderMathMLMath {math} at (0,178) size 186x75
+        RenderMathMLRoot {msqrt} at (0,0) size 186x75
           RenderMathMLOperator {mo} at (17,2) size 14x73
             RenderBlock (anonymous) at (0,0) size 6x16
               RenderText {#text} at (0,-45) size 6x106
@@ -296,13 +296,13 @@ layer at (0,0) size 800x269
             RenderBlock (anonymous) at (0,0) size 4x16
               RenderText {#text} at (0,-45) size 4x106
                 text run at (0,-45) width 4: "|"
-          RenderMathMLOperator {mo} at (163,2) size 7x43
+          RenderMathMLOperator {mo} at (163,2) size 8x73
             RenderBlock (anonymous) at (0,0) size 6x16
               RenderText {#text} at (0,-45) size 6x106
                 text run at (0,-45) width 6: "\x{2016}"
-          RenderMathMLOperator {mo} at (169,2) size 16x43
+          RenderMathMLOperator {mo} at (170,2) size 16x43
             RenderBlock (anonymous) at (0,0) size 8x16
               RenderText {#text} at (0,-45) size 8x106
                 text run at (0,-45) width 8: "\x{2225}"
-          RenderMathMLSpace {mspace} at (184,2) size 0x42
+          RenderMathMLSpace {mspace} at (185,2) size 0x42
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/mathml/presentation/mo-stretch-expected.txt
+++ b/LayoutTests/platform/ios/mathml/presentation/mo-stretch-expected.txt
@@ -53,7 +53,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-2) size 5x18
                 text run at (0,-1) width 5: "|"
-          RenderMathMLOperator {mo} at (90,7) size 8x16
+          RenderMathMLOperator {mo} at (90,11) size 8x16
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-2) size 7x18
                 text run at (0,-1) width 7: "\x{2016}"
@@ -113,7 +113,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-2) size 5x18
                 text run at (0,-1) width 5: "|"
-          RenderMathMLOperator {mo} at (111,0) size 8x76
+          RenderMathMLOperator {mo} at (111,0) size 8x142
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-2) size 7x18
                 text run at (0,-1) width 7: "\x{2016}"
@@ -174,7 +174,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-2) size 5x18
                 text run at (0,-1) width 5: "|"
-          RenderMathMLOperator {mo} at (111,0) size 8x51
+          RenderMathMLOperator {mo} at (111,0) size 8x92
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-2) size 7x18
                 text run at (0,-1) width 7: "\x{2016}"
@@ -235,7 +235,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-2) size 5x18
                 text run at (0,-1) width 5: "|"
-          RenderMathMLOperator {mo} at (97,6) size 8x15
+          RenderMathMLOperator {mo} at (97,2) size 8x33
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-2) size 7x18
                 text run at (0,-1) width 7: "\x{2016}"
@@ -296,7 +296,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-2) size 5x18
                 text run at (0,-1) width 5: "|"
-          RenderMathMLOperator {mo} at (130,3) size 8x42
+          RenderMathMLOperator {mo} at (130,3) size 8x73
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-2) size 7x18
                 text run at (0,-1) width 7: "\x{2016}"

--- a/LayoutTests/platform/mac/mathml/presentation/mo-stretch-expected.txt
+++ b/LayoutTests/platform/mac/mathml/presentation/mo-stretch-expected.txt
@@ -53,7 +53,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-1) size 5x17
                 text run at (0,0) width 5: "|"
-          RenderMathMLOperator {mo} at (90,7) size 8x16
+          RenderMathMLOperator {mo} at (90,11) size 8x16
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-1) size 7x17
                 text run at (0,0) width 7: "\x{2016}"
@@ -113,7 +113,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-1) size 5x17
                 text run at (0,0) width 5: "|"
-          RenderMathMLOperator {mo} at (111,0) size 8x76
+          RenderMathMLOperator {mo} at (111,0) size 8x142
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-1) size 7x17
                 text run at (0,0) width 7: "\x{2016}"
@@ -174,7 +174,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-1) size 5x17
                 text run at (0,0) width 5: "|"
-          RenderMathMLOperator {mo} at (111,0) size 8x51
+          RenderMathMLOperator {mo} at (111,0) size 8x92
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-1) size 7x17
                 text run at (0,0) width 7: "\x{2016}"
@@ -235,7 +235,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-1) size 5x17
                 text run at (0,0) width 5: "|"
-          RenderMathMLOperator {mo} at (97,6) size 8x15
+          RenderMathMLOperator {mo} at (97,2) size 8x33
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-1) size 7x17
                 text run at (0,0) width 7: "\x{2016}"
@@ -296,7 +296,7 @@ layer at (0,0) size 800x271
             RenderBlock (anonymous) at (0,0) size 5x15
               RenderText {#text} at (0,-1) size 5x17
                 text run at (0,0) width 5: "|"
-          RenderMathMLOperator {mo} at (130,3) size 8x42
+          RenderMathMLOperator {mo} at (130,3) size 8x73
             RenderBlock (anonymous) at (0,0) size 7x15
               RenderText {#text} at (0,-1) size 7x17
                 text run at (0,0) width 7: "\x{2016}"

--- a/Source/WebCore/mathml/MathMLOperatorDictionary.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorDictionary.cpp
@@ -135,8 +135,8 @@ static constexpr std::array<Entry, dictionarySize> dictionary {
     Entry { 0x302, Postfix, 0, 0, Accent | Stretchy }, // COMBINING CIRCUMFLEX ACCENT
     Entry { 0x311, Postfix, 0, 0, Accent }, // COMBINING INVERTED BREVE
     Entry { 0x3F6, Infix, 5, 5, 0 }, // GREEK REVERSED LUNATE EPSILON SYMBOL
-    Entry { 0x2016, Prefix, 0, 0, Fence | Stretchy }, // DOUBLE VERTICAL LINE
-    Entry { 0x2016, Postfix, 0, 0, Fence | Stretchy }, // DOUBLE VERTICAL LINE
+    Entry { 0x2016, Prefix, 0, 0, Fence | Stretchy | Symmetric }, // DOUBLE VERTICAL LINE
+    Entry { 0x2016, Postfix, 0, 0, Fence | Stretchy | Symmetric }, // DOUBLE VERTICAL LINE
     Entry { 0x2018, Prefix, 0, 0, Fence }, // LEFT SINGLE QUOTATION MARK
     Entry { 0x2019, Postfix, 0, 0, Fence }, // RIGHT SINGLE QUOTATION MARK
     Entry { 0x201A, Postfix, 0, 0, Accent }, // SINGLE LOW-9 QUOTATION MARK


### PR DESCRIPTION
#### fd9720f6c31924452f80959059bdc40ca76e0eed
<pre>
U+2016 (DOUBLE VERTICAL LINE) is missing the symmetric property in the operator dictionary
<a href="https://bugs.webkit.org/show_bug.cgi?id=317070">https://bugs.webkit.org/show_bug.cgi?id=317070</a>
<a href="https://rdar.apple.com/179558196">rdar://179558196</a>

Reviewed by Frédéric Wang Nélar.

The operator dictionary entries for U+2016 ‖ DOUBLE VERTICAL LINE (prefix and
postfix forms) were missing the symmetric property. Per the MathML Core
operator dictionary [1], both forms are { stretchy, symmetric } (categories F
and G). WebKit only had { Fence, Stretchy }, so a stretchy ‖ was not stretched
symmetrically about the math axis.

Add the Symmetric flag to both entries. Verified against the WPT operator
dictionary data (operator-dictionary.json) that U+2016 is the only character
whose symmetric property was missing.

[1] <a href="https://w3c.github.io/mathml-core/#operator-dictionary-human">https://w3c.github.io/mathml-core/#operator-dictionary-human</a>

* Source/WebCore/mathml/MathMLOperatorDictionary.cpp:

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-symmetric-001-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-symmetric-006-expected.txt: Ditto

&gt; Rebaselines:
* LayoutTests/platform/mac/mathml/presentation/mo-stretch-expected.txt: Rebaselined
* LayoutTests/platform/glib/mathml/presentation/mo-stretch-expected.txt: Ditto
* LayoutTests/platform/ios/mathml/presentation/mo-stretch-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/316867@main">https://commits.webkit.org/316867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6866e4feabe7cde39f3543729a7dbb0359f886cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125986 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d27fb076-8963-4411-89d7-76e16eb312ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130966 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92063 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7300a1b-9a8b-4726-a5c3-b3af53bebf9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111478 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/162468fa-b6ee-4e25-9814-8f49aa268cf2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31120 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180213 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32937 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35279 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139403 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41854 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38786 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42542 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27613 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105987 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34555 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114302 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41046 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5698 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40443 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->