### PR TITLE
[LBSE] Include descendant transforms in SVG visual overflow

### DIFF
--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -153,7 +153,7 @@ FloatRect SVGBoundingBoxComputation::handleRootOrContainer(const SVGBoundingBoxC
         ASSERT(child.isSVGLayerAwareRenderer());
         ASSERT(!child.isRenderSVGRoot());
 
-        auto transform = SVGTransformComputation(child).computeAccumulatedTransform(m_renderer.ptr(), TransformState::TrackSVGCTMMatrix);
+        auto transform = SVGTransformComputation(child).computeAccumulatedTransform(m_renderer.ptr(), TransformState::TrackSVGCTMMatrix, StopAtRendererTransform::Exclude);
         return transform.isIdentity() ? std::nullopt : std::make_optional(WTF::move(transform));
     };
 
@@ -239,9 +239,9 @@ FloatRect SVGBoundingBoxComputation::handleRootOrContainer(const SVGBoundingBoxC
         ASSERT(is<RenderSVGViewportContainer>(m_renderer) || is<RenderSVGResourceMarker>(m_renderer) || is<RenderSVGRoot>(m_renderer));
 
         LayoutRect overflowClipRect;
-        if (CheckedPtr svgModelObject = dynamicDowncast<RenderSVGModelObject>(m_renderer.get()))
-            overflowClipRect = svgModelObject->overflowClipRect(svgModelObject->currentSVGLayoutLocation());
-        else if (CheckedPtr box = dynamicDowncast<RenderBox>(m_renderer.get()))
+        if (CheckedPtr svgModelObject = dynamicDowncast<RenderSVGModelObject>(m_renderer.get())) {
+            overflowClipRect = svgModelObject->overflowClipRect(LayoutPoint());
+        } else if (CheckedPtr box = dynamicDowncast<RenderBox>(m_renderer.get()))
             overflowClipRect = box->overflowClipRect(box->location());
         else {
             ASSERT_NOT_REACHED();
@@ -322,14 +322,19 @@ void SVGBoundingBoxComputation::adjustBoxForClippingAndEffects(const SVGBounding
 
 LayoutRect SVGBoundingBoxComputation::computeVisualOverflowRect(const RenderLayerModelObject& renderer)
 {
-    DecorationOptions options = repaintBoundingBoxDecoration | DecorationOption::IncludeOutline | DecorationOption::IgnoreTransformations;
+    // Visual overflow must include descendant transforms: a non-layer transformed descendant paints
+    // directly into this renderer, so its transformed bounds belong here. (The transform-ignored
+    // variant is reserved for objectBoundingBoxWithoutTransformations, which defines the SVG layout
+    // location and must stay flattened.) The result is expressed relative to nominalSVGLayoutLocation(),
+    // so a container whose content is shifted by a descendant transform is bounded where it paints.
+    DecorationOptions options = repaintBoundingBoxDecoration | DecorationOption::IncludeOutline;
     if (is<RenderSVGContainer>(renderer))
         options = options | DecorationOption::UseFilterBoxOnEmptyRect;
-    auto repaintBoundingBoxWithoutTransformations = computeDecoratedBoundingBox(renderer, options);
-    if (repaintBoundingBoxWithoutTransformations.isEmpty())
+    auto decoratedBoundingBox = computeDecoratedBoundingBox(renderer, options);
+    if (decoratedBoundingBox.isEmpty())
         return { };
 
-    auto visualOverflowRect = enclosingLayoutRect(repaintBoundingBoxWithoutTransformations);
+    auto visualOverflowRect = enclosingLayoutRect(decoratedBoundingBox);
     visualOverflowRect.moveBy(-renderer.nominalSVGLayoutLocation());
     return visualOverflowRect;
 }

--- a/Source/WebCore/rendering/svg/SVGTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGTransformComputation.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+enum class StopAtRendererTransform : bool { Exclude, Include };
+
 class SVGTransformComputation {
     WTF_MAKE_NONCOPYABLE(SVGTransformComputation);
 public:
@@ -39,7 +41,7 @@ public:
 
     ~SVGTransformComputation() = default;
 
-    AffineTransform computeAccumulatedTransform(const RenderLayerModelObject* stopAtRenderer, TransformState::TransformMatrixTracking trackingMode) const
+    AffineTransform computeAccumulatedTransform(const RenderLayerModelObject* stopAtRenderer, TransformState::TransformMatrixTracking trackingMode, StopAtRendererTransform stopAtRendererTransform = StopAtRendererTransform::Include) const
     {
         // The mapping into parent coordinate systems stops at this renderer,
         // as mapLocalContainer exits if "ancestorContainer == this" is fulfilled.
@@ -63,8 +65,11 @@ public:
             if (!stopAtRenderer) {
                 if (auto* svgRoot = ancestorsOfType<RenderSVGRoot>(*renderer).first())
                     ancestorContainer = svgRoot->viewportContainer();
-            } else if (const auto* enclosingLayerRenderer = ancestorsOfType<RenderLayerModelObject>(*stopAtRenderer).first())
-                ancestorContainer = enclosingLayerRenderer;
+            } else if (stopAtRendererTransform == StopAtRendererTransform::Include) {
+                if (const auto* enclosingLayerRenderer = ancestorsOfType<RenderLayerModelObject>(*stopAtRenderer).first())
+                    ancestorContainer = enclosingLayerRenderer;
+            } else
+                ancestorContainer = stopAtRenderer;
         } else if (trackingMode == TransformState::TrackSVGScreenCTMMatrix && stopAtRenderer) {
             ASSERT(stopAtRenderer->isComposited());
             ancestorContainer = ancestorsOfType<RenderLayerModelObject>(*stopAtRenderer).first();


### PR DESCRIPTION
#### 6fd2e01a5273642242a6a11bc3345348eb2b7319
<pre>
[LBSE] Include descendant transforms in SVG visual overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=317071">https://bugs.webkit.org/show_bug.cgi?id=317071</a>

Reviewed by Rob Buis.

The SVG visual overflow rect ignored the transforms of non-layer
descendants. Such a descendant paints directly into its container, so its
transformed bounds belong to the container&apos;s overflow. Ignoring them
under-sized the box and clipped content whose painted position is shifted by
a nested transformed &lt;g&gt; or nested &lt;svg&gt; with viewBox.

The fix stops computeVisualOverflowRect from passing IgnoreTransformations so
descendant transforms are included, while objectBoundingBoxWithoutTransformations
keeps its flattened convention.

Because computeAccumulatedTransform stops at the parent of stopAtRenderer, it
baked that renderer&apos;s own transform into the result - this is necessary for
getCTM()/getScreenCTM() but double-counts in the bounding-box recursion once
the container is mapped by its parent, so a new StopAtRendererTransform enum
(default Include) lets that recursion pass Exclude.

Finally, the viewport-container overflow clip is now requested at origin (0,0)
so it lands in the box&apos;s local space fixing overflow clipping both under
conditional and forced layer creation.

* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleRootOrContainer const):
(WebCore::SVGBoundingBoxComputation::computeVisualOverflowRect):
* Source/WebCore/rendering/svg/SVGTransformComputation.h:
(WebCore::SVGTransformComputation::computeAccumulatedTransform const):

Canonical link: <a href="https://commits.webkit.org/315171@main">https://commits.webkit.org/315171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1606ad6ae2d0f3e6032f7d0ced6eef6d296b71bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41829 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35415 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41786 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171231 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111467 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26296 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180200 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32924 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/30631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41841 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139254 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42529 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/150704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105941 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34542 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114289 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40430 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/5686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->