### PR TITLE
[LBSE] Hit-test SVG text per glyph in its SVG coordinate system

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -703,6 +703,10 @@ bool RenderSVGText::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
 
     auto adjustedLocation = accumulatedOffset + location();
 
+    // SVG text is hit per glyph in the foreground phase only, like RenderSVGShape.
+    if (hitTestAction != HitTestAction::Foreground)
+        return false;
+
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, style().pointerEvents());
     if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
         if ((hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke))
@@ -715,14 +719,18 @@ bool RenderSVGText::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
 
             SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-            auto localPoint = locationInContainer.point();
+            // The inline text fragments are positioned in this element's SVG coordinate system, so
+            // the query point and the offset that places the line boxes must both be expressed there.
+            // coordinateSystemOriginTranslation maps the caller's space into it, and is non-zero for
+            // a text layer whose origin differs from the SVG coordinate system. Shift both the
+            // location and the offset by it.
             auto coordinateSystemOriginTranslation = nominalSVGLayoutLocation() - adjustedLocation;
-            localPoint.move(coordinateSystemOriginTranslation);
+            HitTestLocation localLocation(locationInContainer, coordinateSystemOriginTranslation);
 
-            if (!pointInSVGClippingArea(localPoint))
+            if (!pointInSVGClippingArea(localLocation.point()))
                 return false;
 
-            return RenderBlock::nodeAtPoint(request, result, locationInContainer, accumulatedOffset, hitTestAction);
+            return RenderBlock::nodeAtPoint(request, result, localLocation, accumulatedOffset + coordinateSystemOriginTranslation, hitTestAction);
         }
     }
 


### PR DESCRIPTION
#### c3aca8ab0133d23a5dab22681ac48710c149b947
<pre>
[LBSE] Hit-test SVG text per glyph in its SVG coordinate system
<a href="https://bugs.webkit.org/show_bug.cgi?id=317072">https://bugs.webkit.org/show_bug.cgi?id=317072</a>

Reviewed by Rob Buis.

RenderSVGText::nodeAtPoint forwarded locationInContainer and accumulatedOffset
straight to RenderBlock. That works for the hitTestChildrenInDOMOrderForSVG
path, which queries only in the Foreground phase with the point already in
SVG space. But a (force-created) text layer is hit-tested via RenderObject&apos;s
hitTest(): the point arrives in the layer&apos;s own space with a zero offset, and
the Float and ChildBlockBackgrounds phases run too. Since the
inline text fragments use absolute positions in the element&apos;s SVG coordinate
system, the unshifted point missed every glyph -&gt; on-glyph clicks only appeared
to work because those extra phases fell back to RenderBlock and hit the text&apos;s
block box, which also wrongly claimed off-glyph points inside the box....

The fix mirrors RenderSVGShape::nodeAtPoint. It bails out unless hitTestAction
is Foreground, so the block-box phases never run, and expresses the query in
the SVG coordinate system by shifting both the location (rect-preserving, so
eventSender rect-based tests keep their tolerance) and the offset by
coordinateSystemOriginTranslation (= nominalSVGLayoutLocation -
adjustedLocation). The forwarded offset becomes nominal - location(), matching
the hitTestChildrenInDOMOrderForSVG path.

Unchanged test results in the conditional layer creation mode (not upstream yet),
and fixes all svg/hittest/text-* + svg/custom/pointer-events-text-css-transform
when forcing layer creation.

* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::nodeAtPoint):

Canonical link: <a href="https://commits.webkit.org/315172@main">https://commits.webkit.org/315172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8d5dcfa4eb50cc780a64ba6db03d1bd425a76ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41787 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/130956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171232 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111468 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31109 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26297 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142394 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180201 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32925 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/30630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41842 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139255 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42530 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105948 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34543 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41034 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40431 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5685 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->