### PR TITLE
[WTF] FAST_ALLOCATED and related macros silently drop alignment for over-aligned types

### DIFF
--- a/Source/WTF/wtf/DebugHeap.h
+++ b/Source/WTF/wtf/DebugHeap.h
@@ -74,6 +74,8 @@ private:
 \
         static void* tryRealloc(void* p, size_t size) { return debugHeap().realloc(p, size); } \
 \
+        static void* alignedMalloc(size_t alignment, size_t size) { return debugHeap().memalign(alignment, size, true); } \
+\
         static void free(void* p) { debugHeap().free(p); } \
 \
         static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity) { return capacity + capacity / 4 + 1; } \
@@ -106,6 +108,8 @@ private:
         static void* realloc(void* p, size_t size) { return debugHeap().reallocCompact(p, size); } \
 \
         static void* tryRealloc(void* p, size_t size) { return debugHeap().reallocCompact(p, size); } \
+\
+        static void* alignedMalloc(size_t alignment, size_t size) { return debugHeap().memalignCompact(alignment, size, true); } \
 \
         static void free(void* p) { debugHeap().free(p); } \
 \

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -265,6 +265,8 @@ struct FastMalloc {
         return nullptr;
     }
     
+    static void* alignedMalloc(size_t alignment, size_t size) { return fastAlignedMalloc(alignment, size); }
+
     static void free(void* p) { fastFree(p); }
 
     static void fastFree(void* p) { ::WTF::fastFree(p); }
@@ -316,6 +318,8 @@ struct FastCompactMalloc {
             return realResult;
         return nullptr;
     }
+
+    static void* alignedMalloc(size_t alignment, size_t size) { return fastCompactAlignedMalloc(alignment, size); }
 
     static void free(void* p) { fastFree(p); }
 
@@ -482,6 +486,26 @@ using WTF::fastCompactAlignedMalloc;
     { \
         ::WTF::fastFree(p); \
     } \
+    \
+    void* operator new(size_t size, std::align_val_t alignment) \
+    { \
+        return ::WTF::fastAlignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete(void* p, std::align_val_t) \
+    { \
+        ::WTF::fastFree(p); \
+    } \
+    \
+    void* operator new[](size_t size, std::align_val_t alignment) \
+    { \
+        return ::WTF::fastAlignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete[](void* p, std::align_val_t) \
+    { \
+        ::WTF::fastFree(p); \
+    } \
     void* operator new(size_t, NotNullTag, void* location) \
     { \
         ASSERT(location); \
@@ -516,6 +540,26 @@ using WTF::fastCompactAlignedMalloc;
     } \
     \
     void operator delete[](void* p) \
+    { \
+        ::WTF::fastFree(p); \
+    } \
+    \
+    void* operator new(size_t size, std::align_val_t alignment) \
+    { \
+        return ::WTF::fastCompactAlignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete(void* p, std::align_val_t) \
+    { \
+        ::WTF::fastFree(p); \
+    } \
+    \
+    void* operator new[](size_t size, std::align_val_t alignment) \
+    { \
+        return ::WTF::fastCompactAlignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete[](void* p, std::align_val_t) \
     { \
         ::WTF::fastFree(p); \
     } \

--- a/Source/WTF/wtf/ForbidHeapAllocation.h
+++ b/Source/WTF/wtf/ForbidHeapAllocation.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <new>
 #include <wtf/StdLibExtras.h>
 
 // We do not delete "delete" operators to allow classes to have a virtual destructor. The following code raises a compile error like "error: attempt to use a deleted function".
@@ -42,6 +43,8 @@ private: \
     void* operator new[](size_t, void*) = delete; \
     void* operator new(size_t) = delete; \
     void* operator new[](size_t size) = delete; \
+    void* operator new(size_t, std::align_val_t) = delete; \
+    void* operator new[](size_t, std::align_val_t) = delete; \
     void* operator new(size_t, NotNullTag, void*) = delete; \
     typedef int __thisIsHereToForceASemicolonAfterThisForbidHeapAllocationMacro
 
@@ -57,6 +60,8 @@ public: \
 private: \
     void* operator new(size_t) = delete; \
     void* operator new[](size_t size) = delete; \
+    void* operator new(size_t, std::align_val_t) = delete; \
+    void* operator new[](size_t, std::align_val_t) = delete; \
     typedef int __thisIsHereToForceASemicolonAfterThisForbidHeapAllocationAllowingPlacementNewMacro
 
 // WTF::usesTZoneHeap is defined in FastMalloc.h

--- a/Source/WTF/wtf/MallocCommon.h
+++ b/Source/WTF/wtf/MallocCommon.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <new>
 #include <wtf/Assertions.h>
 #include <wtf/StdLibExtras.h>
 
@@ -132,6 +133,26 @@ using WTF::ForbidMallocUseForCurrentThreadScope;
     { \
         return alloc::free(p); \
     } \
+    \
+    void* operator new(size_t size, std::align_val_t alignment) \
+    { \
+        return alloc::alignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete(void* p, std::align_val_t) \
+    { \
+        alloc::free(p); \
+    } \
+    \
+    void* operator new[](size_t size, std::align_val_t alignment) \
+    { \
+        return alloc::alignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete[](void* p, std::align_val_t) \
+    { \
+        alloc::free(p); \
+    } \
     void* operator new(size_t, NotNullTag, void* location) \
     { \
         ASSERT(location); \
@@ -165,6 +186,26 @@ using WTF::ForbidMallocUseForCurrentThreadScope;
     } \
     \
     void operator delete[](void* p) \
+    { \
+        classname##Malloc::free(p); \
+    } \
+    \
+    void* operator new(size_t size, std::align_val_t alignment) \
+    { \
+        return classname##Malloc::alignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete(void* p, std::align_val_t) \
+    { \
+        classname##Malloc::free(p); \
+    } \
+    \
+    void* operator new[](size_t size, std::align_val_t alignment) \
+    { \
+        return classname##Malloc::alignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete[](void* p, std::align_val_t) \
     { \
         classname##Malloc::free(p); \
     } \

--- a/Source/WTF/wtf/SequesteredMalloc.h
+++ b/Source/WTF/wtf/SequesteredMalloc.h
@@ -127,6 +127,8 @@ struct SequesteredArenaMalloc {
         return nullptr;
     }
 
+    static void* alignedMalloc(size_t alignment, size_t size) { return sequesteredArenaAlignedMalloc(alignment, size); }
+
     static void free(void* p) { sequesteredArenaFree(p); }
 
     static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity)
@@ -189,6 +191,26 @@ using WTF::sequesteredArenaAlignedFree;
     void operator delete[](void* p) \
     { \
         ::WTF::sequesteredArenaFree(p); \
+    } \
+    \
+    void* operator new(size_t size, std::align_val_t alignment) \
+    { \
+        return ::WTF::sequesteredArenaAlignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete(void* p, std::align_val_t) \
+    { \
+        ::WTF::sequesteredArenaAlignedFree(p); \
+    } \
+    \
+    void* operator new[](size_t size, std::align_val_t alignment) \
+    { \
+        return ::WTF::sequesteredArenaAlignedMalloc(static_cast<size_t>(alignment), size); \
+    } \
+    \
+    void operator delete[](void* p, std::align_val_t) \
+    { \
+        ::WTF::sequesteredArenaAlignedFree(p); \
     } \
     void* operator new(size_t, NotNullTag, void* location) \
     { \

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -57,6 +57,7 @@ set(TestWTF_SOURCES
     Tests/WTF/EmbeddedFixedVector.cpp
     Tests/WTF/EnumTraits.cpp
     Tests/WTF/Expected.cpp
+    Tests/WTF/FastMalloc.cpp
     Tests/WTF/FileSystem.cpp
     Tests/WTF/FormattedLogging.cpp
     Tests/WTF/FixedBitVector.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1155,6 +1155,7 @@
 				WTF/EnumSet.cpp,
 				WTF/EnumTraits.cpp,
 				WTF/Expected.cpp,
+				WTF/FastMalloc.cpp,
 				WTF/FileSystem.cpp,
 				WTF/FixedBitVector.cpp,
 				WTF/FixedVector.cpp,

--- a/Tools/TestWebKitAPI/Tests/WTF/FastMalloc.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FastMalloc.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Anthropic PBC. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/FastMalloc.h>
+
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+constexpr size_t overAlignment = 64;
+
+struct alignas(overAlignment) OverAlignedFastAllocated {
+    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(OverAlignedFastAllocated);
+    char contents[176];
+};
+
+struct alignas(overAlignment) OverAlignedFastCompactAllocated {
+    WTF_DEPRECATED_MAKE_STRUCT_FAST_COMPACT_ALLOCATED(OverAlignedFastCompactAllocated);
+    char contents[176];
+};
+
+struct alignas(overAlignment) OverAlignedConfigurableAllocated {
+    WTF_MAKE_STRUCT_CONFIGURABLE_ALLOCATED(FastMalloc);
+    char contents[176];
+};
+
+template<typename T>
+static void testOverAlignedAllocations()
+{
+    Vector<T*> allocations;
+    for (size_t i = 0; i < 5000; ++i) {
+        T* pointer = new T;
+        EXPECT_FALSE(reinterpret_cast<uintptr_t>(pointer) & (overAlignment - 1));
+        allocations.append(pointer);
+    }
+    for (T* pointer : allocations)
+        delete pointer;
+}
+
+TEST(WTF_FastMalloc, OverAlignedFastAllocated)
+{
+    testOverAlignedAllocations<OverAlignedFastAllocated>();
+}
+
+TEST(WTF_FastMalloc, OverAlignedFastCompactAllocated)
+{
+    testOverAlignedAllocations<OverAlignedFastCompactAllocated>();
+}
+
+TEST(WTF_FastMalloc, OverAlignedConfigurableAllocated)
+{
+    testOverAlignedAllocations<OverAlignedConfigurableAllocated>();
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 5cab20ee61291ecd14274c539c572cd0adf9053e
<pre>
[WTF] FAST_ALLOCATED and related macros silently drop alignment for over-aligned types
<a href="https://bugs.webkit.org/show_bug.cgi?id=317075">https://bugs.webkit.org/show_bug.cgi?id=317075</a>

Reviewed by NOBODY (OOPS!).

WTF_DEPRECATED_MAKE_FAST_ALLOCATED_IMPL and friends only declare
operator new(size_t). Class-scope allocation functions hide the global ones,
so a new-expression for an over-aligned class (e.g. alignas(64)) never calls
operator new(size_t, std::align_val_t) and silently falls back to fastMalloc,
which does not honor the alignment. This is undefined behavior in every
configuration where WTF_MAKE_TZONE_ALLOCATED falls back to these macros
(non-Darwin ports, Darwin builds with TZONE_MALLOC disabled). After
<a href="https://commits.webkit.org/314634@main">314634@main</a> made JSC::Lexer alignas(64) and heap-allocated, this crashes on
x86_64 because clang emits 64-byte-aligned stores in the Lexer constructor.

Fix this by adding std::align_val_t overloads of operator new/new[]/delete/
delete[] to the affected macros:
- WTF_DEPRECATED_MAKE_FAST_ALLOCATED_IMPL / FAST_COMPACT_ALLOCATED_IMPL
  route through fastAlignedMalloc / fastCompactAlignedMalloc.
- WTF_MAKE_CONFIGURABLE_ALLOCATED_IMPL routes through alloc::alignedMalloc,
  with alignedMalloc added to FastMalloc, FastCompactMalloc,
  SequesteredArenaMalloc, and the DebugHeap-backed allocator structs.
- WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_COMMON routes through
  sequesteredArenaAlignedMalloc / sequesteredArenaAlignedFree.
- WTF_FORBID_HEAP_ALLOCATION deletes the std::align_val_t overloads so
  over-aligned classes still fail to compile when heap-allocated.

Add a TestWTF case verifying that alignas(64) structs using these macros are
allocated 64-byte aligned.

This was observed as a real SIGSEGV on the very first source parse in Bun
(JSCOnly on macOS x86_64 with TZONE_MALLOC disabled), and the fix resolves it.

Test: Tools/TestWebKitAPI/Tests/WTF/FastMalloc.cpp

* Source/WTF/wtf/DebugHeap.h:
* Source/WTF/wtf/FastMalloc.h:
(WTF::FastMalloc::alignedMalloc):
(WTF::FastCompactMalloc::alignedMalloc):
* Source/WTF/wtf/ForbidHeapAllocation.h:
* Source/WTF/wtf/MallocCommon.h:
* Source/WTF/wtf/SequesteredMalloc.h:
(WTF::SequesteredArenaMalloc::alignedMalloc):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/FastMalloc.cpp: Added.
(TestWebKitAPI::testOverAlignedAllocations):
(TestWebKitAPI::TEST(WTF_FastMalloc, OverAlignedFastAllocated)):
(TestWebKitAPI::TEST(WTF_FastMalloc, OverAlignedFastCompactAllocated)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cab20ee61291ecd14274c539c572cd0adf9053e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169282 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43204 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36465 "Hash 5cab20ee for PR 67138 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131856 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92789 "1 flakes 8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34496 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/36465 "Hash 5cab20ee for PR 67138 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31997 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27338 "Built successfully") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/36465 "Hash 5cab20ee for PR 67138 does not build (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143469 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/36465 "Hash 5cab20ee for PR 67138 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181238 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30537 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140312 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42860 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/36465 "Hash 5cab20ee for PR 67138 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43549 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/36465 "Hash 5cab20ee for PR 67138 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107481 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35420 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115314 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201961 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42059 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/36465 "Hash 5cab20ee for PR 67138 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54169 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41452 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->