### PR TITLE
[JSC] `Array.from(map.keys())` fast path ignores `Symbol.iterator` overrides

### DIFF
--- a/JSTests/stress/array-from-map-iterator-symbol-iterator-override.js
+++ b/JSTests/stress/array-from-map-iterator-symbol-iterator-override.js
@@ -1,0 +1,51 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldBeArray(a, b) {
+    shouldBe(a.length, b.length);
+    for (let i = 0; i < a.length; i++)
+        shouldBe(a[i], b[i]);
+}
+
+// Array.from performs GetMethod(items, @@iterator) and iterates whatever that method
+// returns, so an own or inherited Symbol.iterator override must be respected.
+
+// Own Symbol.iterator on the map iterator.
+{
+    const iterator = new Map([[1, 'a'], [3, 'b']]).keys();
+    Object.defineProperty(iterator, Symbol.iterator, { value: () => [42][Symbol.iterator]() });
+    shouldBeArray(Array.from(iterator), [42]);
+}
+{
+    const iterator = new Map([[1, 'a'], [3, 'b']]).values();
+    Object.defineProperty(iterator, Symbol.iterator, { value: () => [42][Symbol.iterator]() });
+    shouldBeArray(Array.from(iterator), [42]);
+}
+
+// Own Symbol.iterator on %MapIteratorPrototype%.
+{
+    const mapIteratorPrototype = Object.getPrototypeOf(new Map().keys());
+    Object.defineProperty(mapIteratorPrototype, Symbol.iterator, { value: () => [43][Symbol.iterator](), configurable: true });
+    shouldBeArray(Array.from(new Map([[1, 'a'], [3, 'b']]).keys()), [43]);
+    delete mapIteratorPrototype[Symbol.iterator];
+    shouldBeArray(Array.from(new Map([[1, 'a'], [3, 'b']]).keys()), [1, 3]);
+}
+
+// Replaced %IteratorPrototype%[Symbol.iterator].
+{
+    const iteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(new Map().keys()));
+    const original = iteratorPrototype[Symbol.iterator];
+    iteratorPrototype[Symbol.iterator] = () => [44][Symbol.iterator]();
+    shouldBeArray(Array.from(new Map([[1, 'a'], [3, 'b']]).keys()), [44]);
+    iteratorPrototype[Symbol.iterator] = original;
+    shouldBeArray(Array.from(new Map([[1, 'a'], [3, 'b']]).keys()), [1, 3]);
+}
+
+// Unrelated own property does not disable the fast path result.
+{
+    const iterator = new Map([[1, 'a'], [3, 'b']]).keys();
+    iterator.foo = 42;
+    shouldBeArray(Array.from(iterator), [1, 3]);
+}

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2262,6 +2262,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, this->arrayPrototype(), vm.propertyNames->join), m_arrayJoinWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, this->arrayPrototype(), vm.propertyNames->toString), m_arrayToStringWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, mapIteratorPrototype, vm.propertyNames->next), m_mapIteratorProtocolWatchpointSet);
+    installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_iteratorPrototype.get(), vm.propertyNames->iteratorSymbol), m_mapIteratorProtocolWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, setIteratorPrototype, vm.propertyNames->next), m_setIteratorProtocolWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_stringIteratorPrototype.get(), vm.propertyNames->next), m_stringIteratorProtocolWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->iteratorSymbol), m_stringIteratorProtocolWatchpointSet);
@@ -2315,6 +2316,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     // invalidated when a "return" property appears anywhere on the iterator's prototype chain.
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, arrayIteratorPrototype, vm.propertyNames->returnKeyword, m_iteratorPrototype.get()), m_arrayIteratorProtocolWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, mapIteratorPrototype, vm.propertyNames->returnKeyword, m_iteratorPrototype.get()), m_mapIteratorProtocolWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, mapIteratorPrototype, vm.propertyNames->iteratorSymbol, m_iteratorPrototype.get()), m_mapIteratorProtocolWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, setIteratorPrototype, vm.propertyNames->returnKeyword, m_iteratorPrototype.get()), m_setIteratorProtocolWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringIteratorPrototype.get(), vm.propertyNames->returnKeyword, m_iteratorPrototype.get()), m_stringIteratorProtocolWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_iteratorPrototype.get(), vm.propertyNames->returnKeyword, objectPrototype()), m_arrayIteratorProtocolWatchpointSet);

--- a/Source/JavaScriptCore/runtime/MapIteratorPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/MapIteratorPrototypeInlines.h
@@ -46,6 +46,8 @@ ALWAYS_INLINE bool mapIteratorProtocolIsFastAndNonObservable(VM& vm, JSMapIterat
             return false;
         if (mapIterator->getDirectOffset(vm, vm.propertyNames->returnKeyword) != invalidOffset)
             return false;
+        if (mapIterator->getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
+            return false;
     }
 
     return true;


### PR DESCRIPTION
#### 5546cde98cd08c8c21a393d978444db7eb9c8918
<pre>
[JSC] `Array.from(map.keys())` fast path ignores `Symbol.iterator` overrides
<a href="https://bugs.webkit.org/show_bug.cgi?id=317076">https://bugs.webkit.org/show_bug.cgi?id=317076</a>

Reviewed by Yusuke Suzuki.

Array.from performs GetMethod(items, @@iterator) and iterates whatever that
method returns, but the Array.from(map.keys()) fast path only checks
mapIteratorProtocolIsFastAndNonObservable, a GetIteratorDirect-style guard
that never looks at @@iterator. An own Symbol.iterator on the iterator, one
added to %MapIteratorPrototype%, or a replaced
%Iterator.prototype%[Symbol.iterator] is ignored and the fast path keeps
draining the map iterator directly.

Test: JSTests/stress/array-from-map-iterator-symbol-iterator-override.js

* JSTests/stress/array-from-map-iterator-symbol-iterator-override.js: Added.
(shouldBe):
(shouldBeArray):
(string_appeared_here.keys):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::mapIteratorIsIterableFastAndNonObservable):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/315554@main">https://commits.webkit.org/315554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41acbbf95fe7b1eadef278fedbcb13b93c0c86d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127037 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131892 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112396 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32033 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27381 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/600 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181281 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30580 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140348 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42903 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140186 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37732 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43592 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107573 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35453 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115357 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202004 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42102 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6647 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54181 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41638 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->