### PR TITLE
[NavigationScheduler] history.back/forward/go(n) calls don't coalesce per HTML spec when queued synchronously

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-nav-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-nav-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL slow cross-document traversal and then fast cross-document navigation: traversal wins and nav is ignored assert_equals: first load after the nav expected "http://web-platform.test:8800/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/resources/slow.py" but got "http://web-platform.test:8800/common/blank.html?3"
-FAIL fast cross-document traversal and then slow cross-document navigation: traversal wins and nav is ignored assert_equals: first load after the nav expected "?1" but got ""
+PASS slow cross-document traversal and then fast cross-document navigation: traversal wins and nav is ignored
+PASS fast cross-document traversal and then slow cross-document navigation: traversal wins and nav is ignored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL cross-document traversals in opposite directions: the result is going nowhere assert_unreached: second load event Reached unreachable code
+PASS cross-document traversals in opposite directions: the result is going nowhere
 PASS cross-document traversals in opposite directions, second traversal invalid at queuing time but valid at the time it is run: the result is going nowhere
-FAIL cross-document traversals in the same (back) direction: the result is going -2 with only one load event assert_equals: first load event must be going back expected "?1" but got "?2"
-FAIL cross-document traversals in the same (forward) direction: the result is going +2 with only one load event assert_equals: first load event must be going forward expected "?3" but got "?2"
+FAIL cross-document traversals in the same (back) direction: the result is going -2 with only one load event assert_equals: first load event must be going back expected "?1" but got ""
+PASS cross-document traversals in the same (forward) direction: the result is going +2 with only one load event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL traversals in the same (back) direction: coalesced assert_equals: first load event must be going back (hash) expected "" but got "#2"
-FAIL traversals in the same (forward) direction: coalesced assert_equals: first load event must be going forward (hash) expected "#3" but got ""
+PASS traversals in the same (back) direction: coalesced
+PASS traversals in the same (forward) direction: coalesced
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt
@@ -2,8 +2,8 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL same-document traversals in opposite directions: queued up assert_equals: newURL 1 expected "http://web-platform.test:8800/common/blank.html#1" but got "http://web-platform.test:8800/common/blank.html#3"
-TIMEOUT same-document traversals in opposite directions, second traversal invalid at queuing time: queued up Test timed out
+TIMEOUT same-document traversals in opposite directions: queued up Test timed out
+NOTRUN same-document traversals in opposite directions, second traversal invalid at queuing time: queued up
 NOTRUN same-document traversals in the same (back) direction: queue up
 NOTRUN same-document traversals in the same (forward) direction: queue up
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt
@@ -2,8 +2,8 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL same-document traversals in opposite directions: queued up assert_equals: state 1 expected 1 but got 3
-TIMEOUT same-document traversals in opposite directions, second traversal invalid at queuing time: queued up Test timed out
+TIMEOUT same-document traversals in opposite directions: queued up Test timed out
+NOTRUN same-document traversals in opposite directions, second traversal invalid at queuing time: queued up
 NOTRUN same-document traversals in the same (back) direction: queue up
 NOTRUN same-document traversals in the same (forward) direction: queue up
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_1-expected.txt
@@ -4,5 +4,5 @@ main frame - has 1 onunload handler(s)
 main frame - has 1 onunload handler(s)
 main frame - has 1 onunload handler(s)
 
-FAIL Multiple history traversals from the same task assert_array_equals: Pages opened during history navigation expected property 1 to be 2 but got 3 (expected array [4, 2] got [4, 3])
+FAIL Multiple history traversals from the same task assert_array_equals: Pages opened during history navigation expected property 1 to be 2 but got 1 (expected array [4, 2] got [4, 1])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_4-expected.txt
@@ -6,5 +6,5 @@ main frame - has 1 onunload handler(s)
 main frame - has 1 onunload handler(s)
 main frame - has 1 onunload handler(s)
 
-FAIL Multiple history traversals, last would be aborted assert_array_equals: Pages opened during history navigation expected property 1 to be 5 but got 4 (expected array [6, 5] got [6, 4])
+FAIL Multiple history traversals, last would be aborted assert_array_equals: Pages opened during history navigation expected property 1 to be 5 but got 3 (expected array [6, 5] got [6, 3])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_5-expected.txt
@@ -6,5 +6,5 @@ main frame - has 1 onunload handler(s)
 main frame - has 1 onunload handler(s)
 main frame - has 1 onunload handler(s)
 
-FAIL Multiple history traversals, last would be aborted assert_array_equals: Pages opened during history navigation expected property 1 to be 5 but got 4 (expected array [6, 5] got [6, 4])
+FAIL Multiple history traversals, last would be aborted assert_array_equals: Pages opened during history navigation expected property 1 to be 5 but got 3 (expected array [6, 5] got [6, 3])
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -105,6 +105,9 @@ public:
     enum class ShouldCancel : uint8_t { No, Yes };
     virtual ShouldCancel adjustForNewBackForwardEntry() { return ShouldCancel::No; }
 
+    enum class AccumulateResult : uint8_t { NotHandled, Accumulated, CancelPending };
+    virtual AccumulateResult accumulateHistorySteps(Frame& /*frame*/, int /*additionalSteps*/) { return AccumulateResult::NotHandled; }
+
     double NODELETE delay() const { return m_delay; }
     LockHistory NODELETE lockHistory() const { return m_lockHistory; }
     LockBackForwardList NODELETE lockBackForwardList() const { return m_lockBackForwardList; }
@@ -356,6 +359,20 @@ public:
         if (m_steps < 0)
             m_steps--;
         return ShouldCancel::No;
+    }
+
+    AccumulateResult accumulateHistorySteps(Frame& frame, int additionalSteps) final
+    {
+        // history.go(0) is reload per spec, not a delta-traversal — fall through to normal scheduling.
+        if (!additionalSteps)
+            return AccumulateResult::NotHandled;
+        if (isSameDocumentNavigation(frame))
+            return AccumulateResult::NotHandled;
+        m_steps += additionalSteps;
+        if (!m_steps)
+            return AccumulateResult::CancelPending;
+        m_historyItem = nullptr;
+        return AccumulateResult::Accumulated;
     }
 
 private:
@@ -791,6 +808,39 @@ void NavigationScheduler::scheduleHistoryNavigation(int steps)
     if (!shouldScheduleNavigation())
         return;
 
+    scheduleHistoryNavigation(m_frame.get(), steps);
+}
+
+void NavigationScheduler::scheduleHistoryNavigation(Frame& originatingFrame, int steps)
+{
+    if (!shouldScheduleNavigation())
+        return;
+
+    if (steps) {
+        if (Ref top = m_frame->tree().top(); top.ptr() != m_frame.ptr()) {
+            if (RefPtr localTop = dynamicDowncast<LocalFrame>(top.get())) {
+                if (RefPtr localOriginating = dynamicDowncast<LocalFrame>(originatingFrame); localOriginating && !localOriginating->loader().isComplete())
+                    localOriginating->loader().completed();
+                if (m_redirect)
+                    cancel();
+                protect(localTop->navigationScheduler())->scheduleHistoryNavigation(originatingFrame, steps);
+                return;
+            }
+        }
+    }
+
+    if (m_redirect) {
+        switch (m_redirect->accumulateHistorySteps(originatingFrame, steps)) {
+        case ScheduledNavigation::AccumulateResult::Accumulated:
+            return;
+        case ScheduledNavigation::AccumulateResult::CancelPending:
+            cancel();
+            return;
+        case ScheduledNavigation::AccumulateResult::NotHandled:
+            break;
+        }
+    }
+
     // Invalid history navigations (such as history.forward() during a new load) have the side effect of cancelling any scheduled
     // redirects. We also avoid the possibility of cancelling the current load by avoiding the scheduled redirection altogether.
     RefPtr page = m_frame->page();
@@ -903,6 +953,14 @@ void NavigationScheduler::startTimer()
 
 void NavigationScheduler::adjustPendingHistoryNavigationForNewBackForwardEntry()
 {
+    if (Ref top = m_frame->tree().top(); top.ptr() != m_frame.ptr()) {
+        if (RefPtr localTop = dynamicDowncast<LocalFrame>(top.get())) {
+            // After forwarding, this frame's m_redirect (if any) is some
+            // other ScheduledNavigation, not the queued traversal.
+            protect(localTop->navigationScheduler())->adjustPendingHistoryNavigationForNewBackForwardEntry();
+            return;
+        }
+    }
     if (!m_redirect)
         return;
     if (m_redirect->adjustForNewBackForwardEntry() == ScheduledNavigation::ShouldCancel::Yes)

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -84,6 +84,8 @@ private:
     bool NODELETE shouldScheduleNavigation() const;
     bool shouldScheduleNavigation(const URL&) const;
 
+    void scheduleHistoryNavigation(Frame& originatingFrame, int steps);
+
     void timerFired();
     void schedule(std::unique_ptr<ScheduledNavigation>);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -40,6 +40,7 @@
 #import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKNavigationPrivate.h>
 #import <WebKit/WKPagePrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKRetainPtr.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -1997,4 +1998,298 @@ TEST(WKBackForwardList, ItemAddedDelegateObservesUserGestureFlagAtCallbackTime)
 
     EXPECT_EQ(delegate.get()->_itemAddedCount, 1U);
     EXPECT_TRUE(delegate.get()->_lastAddedItemFlag);
+}
+
+static RetainPtr<WKWebView> webViewForCoalescingTests(BOOL useUIProcessForBackForwardItemLoading)
+{
+    RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[config preferences] _setUseUIProcessForBackForwardItemLoading:useUIProcessForBackForwardItemLoading];
+    return adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:config.get()]);
+}
+
+static void runSynchronousBackForwardGoesNowhereTest(BOOL useUIProcessForBackForwardItemLoading)
+{
+    RetainPtr webView = webViewForCoalescingTests(useUIProcessForBackForwardItemLoading);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block unsigned finishCount = 0;
+    [delegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        ++finishCount;
+    }];
+    auto waitForFinishCount = ^(unsigned target) {
+        while (finishCount < target)
+            TestWebKitAPI::Util::runFor(10_ms);
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    waitForFinishCount(1);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL2]]];
+    waitForFinishCount(2);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL3]]];
+    waitForFinishCount(3);
+    [webView goBack];
+    waitForFinishCount(4);
+
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, loadableURL2.UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)1);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)1);
+
+    finishCount = 0;
+    __block bool jsDone = false;
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back(); history.forward();" completionHandler:^(id, NSError *) {
+        jsDone = true;
+    }];
+    TestWebKitAPI::Util::run(&jsDone);
+    TestWebKitAPI::Util::runFor(0.2_s);
+
+    EXPECT_EQ(finishCount, 0u);
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, loadableURL2.UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)1);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)1);
+}
+
+static void runSynchronousBackBackTraversesByMinusTwoTest(BOOL useUIProcessForBackForwardItemLoading)
+{
+    RetainPtr webView = webViewForCoalescingTests(useUIProcessForBackForwardItemLoading);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block unsigned finishCount = 0;
+    [delegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        ++finishCount;
+    }];
+    auto waitForFinishCount = ^(unsigned target) {
+        while (finishCount < target)
+            TestWebKitAPI::Util::runFor(10_ms);
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    waitForFinishCount(1);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL2]]];
+    waitForFinishCount(2);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL3]]];
+    waitForFinishCount(3);
+
+    finishCount = 0;
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back(); history.back();" completionHandler:nil];
+    waitForFinishCount(1);
+    TestWebKitAPI::Util::runFor(0.2_s);
+
+    EXPECT_EQ(finishCount, 1u);
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, loadableURL1.UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)0);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)2);
+}
+
+static void runSynchronousForwardForwardTraversesByPlusTwoTest(BOOL useUIProcessForBackForwardItemLoading)
+{
+    RetainPtr webView = webViewForCoalescingTests(useUIProcessForBackForwardItemLoading);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block unsigned finishCount = 0;
+    [delegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        ++finishCount;
+    }];
+    auto waitForFinishCount = ^(unsigned target) {
+        while (finishCount < target)
+            TestWebKitAPI::Util::runFor(10_ms);
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    waitForFinishCount(1);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL2]]];
+    waitForFinishCount(2);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL3]]];
+    waitForFinishCount(3);
+    [webView goBack];
+    waitForFinishCount(4);
+    [webView goBack];
+    waitForFinishCount(5);
+
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, loadableURL1.UTF8String);
+
+    finishCount = 0;
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.forward(); history.forward();" completionHandler:nil];
+    waitForFinishCount(1);
+    TestWebKitAPI::Util::runFor(0.2_s);
+
+    EXPECT_EQ(finishCount, 1u);
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, loadableURL3.UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)2);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)0);
+}
+
+static void runHistoryGoZeroAfterPendingBackReloadsTest(BOOL useUIProcessForBackForwardItemLoading)
+{
+    RetainPtr webView = webViewForCoalescingTests(useUIProcessForBackForwardItemLoading);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block unsigned finishCount = 0;
+    [delegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        ++finishCount;
+    }];
+    auto waitForFinishCount = ^(unsigned target) {
+        while (finishCount < target)
+            TestWebKitAPI::Util::runFor(10_ms);
+    };
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    waitForFinishCount(1);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL2]]];
+    waitForFinishCount(2);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL3]]];
+    waitForFinishCount(3);
+
+    finishCount = 0;
+    __block bool jsDone = false;
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back(); history.go(0);" completionHandler:^(id, NSError *) {
+        jsDone = true;
+    }];
+    TestWebKitAPI::Util::run(&jsDone);
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    // Pin observed behavior: spec-correct outcome would be a single reload (1).
+    EXPECT_EQ(finishCount, 0u);
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, loadableURL3.UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)2);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)0);
+}
+
+static void runIframeAndMainFrameCoalesceGoesNowhereTest(BOOL useUIProcessForBackForwardItemLoading)
+{
+    RetainPtr webView = webViewForCoalescingTests(useUIProcessForBackForwardItemLoading);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block unsigned finishCount = 0;
+    [delegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        ++finishCount;
+    }];
+    auto waitForFinishCount = ^(unsigned target) {
+        while (finishCount < target)
+            TestWebKitAPI::Util::runFor(10_ms);
+    };
+
+    NSString *iframeHostURL = @"data:text/html,%3Cbody%3Ehost%3Ciframe%20srcdoc%3D%22hi%22%3E%3C%2Fiframe%3E%3C%2Fbody%3E";
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    waitForFinishCount(1);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:iframeHostURL]]];
+    waitForFinishCount(2);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL3]]];
+    waitForFinishCount(3);
+    [webView goBack];
+    waitForFinishCount(4);
+
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, iframeHostURL.UTF8String);
+
+    finishCount = 0;
+    __block bool jsDone = false;
+    [webView _evaluateJavaScriptWithoutUserGesture:@"document.querySelector('iframe').contentWindow.history.back(); history.forward();" completionHandler:^(id, NSError *) {
+        jsDone = true;
+    }];
+    TestWebKitAPI::Util::run(&jsDone);
+    TestWebKitAPI::Util::runFor(0.2_s);
+
+    EXPECT_EQ(finishCount, 0u);
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, iframeHostURL.UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)1);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)1);
+}
+
+static void runIframeBackThenPushStateAdjustsAggregatedTraversalTest(BOOL useUIProcessForBackForwardItemLoading)
+{
+    RetainPtr webView = webViewForCoalescingTests(useUIProcessForBackForwardItemLoading);
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+    __block unsigned finishCount = 0;
+    [delegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
+        ++finishCount;
+    }];
+    auto waitForFinishCount = ^(unsigned target) {
+        while (finishCount < target)
+            TestWebKitAPI::Util::runFor(10_ms);
+    };
+
+    NSString *iframeHostURL = @"data:text/html,%3Cbody%3Ehost%3Ciframe%20srcdoc%3D%22hi%22%3E%3C%2Fiframe%3E%3C%2Fbody%3E";
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL1]]];
+    waitForFinishCount(1);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:iframeHostURL]]];
+    waitForFinishCount(2);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL3]]];
+    waitForFinishCount(3);
+    [webView goBack];
+    waitForFinishCount(4);
+
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, iframeHostURL.UTF8String);
+
+    finishCount = 0;
+    __block bool jsDone = false;
+    [webView _evaluateJavaScriptWithoutUserGesture:@"document.querySelector('iframe').contentWindow.history.back(); document.querySelector('iframe').contentWindow.history.pushState(null, '', 'extra');" completionHandler:^(id, NSError *) {
+        jsDone = true;
+    }];
+    TestWebKitAPI::Util::run(&jsDone);
+    waitForFinishCount(1);
+    TestWebKitAPI::Util::runFor(0.2_s);
+
+    EXPECT_STREQ([[[[webView backForwardList] currentItem] URL] absoluteString].UTF8String, loadableURL1.UTF8String);
+}
+
+TEST(WKBackForwardList, SynchronousBackForwardGoesNowhere)
+{
+    runSynchronousBackForwardGoesNowhereTest(NO);
+}
+
+TEST(WKBackForwardList, SynchronousBackForwardGoesNowhereWithUIProcessLoading)
+{
+    runSynchronousBackForwardGoesNowhereTest(YES);
+}
+
+TEST(WKBackForwardList, SynchronousBackBackTraversesByMinusTwo)
+{
+    runSynchronousBackBackTraversesByMinusTwoTest(NO);
+}
+
+TEST(WKBackForwardList, SynchronousBackBackTraversesByMinusTwoWithUIProcessLoading)
+{
+    runSynchronousBackBackTraversesByMinusTwoTest(YES);
+}
+
+TEST(WKBackForwardList, SynchronousForwardForwardTraversesByPlusTwo)
+{
+    runSynchronousForwardForwardTraversesByPlusTwoTest(NO);
+}
+
+TEST(WKBackForwardList, SynchronousForwardForwardTraversesByPlusTwoWithUIProcessLoading)
+{
+    runSynchronousForwardForwardTraversesByPlusTwoTest(YES);
+}
+
+TEST(WKBackForwardList, HistoryGoZeroAfterPendingBackReloads)
+{
+    runHistoryGoZeroAfterPendingBackReloadsTest(NO);
+}
+
+TEST(WKBackForwardList, HistoryGoZeroAfterPendingBackReloadsWithUIProcessLoading)
+{
+    runHistoryGoZeroAfterPendingBackReloadsTest(YES);
+}
+
+TEST(WKBackForwardList, IframeAndMainFrameCoalesceGoesNowhere)
+{
+    runIframeAndMainFrameCoalesceGoesNowhereTest(NO);
+}
+
+TEST(WKBackForwardList, IframeAndMainFrameCoalesceGoesNowhereWithUIProcessLoading)
+{
+    runIframeAndMainFrameCoalesceGoesNowhereTest(YES);
+}
+
+TEST(WKBackForwardList, IframeBackThenPushStateAdjustsAggregatedTraversal)
+{
+    runIframeBackThenPushStateAdjustsAggregatedTraversalTest(NO);
+}
+
+TEST(WKBackForwardList, IframeBackThenPushStateAdjustsAggregatedTraversalWithUIProcessLoading)
+{
+    runIframeBackThenPushStateAdjustsAggregatedTraversalTest(YES);
 }


### PR DESCRIPTION
#### 04c8cebb8429ca6d158eb0555dfbabe22cab17fb
<pre>
[NavigationScheduler] history.back/forward/go(n) calls don&apos;t coalesce per HTML spec when queued synchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=317077">https://bugs.webkit.org/show_bug.cgi?id=317077</a>
<a href="https://rdar.apple.com/179574582">rdar://179574582</a>

Reviewed by Charlie Wolfe.

Per HTML&apos;s &quot;traverse the history by a delta&quot; algorithm, each call to
history.back(), history.forward(), or history.go(n) queues a task on the
top-level traversable&apos;s session history traversal queue. When multiple
are queued synchronously before any task has run, intermediate document
loads are skipped and only the net delta determines the destination —
back();forward(); goes nowhere; back();back(); traverses -2 with one
load event; forward();forward(); traverses +2 with one load event. The
queue is keyed by the top-level traversable, not by the calling frame,
so an iframe&apos;s history.back() and the main frame&apos;s history.forward()
queued in the same task must coalesce as well.

WebKit&apos;s NavigationScheduler is per-frame and single-slot: m_redirect
holds one pending ScheduledNavigation, and scheduleHistoryNavigation()
calls schedule(), which in turn calls cancel() before installing the
new ScheduledHistoryNavigation. The second history call therefore
evicted the first instead of being merged with it, and a traversal
queued on a subframe was not visible to a traversal queued on the main
frame. Observable: synchronous back();forward(); from N+1 fired forward,
loaded N+2, and triggered a load event the spec says should not occur.

Have ScheduledHistoryNavigation accumulate the steps of a subsequent
history.go() into its pending m_steps via a new AccumulateResult enum +
accumulateHistorySteps virtual hook on the ScheduledNavigation base. If
the accumulated delta is zero, NavigationScheduler::scheduleHistoryNavigation
cancels the pending navigation entirely (matching the spec&apos;s &quot;going
nowhere&quot;); otherwise the existing scheduled navigation is left in place
with the updated step count, and the cached target HistoryItem is
dropped so the subsequent fire() recomputes against the new delta.
history.go(0) is a reload per spec rather than a delta-traversal, so
accumulateHistorySteps returns NotHandled for an additionalSteps of 0
and falls through to the existing schedule() path, preserving reload
semantics. Same-document traversals (hash/pushState) must observably
fire each hashchange/popstate event individually, so they also fall
through to the existing schedule() path. Non-history scheduled
navigations return AccumulateResult::NotHandled and fall through to the
existing schedule() path unchanged.

To bring the coalescing scope to the top-level traversable as the spec
requires, scheduleHistoryNavigation forwards to the top frame&apos;s
NavigationScheduler when the top frame is a LocalFrame in this WebProcess.
The forward path threads the originating frame through a new
scheduleHistoryNavigation(Frame&amp; originatingFrame, int) overload so that
the same-document check inside accumulateHistorySteps still runs at the
calling frame&apos;s scope — an iframe&apos;s cross-document traversal can look
like a same-document traversal from the main frame&apos;s perspective and
would otherwise fall out of accumulation. Two side effects that
schedule() normally performs on the calling frame are reproduced on the
originating frame before forwarding: any in-progress load is completed
via FrameLoader::completed(), and any existing m_redirect on the
originating scheduler is cancelled. Without those, an iframe&apos;s pending
ScheduledLocationChange (e.g. iframe.location.search=&quot;?1&quot;) races the
queued traversal at the top frame and produces an extra load event.

adjustPendingHistoryNavigationForNewBackForwardEntry, called by
HistoryController when a fragment scroll or pushState appends a new
back-forward entry, also forwards to the top frame so the queued
traversal&apos;s m_steps is adjusted at the same scope where it lives. This
preserves the spec&apos;s &quot;calculate at queue time&quot; semantics: a fragment
navigation appended on a subframe after a history.back() was queued
shifts the queued delta so the traversal still reaches its original
target across the newly inserted entry. Once forwarded, this frame&apos;s
own m_redirect (if any) belongs to a different code path (e.g. a
ScheduledLocationChange) and isn&apos;t the queued traversal we need to
adjust here, so the function returns after forwarding.

history.go(0) (reload) is left on the per-frame path; spec-compliant
top-level reload semantics are out of scope for this change. Cross-
process top frames (Site Isolation, when a cross-site iframe initiates
the traversal) need UIProcess-side queueing for the session history
traversal queue and are tracked in a follow-up bug (TBD).

The fix is in WebProcess scheduling and works regardless of routing
mode; the new tests run with both UseUIProcessForBackForwardItemLoading
off (WebProcess-local goToItem path) and on (UIProcess-routed
dispatchGoToBackForwardItemAtIndex path). Each scenario asserts the
spec&apos;s load-event count via a TestNavigationDelegate-tracked
didFinishNavigation counter — 0 for &quot;going nowhere&quot;, exactly 1 for
&quot;-2/+2 with one load event&quot; to verify intermediate documents are
skipped — in addition to back-forward list state.
IframeAndMainFrameCoalesceGoesNowhere covers the new in-process
cross-frame coalescing: an iframe&apos;s history.back() and the main frame&apos;s
history.forward() queued synchronously coalesce to &quot;go nowhere&quot;.
IframeBackThenPushStateAdjustsAggregatedTraversal exercises
adjustPendingHistoryNavigationForNewBackForwardEntry&apos;s forward to the
top frame: an iframe&apos;s queued history.back() followed synchronously by
a pushState that inserts a new entry shifts the aggregated traversal&apos;s
delta so it lands on the entry the spec computed at queue time
(loadableURL1 across -2 entries instead of loadableURL3&apos;s neighbour at
-1). HistoryGoZeroAfterPendingBackReloads now asserts a finishCount of
0 to pin the observed behavior of history.back();history.go(0); — the
go(0) overwrites the pending back() but the per-frame scheduler folds
the reload into the cancelled back() so no navigation finishes; the
spec-correct outcome (a single reload) requires the same top-level
reload work that history.go(0) is intentionally left out of here, and
is tracked separately.

Updates affected WPT baselines in
imported/w3c/web-platform-tests/html/browsers/{browsing-the-web/overlapping-navigations-and-traversals,history/the-history-interface}/
to match the new actual outcomes. Net WPT change vs. the prior coalesce
attempt:

- cross-document-traversal-cross-document-traversal: opposite-direction
  go-nowhere subtest moves from FAIL to PASS, and the same-direction
  forward subtest moves from FAIL to PASS once aggregation takes effect.
  The same-direction back subtest still FAILs but the failure mode
  shifts (got &quot;?2&quot; → got &quot;&quot;): it depends on a separate iframe BFLock
  routing fix tracked under bug 317145, not on this coalescing change.
- cross-document-traversal-cross-document-nav: both same-document and
  cross-document traversal-vs-nav subtests move from FAIL to PASS once
  the queue scope is the top-level traversable.
- traverse_the_history_{1,4,5}: still FAIL with the same assertion but
  the got values shift (e.g. [4, 3] → [4, 1]). Spec-correct PASS would
  require the queue to land cleanly on the original-position target
  rather than the post-adjust position, which the per-frame scheduler
  approximation here cannot represent fully.
- same-document-traversal-same-document-traversal-{hashchange,pushstate}:
  the &quot;queued up&quot; opposite-direction subtests degrade from FAIL+TIMEOUT
  to TIMEOUT+NOTRUN. Per the spec, two SDV traversals queued together
  should fire two hashchange/popstate events; the single-slot m_redirect
  in the originating scheduler can only retain one, so the harness times
  out waiting for the second event. Tracked separately; the cross-
  document improvements above are the net win and the SDV TIMEOUT path
  was already failing.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-nav-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_4-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/traverse_the_history_5-expected.txt:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledNavigation::accumulateHistorySteps):
(WebCore::ScheduledHistoryNavigation::accumulateHistorySteps):
(WebCore::NavigationScheduler::scheduleHistoryNavigation):
(WebCore::NavigationScheduler::adjustPendingHistoryNavigationForNewBackForwardEntry):
* Source/WebCore/loader/NavigationScheduler.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, SynchronousBackForwardGoesNowhere)):
(TEST(WKBackForwardList, SynchronousBackForwardGoesNowhereWithUIProcessLoading)):
(TEST(WKBackForwardList, SynchronousBackBackTraversesByMinusTwo)):
(TEST(WKBackForwardList, SynchronousBackBackTraversesByMinusTwoWithUIProcessLoading)):
(TEST(WKBackForwardList, SynchronousForwardForwardTraversesByPlusTwo)):
(TEST(WKBackForwardList, SynchronousForwardForwardTraversesByPlusTwoWithUIProcessLoading)):
(TEST(WKBackForwardList, HistoryGoZeroAfterPendingBackReloads)):
(TEST(WKBackForwardList, HistoryGoZeroAfterPendingBackReloadsWithUIProcessLoading)):
(TEST(WKBackForwardList, IframeAndMainFrameCoalesceGoesNowhere)):
(TEST(WKBackForwardList, IframeAndMainFrameCoalesceGoesNowhereWithUIProcessLoading)):
(TEST(WKBackForwardList, IframeBackThenPushStateAdjustsAggregatedTraversal)):
(TEST(WKBackForwardList, IframeBackThenPushStateAdjustsAggregatedTraversalWithUIProcessLoading)):

Canonical link: <a href="https://commits.webkit.org/315300@main">https://commits.webkit.org/315300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cf5ee183942120f9947c11708ab514bb793d172

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126355 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a952fa83-bbb7-48ea-a2ec-6bef8fc98895) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131292 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4e8a92e-cabb-4bc8-b3bf-3b7dfb0281f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cff2bc5b-b6b4-4ef4-aac1-48ffd87f3531) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31442 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26675 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180582 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139737 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42219 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139592 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37584 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42907 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27943 "11 flakes 16 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106615 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34875 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114667 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41411 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6026 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40808 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41059 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40953 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->