### PR TITLE
[CMake] Set ARCH from SDKSettings.json/host on Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,32 +14,6 @@ if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
     include(WebKitXcodeSDK)
 endif ()
 
-if (PORT STREQUAL "IOS")
-    # FIXME: Delete or merge into WebKitXcodeSDK logic.
-    set(CMAKE_SYSTEM_NAME iOS)
-    if (NOT CMAKE_OSX_ARCHITECTURES)
-        if (CMAKE_OSX_SYSROOT MATCHES "\\.Internal\\.sdk$" AND NOT CMAKE_OSX_SYSROOT MATCHES "[Ss]imulator")
-            execute_process(COMMAND uname -m
-                OUTPUT_VARIABLE _host_arch
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-            if (_host_arch STREQUAL "arm64")
-                set(CMAKE_OSX_ARCHITECTURES "arm64e" CACHE STRING "Target architecture" FORCE)
-                message(STATUS "iOS: arm64e enabled (internal device SDK detected)")
-            endif ()
-        else ()
-            set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Target architecture" FORCE)
-        endif ()
-    endif ()
-
-    if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "18.0" CACHE STRING "Minimum iOS version" FORCE)
-    endif ()
-
-    if (NOT CMAKE_SYSTEM_PROCESSOR)
-        set(CMAKE_SYSTEM_PROCESSOR "aarch64" CACHE STRING "Target processor" FORCE)
-    endif ()
-endif ()
-
 project(WebKit LANGUAGES C CXX)
 
 # -----------------------------------------------------------------------------

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -78,7 +78,7 @@
 #define BOS_HAIKU 1
 #endif
 
-#if BOS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
+#if BOS(DARWIN)
 #if TARGET_OS_IOS
 #define BOS_IOS 1
 #define BPLATFORM_IOS 1

--- a/Source/bmalloc/libpas/src/libpas/pas_platform.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_platform.h
@@ -153,7 +153,7 @@
 #define PAS_OS_WINDOWS 1
 #endif
 
-#if PAS_OS(DARWIN) && !defined(BUILDING_WITH_CMAKE)
+#if PAS_OS(DARWIN)
 #if TARGET_OS_IOS
 #define PAS_OS_IOS 1
 #define PAS_PLATFORM_IOS 1

--- a/Source/cmake/WebKitXcodeSDK.cmake
+++ b/Source/cmake/WebKitXcodeSDK.cmake
@@ -16,14 +16,60 @@ function(WEBKIT_RESOLVE_SDK)
             string(JSON _sdk_version GET ${_sdk_settings} Version)
             set(_sdk_version "${_sdk_version}" PARENT_SCOPE)
             string(JSON _sdk_canonical_name GET ${_sdk_settings} CanonicalName)
+            string(JSON _platform_name GET ${_sdk_settings} DefaultProperties PLATFORM_NAME)
 
             message(STATUS "Xcode SDK: ${_sdk_canonical_name} at ${_sdk_path}")
             set(CMAKE_OSX_SYSROOT "${_sdk_path}" CACHE PATH "" FORCE)
             if (_sdk_path MATCHES "\\.[Ii]nternal.sdk$")
-                set(USE_APPLE_INTERNAL_SDK ON PARENT_SCOPE)
+                set(USE_APPLE_INTERNAL_SDK ON CACHE BOOL "" FORCE)
             else ()
-                set(USE_APPLE_INTERNAL_SDK OFF PARENT_SCOPE)
+                set(USE_APPLE_INTERNAL_SDK OFF CACHE BOOL "" FORCE)
             endif ()
+
+            if (NOT CMAKE_OSX_ARCHITECTURES)
+                # Build the supported-archs list from SDKSettings.json's
+                # SupportedTargets.<platform>.Archs. Order works out
+                # to match our preferred build defaults.
+                string(JSON _archs_length LENGTH ${_sdk_settings}
+                    SupportedTargets ${_platform_name} Archs)
+                set(_supported_archs "")
+                math(EXPR _archs_last "${_archs_length} - 1")
+                foreach (_i RANGE 0 ${_archs_last})
+                    string(JSON _arch_i GET ${_sdk_settings}
+                        SupportedTargets ${_platform_name} Archs ${_i})
+                    list(APPEND _supported_archs "${_arch_i}")
+                endforeach ()
+
+                # FIXME: This is different from what we do in the xcodebuild. For devices,
+                # we default to building for all architectures supported by the device 
+                # (for iOS devices, just arm64e). For simulators, we query the system for
+                # created simulator targets and match their architecture (usually arm64).
+                if (PORT STREQUAL "Mac" OR PORT STREQUAL "JSCOnly")
+                    # When building for the host machine CMAKE_HOST_SYSTEM_PROCESSOR 
+                    # isn't populated until `project()` is called, so consult `uname -m`.
+                    # Only set _arch if SDK supports arm64e otherwise let `project()`
+                    # configure.
+                    execute_process(COMMAND uname -m
+                        OUTPUT_VARIABLE _host_arch
+                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+                    if (_host_arch STREQUAL "arm64" AND USE_APPLE_INTERNAL_SDK
+                            AND "arm64e" IN_LIST _supported_archs)
+                        set(_arch "arm64e")
+                        set(_arch_reason "internal SDK + arm64 host")
+                    endif ()
+                else ()
+                    # When Cross-compiling, just trust the SDKSettings's ordering.
+                    list(GET _supported_archs 0 _arch)
+                    set(_arch_reason "first SDK-supported arch")
+                endif ()
+
+                if (DEFINED _arch)
+                    set(CMAKE_OSX_ARCHITECTURES "${_arch}"
+                        CACHE STRING "Target architecture" FORCE)
+                    message(STATUS "Architecture: ${_arch} (${_arch_reason})")
+                endif ()
+            endif ()
+
             return()
         endif ()
     endforeach ()
@@ -104,6 +150,20 @@ elseif (PORT STREQUAL "IOS" AND NOT CMAKE_IOS_SIMULATOR)
 else ()
     message(FATAL_ERROR "Building for an Apple platform without an SDK "
         "directory (CMAKE_OSX_SYSROOT) or supported PORT variable.")
+endif ()
+
+# Cross-compile setup for iOS. CMake doesn't infer CMAKE_SYSTEM_PROCESSOR once
+# CMAKE_SYSTEM_NAME is set, so it has to be supplied explicitly. Both must be
+# in place before project() runs.
+if (PORT STREQUAL "IOS")
+    set(CMAKE_SYSTEM_NAME iOS)
+    if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+        string(REGEX MATCH "^[0-9]+\\.[0-9]+" _ios_deployment_target "${_sdk_version}")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "${_ios_deployment_target}" CACHE STRING "Minimum iOS version" FORCE)
+    endif ()
+    if (NOT CMAKE_SYSTEM_PROCESSOR)
+        set(CMAKE_SYSTEM_PROCESSOR "aarch64" CACHE STRING "Target processor" FORCE)
+    endif ()
 endif ()
 
 # Subsequent use of `xcrun` or any of the system Xcode and BSD tools will


### PR DESCRIPTION
#### 279137d4b89c4e60150341ab8eb8b5b9824a6750
<pre>
[CMake] Set ARCH from SDKSettings.json/host on Darwin
<a href="https://bugs.webkit.org/show_bug.cgi?id=317079">https://bugs.webkit.org/show_bug.cgi?id=317079</a>
<a href="https://rdar.apple.com/179580370">rdar://179580370</a>

Reviewed by Elliott Williams.

Centralize Apple SDK setup in WebKitXcodeSDK.cmake and pick the default
CMAKE_OSX_ARCHITECTURES from the SDK&apos;s SupportedTargets.&lt;platform&gt;.Archs.
This fixes builds with the internal SDK silently building arm64 instead
of arm64e on Apple Silicon hosts.

Selection rule:
 - Mac / JSCOnly: host-native arch, promoted to arm64e when the SDK is
   internal and lists arm64e in SupportedTargets.macosx.Archs. Otherwise
   CMAKE_OSX_ARCHITECTURES is left unset so CMake/clang target the host.
 - iOS device / simulator: take Archs[0] from the SDK -- internal
   iphoneos lists arm64e first, public iphoneos and iphonesimulator
   list arm64 first.

Also moves CMAKE_SYSTEM_NAME, CMAKE_OSX_DEPLOYMENT_TARGET, and
CMAKE_SYSTEM_PROCESSOR setup for iOS out of the top-level CMakeLists.txt
into WebKitXcodeSDK.cmake, and caches USE_APPLE_INTERNAL_SDK so it&apos;s
readable in the same function that sets it without PARENT_SCOPE
plumbing.

The SDK-driven arm64e default exposed a latent inconsistency in
bmalloc / libpas: pas_platform.h:156 and BPlatform.h:81 both excluded
their TargetConditionals-based platform detection from CMake builds
via `&amp;&amp; !defined(BUILDING_WITH_CMAKE)`. Pre-refactor Mac builds were
arm64-only, so PAS_ENABLE_MTE and BENABLE_MTE both evaluated to 0 and
the consistency check at pas_mte_config.h:215 trivially passed. With
arm64e, the two sides diverged (depending on whether a TU received
-DBPLATFORM_MAC=1) and fired the #error. Removing the exclusion makes
both auto-derive from TargetConditionals, matching Xcode-driven builds.

Canonical link: <a href="https://commits.webkit.org/315362@main">https://commits.webkit.org/315362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/639c4c5b3fb609cb0ed2a1f98237507b1f2f38f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42375 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35970 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126523 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc0a439c-68b3-4c76-a02e-c428e9e4ba4d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131450 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf2b6050-00c4-4fe2-ad0b-1cee0578f53f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111954 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f64062a-347d-4239-9a0c-7967b2ebcd2d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26842 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/143 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180748 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30067 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139899 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42387 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139743 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43076 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106844 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35024 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201495 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41579 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6185 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54087 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->