### PR TITLE
[Text Extraction] Concatenate all label text for form controls

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
@@ -15,6 +15,9 @@ root
                 input placeholder=Password name=password minlength=3 maxlength=20 required secure
                 input placeholder=Email pattern=[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$ name=email required
                 input placeholder='Zip Code' pattern=[0-9]{5} name=zipcode minlength=5 maxlength=5
+                'Email Address'
+                input label='Email Address Password' name=multi-step
+                'Password'
 
 -- html
 
@@ -34,6 +37,9 @@ root
                 <input type='password' placeholder='Password' name='password' minlength=3 maxlength=20 required>
                 <input type='text' placeholder='Email' pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$' name='email' required>
                 <input type='text' placeholder='Zip Code' pattern='[0-9]{5}' name='zipcode' minlength=5 maxlength=5>
+                Email Address
+                <input type='text' label='Email Address Password' name='multi-step'>
+                Password
             </form>
         </section>
     </main>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html
@@ -67,6 +67,12 @@ main {
                 <input name="email" placeholder="Email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$" required />
                 <input name="zipcode" placeholder="Zip Code" pattern="[0-9]{5}" minlength="5" maxlength="5" />
             </div>
+            <br>
+            <div class="form-container">
+                <label for="multi-label-input">Email Address</label>
+                <input id="multi-label-input" name="multi-step" />
+                <label for="multi-label-input">Password</label>
+            </div>
         </form>
         <select>
             <option value="one">Number 1</option>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -479,16 +479,21 @@ static inline String labelText(HTMLElement& element)
     if (!labels)
         return { };
 
-    RefPtr<Element> firstRenderedLabel;
+    StringBuilder builder;
     for (unsigned index = 0; index < labels->length(); ++index) {
-        if (RefPtr label = dynamicDowncast<Element>(labels->item(index)); label && label->renderer())
-            firstRenderedLabel = WTF::move(label);
+        RefPtr label = dynamicDowncast<Element>(labels->item(index));
+        if (!label || !label->renderer())
+            continue;
+
+        auto text = label->textContent().simplifyWhiteSpace(isASCIIWhitespace);
+        if (text.isEmpty())
+            continue;
+
+        if (!builder.isEmpty())
+            builder.append(' ');
+        builder.append(WTF::move(text));
     }
-
-    if (firstRenderedLabel)
-        return firstRenderedLabel->textContent().simplifyWhiteSpace(isASCIIWhitespace);
-
-    return { };
+    return builder.toString();
 }
 
 static inline std::optional<FloatRect> visibleAssociatedLabelBounds(HTMLElement& element)


### PR DESCRIPTION
#### 6bd6d7813da4f9ad8cf98ddd6b6001584c3cb9f8
<pre>
[Text Extraction] Concatenate all label text for form controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=317081">https://bugs.webkit.org/show_bug.cgi?id=317081</a>
<a href="https://rdar.apple.com/179590407">rdar://179590407</a>

Reviewed by Richard Robinson.

Concatenate all relevant label text when extracting text representation for form controls. On
<a href="https://nypost.com/account/settings">https://nypost.com/account/settings</a>, after entering an email and clicking Continue, the readonly
email input is labeled by both &quot;Email Address&quot; and &quot;Password&quot;; we currently only surface &quot;Password&quot;
as the label text, which occasionally confuses the agent.

After this change, the label text becomes &quot;Email Address Password&quot;.

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::labelText):

Canonical link: <a href="https://commits.webkit.org/315184@main">https://commits.webkit.org/315184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f1df44edee28c00653e7cf779139b4ec534eebe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125996 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/585d4294-c6ff-4fa3-bdb1-f995af089365) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130970 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c281be9-0af0-488d-9aa6-55c6d4b5d65c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111482 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27350a8f-bedc-4a51-b280-2329d754ccb7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32424 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31127 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26319 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142410 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180223 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32947 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139407 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41864 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35286 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139270 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37508 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150720 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106009 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34559 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27618 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114312 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40453 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5702 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->