### PR TITLE
Cherry-pick 314443@main (349e1d854950). https://bugs.webkit.org/show_bug.cgi?id=316156

### DIFF
--- a/JSTests/stress/temporal-iso8601-parse-bounds.js
+++ b/JSTests/stress/temporal-iso8601-parse-bounds.js
@@ -1,0 +1,88 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${expected} but got ${actual}`);
+}
+
+function shouldThrowRangeError(fn, msg) {
+    let thrown = null;
+    try { fn(); } catch (e) { thrown = e; }
+    if (!thrown)
+        throw new Error(`${msg}: expected RangeError but nothing was thrown`);
+    if (!(thrown instanceof RangeError))
+        throw new Error(`${msg}: expected RangeError but got ${thrown}`);
+}
+
+// ISO8601::parseDate() used to read past the end of the buffer for short
+// truncated strings: month/day length guards only applied to the Date format.
+// All of these must throw RangeError instead of crashing.
+{
+    const crashers = [
+        ["PlainDate", "0"],
+        ["PlainDate", "1"],
+        ["PlainDate", "12"],
+        ["PlainDate", "123"],
+        ["PlainDate", "12-"],
+        ["Instant", "1"],
+        ["PlainTime", "1"],
+        ["PlainDateTime", "12"],
+        ["PlainMonthDay", "1"],
+        ["PlainMonthDay", "12"],
+        ["PlainMonthDay", "12-"],
+        ["PlainMonthDay", "121"],
+        ["PlainMonthDay", "--1"],
+        ["PlainMonthDay", "--12"],
+        ["PlainMonthDay", "--12-"],
+        ["PlainMonthDay", "--121"],
+        ["PlainMonthDay", "02-2"],
+        ["PlainMonthDay", "2024-01"],
+        ["PlainMonthDay", "202401"],
+        ["PlainMonthDay", "2021-12"],
+        ["PlainMonthDay", "2024-05"],
+        ["PlainYearMonth", "2024-0"],
+        ["PlainYearMonth", "2024-01-"],
+        ["PlainYearMonth", "2024-01-1"],
+        ["PlainYearMonth", "202401-"],
+        ["PlainYearMonth", "2024011"],
+        ["PlainYearMonth", "12-1"],
+        ["ZonedDateTime", "1"],
+        ["ZonedDateTime", "12"],
+        ["PlainDate", "2024-0"],
+        ["PlainDate", "2024-01-"],
+        ["PlainDate", "2024-01-1"],
+        ["PlainDate", "1976111"],
+        ["PlainDate", "19761"],
+    ];
+    for (const [type, string] of crashers)
+        shouldThrowRangeError(() => Temporal[type].from(string), `${type}.from(${JSON.stringify(string)})`);
+}
+
+// Valid strings must keep working.
+{
+    shouldBe(Temporal.PlainDate.from("2024-01-15").toString(), "2024-01-15", "PlainDate hyphenated");
+    shouldBe(Temporal.PlainDate.from("20240115").toString(), "2024-01-15", "PlainDate compact");
+    shouldBe(Temporal.PlainDate.from("+002024-01-15").toString(), "2024-01-15", "PlainDate extended year");
+    shouldBe(Temporal.PlainDate.from("2024-01-15T12:30").toString(), "2024-01-15", "PlainDate with time");
+    shouldBe(Temporal.PlainDate.from("2024-01-01[u-ca=iso8601]").toString(), "2024-01-01", "calendar annotation");
+
+    shouldBe(Temporal.PlainYearMonth.from("2024-01").toString(), "2024-01", "YearMonth hyphenated");
+    shouldBe(Temporal.PlainYearMonth.from("202401").toString(), "2024-01", "YearMonth compact");
+    shouldBe(Temporal.PlainYearMonth.from("2024-01[u-ca=iso8601]").toString(), "2024-01", "YearMonth annotated");
+    shouldBe(Temporal.PlainYearMonth.from("19761118").toString(), "1976-11", "YearMonth compact full date");
+    shouldBe(Temporal.PlainYearMonth.from("1976-11-18").toString(), "1976-11", "YearMonth full date");
+    shouldBe(Temporal.PlainYearMonth.from("1976-11-18T15:23:30").toString(), "1976-11", "YearMonth full datetime");
+    shouldBe(Temporal.PlainYearMonth.from("19761118T15:23").toString(), "1976-11", "YearMonth compact datetime");
+
+    shouldBe(Temporal.PlainMonthDay.from("12-14").toString(), "12-14", "MonthDay hyphenated");
+    shouldBe(Temporal.PlainMonthDay.from("1214").toString(), "12-14", "MonthDay compact");
+    shouldBe(Temporal.PlainMonthDay.from("--12-14").toString(), "12-14", "MonthDay double hyphen");
+    shouldBe(Temporal.PlainMonthDay.from("--1214").toString(), "12-14", "MonthDay double hyphen compact");
+    shouldBe(Temporal.PlainMonthDay.from("1130[u-ca=iso8601]").toString(), "11-30", "MonthDay annotated");
+    shouldBe(Temporal.PlainMonthDay.from("1118[+01:00]").toString(), "11-18", "MonthDay timezone annotation");
+    shouldBe(Temporal.PlainMonthDay.from("1976-11-18").toString(), "11-18", "MonthDay full date");
+    shouldBe(Temporal.PlainMonthDay.from("1976-11-18T15:23:30").toString(), "11-18", "MonthDay full datetime");
+
+    shouldBe(Temporal.PlainDateTime.from("2024-01-15T12:30").toString(), "2024-01-15T12:30:00", "PlainDateTime");
+    shouldBe(Temporal.ZonedDateTime.from("2024-01-15T12:30[UTC]").toString(), "2024-01-15T12:30:00+00:00[UTC]", "ZonedDateTime");
+}

--- a/LayoutTests/fetch/request-clone-without-target-address-space-crash-expected.txt
+++ b/LayoutTests/fetch/request-clone-without-target-address-space-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Cloning a Request without targetAddressSpace in init must not crash
+

--- a/LayoutTests/fetch/request-clone-without-target-address-space-crash.html
+++ b/LayoutTests/fetch/request-clone-without-target-address-space-crash.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LocalNetworkAccessEnabled=true ] -->
+<html>
+<head>
+<title>Cloning a Request without targetAddressSpace in init must not crash</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(() => {
+    const original = new Request("http://example.com/");
+    assert_equals(original.targetAddressSpace, "public");
+
+    // Constructing a Request from another Request without specifying
+    // targetAddressSpace in the init dictionary must not crash and must
+    // preserve the original's value.
+    const clone = new Request(original);
+    assert_equals(clone.targetAddressSpace, "public");
+
+    const cloneWithEmptyInit = new Request(original, { });
+    assert_equals(cloneWithEmptyInit.targetAddressSpace, "public");
+
+    const cloneWithOtherInit = new Request(original, { method: "POST" });
+    assert_equals(cloneWithOtherInit.targetAddressSpace, "public");
+}, "Cloning a Request without targetAddressSpace in init must not crash");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+PASS random() whose 'max' argument fails to resolve is invalid at computed-value time (falls back to initial 'auto')
+PASS random() whose 'min' argument fails to resolve is invalid at computed-value time (falls back to initial 'auto')
+PASS random() with resolvable arguments produces a value within [min, max]
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values: random() with an argument that is invalid at computed-value time</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#random">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn">
+<meta name="assert" content="When an argument of random() cannot be resolved at computed-value time (here anchor-size() used on a non-out-of-flow element), the declaration is invalid at computed-value time and the property falls back to its initial value. random() with resolvable arguments still produces a value within [min, max].">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+/* The container fixes the containing block width, so a child whose 'width'
+   becomes invalid at computed-value time (falls back to the initial 'auto')
+   has a deterministic used width of 400px. */
+#container { width: 400px; }
+
+/* anchor-size() resolves to nothing on a statically-positioned element, so the
+   argument it appears in fails to evaluate, making the whole random() invalid
+   at computed-value time.
+
+   The earlier 'width: 50px' declaration disambiguates two outcomes that would
+   otherwise both produce the initial 'auto':
+     - If random() is supported and the argument fails at computed-value time,
+       the property is invalid at computed-value time and reverts to the initial
+       value 'auto' (400px in this container), NOT to the earlier 50px.
+     - If random() is not supported at all, its declaration is dropped at parse
+       time and the earlier 'width: 50px' wins. */
+#max-unresolvable { width: 50px; width: random(0px, anchor-size(width), 100px); }
+#min-unresolvable { width: 50px; width: random(anchor-size(width), 100px, 1px); }
+
+/* Control: all arguments resolve, so random() produces a value in [10px, 20px]. */
+#resolvable { width: random(10px, 20px); }
+</style>
+<div id="container">
+  <div id="max-unresolvable"></div>
+  <div id="min-unresolvable"></div>
+  <div id="resolvable"></div>
+</div>
+<script>
+function computedWidth(id) {
+  return getComputedStyle(document.getElementById(id)).width;
+}
+
+test(() => {
+  assert_equals(computedWidth('max-unresolvable'), '400px');
+}, "random() whose 'max' argument fails to resolve is invalid at computed-value time (falls back to initial 'auto')");
+
+test(() => {
+  assert_equals(computedWidth('min-unresolvable'), '400px');
+}, "random() whose 'min' argument fails to resolve is invalid at computed-value time (falls back to initial 'auto')");
+
+test(() => {
+  const width = parseFloat(computedWidth('resolvable'));
+  assert_greater_than_equal(width, 10, 'resolved width is >= min');
+  assert_less_than_equal(width, 20, 'resolved width is <= max');
+}, "random() with resolvable arguments produces a value within [min, max]");
+</script>

--- a/LayoutTests/js/dom/modules/import-from-javascript-url-new-window-expected.txt
+++ b/LayoutTests/js/dom/modules/import-from-javascript-url-new-window-expected.txt
@@ -1,0 +1,2 @@
+This test passes if import() in the null-URL initial document of a new top-level window rejects with a TypeError instead of crashing the WebContent process.
+PASS

--- a/LayoutTests/js/dom/modules/import-from-javascript-url-new-window.html
+++ b/LayoutTests/js/dom/modules/import-from-javascript-url-new-window.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body onload="test()">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+var w;
+
+function test() {
+    w = window.open("javascript:import('x').then(() => opener.concludeTest('resolved', false), e => opener.concludeTest(String(e), e instanceof TypeError));void 0");
+}
+
+// Called from the opened window once import() settles.
+function concludeTest(result, isTypeError) {
+    var pass = isTypeError && result === "TypeError: Cannot import a module from a document with no base URL.";
+    document.getElementById("console").textContent = pass ? "PASS" : ("FAIL: " + result);
+
+    if (w)
+        w.close();
+
+    setTimeout(doneHandler, 1);
+
+    function doneHandler() {
+        if (!w || w.closed) {
+            if (window.testRunner)
+                testRunner.notifyDone();
+            return;
+        }
+        setTimeout(doneHandler, 1);
+    }
+}
+</script>
+This test passes if import() in the null-URL initial document of a new top-level window rejects with a TypeError instead of crashing the WebContent process.
+<div id="console">FAIL, test did not run</div>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1083,16 +1083,12 @@ static std::optional<PlainDate> parseDate(StringParsingBuffer<CharacterType>& bu
         if (*buffer == '-') {
             splitByHyphen = true;
             buffer.advance();
-            if (buffer.lengthRemaining() < 5 && format == TemporalDateFormat::Date)
-                return std::nullopt;
-        } else {
-            if (buffer.lengthRemaining() < 4 && format == TemporalDateFormat::Date)
-                return std::nullopt;
         }
     }
-    // We ensured that buffer has enough length for month and day. We do not need to check length.
 
     unsigned month = 0;
+    if (buffer.lengthRemaining() < 2)
+        return std::nullopt;
     auto firstMonthCharacter = *buffer;
     if (firstMonthCharacter == '0' || firstMonthCharacter == '1') {
         buffer.advance();
@@ -1112,17 +1108,22 @@ static std::optional<PlainDate> parseDate(StringParsingBuffer<CharacterType>& bu
         return PlainDate(year, month, 1);
     }
 
+    if (buffer.atEnd())
+        return std::nullopt;
+
+    bool consumedDaySeparator = false;
     if (*buffer == '-') {
-        if (splitByHyphen || format != TemporalDateFormat::Date)
+        if (splitByHyphen || format != TemporalDateFormat::Date) {
             buffer.advance();
-        else
+            consumedDaySeparator = true;
+        } else
             return std::nullopt;
     } else if (splitByHyphen)
         return std::nullopt;
 
     unsigned day = 0;
-    auto firstDayCharacter = *buffer;
-    if (firstDayCharacter >= '0' && firstDayCharacter <= '3') {
+    if (buffer.lengthRemaining() >= 2 && *buffer >= '0' && *buffer <= '3') {
+        auto firstDayCharacter = *buffer;
         buffer.advance();
         auto secondDayCharacter = *buffer;
         if (!isASCIIDigit(secondDayCharacter))
@@ -1131,7 +1132,7 @@ static std::optional<PlainDate> parseDate(StringParsingBuffer<CharacterType>& bu
         if (!day || day > daysInMonth(year, month))
             return std::nullopt;
         buffer.advance();
-    } else if (format != TemporalDateFormat::YearMonth)
+    } else if (consumedDaySeparator || format != TemporalDateFormat::YearMonth)
         return std::nullopt;
 
     // PlainDate represents out-of-range years using outOfRangeYear

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -273,11 +273,6 @@ constexpr TargetType clampTo(SourceType value, TargetType min = defaultMinimumFo
     return static_cast<TargetType>(value);
 }
 
-constexpr int clampToInteger(double value)
-{
-    return clampTo<int>(value);
-}
-
 constexpr unsigned clampToUnsigned(double value)
 {
     return clampTo<unsigned>(value);
@@ -291,21 +286,6 @@ constexpr float clampToFloat(double value)
 constexpr int clampToPositiveInteger(double value)
 {
     return clampTo<int>(value, 0);
-}
-
-constexpr int clampToInteger(float value)
-{
-    return clampTo<int>(value);
-}
-
-template<std::integral T>
-constexpr int clampToInteger(T x)
-{
-    constexpr T intMax = static_cast<unsigned>(std::numeric_limits<int>::max());
-
-    if (x >= intMax)
-        return std::numeric_limits<int>::max();
-    return static_cast<int>(x);
 }
 
 // Explicitly accept 64bit result when clamping double value.

--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -91,7 +91,7 @@ Ref<DOMPromise> FetchBodySource::cancel(JSDOMGlobalObject& globalObject, Readabl
 static JSDOMGlobalObject* globalObjectFromBodyOwner(RefPtr<FetchBodyOwner>&& bodyOwner)
 {
     RefPtr context = bodyOwner ? bodyOwner->scriptExecutionContext() : nullptr;
-    return JSC::jsCast<JSDOMGlobalObject*>(context->globalObject());
+    return context ? JSC::jsCast<JSDOMGlobalObject*>(context->globalObject()) : nullptr;
 }
 
 // FIXME: We should be able to take a FragmentedSharedBuffer

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -274,7 +274,7 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
     }
 
     if (RefPtr document = dynamicDowncast<Document>(context); document && document->settings().localNetworkAccessEnabled())
-        m_targetAddressSpace = updateTargetAddressSpaceIfNeeded(*init.targetAddressSpace, m_request.url());
+        m_targetAddressSpace = updateTargetAddressSpaceIfNeeded(init.targetAddressSpace.value_or(input.m_targetAddressSpace), m_request.url());
 
     auto setBodyResult = init.body ? setBody(WTF::move(*init.body)) : setBody(input);
     if (setBodyResult.hasException())

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -738,7 +738,7 @@ void UniqueIDBDatabase::createIndexAsync(UniqueIDBDatabaseTransaction& transacti
 
     CheckedPtr manager = m_manager.get();
     if (!manager)
-        transaction.didCreateIndexAsync(IDBError { ExceptionCode::InvalidStateError });
+        return transaction.didCreateIndexAsync(IDBError { ExceptionCode::InvalidStateError });
 
     auto taskSize = defaultWriteOperationCost + estimateSize(indexInfo);
     manager->requestSpace(m_identifier.origin(), taskSize, [weakThis = WeakPtr { *this }, weakTransaction = WeakPtr { transaction }, indexInfo](bool granted) mutable {

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -398,7 +398,12 @@ JSC::JSInternalPromise* ScriptModuleLoader::importModule(JSC::JSGlobalObject* js
                 scriptFetcher = WorkerScriptFetcher::create(*parameters, FetchOptions::Credentials::SameOrigin, destination, ReferrerPolicy::EmptyString);
         }
     }
-    ASSERT(baseURL.isValid());
+
+    if (!baseURL.isValid()) {
+        scope.release();
+        return rejectPromise(*m_context, globalObject, ExceptionCode::TypeError, "Cannot import a module from a document with no base URL."_s);
+    }
+
     ASSERT(scriptFetcher);
     ASSERT(parameters);
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -202,7 +202,7 @@ std::optional<double> evaluate(const IndirectNode<Random>& root, const Evaluatio
         return { };
 
     auto max = evaluate(root->max, options);
-    if (!min)
+    if (!max)
         return { };
 
     auto step = evaluate(root->step, options);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1394,8 +1394,8 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
         adjustForAbsoluteZoom(renderer->scrollTop(), *renderer)
     );
     IntPoint scrollPosition(
-        clampToInteger(scrollToOptions.left.value() * renderer->style().usedZoom()),
-        clampToInteger(scrollToOptions.top.value() * renderer->style().usedZoom())
+        clampTo<int>(scrollToOptions.left.value() * renderer->style().usedZoom()),
+        clampTo<int>(scrollToOptions.top.value() * renderer->style().usedZoom())
     );
 
     auto animated = useSmoothScrolling(scrollToOptions.behavior.value_or(ScrollBehavior::Auto), this) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
@@ -1732,14 +1732,14 @@ void Element::setScrollLeft(int newLeft)
 
     if (document->scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
-            IntPoint position(static_cast<int>(newLeft * frame->pageZoomFactor() * frame->frameScaleFactor()), frame->view()->scrollY());
+            IntPoint position(clampTo<int>(newLeft * frame->pageZoomFactor() * frame->frameScaleFactor()), frame->view()->scrollY());
             frame->protectedView()->setScrollPosition(position, options);
         }
         return;
     }
 
     if (CheckedPtr renderer = renderBox()) {
-        int clampedLeft = clampToInteger(newLeft * renderer->style().usedZoom());
+        int clampedLeft = clampTo<int>(newLeft * renderer->style().usedZoom());
         renderer->setScrollLeft(clampedLeft, options);
         if (CheckedPtr scrollableArea = renderer && renderer->layer() ? renderer->layer()->scrollableArea() : nullptr)
             scrollableArea->setScrollShouldClearLatchedState(true);
@@ -1758,14 +1758,14 @@ void Element::setScrollTop(int newTop)
 
     if (document->scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
-            IntPoint position(frame->view()->scrollX(), static_cast<int>(newTop * frame->pageZoomFactor() * frame->frameScaleFactor()));
+            IntPoint position(frame->view()->scrollX(), clampTo<int>(newTop * frame->pageZoomFactor() * frame->frameScaleFactor()));
             frame->protectedView()->setScrollPosition(position, options);
         }
         return;
     }
 
     if (CheckedPtr renderer = renderBox()) {
-        int clampedTop = clampToInteger(newTop * renderer->style().usedZoom());
+        int clampedTop = clampTo<int>(newTop * renderer->style().usedZoom());
         renderer->setScrollTop(clampedTop, options);
         if (CheckedPtr scrollableArea = renderer && renderer->layer() ? renderer->layer()->scrollableArea() : nullptr)
             scrollableArea->setScrollShouldClearLatchedState(true);

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -321,8 +321,6 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     if (!frame->page() || frame->protectedPage()->subframeCount() >= Page::maxNumberOfFrames)
         return nullptr;
 
-    if (frame->tree().depth() >= Page::maxFrameDepth)
-
     if (!canCreateSubFrame())
         return nullptr;
 

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -82,7 +82,7 @@ public:
     }
     explicit LayoutUnit(double value)
     {
-        m_value = clampToInteger(value * kFixedPointDenominator);
+        m_value = clampTo<int>(value * kFixedPointDenominator);
     }
 
     LayoutUnit& operator=(const LayoutUnit&) = default;
@@ -92,12 +92,12 @@ public:
 
     static LayoutUnit fromFloatCeil(float value)
     {
-        return fromRawValue(clampToInteger(ceilf(value * kFixedPointDenominator)));
+        return fromRawValue(clampTo<int>(ceilf(value * kFixedPointDenominator)));
     }
 
     static LayoutUnit fromFloatFloor(float value)
     {
-        return fromRawValue(clampToInteger(floorf(value * kFixedPointDenominator)));
+        return fromRawValue(clampTo<int>(floorf(value * kFixedPointDenominator)));
     }
 
     static LayoutUnit fromFloatRound(float value)

--- a/Source/WebCore/platform/graphics/DoublePoint.h
+++ b/Source/WebCore/platform/graphics/DoublePoint.h
@@ -138,12 +138,12 @@ constexpr DoublePoint operator-(const DoublePoint& a, const DoubleSize& b)
 
 inline IntPoint flooredIntPoint(const DoublePoint& p)
 {
-    return IntPoint(clampToInteger(floor(p.x())), clampToInteger(floor(p.y())));
+    return IntPoint(clampTo<int>(floor(p.x())), clampTo<int>(floor(p.y())));
 }
 
 inline IntPoint roundedIntPoint(const DoublePoint& p)
 {
-    return IntPoint(clampToInteger(round(p.x())), clampToInteger(round(p.y())));
+    return IntPoint(clampTo<int>(round(p.x())), clampTo<int>(round(p.y())));
 }
 
 inline DoubleSize toDoubleSize(const DoublePoint& a)

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -266,29 +266,29 @@ inline void FloatPoint::rotate(double angleInRadians, const FloatPoint& aboutPoi
 
 inline IntSize flooredIntSize(const FloatPoint& p)
 {
-    return IntSize(clampToInteger(floorf(p.x())), clampToInteger(floorf(p.y())));
+    return IntSize(clampTo<int>(floorf(p.x())), clampTo<int>(floorf(p.y())));
 }
 
 #if USE(CG)
 inline IntPoint roundedIntPoint(const CGPoint& p)
 {
-    return IntPoint(clampToInteger(roundf(p.x)), clampToInteger(roundf(p.y)));
+    return IntPoint(clampTo<int>(roundf(p.x)), clampTo<int>(roundf(p.y)));
 }
 #endif
 
 inline IntPoint roundedIntPoint(const FloatPoint& p)
 {
-    return IntPoint(clampToInteger(roundf(p.x())), clampToInteger(roundf(p.y())));
+    return IntPoint(clampTo<int>(roundf(p.x())), clampTo<int>(roundf(p.y())));
 }
 
 inline IntPoint flooredIntPoint(const FloatPoint& p)
 {
-    return IntPoint(clampToInteger(floorf(p.x())), clampToInteger(floorf(p.y())));
+    return IntPoint(clampTo<int>(floorf(p.x())), clampTo<int>(floorf(p.y())));
 }
 
 inline IntPoint ceiledIntPoint(const FloatPoint& p)
 {
-    return IntPoint(clampToInteger(ceilf(p.x())), clampToInteger(ceilf(p.y())));
+    return IntPoint(clampTo<int>(ceilf(p.x())), clampTo<int>(ceilf(p.y())));
 }
 
 inline FloatPoint floorPointToDevicePixels(const FloatPoint& p, float deviceScaleFactor)

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -242,22 +242,22 @@ inline bool areEssentiallyEqual(const FloatSize& a, const FloatSize& b)
 
 inline IntSize roundedIntSize(const FloatSize& p)
 {
-    return IntSize(clampToInteger(roundf(p.width())), clampToInteger(roundf(p.height())));
+    return IntSize(clampTo<int>(roundf(p.width())), clampTo<int>(roundf(p.height())));
 }
 
 inline IntSize flooredIntSize(const FloatSize& p)
 {
-    return IntSize(clampToInteger(floorf(p.width())), clampToInteger(floorf(p.height())));
+    return IntSize(clampTo<int>(floorf(p.width())), clampTo<int>(floorf(p.height())));
 }
 
 inline IntSize expandedIntSize(const FloatSize& p)
 {
-    return IntSize(clampToInteger(ceilf(p.width())), clampToInteger(ceilf(p.height())));
+    return IntSize(clampTo<int>(ceilf(p.width())), clampTo<int>(ceilf(p.height())));
 }
 
 inline IntPoint flooredIntPoint(const FloatSize& p)
 {
-    return IntPoint(clampToInteger(floorf(p.width())), clampToInteger(floorf(p.height())));
+    return IntPoint(clampTo<int>(floorf(p.width())), clampTo<int>(floorf(p.height())));
 }
 
 constexpr FloatSize FloatSize::nanSize()

--- a/Source/WebCore/platform/graphics/IntPoint.cpp
+++ b/Source/WebCore/platform/graphics/IntPoint.cpp
@@ -33,8 +33,8 @@
 namespace WebCore {
 
 IntPoint::IntPoint(const FloatPoint& p)
-    : m_x(clampToInteger(p.x()))
-    , m_y(clampToInteger(p.y()))
+    : m_x(clampTo<int>(p.x()))
+    , m_y(clampTo<int>(p.y()))
 {
 }
 

--- a/Source/WebCore/platform/graphics/IntRect.cpp
+++ b/Source/WebCore/platform/graphics/IntRect.cpp
@@ -39,8 +39,8 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IntRect);
 
 IntRect::IntRect(const FloatRect& r)
-    : m_location(clampToInteger(r.x()), clampToInteger(r.y()))
-    , m_size(clampToInteger(r.width()), clampToInteger(r.height()))
+    : m_location(clampTo<int>(r.x()), clampTo<int>(r.y()))
+    , m_size(clampTo<int>(r.width()), clampTo<int>(r.height()))
 {
 }
 

--- a/Source/WebCore/platform/graphics/IntSize.cpp
+++ b/Source/WebCore/platform/graphics/IntSize.cpp
@@ -33,8 +33,8 @@
 namespace WebCore {
 
 IntSize::IntSize(const FloatSize& s)
-    : m_width(clampToInteger(s.width()))
-    , m_height(clampToInteger(s.height()))
+    : m_width(clampTo<int>(s.width()))
+    , m_height(clampTo<int>(s.height()))
 {
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -446,7 +446,7 @@ static constexpr IntSize fallbackMaxSurfaceDimension()
 
 static IntSize computeMaximumSurfaceSize()
 {
-    auto maxSize = IntSize { clampToInteger(IOSurfaceGetPropertyMaximum(kIOSurfaceWidth)), clampToInteger(IOSurfaceGetPropertyMaximum(kIOSurfaceHeight)) };
+    auto maxSize = IntSize { clampTo<int>(IOSurfaceGetPropertyMaximum(kIOSurfaceWidth)), clampTo<int>(IOSurfaceGetPropertyMaximum(kIOSurfaceHeight)) };
 
     // On iOS, there's an additional 8K clamp in CA (rdar://101936907).
     // On some macOS VMs, IOSurfaceGetPropertyMaximum() returns INT_MAX (rdar://113661708).

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.cpp
@@ -50,7 +50,7 @@ TextStream& operator<<(TextStream& ts, TransformOperation::Type type)
     case TransformOperation::Type::SkewY: ts << "skewY"_s; break;
     case TransformOperation::Type::Skew: ts << "skew"_s; break;
     case TransformOperation::Type::Matrix: ts << "matrix"_s; break;
-    case TransformOperation::Type::ScaleZ: ts << "scaleX"_s; break;
+    case TransformOperation::Type::ScaleZ: ts << "scaleZ"_s; break;
     case TransformOperation::Type::Scale3D: ts << "scale3d"_s; break;
     case TransformOperation::Type::TranslateZ: ts << "translateZ"_s; break;
     case TransformOperation::Type::Translate3D: ts << "translate3d"_s; break;

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -174,7 +174,7 @@ AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, Attachmen
         attachmentRect.unite(line.backgroundRect);
     if (!subtitleTextRect.isEmpty()) {
         FloatRect roundedSubtitleTextRect = subtitleTextRect;
-        roundedSubtitleTextRect.inflateX(attachmentSubtitleWidthIncrement - clampToInteger(ceilf(subtitleTextRect.width())) % attachmentSubtitleWidthIncrement);
+        roundedSubtitleTextRect.inflateX(attachmentSubtitleWidthIncrement - clampTo<int>(ceilf(subtitleTextRect.width())) % attachmentSubtitleWidthIncrement);
         attachmentRect.unite(roundedSubtitleTextRect);
     }
     attachmentRect.inflate(attachmentMargin);

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -111,7 +111,7 @@ Adjuster::Adjuster(const Document& document, const RenderStyle& parentStyle, con
 static void addIntrinsicMargins(RenderStyle& style)
 {
     // Intrinsic margin value.
-    const auto intrinsicMargin = Style::MarginEdge::Fixed { static_cast<float>(clampToInteger(2 * style.usedZoom())) };
+    const auto intrinsicMargin = Style::MarginEdge::Fixed { static_cast<float>(clampTo<int>(2 * style.usedZoom())) };
 
     // FIXME: Using width/height alone and not also dealing with min-width/max-width is flawed.
     // FIXME: Using "hasQuirk" to decide the margin wasn't set is kind of lame.

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -746,8 +746,7 @@ bool NetworkStorageManager::persistOrigin(const WebCore::ClientOrigin& origin)
         return false;
     }
 
-    FileSystem::overwriteEntireFile(persistedFilePath(origin), std::span<uint8_t> { });
-    return true;
+    return !!FileSystem::overwriteEntireFile(persistedFilePath(origin), std::span<uint8_t> { });
 }
 
 void NetworkStorageManager::persist(const WebCore::ClientOrigin& origin, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -121,7 +121,7 @@ static IntPoint positionFromEvent(WPEEvent* event)
 {
     double x, y;
     if (wpe_event_get_position(event, &x, &y))
-        return { clampToInteger(x), clampToInteger(y) };
+        return { clampTo<int>(x), clampTo<int>(y) };
     return { };
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -66,7 +66,7 @@ DropTarget::DropTarget(GtkWidget* webView)
         if (drop.m_drop != gdkDrop)
             return static_cast<GdkDragAction>(0);
 
-        drop.enter({ clampToInteger(x), clampToInteger(y) });
+        drop.enter({ clampTo<int>(x), clampTo<int>(y) });
         return dragOperationToSingleGdkDragAction(drop.m_operation);
     }), this);
 
@@ -75,7 +75,7 @@ DropTarget::DropTarget(GtkWidget* webView)
         if (drop.m_drop != gdkDrop)
             return static_cast<GdkDragAction>(0);
 
-        drop.update({ clampToInteger(x), clampToInteger(y) });
+        drop.update({ clampTo<int>(x), clampTo<int>(y) });
         return dragOperationToSingleGdkDragAction(drop.m_operation);
     }), this);
 
@@ -92,7 +92,7 @@ DropTarget::DropTarget(GtkWidget* webView)
         if (drop.m_drop != gdkDrop)
             return FALSE;
 
-        drop.drop({ clampToInteger(x), clampToInteger(y) });
+        drop.drop({ clampTo<int>(x), clampTo<int>(y) });
         return TRUE;
     }), this);
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1491,10 +1491,10 @@ static gboolean webkitWebViewBaseScrollEvent(GtkWidget* widget, GdkEventScroll* 
     auto phase = gdk_event_is_scroll_stop_event(event) ? WebWheelEvent::Phase::Ended : WebWheelEvent::Phase::Changed;
     double x, y;
     gdk_event_get_coords(event, &x, &y);
-    IntPoint position(clampToInteger(x), clampToInteger(y));
+    IntPoint position(clampTo<int>(x), clampTo<int>(y));
     double xRoot, yRoot;
     gdk_event_get_root_coords(event, &xRoot, &yRoot);
-    IntPoint globalPosition(clampToInteger(xRoot), clampToInteger(yRoot));
+    IntPoint globalPosition(clampTo<int>(xRoot), clampTo<int>(yRoot));
 
     bool hasPreciseScrollingDeltas = false;
     FloatSize wheelTicks;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
@@ -94,7 +94,7 @@ static WebCore::VideoFrameRotation computeVideoFrameRotation(int rotation)
 
     AVCaptureDeviceRotationCoordinator* coordinator = (AVCaptureDeviceRotationCoordinator*)object;
     String persistentId = [coordinator device].uniqueID;
-    auto rotation = computeVideoFrameRotation(clampToInteger([coordinator videoRotationAngleForHorizonLevelPreview]));
+    auto rotation = computeVideoFrameRotation(clampTo<int>([coordinator videoRotationAngleForHorizonLevelPreview]));
 
     RunLoop::mainSingleton().dispatch([protectedSelf = retainPtr(self), self, persistentId = WTF::move(persistentId).isolatedCopy(), rotation] {
         if (_managerProxy)
@@ -122,7 +122,7 @@ static WebCore::VideoFrameRotation computeVideoFrameRotation(int rotation)
         iterator->value = WTF::move(coordinator);
     }
 
-    return computeVideoFrameRotation((clampToInteger([iterator->value videoRotationAngleForHorizonLevelPreview])));
+    return computeVideoFrameRotation((clampTo<int>([iterator->value videoRotationAngleForHorizonLevelPreview])));
 }
 
 -(void)stop:(const String&)persistentId {

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -244,9 +244,9 @@ void WebSWClientConnection::getRegistrations(SecurityOriginData&& topOrigin, con
         return;
     }
 
-    runOrDelayTaskForImport([weakThis = WeakPtr { *this }, callback = WTF::move(callback), topOrigin = WTF::move(topOrigin), clientURL]() mutable {
+    runOrDelayTaskForImport([weakThis = WeakPtr { *this }, completionHandler = CompletionHandlerWithFinalizer<void(Vector<ServiceWorkerRegistrationData>&&)>(WTF::move(callback), [](auto& callback) { callback({ }); }), topOrigin = WTF::move(topOrigin), clientURL]() mutable {
         if (RefPtr protectedThis = weakThis.get())
-            protectedThis->sendWithAsyncReply(Messages::WebSWServerConnection::GetRegistrations { topOrigin, clientURL }, WTF::move(callback));
+            protectedThis->sendWithAsyncReply(Messages::WebSWServerConnection::GetRegistrations { topOrigin, clientURL }, WTF::move(completionHandler));
     });
 }
 
@@ -259,6 +259,14 @@ void WebSWClientConnection::connectionToServerLost()
 void WebSWClientConnection::clear()
 {
     clearPendingJobs();
+
+    auto retrieveRecordResponseBodyCallbacks = std::exchange(m_retrieveRecordResponseBodyCallbacks, { });
+    for (auto& callback : retrieveRecordResponseBodyCallbacks.values())
+        callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "Connection to network process lost"_s }));
+
+    // Destroying these tasks fires their captured CompletionHandlerWithFinalizer
+    // objects, which resolves the corresponding JS-visible promises with default values.
+    m_tasksPendingOriginImport.clear();
 }
 
 void WebSWClientConnection::terminateWorkerForTesting(ServiceWorkerIdentifier identifier, CompletionHandler<void()>&& callback)

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -405,9 +405,9 @@ void EventDispatcher::stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
 void EventDispatcher::flushMomentumEventLoggingSoon()
 {
-    // FIXME: Nothing keeps this alive.
-    queue().dispatchAfter(1_s, [this] {
-        m_momentumEventDispatcher->flushLog();
+    queue().dispatchAfter(1_s, [weakThis = WeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis)
+            protectedThis->m_momentumEventDispatcher->flushLog();
     });
 }
 #endif

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2747,19 +2747,15 @@ sub shouldRemoveCMakeCache(@)
     }
 
     my $cacheFileModifiedTime = stat($cmakeCache)->mtime;
-    my $platformConfiguration = File::Spec->catdir(sourceDir(), "Source", "cmake", "Options" . cmakeBasedPortName() . ".cmake");
-    if ($cacheFileModifiedTime < stat($platformConfiguration)->mtime) {
-        return 1;
-    }
 
-    my $globalConfiguration = File::Spec->catdir(sourceDir(), "Source", "cmake", "OptionsCommon.cmake");
-    if ($cacheFileModifiedTime < stat($globalConfiguration)->mtime) {
-        return 1;
-    }
-
-    my $compilerFlagsCMake = File::Spec->catdir(sourceDir(), "Source", "cmake", "WebKitCompilerFlags.cmake");
-    if ($cacheFileModifiedTime < stat($compilerFlagsCMake)->mtime) {
-        return 1;
+    # Any .cmake file under Source/cmake can influence the generated cache, so
+    # glob them all instead of enumerating by hand. Top level only; use
+    # File::Find if cmake modules ever move into subdirectories.
+    my $cmakeModuleDirectory = File::Spec->catdir(sourceDir(), "Source", "cmake");
+    for my $cmakeFile (bsd_glob(File::Spec->catfile($cmakeModuleDirectory, "*.cmake"))) {
+        if ($cacheFileModifiedTime < stat($cmakeFile)->mtime) {
+            return 1;
+        }
     }
 
     # FIXME: This probably does not work as expected, or the next block to
@@ -2773,13 +2769,6 @@ sub shouldRemoveCMakeCache(@)
     my $inspectorImageDirectory = File::Spec->catdir(sourceDir(), "Source", "WebInspectorUI", "UserInterface", "Images");
     if ($cacheFileModifiedTime < stat($inspectorImageDirectory)->mtime) {
         return 1;
-    }
-
-    if(isAnyWindows()) {
-        my $winConfiguration = File::Spec->catdir(sourceDir(), "Source", "cmake", "OptionsWin.cmake");
-        if ($cacheFileModifiedTime < stat($winConfiguration)->mtime) {
-            return 1;
-        }
     }
 
     # If a change on the JHBuild moduleset has been done, we need to clean the cache as well.

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -89,7 +89,7 @@ TEST(WTF, clampToIntLongLong)
     EXPECT_EQ(clampTo<int>(underflowInt), minInt);
 }
 
-TEST(WTF, clampToIntegerFloat)
+TEST(WTF, clampToIntFloat)
 {
     // This test is inaccurate as floats will round the min / max integer
     // due to the narrow mantissa. However it will properly checks within
@@ -107,14 +107,14 @@ TEST(WTF, clampToIntegerFloat)
     EXPECT_GT(overflowInt, maxInt);
     EXPECT_LT(underflowInt, minInt);
 
-    EXPECT_EQ(clampToInteger(maxInt), static_cast<int>(maxInt));
-    EXPECT_EQ(clampToInteger(minInt), std::numeric_limits<int>::min());
+    EXPECT_EQ(clampTo<int>(maxInt), static_cast<int>(maxInt));
+    EXPECT_EQ(clampTo<int>(minInt), std::numeric_limits<int>::min());
 
-    EXPECT_EQ(clampToInteger(overflowInt), std::numeric_limits<int>::max());
-    EXPECT_EQ(clampToInteger(underflowInt), std::numeric_limits<int>::min());
+    EXPECT_EQ(clampTo<int>(overflowInt), std::numeric_limits<int>::max());
+    EXPECT_EQ(clampTo<int>(underflowInt), std::numeric_limits<int>::min());
 }
 
-TEST(WTF, clampToIntegerDouble)
+TEST(WTF, clampToIntDouble)
 {
     double maxInt = std::numeric_limits<int>::max();
     double minInt = std::numeric_limits<int>::min();
@@ -124,11 +124,35 @@ TEST(WTF, clampToIntegerDouble)
     EXPECT_GT(overflowInt, maxInt);
     EXPECT_LT(underflowInt, minInt);
 
-    EXPECT_EQ(clampToInteger(maxInt), maxInt);
-    EXPECT_EQ(clampToInteger(minInt), minInt);
+    EXPECT_EQ(clampTo<int>(maxInt), maxInt);
+    EXPECT_EQ(clampTo<int>(minInt), minInt);
 
-    EXPECT_EQ(clampToInteger(overflowInt), maxInt);
-    EXPECT_EQ(clampToInteger(underflowInt), minInt);
+    EXPECT_EQ(clampTo<int>(overflowInt), maxInt);
+    EXPECT_EQ(clampTo<int>(underflowInt), minInt);
+}
+
+TEST(WTF, clampToIntIntegral)
+{
+    constexpr int intMax = std::numeric_limits<int>::max();
+    constexpr int intMin = std::numeric_limits<int>::min();
+
+    // int64_t: values in range pass through, out-of-range clamps both ends.
+    EXPECT_EQ(clampTo<int>(int64_t { 0 }), 0);
+    EXPECT_EQ(clampTo<int>(int64_t { 42 }), 42);
+    EXPECT_EQ(clampTo<int>(int64_t { -42 }), -42);
+    EXPECT_EQ(clampTo<int>(int64_t { intMax }), intMax);
+    EXPECT_EQ(clampTo<int>(int64_t { intMin }), intMin);
+    EXPECT_EQ(clampTo<int>(static_cast<int64_t>(intMax) + 1), intMax);
+    EXPECT_EQ(clampTo<int>(static_cast<int64_t>(intMin) - 1), intMin);
+    EXPECT_EQ(clampTo<int>(std::numeric_limits<int64_t>::max()), intMax);
+    EXPECT_EQ(clampTo<int>(std::numeric_limits<int64_t>::min()), intMin);
+
+    // uint64_t: in-range values pass through, large values clamp to intMax.
+    EXPECT_EQ(clampTo<int>(uint64_t { 0 }), 0);
+    EXPECT_EQ(clampTo<int>(uint64_t { 42 }), 42);
+    EXPECT_EQ(clampTo<int>(static_cast<uint64_t>(intMax)), intMax);
+    EXPECT_EQ(clampTo<int>(static_cast<uint64_t>(intMax) + 1), intMax);
+    EXPECT_EQ(clampTo<int>(std::numeric_limits<uint64_t>::max()), intMax);
 }
 
 TEST(WTF, clampToFloat)


### PR DESCRIPTION
#### 192593a7783d8f293746955ca2da479113376951
<pre>
Cherry-pick <a href="https://commits.webkit.org/314443@main">314443@main</a> (349e1d854950). <a href="https://bugs.webkit.org/show_bug.cgi?id=316156">https://bugs.webkit.org/show_bug.cgi?id=316156</a>

    Fix potential null deference under globalObjectFromBodyOwner()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316156">https://bugs.webkit.org/show_bug.cgi?id=316156</a>

    Reviewed by Youenn Fablet.

    The code clearly deals with the context being null initially but then
    unconditionally deferences it.

    * Source/WebCore/Modules/fetch/FetchBodySource.cpp:
    (WebCore::globalObjectFromBodyOwner):

    Canonical link: <a href="https://commits.webkit.org/314443@main">https://commits.webkit.org/314443@main</a>
</pre>
----------------------------------------------------------------------
#### 5d4d9c6d530eaedf26a7c469a7ff63175f53bc9f
<pre>
Cherry-pick <a href="https://commits.webkit.org/314444@main">314444@main</a> (a3f3cda54a85). <a href="https://bugs.webkit.org/show_bug.cgi?id=316157">https://bugs.webkit.org/show_bug.cgi?id=316157</a>

    Crash in FetchRequest::initializeWith() when LocalNetworkAccess is enabled
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316157">https://bugs.webkit.org/show_bug.cgi?id=316157</a>

    Reviewed by Youenn Fablet.

    When constructing a Request from another Request without specifying
    targetAddressSpace in the init dictionary (e.g. `new Request(other)`),
    FetchRequest::initializeWith() dereferenced the empty
    std::optional&lt;IPAddressSpace&gt; from FetchRequestInit::targetAddressSpace,
    which traps with hardened libc++. The IDL member has no default value, so
    the optional is std::nullopt whenever the caller omits it.

    Inherit the target address space from the input request when init does
    not specify one, mirroring the behavior of FetchRequest::clone().

    Test: fetch/request-clone-without-target-address-space-crash.html

    * LayoutTests/fetch/request-clone-without-target-address-space-crash-expected.txt: Added.
    * LayoutTests/fetch/request-clone-without-target-address-space-crash.html: Added.
    * Source/WebCore/Modules/fetch/FetchRequest.cpp:
    (WebCore::FetchRequest::initializeWith):

    Canonical link: <a href="https://commits.webkit.org/314444@main">https://commits.webkit.org/314444@main</a>
</pre>
----------------------------------------------------------------------
#### 6c42e1995d8e50629b376c2645e4e41b8e5c69d6
<pre>
Cherry-pick <a href="https://commits.webkit.org/314612@main">314612@main</a> (d58bad697e50). <a href="https://bugs.webkit.org/show_bug.cgi?id=316366">https://bugs.webkit.org/show_bug.cgi?id=316366</a>

    [JSC] `ISO8601::parseDate` reads past the end of the buffer for short invalid strings
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316366">https://bugs.webkit.org/show_bug.cgi?id=316366</a>

    Reviewed by Yusuke Suzuki.

    The month/day length guards in parseDate only applied to the Date format, so
    short truncated strings like &quot;0&quot;, &quot;2024-01-&quot; or &quot;2024-05&quot; reached unchecked
    buffer dereferences via PlainYearMonth/PlainMonthDay parsing (and via the
    year-less month parsing path for all formats), crashing Release builds with a
    span bounds trap. Check the remaining length at every month/day read
    regardless of format, and require a day to follow a consumed day separator so
    trailing-hyphen strings are rejected instead of read out of bounds.

    Test: JSTests/stress/temporal-iso8601-parse-bounds.js

    * JSTests/stress/temporal-iso8601-parse-bounds.js: Added.
    (shouldBe):
    (throw.new.Error):
    * Source/JavaScriptCore/runtime/ISO8601.cpp:
    (JSC::ISO8601::parseDate):

    Canonical link: <a href="https://commits.webkit.org/314612@main">https://commits.webkit.org/314612@main</a>
</pre>
----------------------------------------------------------------------
#### f72605b43e85f447dd01c8ab9bd4533932788fe3
<pre>
Cherry-pick <a href="https://commits.webkit.org/314768@main">314768@main</a> (59604007e4c6). <a href="https://bugs.webkit.org/show_bug.cgi?id=312357">https://bugs.webkit.org/show_bug.cgi?id=312357</a>

    clampToInteger&lt;T&gt; does not clamp values below INT_MIN
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316511">https://bugs.webkit.org/show_bug.cgi?id=316511</a>

    Reviewed by Darin Adler.

    clampToInteger had three overloads. The float and double versions were thin
    wrappers that delegated to clampTo&lt;int&gt;. The integral version was its own
    implementation that only clamped the upper bound — for values below INT_MIN it
    fell through to a bare static_cast&lt;int&gt;(x), which is implementation-defined for
    out-of-range conversions. In practice, clampToInteger&lt;int64_t&gt;(INT64_MIN)
    returned 0 and clampToInteger&lt;int64_t&gt;(INT_MIN - 1) returned INT_MAX instead of
    clamping to INT_MIN.

    The integral version was also miscompiled for narrow signed/unsigned T (int8_t,
    int16_t, uint8_t, uint16_t) because `static_cast&lt;unsigned&gt;(INT_MAX)` truncates
    when assigned to `T intMax` — caught by -Werror=constant-conversion, so those
    instantiations were unreachable from production code.

    Rather than fix the integral overload in place, remove the API entirely and
    migrate callers to clampTo&lt;int&gt;(value), whose existing overload set already
    handles every integral and floating-point source type with correct two-sided
    clamping.

    Test: Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp

    * Source/WTF/wtf/MathExtras.h:
    (clampToInteger): Deleted.
    * Source/WebCore/dom/Element.cpp:
    (WebCore::Element::scrollTo):
    (WebCore::Element::setScrollLeft):
    (WebCore::Element::setScrollTop):
    * Source/WebCore/platform/LayoutUnit.h:
    (WebCore::LayoutUnit::LayoutUnit):
    (WebCore::LayoutUnit::fromFloatCeil):
    (WebCore::LayoutUnit::fromFloatFloor):
    * Source/WebCore/platform/graphics/DoublePoint.h:
    (WebCore::flooredIntPoint):
    (WebCore::roundedIntPoint):
    * Source/WebCore/platform/graphics/FloatPoint.h:
    (WebCore::flooredIntSize):
    (WebCore::roundedIntPoint):
    (WebCore::flooredIntPoint):
    (WebCore::ceiledIntPoint):
    * Source/WebCore/platform/graphics/FloatSize.h:
    (WebCore::roundedIntSize):
    (WebCore::flooredIntSize):
    (WebCore::expandedIntSize):
    (WebCore::flooredIntPoint):
    * Source/WebCore/platform/graphics/IntPoint.cpp:
    (WebCore::IntPoint::IntPoint):
    * Source/WebCore/platform/graphics/IntRect.cpp:
    (WebCore::IntRect::IntRect):
    * Source/WebCore/platform/graphics/IntSize.cpp:
    (WebCore::IntSize::IntSize):
    * Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
    (WebCore::computeMaximumSurfaceSize):
    * Source/WebCore/rendering/AttachmentLayout.mm:
    (WebCore::AttachmentLayout::AttachmentLayout):
    * Source/WebCore/style/StyleAdjuster.cpp:
    (WebCore::Style::addIntrinsicMargins):
    * Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp:
    (WebKit::positionFromEvent):
    * Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
    (WebKit::DropTarget::DropTarget):
    * Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
    (webkitWebViewBaseScrollEvent):
    * Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm:
    (-[WKRotationCoordinatorObserver observeValueForKeyPath:ofObject:change:context:]):
    (-[WKRotationCoordinatorObserver start:layer:]):
    * Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
    (TestWebKitAPI::TEST(WTF, clampToIntFloat)):
    (TestWebKitAPI::TEST(WTF, clampToIntDouble)):
    (TestWebKitAPI::TEST(WTF, clampToIntIntegral)):
    (TestWebKitAPI::TEST(WTF, clampToIntegerFloat)): Deleted.
    (TestWebKitAPI::TEST(WTF, clampToIntegerDouble)): Deleted.

    Canonical link: <a href="https://commits.webkit.org/314768@main">https://commits.webkit.org/314768@main</a>
</pre>
----------------------------------------------------------------------
#### ae5d38a0c3027760d0d25d7cbbedfb15416e3186
<pre>
Cherry-pick <a href="https://commits.webkit.org/314856@main">314856@main</a> (2fa8d7a994ae). <a href="https://bugs.webkit.org/show_bug.cgi?id=316603">https://bugs.webkit.org/show_bug.cgi?id=316603</a>

    NetworkStorageManager::persistOrigin() may return true in case of error
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316603">https://bugs.webkit.org/show_bug.cgi?id=316603</a>

    Reviewed by Sihui Liu.

    NetworkStorageManager::persistOrigin() may return true in case of error,
    because it fails to check if FileSystem::overwriteEntireFile() succeeded.

    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
    (WebKit::NetworkStorageManager::persistOrigin):

    Canonical link: <a href="https://commits.webkit.org/314856@main">https://commits.webkit.org/314856@main</a>
</pre>
----------------------------------------------------------------------
#### 9662a690116cf0bf2ac7f8530f91ac093e3b42b8
<pre>
Cherry-pick <a href="https://commits.webkit.org/314855@main">314855@main</a> (5fb99ecfd74c). <a href="https://bugs.webkit.org/show_bug.cgi?id=316616">https://bugs.webkit.org/show_bug.cgi?id=316616</a>

    Fix unsafe capture of `this` in EventDispatcher::flushMomentumEventLoggingSoon()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316616">https://bugs.webkit.org/show_bug.cgi?id=316616</a>

    Reviewed by Rupin Mittal.

    * Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
    (WebKit::EventDispatcher::flushMomentumEventLoggingSoon):

    Canonical link: <a href="https://commits.webkit.org/314855@main">https://commits.webkit.org/314855@main</a>
</pre>
----------------------------------------------------------------------
#### d5aca6dd35107bde77b592cc8c7ea544bed00368
<pre>
Cherry-pick <a href="https://commits.webkit.org/314859@main">314859@main</a> (e319714bc528). <a href="https://bugs.webkit.org/show_bug.cgi?id=316631">https://bugs.webkit.org/show_bug.cgi?id=316631</a>

    WebSWClientConnection leaks pending callbacks when the network process connection is lost
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316631">https://bugs.webkit.org/show_bug.cgi?id=316631</a>

    Reviewed by Youenn Fablet.

    WebSWClientConnection::clear() — invoked from connectionToServerLost()
    on network-process death and from the destructor — only called the base
    class clearPendingJobs() and never drained the two per-instance queues
    holding pending callbacks:

    1. m_retrieveRecordResponseBodyCallbacks (HashMap of streaming
       BackgroundFetch record-body callbacks). retrieveRecordResponseBody()
       sends a fire-and-forget IPC and the callbacks fire only from the
       notifyRecordResponseBodyChunk / notifyRecordResponseBodyEnd replies.
       With the network process gone, the replies never arrive and each
       in-flight body retrieval was silently dropped, leaving the
       FetchResponse body / ReadableStream consumer on the JS side pending
       forever. WorkerSWClientConnection::contextStopped() already handles
       the equivalent case correctly (WorkerSWClientConnection.cpp:120-122).

    2. m_tasksPendingOriginImport (Deque of tasks awaiting
       setSWOriginTableIsImported()). With the connection closed,
       setSWOriginTableIsImported() will never run, so the queue was only
       emptied via the eventual destruction of the WebSWClientConnection.
       getRegistrations() captured a plain CompletionHandler in the queued
       task — destroying it unfired hit the
       ASSERT_WITH_MESSAGE(!m_function, &quot;Completion handler should always
       be called&quot;) in debug and left the JS getRegistrations() promise hung
       in release.

    Fix clear() to drain both queues. Body callbacks are invoked with an
    errorDomainWebKitInternal ResourceError. The pending-import tasks are
    cleared by destruction; matchRegistration() already wrapped its callback
    in a CompletionHandlerWithFinalizer that supplies std::nullopt on
    destruction, so the destructor chain fires the JS-visible callback.
    Apply the same wrapping to getRegistrations() (finalizer supplies an
    empty Vector) so its destruction is also safe and observable.
    std::exchange the body-callback map onto the stack before iterating to
    avoid reentrant-mutation hazards.

    * Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
    (WebKit::WebSWClientConnection::getRegistrations):
    Wrap the GetRegistrationsCallback in CompletionHandlerWithFinalizer with
    an empty-Vector finalizer, mirroring matchRegistration().
    (WebKit::WebSWClientConnection::clear):
    Drain m_retrieveRecordResponseBodyCallbacks with a &quot;Connection to
    network process lost&quot; ResourceError, and clear m_tasksPendingOriginImport
    so each queued task&apos;s CompletionHandlerWithFinalizer destructor resolves
    the corresponding JS promise with a default value.

    Canonical link: <a href="https://commits.webkit.org/314859@main">https://commits.webkit.org/314859@main</a>
</pre>
----------------------------------------------------------------------
#### e14af76db5378033ede5e4ae5430600733d2c56d
<pre>
Cherry-pick <a href="https://commits.webkit.org/314927@main">314927@main</a> (cd4bc5c21722). <a href="https://bugs.webkit.org/show_bug.cgi?id=316772">https://bugs.webkit.org/show_bug.cgi?id=316772</a>

    TransformOperation TextStream uses &quot;scaleX&quot; for ScaleZ
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316772">https://bugs.webkit.org/show_bug.cgi?id=316772</a>
    <a href="https://rdar.apple.com/179221212">rdar://179221212</a>

    Reviewed by Sam Weinig.

    * Source/WebCore/platform/graphics/transforms/TransformOperation.cpp:
    (WebCore::operator&lt;&lt;):

    Canonical link: <a href="https://commits.webkit.org/314927@main">https://commits.webkit.org/314927@main</a>
</pre>
----------------------------------------------------------------------
#### 247b3f9bf95527701b1ac49b0ea08fea7d0e6acf
<pre>
Cherry-pick <a href="https://commits.webkit.org/314964@main">314964@main</a> (f46ff32d3af2). <a href="https://bugs.webkit.org/show_bug.cgi?id=316837">https://bugs.webkit.org/show_bug.cgi?id=316837</a>

    Resolve stray `if` in loadSubframe
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316837">https://bugs.webkit.org/show_bug.cgi?id=316837</a>
    <a href="https://rdar.apple.com/179278333">rdar://179278333</a>

    Reviewed by Alex Christensen.

    The return was removed in <a href="https://commits.webkit.org/293666@main">293666@main</a> without removing the `if`. Remove. The depth check still
    happens in canCreateSubFrame().

    * Source/WebCore/loader/SubframeLoader.cpp:
    (WebCore::FrameLoader::SubframeLoader::loadSubframe):

    Canonical link: <a href="https://commits.webkit.org/314964@main">https://commits.webkit.org/314964@main</a>
</pre>
----------------------------------------------------------------------
#### d454ef73951568334fda589b3d12ea548d1c68fd
<pre>
herry-pick <a href="https://commits.webkit.org/315086@main">315086@main</a> (7abc2361027f). <a href="https://bugs.webkit.org/show_bug.cgi?id=312365">https://bugs.webkit.org/show_bug.cgi?id=312365</a>

    [CMake] Glob all Source/cmake/*.cmake files when deciding to remove CMakeCache.txt

    Reviewed by Carlos Alberto Lopez Perez.

    shouldRemoveCMakeCache() only checked a hand-picked subset of cmake files
    (the port Options file, OptionsCommon and WebKitCompilerFlags) against the
    cache mtime, so edits to other configuration files that influence the
    generated cache -- WebKitFeatures, VersioningUtils, did not trigger an
    automatic reconfigure.

    Replace the enumerated checks (and the redundant Windows-only OptionsWin
    special case) with a glob over Source/cmake/*.cmake, so every current and
    future module is covered automatically.

    * Tools/Scripts/webkitdirs.pm:
    (shouldRemoveCMakeCache):

    Canonical link: <a href="https://commits.webkit.org/315086@main">https://commits.webkit.org/315086@main</a>
</pre>
----------------------------------------------------------------------
#### d855e2eeeacf3318114c60fd7c37c41c1635fa47
<pre>
Cherry-pick <a href="https://commits.webkit.org/315177@main">315177@main</a> (1683eb4fed1d). <a href="https://bugs.webkit.org/show_bug.cgi?id=316972">https://bugs.webkit.org/show_bug.cgi?id=316972</a>

    random() crashes when one of its arguments is invalid at computed-value time
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316972">https://bugs.webkit.org/show_bug.cgi?id=316972</a>

    Reviewed by Darin Adler.

    The evaluator for random() in CSSCalcTree+Evaluation.cpp evaluated its `max`
    argument but then re-checked `min` (already known to be engaged from the check
    above) instead of `max`. As a result, a `max` argument that fails to evaluate at
    computed-value time -- e.g. an anchor-size() used on a non-out-of-flow element,
    which resolves to nothing -- was not caught, and the subsequent `*max` then
    dereferenced a disengaged std::optional&lt;double&gt;. With hardened libc++ this traps
    (SIGTRAP) and crashes the WebContent process; otherwise it reads uninitialized
    memory and produces a garbage result.

    Fix this by checking the result of evaluating `max`. When any argument fails to
    resolve, random() correctly evaluates to nothing, making the declaration invalid
    at computed-value time so the property falls back to its initial value.

    Test: imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative.html

    * LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative-expected.txt: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-unresolvable-argument.tentative.html: Added.
    * Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
    (WebCore::CSSCalc::evaluate):

    Canonical link: <a href="https://commits.webkit.org/315177@main">https://commits.webkit.org/315177@main</a>
</pre>
----------------------------------------------------------------------
#### c421722321eed48811aa8eaa196171e1608ba5c2
<pre>
Cherry-pick <a href="https://commits.webkit.org/315182@main">315182@main</a> (5ab18c7407f7). <a href="https://bugs.webkit.org/show_bug.cgi?id=317046">https://bugs.webkit.org/show_bug.cgi?id=317046</a>

    UniqueIDBDatabase::createIndexAsync() is missing an early return on the null-manager path
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317046">https://bugs.webkit.org/show_bug.cgi?id=317046</a>
    <a href="https://rdar.apple.com/179526370">rdar://179526370</a>

    Reviewed by Rupin Mittal.

    When m_manager is null the method invoked transaction.didCreateIndexAsync() but did not return,
    falling through to manager-&gt;requestSpace() and dereferencing the null CheckedPtr. Add the missing
    return, matching every other null-manager check in the file.

    * Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
    (WebCore::IDBServer::UniqueIDBDatabase::createIndexAsync):

    Canonical link: <a href="https://commits.webkit.org/315182@main">https://commits.webkit.org/315182@main</a>
</pre>
----------------------------------------------------------------------
#### 2778adeae17c43b1cc3f03bc74301296197d54c0
<pre>
Cherry-pick <a href="https://commits.webkit.org/315109@main">315109@main</a> (6cc340adc68d). <a href="https://bugs.webkit.org/show_bug.cgi?id=316862">https://bugs.webkit.org/show_bug.cgi?id=316862</a>

    Importing modules from a document with no base URL causes null deref
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316862">https://bugs.webkit.org/show_bug.cgi?id=316862</a>
    <a href="https://rdar.apple.com/179143870">rdar://179143870</a>

    Reviewed by Yusuke Suzuki.

    This replaces an assertion that the base URL is valid when dynamically importing a module
    from ScriptModuleLoader with an actual validation.

    Test: js/dom/modules/import-from-javascript-url-new-window.html

    * LayoutTests/js/dom/modules/import-from-javascript-url-new-window-expected.txt: Added.
    * LayoutTests/js/dom/modules/import-from-javascript-url-new-window.html: Added.
    * Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
    (WebCore::ScriptModuleLoader::importModule):

    Canonical link: <a href="https://commits.webkit.org/315109@main">https://commits.webkit.org/315109@main</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/192593a7783d8f293746955ca2da479113376951

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168300 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/41857 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35443 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177628 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126001 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170166 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/42232 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41814 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130977 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126001 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171259 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/42232 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/35443 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111489 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/42232 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41814 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26324 "Built successfully") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160919 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/42232 "The change is no longer eligible for processing.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180228 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/29547 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/32952 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35443 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139414 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/41869 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/41814 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139277 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/42557 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/35443 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106029 "The change is no longer eligible for processing.") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25633 "") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/42557 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35443 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200978 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/41061 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114317 "The change is no longer eligible for processing.") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53989 "Found 9 new JSC stress test failures: stress/temporal-iso8601-parse-bounds.js.bytecode-cache, stress/temporal-iso8601-parse-bounds.js.default, stress/temporal-iso8601-parse-bounds.js.dfg-eager, stress/temporal-iso8601-parse-bounds.js.dfg-eager-no-cjit-validate, stress/temporal-iso8601-parse-bounds.js.eager-jettison-no-cjit, stress/temporal-iso8601-parse-bounds.js.mini-mode, stress/temporal-iso8601-parse-bounds.js.no-cjit-collect-continuously, stress/temporal-iso8601-parse-bounds.js.no-cjit-validate-phases, stress/temporal-iso8601-parse-bounds.js.no-llint (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/40458 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/35443 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/40709 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/40603 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->