### PR TITLE
REGRESSION (macOS 26): Horizontal rubber-banding causes trouble with vertical scrolling

### DIFF
--- a/LayoutTests/fast/scrolling/mac/vertical-scroll-with-horizontal-deviation-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/vertical-scroll-with-horizontal-deviation-expected.txt
@@ -1,0 +1,8 @@
+Tests that a horizontal deviation during a vertical scroll does not cause horizontal rubberbanding or halt vertical scrolling
+PASS sawHorizontalRubberband is false
+PASS window.scrollY != initialScrollY is true
+PASS scrolledVerticallyAfterHorizontalDeltas is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/vertical-scroll-with-horizontal-deviation.html
+++ b/LayoutTests/fast/scrolling/mac/vertical-scroll-with-horizontal-deviation.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+            width: 200%;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        var initialScrollY;
+        var sawHorizontalRubberband = false;
+        var sawHorizontalWheelEvent = false;
+        var scrollYAtLastHorizontalWheelEvent = 0;
+        var scrolledVerticallyAfterHorizontalDeltas = false;
+
+        async function resetScrollPositions()
+        {
+            // Sit at the left edge horizontally (so a sideways push rubberbands) and mid-way vertically
+            // (so the vertical scroll itself doesn't rubberband).
+            window.scrollTo(0, 300);
+            // Wait for scroll events to fire.
+            await UIHelper.renderingUpdate();
+
+            initialScrollY = window.scrollY;
+            sawHorizontalRubberband = false;
+            sawHorizontalWheelEvent = false;
+            scrolledVerticallyAfterHorizontalDeltas = false;
+        }
+
+        async function doMouseWheelScroll()
+        {
+            // A predominantly-vertical scroll that includes a short burst of horizontal-dominant events
+            // pushing against the pinned left edge, as the wheel-event delta filter sometimes emits
+            // during a near-vertical trackpad scroll. viewX is toggled to defeat event coalescing so
+            // each event keeps its own 16ms timestamp.
+            const wheelEventSequence = {
+                "events" : [
+                    { type : "wheel", viewX : 100, viewY : 100, deltaY : -10, phase : "began" },
+                    { type : "wheel", viewX : 101, deltaY : -40, phase : "changed" },
+                    { type : "wheel", viewX : 100, deltaY : -40, phase : "changed" },
+                    { type : "wheel", viewX : 101, deltaY : -40, phase : "changed" },
+                    // Horizontal burst against the left edge.
+                    { type : "wheel", viewX : 100, deltaX : 12, phase : "changed" },
+                    { type : "wheel", viewX : 101, deltaX : 12, phase : "changed" },
+                    // Back to vertical.
+                    { type : "wheel", viewX : 100, deltaY : -40, phase : "changed" },
+                    { type : "wheel", viewX : 101, deltaY : -40, phase : "changed" },
+                    { type : "wheel", viewX : 100, deltaY : -40, phase : "changed" },
+                    { type : "wheel", phase : "ended" }
+                ]
+            };
+
+            await UIHelper.sendEventStream(wheelEventSequence);
+            await UIHelper.waitForEvent(window, 'scrollend');
+        }
+
+        async function testVerticalScrollWithHorizontalDeviation()
+        {
+            await resetScrollPositions();
+
+            await doMouseWheelScroll();
+
+            // The horizontal burst should not have caused horizontal rubberbanding.
+            shouldBeFalse('sawHorizontalRubberband');
+            // Vertical scrolling should have happened...
+            shouldBeTrue('window.scrollY != initialScrollY');
+            // ...and should have continued after the horizontal deltas (the burst must not have halted it).
+            shouldBeTrue('scrolledVerticallyAfterHorizontalDeltas');
+        }
+
+        async function scrollTest()
+        {
+            debug('Tests that a horizontal deviation during a vertical scroll does not cause horizontal rubberbanding or halt vertical scrolling');
+
+            await testVerticalScrollWithHorizontalDeviation();
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            // Detect when the horizontal-delta events arrive, and remember the vertical scroll offset then.
+            window.addEventListener('wheel', (event) => {
+                if (Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
+                    sawHorizontalWheelEvent = true;
+                    scrollYAtLastHorizontalWheelEvent = window.scrollY;
+                }
+            }, { passive: true });
+
+            window.addEventListener('scroll', () => {
+                if (window.scrollX < 0)
+                    sawHorizontalRubberband = true;
+                // Any vertical movement seen after the horizontal-delta events means vertical scrolling
+                // was not halted by the deviation.
+                if (sawHorizontalWheelEvent && window.scrollY != scrollYAtLastHorizontalWheelEvent)
+                    scrolledVerticallyAfterHorizontalDeltas = true;
+            }, false);
+
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/vertical-then-horizontal-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/vertical-then-horizontal-scroll-expected.txt
@@ -1,0 +1,8 @@
+
+Tests that an L-shaped fingers-down gesture scrolls vertically then horizontally
+PASS window.scrollY != initialScrollY is true
+PASS window.scrollX != initialScrollX is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/vertical-then-horizontal-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/vertical-then-horizontal-scroll.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+            width: 200%;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        var initialScrollX;
+        var initialScrollY;
+
+        async function resetScrollPositions(x, y)
+        {
+            window.scrollTo(x, y);
+            // Wait for scroll events to fire.
+            await UIHelper.renderingUpdate();
+        }
+
+        async function doMouseWheelScroll()
+        {
+            // An "L-shaped" gesture with fingers held down throughout: scroll vertically, hold still
+            // (zero-delta events, which still advance the 16ms-per-event timestamp so a real pause
+            // elapses), then scroll horizontally. viewX is toggled to defeat event coalescing.
+            const wheelEventSequence = {
+                "events" : [
+                    { type : "wheel", viewX : 100, viewY : 100, deltaY : -10, phase : "began" },
+                    { type : "wheel", viewX : 101, deltaY : -40, phase : "changed" },
+                    { type : "wheel", viewX : 100, deltaY : -40, phase : "changed" },
+                    { type : "wheel", viewX : 101, deltaY : -40, phase : "changed" },
+                    // Pause with fingers down.
+                    { type : "wheel", viewX : 100, deltaX : 0, deltaY : 0, phase : "changed" },
+                    { type : "wheel", viewX : 101, deltaX : 0, deltaY : 0, phase : "changed" },
+                    { type : "wheel", viewX : 100, deltaX : 0, deltaY : 0, phase : "changed" },
+                    // Now scroll horizontally.
+                    { type : "wheel", viewX : 101, deltaX : -40, phase : "changed" },
+                    { type : "wheel", viewX : 100, deltaX : -40, phase : "changed" },
+                    { type : "wheel", phase : "ended" }
+                ]
+            };
+
+            await UIHelper.sendEventStream(wheelEventSequence);
+            await UIHelper.waitForEvent(window, 'scrollend');
+        }
+
+        async function testLShapedScroll()
+        {
+            // Start mid-way on both axes so movement on either axis is observable regardless of direction.
+            await resetScrollPositions(300, 300);
+            initialScrollX = window.scrollX;
+            initialScrollY = window.scrollY;
+
+            await doMouseWheelScroll();
+
+            // The vertical part of the gesture should have scrolled vertically, and the horizontal part
+            // (after the pause) should have scrolled horizontally.
+            shouldBeTrue('window.scrollY != initialScrollY');
+            shouldBeTrue('window.scrollX != initialScrollX');
+        }
+
+        async function scrollTest()
+        {
+            debug('');
+            debug('Tests that an L-shaped fingers-down gesture scrolls vertically then horizontally');
+
+            await testLShapedScroll();
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -229,6 +229,8 @@ private:
     bool modifyScrollDeltaForStretching(const PlatformWheelEvent&, FloatSize&, bool isHorizontallyStretched, bool isVerticallyStretched);
     bool applyScrollDeltaWithStretching(const PlatformWheelEvent&, FloatSize, bool isHorizontallyStretched, bool isVerticallyStretched);
 
+    FloatSize deltaAlignedToPredominantGestureAxis(MonotonicTime, FloatSize);
+
     void startRubberBandAnimationIfNecessary();
 
     bool startRubberBandAnimation(const FloatSize& initialVelocity, const FloatSize& initialOverscroll);
@@ -298,6 +300,9 @@ private:
     bool m_momentumScrollInProgress { false };
     bool m_ignoreMomentumScrolls { false };
     bool m_isRubberBanding { false };
+
+    FloatSize m_cumulativeGestureDelta;
+    MonotonicTime m_lastGestureEventTime;
 #if ENABLE(TOP_BANNER_VIEW_OVERLAYS)
     bool m_skipAdditionalDeltaAdjustments { false };
 #endif

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -115,6 +115,27 @@ static FloatSize NODELETE deltaAlignedToDominantAxis(FloatSize delta)
     return deltaAlignedToAxis(delta, dominantAxis);
 }
 
+FloatSize ScrollingEffectsController::deltaAlignedToPredominantGestureAxis(MonotonicTime eventTime, FloatSize delta)
+{
+    if (delta.isZero())
+        return delta;
+
+    // Bias the axis alignment to recent events by accumulating deltas in m_cumulativeGestureDelta,
+    // decaying over time. This keeps gesture generally locked to an axis, but allows for
+    // direction changes (e.g. an L-shaped scroll).
+    // 120ms chosen empirically.
+    static constexpr Seconds gestureAxisDecayTimeConstant = 120_ms;
+    if (m_lastGestureEventTime) {
+        auto decay = std::exp(-(eventTime - m_lastGestureEventTime).seconds() / gestureAxisDecayTimeConstant.seconds());
+        m_cumulativeGestureDelta.scale(std::min(decay, 1.0));
+    }
+    m_lastGestureEventTime = eventTime;
+
+    m_cumulativeGestureDelta.expand(std::abs(delta.width()), std::abs(delta.height()));
+
+    return deltaAlignedToAxis(delta, dominantAxisFavoringVertical(m_cumulativeGestureDelta));
+}
+
 static std::optional<BoxSide> NODELETE affectedSideOnDominantAxis(FloatSize delta)
 {
     auto dominantAxis = dominantAxisFavoringVertical(delta);
@@ -150,6 +171,8 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
         m_ignoreMomentumScrolls = false;
         m_lastMomentumScrollTimestamp = { };
         m_momentumVelocity = { };
+        m_cumulativeGestureDelta = { };
+        m_lastGestureEventTime = { };
 
         IntSize stretchAmount = m_client.stretchAmount();
         m_stretchScrollForce.setWidth(reboundDeltaForElasticDelta(stretchAmount.width()));
@@ -192,8 +215,8 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
     delta += eventDelta;
 
     if (wheelEvent.isGestureEvent()) {
-        // FIXME: This replicates what WheelEventDeltaFilter does. We should apply that to events in all phases, and remove axis locking here (webkit.org/b/231207).
-        delta = deltaAlignedToDominantAxis(delta);
+        // FIXME: This axis locking replicates what WheelEventDeltaFilter does. We should apply that to events in all phases, and remove axis locking here (webkit.org/b/231207).
+        delta = deltaAlignedToPredominantGestureAxis(wheelEvent.timestamp(), delta);
     }
 
     auto momentumPhase = wheelEvent.momentumPhase();


### PR DESCRIPTION
#### 834ee921ee13106d142b30a4982174fd50dc3e98
<pre>
REGRESSION (macOS 26): Horizontal rubber-banding causes trouble with vertical scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=303132">https://bugs.webkit.org/show_bug.cgi?id=303132</a>
<a href="https://rdar.apple.com/165449829">rdar://165449829</a>

Reviewed by Abrar Rahman Protyasha.

During rapid up/down scrolling with fingers down on the trackpad, it was easy to trigger
horizontal rubber-banding, which stops the vertical scrolling dead.

Fix by introducing a heuristic that biases axis locking in the direction of
recent wheel events, using an accumulated delta with time-based decay, maintained
in `deltaAlignedToPredominantGestureAxis()`.

This was tuned by feel to keep vertical scrolling locked on the vertical axis, while
allowing an L-shaped fingers-down scroll to move on both axes; this is the kind of
gesture a user might perform when reading zoomed-in content, so needs to work.

Tests: fast/scrolling/mac/vertical-scroll-with-horizontal-deviation.html
       fast/scrolling/mac/vertical-then-horizontal-scroll.html

* LayoutTests/fast/scrolling/mac/vertical-scroll-with-horizontal-deviation-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/vertical-scroll-with-horizontal-deviation.html: Added.
* LayoutTests/fast/scrolling/mac/vertical-then-horizontal-scroll-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/vertical-then-horizontal-scroll.html: Added.
* Source/WebCore/platform/ScrollingEffectsController.h:
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::deltaAlignedToPredominantGestureAxis):
(WebCore::ScrollingEffectsController::handleWheelEvent):

Canonical link: <a href="https://commits.webkit.org/315424@main">https://commits.webkit.org/315424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccc366c87eb454f6743c4b32b136813df9685eb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126675 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131573 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112076 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31723 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27020 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180919 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140020 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139862 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37653 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43231 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107057 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35149 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114996 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41740 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6310 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41134 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41277 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->