### PR TITLE
REGRESSION (311049@main): Clamp the word-boundary search index to the context buffer length in isWordStartMatch()

### DIFF
--- a/LayoutTests/editing/text-iterator/findString-expected.txt
+++ b/LayoutTests/editing/text-iterator/findString-expected.txt
@@ -159,6 +159,10 @@ PASS: Got no match as expected.
 Searching for ‘กช’ in long string with options [AtWordStarts]:
 PASS: Got no match as expected.
 
+Searching for ‘กร the quick brown fox jumps over the lazy dog’ in ‘prefix กร the quick brown fox jumps over the lazy dog’ with options [AtWordStarts]:
+PASS: Got a match at 7,53 as expected.
+PASS: Got no match as expected.
+
 Searching for ‘ ’ in ‘Spaces, the final frontier’ with options [AtWordStarts]:
 PASS: Got a match at 7,8 as expected.
 PASS: Got a match at 11,12 as expected.

--- a/LayoutTests/editing/text-iterator/findString.html
+++ b/LayoutTests/editing/text-iterator/findString.html
@@ -107,6 +107,13 @@
         await testFindString(bufferSizedString.substring(0, searchBufferUnoverlappedSize - 1) + " " + thaiWords.join("") + bufferSizedString, thaiWords[0], ["AtWordStarts"], [[searchBufferUnoverlappedSize, searchBufferUnoverlappedSize + 2], [searchBufferUnoverlappedSize + 12, searchBufferUnoverlappedSize + 14], []]);
         await testFindString(bufferSizedString.substring(0, searchBufferUnoverlappedSize - 3) + " " + thaiWords[4] + bufferSizedString, thaiWords[2], ["AtWordStarts"], [[]]);
 
+        // A match that starts within a complex-context (Thai) run but extends
+        // past it into characters that do not require dictionary context. The
+        // word-boundary context window is trimmed to the Thai run, so the match
+        // length exceeds the trimmed window; the word-start check must not read
+        // past the end of the trimmed string. rdar://179438867
+        await testFindString("prefix " + thaiWords[0] + " the quick brown fox jumps over the lazy dog", thaiWords[0] + " the quick brown fox jumps over the lazy dog", ["AtWordStarts"], [[7, 53], []]);
+
         await testFindString("Spaces, the final frontier", " ", ["AtWordStarts"], [[7, 8], [11, 12], [17, 18], []]);
         await testFindString("Use an @import rule", "@", ["AtWordStarts"], [[7, 8], []]);
         await testFindString("If ((x + 5) * 2) = 14, then x = 2", "(x", ["AtWordStarts"], [[4, 6], []]);

--- a/Source/WebCore/editing/ICUSearcher.cpp
+++ b/Source/WebCore/editing/ICUSearcher.cpp
@@ -344,7 +344,8 @@ bool isWordStartMatch(std::span<const char16_t> buffer, size_t start, size_t len
     auto [contextBuffer, contextOffset] = extractSubspanIncludingContextNeededForDictionaryBasedWordBreak(buffer, start);
     size_t adjustedStart = start - contextOffset;
 
-    size_t wordBreakSearchStart = adjustedStart + length;
+    // Clamp because the trimmed context window may be shorter than adjustedStart + length.
+    size_t wordBreakSearchStart = std::min(adjustedStart + length, contextBuffer.size());
     while (wordBreakSearchStart > adjustedStart)
         wordBreakSearchStart = findNextWordFromIndex(contextBuffer, wordBreakSearchStart, false /* backwards */);
     return wordBreakSearchStart == adjustedStart;


### PR DESCRIPTION
#### 03015890a6a276e1836e96bded758609ac1cd501
<pre>
REGRESSION (311049@main): Clamp the word-boundary search index to the context buffer length in isWordStartMatch()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=317083">https://bugs.webkit.org/show_bug.cgi?id=317083</a>&gt;
&lt;<a href="https://rdar.apple.com/179591659">rdar://179591659</a>&gt;

Reviewed by Cole Carley.

In `isWordStartMatch()`, the buffer is first trimmed to a context window
by `extractSubspanIncludingContextNeededForDictionaryBasedWordBreak()`,
which can return a span shorter than the original match range when the
trailing characters do not require dictionary context.  The full-buffer
invariant `start + length &lt;= buffer.size()` does not carry over to the
trimmed span, so `adjustedStart + length` can exceed `contextBuffer`&apos;s
length and be passed to `findNextWordFromIndex()` as a starting index
beyond the end of the string it builds, reading out of bounds.

Clamp the starting index to `contextBuffer.size()` before the search.
The clamp never drops below `adjustedStart` because the trimmed span
always includes `start`, so the search loop&apos;s termination is preserved.

Test: editing/text-iterator/findString.html

* LayoutTests/editing/text-iterator/findString.html:
- Add an AtWordStarts test case whose match starts in a complex-context
  (Thai) run but extends past it, exercising the trimmed-window path.
* LayoutTests/editing/text-iterator/findString-expected.txt:
- Update results.
* Source/WebCore/editing/ICUSearcher.cpp:
(WebCore::isWordStartMatch):

Canonical link: <a href="https://commits.webkit.org/315233@main">https://commits.webkit.org/315233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29ab6feac283435a2ed32ed16bff6bddb1baad70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126014 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/940ec4b6-b91d-470e-8c75-9071ebeb23b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130987 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92085 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac16a663-c896-478a-ad75-6f6a0cefed35) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111499 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a75fc126-4c92-4ea6-8117-03335ab94379) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32439 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31142 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26337 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142425 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180241 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32965 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139424 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139287 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150741 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106056 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27639 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41074 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114330 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40471 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5723 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40722 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->