### PR TITLE
[JSC] Store `usedRegisters` only on `RepatchingPropertyInlineCache`

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -208,7 +208,7 @@ bool InlineAccess::generateSelfPropertyAccess(PropertyInlineCache& propertyCache
 
 ALWAYS_INLINE static GPRReg getScratchRegister(PropertyInlineCache& propertyCache)
 {
-    ScratchRegisterAllocator allocator(propertyCache.usedRegisters.toRegisterSet());
+    ScratchRegisterAllocator allocator(propertyCache.usedRegisters().toRegisterSet());
     allocator.lock(propertyCache.m_baseGPR);
     allocator.lock(propertyCache.m_valueGPR);
     allocator.lock(propertyCache.m_extraGPR);

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -1323,7 +1323,7 @@ void InlineCacheCompiler::emitExplicitExceptionHandler()
 
 ScratchRegisterAllocator InlineCacheCompiler::makeDefaultScratchAllocator(GPRReg extraToLock)
 {
-    ScratchRegisterAllocator allocator(m_propertyCache.usedRegisters.toRegisterSet());
+    ScratchRegisterAllocator allocator(m_propertyCache.usedRegisters().toRegisterSet());
     allocator.lock(m_propertyCache.baseRegs());
     allocator.lock(m_propertyCache.valueRegs());
     allocator.lock(m_propertyCache.m_extraGPR);

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -838,8 +838,6 @@ void HandlerPropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& v
     if (unlinkedPropertyCache.canBeMegamorphic)
         bufferingCountdown = 1;
 
-    usedRegisters = RegisterSet::stubUnavailableRegisters().toScalarRegisterSet();
-
     m_slowOperation = slowOperationFromUnlinkedPropertyInlineCache(unlinkedPropertyCache);
     initializePredefinedRegisters();
 }
@@ -875,8 +873,6 @@ void HandlerPropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache(Co
 
     if (unlinkedPropertyCache.canBeMegamorphic)
         bufferingCountdown = 1;
-
-    usedRegisters = RegisterSet::stubUnavailableRegisters().toScalarRegisterSet();
 
     m_slowOperation = slowOperationFromUnlinkedPropertyInlineCache(unlinkedPropertyCache);
     initializePredefinedRegisters();

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -388,6 +388,10 @@ public:
 
     JSGlobalObject* globalObject() const { return m_globalObject; }
 
+    inline ScalarRegisterSet usedRegisters() const;
+    inline void setUsedRegisters(ScalarRegisterSet);
+    inline void removeUsedRegister(GPRReg);
+
     void resetStubAsJumpInAccess(CodeBlock*);
 
     GPRReg thisGPR() const { return m_extraGPR; }
@@ -437,8 +441,6 @@ private:
     // That's not so bad - we'll get rid of the redundant ones once we regenerate.
     Variant<std::monostate, Vector<StructureID>, Vector<std::tuple<StructureID, CacheableIdentifier>>> m_bufferedStructures WTF_GUARDED_BY_LOCK(m_bufferedStructuresLock);
 public:
-
-    ScalarRegisterSet usedRegisters;
 
     CallSiteIndex callSiteIndex;
 
@@ -697,6 +699,8 @@ public:
     CodeLocationCall<JSInternalPtrTag> m_slowPathCallLocation;
     std::unique_ptr<PolymorphicAccess> m_stub;
 
+    ScalarRegisterSet m_usedRegisters;
+
     uint32_t inlineCodeSize() const
     {
         int32_t inlineSize = MacroAssembler::differenceBetweenCodePtr(startLocation, doneLocation);
@@ -704,6 +708,25 @@ public:
         return inlineSize;
     }
 };
+
+inline ScalarRegisterSet PropertyInlineCache::usedRegisters() const
+{
+    if (auto* repatching = dynamicDowncast<RepatchingPropertyInlineCache>(*this))
+        return repatching->m_usedRegisters;
+    return RegisterSet::stubUnavailableRegisters().toScalarRegisterSet();
+}
+
+inline void PropertyInlineCache::setUsedRegisters(ScalarRegisterSet value)
+{
+    ASSERT(is<RepatchingPropertyInlineCache>(*this));
+    downcast<RepatchingPropertyInlineCache>(*this).m_usedRegisters = value;
+}
+
+inline void PropertyInlineCache::removeUsedRegister(GPRReg reg)
+{
+    ASSERT(is<RepatchingPropertyInlineCache>(*this));
+    downcast<RepatchingPropertyInlineCache>(*this).m_usedRegisters.remove(reg);
+}
 
 inline auto appropriateGetByIdOptimizeFunction(AccessType type) -> decltype(&operationGetByIdOptimize)
 {

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -53,8 +53,10 @@ class JITCode;
 class JITCompiler;
 
 struct UnlinkedPropertyInlineCache : JSC::UnlinkedPropertyInlineCache {
+    void setUsedRegisters(ScalarRegisterSet value) { m_usedRegisters = value; }
+    void removeUsedRegister(GPRReg reg) { m_usedRegisters.remove(reg); }
+
     CodeOrigin codeOrigin;
-    ScalarRegisterSet usedRegisters;
     CallSiteIndex callSiteIndex;
     GPRReg m_baseGPR { InvalidGPRReg };
     GPRReg m_valueGPR { InvalidGPRReg };
@@ -67,6 +69,9 @@ struct UnlinkedPropertyInlineCache : JSC::UnlinkedPropertyInlineCache {
     GPRReg m_extraTagGPR { InvalidGPRReg };
     GPRReg m_extra2TagGPR { InvalidGPRReg };
 #endif
+
+private:
+    ScalarRegisterSet m_usedRegisters;
 };
 
 struct UnlinkedCallLinkInfo : JSC::UnlinkedCallLinkInfo {

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.h
@@ -97,7 +97,7 @@ public:
         } else {
             propertyCache.codeOrigin = codeOrigin;
             propertyCache.callSiteIndex = callSiteIndex;
-            propertyCache.usedRegisters = usedRegisters.toScalarRegisterSet();
+            propertyCache.setUsedRegisters(usedRegisters.toScalarRegisterSet());
         }
         if constexpr (std::is_same_v<std::decay_t<PropertyInlineCache>, JSC::PropertyInlineCache>) {
             if (codeOrigin.inlineCallFrame())
@@ -245,7 +245,7 @@ public:
     {
         JITByIdGenerator::setUpPropertyInlineCacheImpl(propertyCache, codeBlock, accessType, cacheType, codeOrigin, callSiteIndex, usedRegisters, propertyName, baseRegs, valueRegs, propertyCacheGPR);
         if constexpr (!std::is_same_v<std::decay_t<PropertyInlineCache>, BaselineUnlinkedPropertyInlineCache>)
-            propertyCache.usedRegisters.remove(scratchGPR);
+            propertyCache.removeUsedRegister(scratchGPR);
         else
             UNUSED_PARAM(scratchGPR);
     }


### PR DESCRIPTION
#### 3429f34cbda218ea107c11726e9832214790245d
<pre>
[JSC] Store `usedRegisters` only on `RepatchingPropertyInlineCache`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317087">https://bugs.webkit.org/show_bug.cgi?id=317087</a>

Reviewed by Keith Miller.

The scratch-register set (usedRegisters) lived on the base PropertyInlineCache,
so every HandlerPropertyInlineCache carried it even though handler ICs never need
it: Baseline and DFG data ICs run with the fixed data-IC register convention, so
their unavailable-register set is always the constant stubUnavailableRegisters().
Only repatching ICs need a per-instance set, because their registers are chosen by
the register allocator at the call site.

Move the field to RepatchingPropertyInlineCache::m_usedRegisters and expose it
through a base usedRegisters() accessor that returns the constant for handler ICs
and the stored set for repatching ICs. This shrinks the dominant
HandlerPropertyInlineCache from 136 to 128 bytes on arm64; since Baseline handler
ICs are stored in a packed array (stride sizeof(...)), this is a linear per-IC saving.
RepatchingPropertyInlineCache is unchanged in size.

* Source/JavaScriptCore/bytecode/InlineAccess.cpp:
(JSC::getScratchRegister):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::makeDefaultScratchAllocator):
* Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp:
(JSC::HandlerPropertyInlineCache::initializeFromUnlinkedPropertyInlineCache):
(JSC::HandlerPropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache):
* Source/JavaScriptCore/bytecode/PropertyInlineCache.h:
(JSC::PropertyInlineCache::usedRegisters const):
(JSC::PropertyInlineCache::setUsedRegisters):
(JSC::PropertyInlineCache::removeUsedRegister):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
(JSC::DFG::UnlinkedPropertyInlineCache::setUsedRegisters):
(JSC::DFG::UnlinkedPropertyInlineCache::removeUsedRegister):
* Source/JavaScriptCore/jit/JITInlineCacheGenerator.h:
(JSC::JITInlineCacheGenerator::setUpPropertyInlineCacheImpl):

Canonical link: <a href="https://commits.webkit.org/315196@main">https://commits.webkit.org/315196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2abe09206f146eda26f7370418d07dc61bae9661

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126024 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130997 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92093 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31153 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26347 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160942 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142437 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180251 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29570 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32975 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139434 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139297 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37518 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42580 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106085 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27647 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201001 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41084 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114340 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53993 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40481 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5732 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->