### PR TITLE
Element.getBoundingClientRect() on SVG <tspan> returns the whole <text> bounds instead of the tspan's own area

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003-expected.txt
@@ -1,5 +1,5 @@
 XXX
 
-FAIL {Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Element assert_equals: left expected 108 but got 8
+PASS {Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Element
 PASS {Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Range
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003-expected.txt
@@ -1,5 +1,0 @@
-XXX
-
-FAIL {Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Element assert_equals: left expected 108 but got 8
-PASS {Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Range
-

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -127,6 +127,7 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderListBox.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGInline.h"
 #include "RenderSVGModelObject.h"
 #include "RenderTextControlSingleLine.h"
 #include "RenderTheme.h"
@@ -1853,7 +1854,13 @@ int Element::scrollHeight()
 inline RefPtr<const SVGElement> elementWithSVGLayoutBox(const Element& element)
 {
     RefPtr svg = dynamicDowncast<SVGElement>(element);
-    return svg && svg->hasAssociatedSVGLayoutBox() ? svg : nullptr;
+    if (!svg || !svg->hasAssociatedSVGLayoutBox())
+        return nullptr;
+
+    if (is<RenderSVGInline>(svg->renderer()))
+        return { };
+
+    return svg;
 }
 
 inline bool NODELETE shouldObtainBoundsFromBoxModel(const Element* element)


### PR DESCRIPTION
#### afe06d98359dd88adf413d5b6be54dfd33c8196e
<pre>
Element.getBoundingClientRect() on SVG &lt;tspan&gt; returns the whole &lt;text&gt; bounds instead of the tspan&apos;s own area
<a href="https://bugs.webkit.org/show_bug.cgi?id=317088">https://bugs.webkit.org/show_bug.cgi?id=317088</a>
<a href="https://rdar.apple.com/179626476">rdar://179626476</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per the SVG 2 spec [1], &quot;The &apos;tspan&apos;, &apos;textPath&apos;, and &apos;a&apos; elements that are
descended from text content elements act as inline elements&quot;, so their CSSOM
box geometry should be each element&apos;s own rendered area. The same section
states that &quot;the object bounding box units are computed relative to the entire
&apos;text&apos; element in all cases, even when different effects are applied to
different &apos;tspan&apos; or &apos;textPath&apos; elements within the same &apos;text&apos; element&quot; -- that
whole-&lt;text&gt; box is correct for objectBoundingBox-unit effects (gradient/
pattern/clip/mask/filter), but not for CSSOM.

Element::getBoundingClientRect() conflated the two: it routes every element with
an SVG layout box through SVGElement::getBoundingBox() -&gt;
RenderSVGInline::objectBoundingBox(), which returns the &lt;text&gt; ancestor&apos;s box.
So `&lt;text&gt;X&lt;tspan&gt;XX&lt;/tspan&gt;&lt;/text&gt;` reported the tspan at the text origin
instead of past the preceding &quot;X&quot;. Range.getBoundingClientRect() was already
correct via RenderSVGInline::absoluteQuads().

Exclude SVG inline elements from elementWithSVGLayoutBox() so they fall through
to the box-model path (absoluteQuads()), matching Range.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextElement">https://w3c.github.io/svgwg/svg2-draft/text.html#TextElement</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003-expected.txt: Progression
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom-view/cssom-getBoundingClientRect-003-expected.txt: Removed.
* Source/WebCore/dom/Element.cpp:
(WebCore::elementWithSVGLayoutBox):

Canonical link: <a href="https://commits.webkit.org/315234@main">https://commits.webkit.org/315234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/212f1c99dea248f3f1fbdddd629e5d1c20b6bc39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177801 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126174 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31125956-b0c3-49dc-9a18-3e00c7dd0ff5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b48915ba-a59f-4611-b412-ea8ac1ad983b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111641 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5780ee8c-421a-4330-8088-1befa03fa881) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31279 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26497 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142563 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180401 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33125 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139567 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139429 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37535 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42730 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106382 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34716 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27775 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41234 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114490 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40631 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5858 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40776 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->