### PR TITLE
scrollIntoView "nearest" aligns to the far edge for an oversized target before the scrollport

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-nearest-oversized-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-nearest-oversized-element-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scrollIntoView nearest aligns an oversized target before the scrollport to its closest (right/bottom) edge
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-nearest-oversized-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-nearest-oversized-element.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>scrollIntoView nearest aligns to the closest edge for an oversized target before the scrollport</title>
+  <link rel="help" href="https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<style>
+#container {
+  width: 200px;
+  height: 200px;
+  overflow: scroll;
+}
+
+#content {
+  width: 1000px;
+  height: 1000px;
+  position: relative;
+}
+
+/* Target is larger than the 200x200 scrollport in both axes. */
+#target {
+  position: absolute;
+  left: 50px;
+  top: 50px;
+  width: 400px;
+  height: 400px;
+  background-color: aqua;
+}
+</style>
+
+<div id="container">
+  <div id="content">
+    <div id="target"></div>
+  </div>
+</div>
+
+<script>
+  test(function() {
+    const targetLeft = target.offsetLeft;
+    const targetTop = target.offsetTop;
+    const targetRight = targetLeft + target.offsetWidth;
+    const targetBottom = targetTop + target.offsetHeight;
+
+    // Scroll so the target is fully above and to the left of the scrollport.
+    container.scrollLeft = targetRight + 100;
+    container.scrollTop = targetBottom + 100;
+
+    target.scrollIntoView({block: 'nearest', inline: 'nearest'});
+
+    // The target is larger than the scrollport and lies before the viewport, so
+    // the closest edge is the target's right/bottom edge. The minimal scroll
+    // aligns the target's bottom-right edge with the scrollport's bottom-right.
+    const expectedLeft = targetRight - container.clientWidth;
+    const expectedTop = targetBottom - container.clientHeight;
+
+    assert_approx_equals(container.scrollLeft, expectedLeft, 1,
+      'inline: nearest aligns the target right edge to the scrollport right edge');
+    assert_approx_equals(container.scrollTop, expectedTop, 1,
+      'block: nearest aligns the target bottom edge to the scrollport bottom edge');
+  }, "scrollIntoView nearest aligns an oversized target before the scrollport to its closest (right/bottom) edge");
+</script>
+</html>

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2023 Google Inc. All rights reserved.
- * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -961,10 +961,14 @@ LayoutRect ScrollableArea::getRectToExposeForScrollIntoView(const LayoutRect& vi
             scrollX = alignX.getHiddenBehavior();
     }
 
-    // If we're trying to align to the closest edge, and the exposeRect is further right
-    // than the visibleBounds, and not bigger than the visible area, then align with the right.
-    if (scrollX == ScrollAlignment::Behavior::AlignToClosestEdge && exposeRect.maxX() > visibleBounds.maxX() && exposeRect.width() < visibleBounds.width())
-        scrollX = ScrollAlignment::Behavior::AlignRight;
+    if (scrollX == ScrollAlignment::Behavior::AlignToClosestEdge) {
+        // The closest edge is the right in two cases:
+        // (1) exposeRect is to the right of and smaller than visibleBounds.
+        // (2) exposeRect is to the left of and larger than visibleBounds.
+        if ((exposeRect.maxX() > visibleBounds.maxX() && exposeRect.width() < visibleBounds.width())
+            || (exposeRect.maxX() < visibleBounds.maxX() && exposeRect.width() > visibleBounds.width()))
+            scrollX = ScrollAlignment::Behavior::AlignRight;
+    }
 
     // Given the X behavior, compute the X coordinate.
     LayoutUnit x;
@@ -1001,10 +1005,14 @@ LayoutRect ScrollableArea::getRectToExposeForScrollIntoView(const LayoutRect& vi
             scrollY = alignY.getHiddenBehavior();
     }
 
-    // If we're trying to align to the closest edge, and the exposeRect is further down
-    // than the visibleBounds, and not bigger than the visible area, then align with the bottom.
-    if (scrollY == ScrollAlignment::Behavior::AlignToClosestEdge && exposeRect.maxY() > visibleBounds.maxY() && exposeRect.height() < visibleBounds.height())
-        scrollY = ScrollAlignment::Behavior::AlignBottom;
+    if (scrollY == ScrollAlignment::Behavior::AlignToClosestEdge) {
+        // The closest edge is the bottom in two cases:
+        // (1) exposeRect is below and smaller than visibleBounds.
+        // (2) exposeRect is above and larger than visibleBounds.
+        if ((exposeRect.maxY() > visibleBounds.maxY() && exposeRect.height() < visibleBounds.height())
+            || (exposeRect.maxY() < visibleBounds.maxY() && exposeRect.height() > visibleBounds.height()))
+            scrollY = ScrollAlignment::Behavior::AlignBottom;
+    }
 
     // Given the Y behavior, compute the Y coordinate.
     LayoutUnit y;


### PR DESCRIPTION
#### 6c2b5860a380be2f0050fbff29c14dffd30dd365
<pre>
scrollIntoView &quot;nearest&quot; aligns to the far edge for an oversized target before the scrollport
<a href="https://bugs.webkit.org/show_bug.cgi?id=253070">https://bugs.webkit.org/show_bug.cgi?id=253070</a>
<a href="https://rdar.apple.com/106356373">rdar://106356373</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/ae8d18613905f501a3ce9ba83193fe77e920afbf">https://chromium.googlesource.com/chromium/blink/+/ae8d18613905f501a3ce9ba83193fe77e920afbf</a>

ScrollableArea::getRectToExposeForScrollIntoView() handled only one of the
two cases in which the closest edge is the right/bottom edge. It aligned to
the right/bottom only when the exposeRect was past the right/bottom of the
scrollport and smaller than it. When the exposeRect is larger than the
scrollport and lies before it (to the left of / above the viewport), the
closest edge is still the right/bottom edge, but the alignment fell through
to the default left/top branch. As a result, scrollIntoView({block: &quot;nearest&quot;,
inline: &quot;nearest&quot;}) on a target bigger than the scrollport scrolled to the
far edge instead of performing the minimal scroll to the nearest edge,
disagreeing with Chrome and Firefox.

Handle both cases: align to the right/bottom edge when the exposeRect is
either (1) past the scrollport and smaller than it, or (2) before the
scrollport and larger than it.

Test: imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-nearest-oversized-element.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-nearest-oversized-element-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-nearest-oversized-element.html: Added.
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::getRectToExposeForScrollIntoView const):

Canonical link: <a href="https://commits.webkit.org/315225@main">https://commits.webkit.org/315225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce54b5f0a9f9b03c18dca9dccb12eaf448738386

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126027 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fde5ec5-5dcd-40b7-805d-9f0b0a95b1e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131000 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92097 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0fd19ef9-4e6c-4d0c-9d16-bf1e57ba0d18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111512 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01dd307a-abf5-4b15-85e6-678d33882a3d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32454 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31155 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26350 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142440 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180254 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32978 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139437 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139300 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37530 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150753 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106098 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34590 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27651 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114343 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40484 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5736 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40629 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->