### PR TITLE
[JSC] Optimize some of Temporal date operations

### DIFF
--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -86,32 +86,33 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 // ISOArithmetic tests — mirrors temporal_rs src/iso.rs tests
 // ---------------------------------------------------------------------------
 
-static void testBalanceISODate()
+static void testAddDaysToISODate()
 {
-    // temporal_rs: test balance_iso_date
-    // 2020-01-32 -> 2020-02-01
-    auto r = balanceISODate(2020, 1, 32);
-    TCHECK_EQ(r.year(), 2020, "balanceISODate: 2020-01-32 year");
-    TCHECK_EQ(r.month(), 2u, "balanceISODate: 2020-01-32 month");
-    TCHECK_EQ(r.day(), 1u, "balanceISODate: 2020-01-32 day");
+    // temporal_rs: test balance_iso_date (now addDaysToISODate — same algorithm, taking a
+    // PlainDate + day delta directly instead of (year, month, day-with-overflow)).
+    // 2020-01-31 +1d -> 2020-02-01
+    auto r = addDaysToISODate(ISO8601::PlainDate { 2020, 1, 31 }, 1);
+    TCHECK_EQ(r.year(), 2020, "addDaysToISODate: 2020-01-31 +1d year");
+    TCHECK_EQ(r.month(), 2u, "addDaysToISODate: 2020-01-31 +1d month");
+    TCHECK_EQ(r.day(), 1u, "addDaysToISODate: 2020-01-31 +1d day");
 
-    // 2020-12-32 -> 2021-01-01
-    auto r2 = balanceISODate(2020, 12, 32);
-    TCHECK_EQ(r2.year(), 2021, "balanceISODate: 2020-12-32 year");
-    TCHECK_EQ(r2.month(), 1u, "balanceISODate: 2020-12-32 month");
-    TCHECK_EQ(r2.day(), 1u, "balanceISODate: 2020-12-32 day");
+    // 2020-12-31 +1d -> 2021-01-01
+    auto r2 = addDaysToISODate(ISO8601::PlainDate { 2020, 12, 31 }, 1);
+    TCHECK_EQ(r2.year(), 2021, "addDaysToISODate: 2020-12-31 +1d year");
+    TCHECK_EQ(r2.month(), 1u, "addDaysToISODate: 2020-12-31 +1d month");
+    TCHECK_EQ(r2.day(), 1u, "addDaysToISODate: 2020-12-31 +1d day");
 
-    // 2020-01-00 -> 2019-12-31
-    auto r3 = balanceISODate(2020, 1, 0);
-    TCHECK_EQ(r3.year(), 2019, "balanceISODate: 2020-01-00 year");
-    TCHECK_EQ(r3.month(), 12u, "balanceISODate: 2020-01-00 month");
-    TCHECK_EQ(r3.day(), 31u, "balanceISODate: 2020-01-00 day");
+    // 2020-01-01 -1d -> 2019-12-31
+    auto r3 = addDaysToISODate(ISO8601::PlainDate { 2020, 1, 1 }, -1);
+    TCHECK_EQ(r3.year(), 2019, "addDaysToISODate: 2020-01-01 -1d year");
+    TCHECK_EQ(r3.month(), 12u, "addDaysToISODate: 2020-01-01 -1d month");
+    TCHECK_EQ(r3.day(), 31u, "addDaysToISODate: 2020-01-01 -1d day");
 
-    // 2020-03-01 (unchanged)
-    auto r4 = balanceISODate(2020, 3, 1);
-    TCHECK_EQ(r4.year(), 2020, "balanceISODate: 2020-03-01 year");
-    TCHECK_EQ(r4.month(), 3u, "balanceISODate: 2020-03-01 month");
-    TCHECK_EQ(r4.day(), 1u, "balanceISODate: 2020-03-01 day");
+    // 2020-03-01 +0d (unchanged)
+    auto r4 = addDaysToISODate(ISO8601::PlainDate { 2020, 3, 1 }, 0);
+    TCHECK_EQ(r4.year(), 2020, "addDaysToISODate: 2020-03-01 +0d year");
+    TCHECK_EQ(r4.month(), 3u, "addDaysToISODate: 2020-03-01 +0d month");
+    TCHECK_EQ(r4.day(), 1u, "addDaysToISODate: 2020-03-01 +0d day");
 }
 
 static void testRegulateISODate()
@@ -364,20 +365,46 @@ static void testAdjustDateDurationRecord()
     ISO8601::Duration base(2, 3, 1, 5, 0, 0, 0, 0, 0, 0);
 
     // Override days only
-    auto r1 = adjustDateDurationRecord(base, 10.0, std::nullopt, std::nullopt);
+    auto r1 = adjustDateDurationRecord(base, 10, std::nullopt, std::nullopt);
     TCHECK_TRUE(r1.has_value(), "adjustDateDur: days override ok");
     TCHECK_EQ(static_cast<int64_t>(r1->years()), 2LL, "adjustDateDur: years preserved");
     TCHECK_EQ(static_cast<int64_t>(r1->months()), 3LL, "adjustDateDur: months preserved");
     TCHECK_EQ(static_cast<int64_t>(r1->days()), 10LL, "adjustDateDur: days overridden");
 
     // Override weeks
-    auto r2 = adjustDateDurationRecord(base, 5.0, 2.0, std::nullopt);
+    auto r2 = adjustDateDurationRecord(base, 5, 2, std::nullopt);
     TCHECK_TRUE(r2.has_value(), "adjustDateDur: weeks override ok");
     TCHECK_EQ(static_cast<int64_t>(r2->weeks()), 2LL, "adjustDateDur: weeks overridden");
 
     // Mixed signs -> invalid, should error
-    auto r3 = adjustDateDurationRecord(base, -10.0, std::nullopt, std::nullopt);
+    auto r3 = adjustDateDurationRecord(base, -10, std::nullopt, std::nullopt);
     TCHECK_TRUE(!r3.has_value(), "adjustDateDur: mixed sign rejected");
+
+    // Day-magnitude limit. isValidDuration enforces |normalizedSeconds| < 2^53 which, for a
+    // date-only Duration, reduces to |days × 86400| < 2^53. The largest `days` that satisfies
+    // this is floor((2^53 - 1) / 86400) = 104249991374; one beyond that rejects.
+    ISO8601::Duration zeroBase(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    constexpr int64_t maxValidDays = 104249991374LL;
+    auto rMax = adjustDateDurationRecord(zeroBase, maxValidDays, std::nullopt, std::nullopt);
+    TCHECK_TRUE(rMax.has_value(), "adjustDateDur: max valid days accepted");
+    auto rOver = adjustDateDurationRecord(zeroBase, maxValidDays + 1, std::nullopt, std::nullopt);
+    TCHECK_TRUE(!rOver.has_value(), "adjustDateDur: days past 2^53/86400 rejected");
+    // Symmetric for negative.
+    auto rMinNeg = adjustDateDurationRecord(zeroBase, -maxValidDays, std::nullopt, std::nullopt);
+    TCHECK_TRUE(rMinNeg.has_value(), "adjustDateDur: negative max valid days accepted");
+    auto rOverNeg = adjustDateDurationRecord(zeroBase, -(maxValidDays + 1), std::nullopt, std::nullopt);
+    TCHECK_TRUE(!rOverNeg.has_value(), "adjustDateDur: negative days past -2^53/86400 rejected");
+
+    // Years/months/weeks 2^32 cap (isValidDuration step 3-5: |y|,|mo|,|w| < 2^32).
+    constexpr int64_t maxField = (static_cast<int64_t>(1) << 32) - 1;
+    auto rMaxY = adjustDateDurationRecord(ISO8601::Duration(maxField, 0, 0, 0, 0, 0, 0, 0, 0, 0), 0, std::nullopt, std::nullopt);
+    TCHECK_TRUE(rMaxY.has_value(), "adjustDateDur: years at 2^32-1 accepted");
+    auto rOverY = adjustDateDurationRecord(ISO8601::Duration(static_cast<int64_t>(1) << 32, 0, 0, 0, 0, 0, 0, 0, 0, 0), 0, std::nullopt, std::nullopt);
+    TCHECK_TRUE(!rOverY.has_value(), "adjustDateDur: years at 2^32 rejected");
+    auto rOverMo = adjustDateDurationRecord(zeroBase, 0, std::nullopt, static_cast<int64_t>(1) << 32);
+    TCHECK_TRUE(!rOverMo.has_value(), "adjustDateDur: months at 2^32 rejected");
+    auto rOverW = adjustDateDurationRecord(zeroBase, 0, static_cast<int64_t>(1) << 32, std::nullopt);
+    TCHECK_TRUE(!rOverW.has_value(), "adjustDateDur: weeks at 2^32 rejected");
 }
 
 // ---------------------------------------------------------------------------
@@ -492,26 +519,26 @@ static void testCalendarDateUntil()
 static void testISODateLimits()
 {
     // Max valid ISO date for Temporal: +275760-09-13 (±1e8 epoch days)
-    // balanceISODate returns outOfRangeYear only when year exceeds the year representation limit
-    auto rMax = balanceISODate(275760, 9, 13);
+    // addDaysToISODate returns outOfRangeYear only when year exceeds the year representation limit
+    auto rMax = addDaysToISODate(ISO8601::PlainDate { 275760, 9, 13 }, 0);
     TCHECK_EQ(rMax.year(), 275760, "limits: max date year");
     TCHECK_EQ(rMax.month(), 9u, "limits: max date month");
     TCHECK_EQ(rMax.day(), 13u, "limits: max date day");
 
     // Min valid ISO date: -271821-04-19
-    auto rMin = balanceISODate(-271821, 4, 19);
+    auto rMin = addDaysToISODate(ISO8601::PlainDate { -271821, 4, 19 }, 0);
     TCHECK_EQ(rMin.year(), -271821, "limits: min date year");
     TCHECK_EQ(rMin.month(), 4u, "limits: min date month");
     TCHECK_EQ(rMin.day(), 19u, "limits: min date day");
 
     // Unix epoch: 1970-01-01
-    auto rEpoch = balanceISODate(1970, 1, 1);
+    auto rEpoch = addDaysToISODate(ISO8601::PlainDate { 1970, 1, 1 }, 0);
     TCHECK_EQ(rEpoch.year(), 1970, "limits: epoch year");
     TCHECK_EQ(rEpoch.month(), 1u, "limits: epoch month");
     TCHECK_EQ(rEpoch.day(), 1u, "limits: epoch day");
 
     // Day before epoch: 1969-12-31
-    auto rEpochMinus1 = balanceISODate(1969, 12, 31);
+    auto rEpochMinus1 = addDaysToISODate(ISO8601::PlainDate { 1969, 12, 31 }, 0);
     TCHECK_EQ(rEpochMinus1.year(), 1969, "limits: epoch-1 year");
     TCHECK_EQ(rEpochMinus1.month(), 12u, "limits: epoch-1 month");
     TCHECK_EQ(rEpochMinus1.day(), 31u, "limits: epoch-1 day");
@@ -3262,7 +3289,7 @@ static void runTemporalRSTests()
     testValidateTemporalRoundingIncrement(); // temporal_rs: RoundingIncrement::validate
 
     // --- plain_date.rs ---
-    testBalanceISODate(); // temporal_rs: (balanceISODate)
+    testAddDaysToISODate(); // temporal_rs: (addDaysToISODate)
     testBalanceISOYearMonth(); // temporal_rs: (balanceISOYearMonth)
     testRegulateISODate(); // temporal_rs: (regulateISODate)
     testISODateAdd(); // temporal_rs: simple_date_add

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -2057,6 +2057,15 @@ ExactTime ExactTime::now()
 // https://tc39.es/proposal-temporal/#sec-temporal-isodatetimewithinlimits
 bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond)
 {
+    // The year strictly inside the valid range is unconditionally OK regardless of the
+    // time-of-day or day-of-month. The absolute min/max epoch instants Temporal admits
+    // are -271821-04-20T00:00:00Z and +275760-09-13T00:00:00Z. isDateTimeWithinLimits
+    // adds a +-1-day slack to those bounds, so the only years where some (month, day, time)
+    // combination can land outside the representable range are the boundary years themselves.
+    // Years strictly inside (-271821, +275760) always pass.
+    if (year > minYear && year < maxYear)
+        return true;
+
     Int128 nanoseconds = ExactTime::fromISOPartsAndOffset(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, 0).epochNanoseconds();
     if (nanoseconds <= (ExactTime::minValue - ExactTime::nsPerDay))
         return false;

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
@@ -466,18 +466,36 @@ static TemporalResult<Int128> epochNanosecondsForDateAndTime(
 
 // adjustDateDurationRecord — internal helper; builds a new date duration with overridden days/weeks/months fields.
 // https://tc39.es/proposal-temporal/#sec-temporal-adjustdatedurationrecord
-TemporalResult<ISO8601::Duration> adjustDateDurationRecord(const ISO8601::Duration& dateDuration, double days, std::optional<double> weeks, std::optional<double> months)
+TemporalResult<ISO8601::Duration> adjustDateDurationRecord(const ISO8601::Duration& dateDuration, int64_t days, std::optional<int64_t> weeks, std::optional<int64_t> months)
 {
     // Step 1: If weeks is not present, set weeks to dateDuration.[[Weeks]].
     // Step 2: If months is not present, set months to dateDuration.[[Months]].
     // (Both handled implicitly by the std::optional parameters.)
-    auto result = ISO8601::Duration {
-        dateDuration.years(),
-        months ? static_cast<int64_t>(months.value()) : dateDuration.months(),
-        weeks ? static_cast<int64_t>(weeks.value()) : dateDuration.weeks(),
-        // Step 3: Return ? CreateDateDurationRecord(dateDuration.[[Years]], months, weeks, days).
-        static_cast<int64_t>(days), 0, 0, 0, 0, Int128(0), Int128(0)
-    };
+    int64_t y = dateDuration.years();
+    int64_t mo = months.value_or(dateDuration.months());
+    int64_t w = weeks.value_or(dateDuration.weeks());
+    int64_t d = days;
+    // Step 3: Return ? CreateDateDurationRecord(dateDuration.[[Years]], months, weeks, days).
+    auto result = ISO8601::Duration { y, mo, w, d, 0, 0, 0, 0, Int128(0), Int128(0) };
+
+    // Skip isValidDuration by filtering the most of legit cases via quick comparison of specified fields.
+    constexpr int64_t fieldLimit = static_cast<int64_t>(1) << 32;
+    constexpr int64_t maxDays = (static_cast<int64_t>(1) << 53) / 86400;
+    bool fastPath = (y > -fieldLimit && y < fieldLimit)
+        && (mo > -fieldLimit && mo < fieldLimit)
+        && (w > -fieldLimit && w < fieldLimit)
+        && (d > -maxDays && d < maxDays);
+    if (fastPath) {
+        int sign = 0;
+        auto check = [&](int64_t v) {
+            if (!sign && v)
+                sign = v > 0 ? 1 : -1;
+            return !((v < 0 && sign > 0) || (v > 0 && sign < 0));
+        };
+        if (check(y) && check(mo) && check(w) && check(d))
+            return result;
+    }
+
     if (!ISO8601::isValidDuration(result))
         return makeUnexpected(rangeError("Temporal.Duration properties must be valid and of consistent sign"_s));
     return result;
@@ -527,12 +545,12 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
         // Step 2.d: r2 = r1 + increment × sign.
         r2 = r1 + increment * sign;
         // Step 2.e: startDuration = AdjustDateDurationRecord(duration.[[Date]], 0, 0, r1).
-        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, 0, r1);
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, 0, static_cast<int64_t>(r1));
         if (!sd)
             return makeUnexpected(sd.error());
         startDuration = *sd;
         // Step 2.f: endDuration = AdjustDateDurationRecord(duration.[[Date]], 0, 0, r2).
-        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, 0, r2);
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, 0, static_cast<int64_t>(r2));
         if (!ed)
             return makeUnexpected(ed.error());
         endDuration = *ed;
@@ -549,7 +567,7 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
             return makeUnexpected(weeksStartResult.error());
         auto weeksStart = *weeksStartResult;
         // Step 3.c: weeksEnd = AddDaysToISODate(weeksStart, duration.[[Date]].[[Days]]).
-        auto weeksEnd = TemporalCore::balanceISODate(weeksStart.year(), static_cast<int32_t>(weeksStart.month()), static_cast<int64_t>(weeksStart.day()) + duration.dateDuration().days());
+        auto weeksEnd = TemporalCore::addDaysToISODate(weeksStart, duration.dateDuration().days());
         // Step 3.d: untilResult = CalendarDateUntil(calendar, weeksStart, weeksEnd, week).
         auto untilResult = TemporalCore::calendarDateUntil(calendarId, weeksStart, weeksEnd, TemporalUnit::Week);
         if (!untilResult)
@@ -560,12 +578,12 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
         r1 = (double)weeks;
         r2 = (double)weeks + increment * sign;
         // Step 3.h: startDuration = AdjustDateDurationRecord(duration.[[Date]], 0, r1).
-        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, r1, std::nullopt);
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, static_cast<int64_t>(r1), std::nullopt);
         if (!sd)
             return makeUnexpected(sd.error());
         startDuration = *sd;
         // Step 3.i: endDuration = AdjustDateDurationRecord(duration.[[Date]], 0, r2).
-        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, r2, std::nullopt);
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, static_cast<int64_t>(r2), std::nullopt);
         if (!ed)
             return makeUnexpected(ed.error());
         endDuration = *ed;
@@ -580,12 +598,12 @@ static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
         r1 = (double)days;
         r2 = (double)days + increment * sign;
         // Step 4.e: startDuration = AdjustDateDurationRecord(duration.[[Date]], r1).
-        auto sd = adjustDateDurationRecord(duration.dateDuration(), r1, std::nullopt, std::nullopt);
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), static_cast<int64_t>(r1), std::nullopt, std::nullopt);
         if (!sd)
             return makeUnexpected(sd.error());
         startDuration = *sd;
         // Step 4.f: endDuration = AdjustDateDurationRecord(duration.[[Date]], r2).
-        auto ed = adjustDateDurationRecord(duration.dateDuration(), r2, std::nullopt, std::nullopt);
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), static_cast<int64_t>(r2), std::nullopt, std::nullopt);
         if (!ed)
             return makeUnexpected(ed.error());
         endDuration = *ed;
@@ -721,7 +739,7 @@ TemporalResult<NudgeResult> nudgeToZonedTime(int32_t sign,
     // Step 3: endDate = AddDaysToISODate(start, sign).
     // Step 4: endDateTime = CombineISODateAndTimeRecord(endDate, isoDateTime.[[Time]]).
     // (Steps 2/4 fused into epochNanosecondsForDateAndTime — no intermediate records.)
-    auto endDate = TemporalCore::balanceISODate(start.year(), static_cast<int32_t>(start.month()), static_cast<int64_t>(start.day()) + sign);
+    auto endDate = TemporalCore::addDaysToISODate(start, sign);
     // Step 5: startEpochNs = GetEpochNanosecondsFor(timeZone, startDateTime, compatible). (steps 2+5 fused)
     auto startNsResult = epochNanosecondsForDateAndTime(start, isoTime, &timeZone);
     if (!startNsResult)
@@ -801,14 +819,14 @@ TemporalResult<NudgeResult> nudgeToDayOrTime(ISO8601::InternalDuration duration,
     auto nudgedEpochNs = diffTime + destEpochNs;
     // Step 11: Let days be 0.
     // Step 12: Let remainder be roundedTime.
-    auto days = 0;
+    int64_t days = 0;
     auto remainder = roundedTime;
     // Step 13: If TemporalUnitCategory(largestUnit) is ~date~, then
     if (largestUnit <= TemporalUnit::Day) {
         // Step 13.a: Set days to roundedWholeDays.
-        days = roundedWholeDays;
+        days = static_cast<int64_t>(roundedWholeDays);
         // Step 13.b: remainder = roundedTime - roundedWholeDays×hoursPerDay (days==roundedWholeDays here).
-        remainder = roundedTime + timeDurationFromComponents(-days * WTF::hoursPerDay, 0, 0, 0, 0, 0);
+        remainder = roundedTime + timeDurationFromComponents(-static_cast<double>(days) * WTF::hoursPerDay, 0, 0, 0, 0, 0);
     }
     // Step 14: Let dateDuration be ! AdjustDateDurationRecord(duration.[[Date]], days).
     auto dateDurationResult = adjustDateDurationRecord(duration.dateDuration(), days, std::nullopt, std::nullopt);

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h
@@ -114,7 +114,7 @@ constexpr int32_t unitIndexInTable(TemporalUnit);
 
 constexpr TemporalUnit unitInTable(int32_t);
 
-TemporalResult<ISO8601::Duration> JS_EXPORT_PRIVATE adjustDateDurationRecord(const ISO8601::Duration& dateDuration, double days, std::optional<double> weeks, std::optional<double> months);
+TemporalResult<ISO8601::Duration> JS_EXPORT_PRIVATE adjustDateDurationRecord(const ISO8601::Duration& dateDuration, int64_t days, std::optional<int64_t> weeks, std::optional<int64_t> months);
 
 TemporalResult<Nudged> JS_EXPORT_PRIVATE nudgeToCalendarUnit(int32_t sign,
     const ISO8601::InternalDuration&, Int128 originEpochNs, Int128 destEpochNs,

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
@@ -57,17 +57,31 @@ ISO8601::PlainYearMonth balanceISOYearMonth(int64_t year, int64_t month)
     return ISO8601::PlainYearMonth(static_cast<int32_t>(year), static_cast<unsigned>(month));
 }
 
-// BalanceISODate — temporal_rs: IsoDate::balance
-// Equivalent to AddDaysToISODate in current spec (days already folded into the day parameter by callers).
+// AddDaysToISODate — temporal_rs: IsoDate::balance (with implicit day fold-in)
 // https://tc39.es/proposal-temporal/#sec-temporal-adddaystoisodate
 // NOTE: Returns { outOfRangeYear, 1, 1 } for out-of-bounds dates instead of throwing (callers check).
-ISO8601::PlainDate balanceISODate(int32_t year, int32_t month, int64_t day)
+ISO8601::PlainDate addDaysToISODate(const ISO8601::PlainDate& date, int64_t days)
 {
+    int32_t year = date.year();
+    int32_t month = static_cast<int32_t>(date.month());
     if (year == ISO8601::outOfRangeYear) [[unlikely]]
         return ISO8601::PlainDate { ISO8601::outOfRangeYear, 1, 1 };
+
+    // PlainDate's month invariant (set by regulateISODate / balanceISOYearMonth at every
+    // construction site reachable from public Temporal entry points) is [1, 12]. We rely
+    // on it for the daysInMonth bound below and for the makeDay(month-1) slow-path math.
+    ASSERT(month >= 1 && month <= 12);
+
+    int64_t newDay = static_cast<int64_t>(date.day()) + days;
+
+    // The new day-of-month already lands in [1, daysInMonth(year, month)] - no overflow into
+    // adjacent months/years, so skip the days-from-1970 + yearMonthDayFromDays roundtrip.
+    if (newDay >= 1 && (newDay <= 31 && newDay <= ISO8601::daysInMonth(year, static_cast<uint8_t>(month)))) [[likely]]
+        return ISO8601::PlainDate { year, static_cast<unsigned>(month), static_cast<unsigned>(newDay) };
+
     // 1. Let epochDays be ISODateToEpochDays(year, month - 1, day).
     // (WTF makeDay takes 0-based month, matching ISODateToEpochDays(year, month-1, day))
-    auto epochDays = makeDay(static_cast<double>(year), static_cast<double>(month - 1), static_cast<double>(day));
+    auto epochDays = makeDay(static_cast<double>(year), static_cast<double>(month - 1), static_cast<double>(newDay));
     // 2. Let ms be EpochDaysToEpochMs(epochDays, 0).
     double ms = makeDate(epochDays, 0);
     double daysToUse = msToDays(ms);
@@ -123,8 +137,8 @@ TemporalResult<ISO8601::PlainDate> isoDateAdd(const ISO8601::PlainDate& plainDat
         return makeUnexpected(rangeError("date time is out of range of ECMAScript representation"_s));
     // 1.c. Let days be duration.[[Days]] + 7 × duration.[[Weeks]].
     // 1.d. Let result be AddDaysToISODate(intermediate, days).
-    int64_t day = static_cast<int64_t>(intermediate1->day()) + duration.days() + static_cast<int64_t>(ISO8601::daysPerWeek) * duration.weeks();
-    auto result = balanceISODate(intermediate1->year(), static_cast<int32_t>(intermediate1->month()), day);
+    int64_t days = duration.days() + static_cast<int64_t>(ISO8601::daysPerWeek) * duration.weeks();
+    auto result = addDaysToISODate(*intermediate1, days);
     // 3. If ISODateWithinLimits(result) is false, throw a RangeError exception.
     if (!ISO8601::isDateTimeWithinLimits(result.year(), result.month(), result.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]]
         return makeUnexpected(rangeError("date time is out of range of ECMAScript representation"_s));
@@ -287,7 +301,7 @@ ISO8601::InternalDuration diffISODateTime(const ISO8601::PlainDate& d1, const IS
     // 7. If timeSign = dateSign, then
     if (dateSign && timeSign && dateSign == timeSign) {
         // a. Set adjustedDate to AddDaysToISODate(adjustedDate, timeSign).
-        adjustedD2 = balanceISODate(adjustedD2.year(), static_cast<int32_t>(adjustedD2.month()), static_cast<int64_t>(adjustedD2.day()) + timeSign);
+        adjustedD2 = addDaysToISODate(adjustedD2, timeSign);
         // b. Set timeDuration to ! Add24HourDaysToTimeDuration(timeDuration, -timeSign).
         timeDiff -= Int128(timeSign) * ISO8601::ExactTime::nsPerDay;
     }

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.h
@@ -39,7 +39,7 @@ namespace TemporalCore {
 
 ISO8601::PlainYearMonth JS_EXPORT_PRIVATE balanceISOYearMonth(int64_t year, int64_t month);
 
-ISO8601::PlainDate JS_EXPORT_PRIVATE balanceISODate(int32_t year, int32_t month, int64_t day);
+ISO8601::PlainDate JS_EXPORT_PRIVATE addDaysToISODate(const ISO8601::PlainDate&, int64_t days);
 
 TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow);
 

--- a/Source/JavaScriptCore/runtime/temporal/core/PlainDateTimeCore.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/PlainDateTimeCore.cpp
@@ -79,8 +79,7 @@ TemporalResult<ISO8601::InternalDuration> differencePlainDateTimeWithRounding(
         int32_t dateSign = isoDateCompare(thisDate, otherDate);
         ISO8601::PlainDate adjustedD2 = otherDate;
         if (dateSign && timeSign && dateSign == timeSign) {
-            adjustedD2 = balanceISODate(adjustedD2.year(), static_cast<int32_t>(adjustedD2.month()),
-                static_cast<int64_t>(adjustedD2.day()) + dateSign);
+            adjustedD2 = addDaysToISODate(adjustedD2, dateSign);
             timeDiff -= Int128(dateSign) * ISO8601::ExactTime::nsPerDay;
         }
         TemporalUnit dateLargestUnit = (largestUnit > TemporalUnit::Day) ? TemporalUnit::Day : largestUnit;

--- a/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
@@ -207,8 +207,7 @@ static TemporalResult<ISO8601::InternalDuration> differenceZonedDateTime(ISO8601
     bool success = false;
     while (dayCorrection <= maxDayCorrection && !success) {
         // Step 11.a: intermediateDate = AddDaysToISODate(endDate, dayCorrection × sign).
-        intermediateDate = balanceISODate(endDate.year(), static_cast<int32_t>(endDate.month()),
-            static_cast<int64_t>(endDate.day()) + dayCorrection * sign);
+        intermediateDate = addDaysToISODate(endDate, static_cast<int64_t>(dayCorrection) * sign);
         // Step 11.b: intermediateDateTime = CombineISODateAndTimeRecord(intermediateDate, startTime).
         // Step 11.c: intermediateNs = GetEpochNanosecondsFor(timeZone, intermediateDateTime, compatible). (11.b+11.c fused)
         auto intermediateNsResult = getEpochNanosecondsFor(timeZone, intermediateDate, startTime, TemporalDisambiguation::Compatible);


### PR DESCRIPTION
#### 33ca7b8504a9c34d6fb9b1a8890330f1751de654
<pre>
[JSC] Optimize some of Temporal date operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=317091">https://bugs.webkit.org/show_bug.cgi?id=317091</a>
<a href="https://rdar.apple.com/179644689">rdar://179644689</a>

Reviewed by Sosuke Suzuki.

This patch adds several optimizations and cleanup of date related operations.

1. Change balanceISODate -&gt; addDaysToISODate to align to the spec. Also
   this makes code clean by getting PlainDate directly.
2. Add fast path to addDaysToISODate, which does not cross the month
   with the added days.
3. Add fast path to adjustDateDurationRecord which can quickly check the
   only given fields.
4. Add fast path to isDateTimeWithinLimits for known valid range of years.

Test: Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp

* Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp:
(JSC::TemporalCore::testAddDaysToISODate):
(JSC::TemporalCore::testAdjustDateDurationRecord):
(JSC::TemporalCore::testISODateLimits):
(JSC::TemporalCore::runTemporalRSTests):
(JSC::TemporalCore::testBalanceISODate): Deleted.
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::isDateTimeWithinLimits):
* Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp:
(JSC::TemporalCore::adjustDateDurationRecord):
(JSC::TemporalCore::computeNudgeWindow):
(JSC::TemporalCore::nudgeToZonedTime):
(JSC::TemporalCore::nudgeToDayOrTime):
* Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h:
* Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp:
(JSC::TemporalCore::addDaysToISODate):
(JSC::TemporalCore::isoDateAdd):
(JSC::TemporalCore::diffISODateTime):
(JSC::TemporalCore::balanceISODate): Deleted.
* Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.h:
* Source/JavaScriptCore/runtime/temporal/core/PlainDateTimeCore.cpp:
(JSC::TemporalCore::differencePlainDateTimeWithRounding):
* Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp:
(JSC::TemporalCore::differenceZonedDateTime):

Canonical link: <a href="https://commits.webkit.org/315205@main">https://commits.webkit.org/315205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31bf56a66cccc850904864a9f41cbf044f6619b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126033 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16b4f70c-1419-41aa-b997-a949e661cbe7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131005 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92102 "1 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/268bbd30-0ffd-405b-9469-03eb8f230f24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111517 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9be51b07-3b19-4e39-978f-ff6c0b535885) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32459 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31161 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26356 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/160951 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142445 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180260 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29579 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32984 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139442 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41901 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35321 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139305 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42589 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106118 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34596 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27656 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201010 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114349 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53995 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40490 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5741 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->