### PR TITLE
Cherry-pick 311277@main (5205050c09a9). https://bugs.webkit.org/show_bug.cgi?id=312253

### DIFF
--- a/LayoutTests/accessibility/aria-owns-crash-after-subtree-update-expected.txt
+++ b/LayoutTests/accessibility/aria-owns-crash-after-subtree-update-expected.txt
@@ -1,0 +1,20 @@
+This tests that mixed DOM + aria-owns cycles do not cause stack-overflow recursion in updateOwnedChildrenIfNecessary().
+
+PASS: typeof t1a.childrenCount === 'number'
+PASS: typeof t2a.childrenCount === 'number'
+PASS: typeof t3self.childrenCount === 'number'
+PASS: typeof t4a.childrenCount === 'number'
+PASS: did not stack overflow.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+a
+b
+c
+child of t2-a
+b
+self
+a-mutated
+b
+c

--- a/LayoutTests/accessibility/aria-owns-crash-after-subtree-update.html
+++ b/LayoutTests/accessibility/aria-owns-crash-after-subtree-update.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<!-- Test 1: Three-element aria-owns cycle. -->
+<div role="group" id="t1-a" aria-owns="t1-b">a</div>
+<div role="group" id="t1-b" aria-owns="t1-c">b</div>
+<div role="group" id="t1-c" aria-owns="t1-a">c</div>
+
+<!-- Test 2: Mixed DOM + aria-owns: A's DOM child has aria-owns back to A. -->
+<div role="group" id="t2-a" aria-owns="t2-b">
+    <div role="group" id="t2-a-child" aria-owns="t2-a">child of t2-a</div>
+</div>
+<div role="group" id="t2-b" aria-owns="t2-a-child">b</div>
+
+<!-- Test 3: Self-owning element. -->
+<div role="group" id="t3-self" aria-owns="t3-self">self</div>
+
+<!-- Test 4: Live-region update scenario, matching a crash seen in the wild
+     (originating from _performLiveRegionUpdate). Mutate content after the
+     AX tree is built to set m_subtreeDirty across the ancestry, then re-query children. -->
+<div role="region" aria-live="polite" id="t4-region">
+    <div role="group" id="t4-a" aria-owns="t4-b">a</div>
+    <div role="group" id="t4-b" aria-owns="t4-c">b</div>
+    <div role="group" id="t4-c" aria-owns="t4-a">c</div>
+</div>
+
+<script>
+var output = "This tests that mixed DOM + aria-owns cycles do not cause stack-overflow recursion in updateOwnedChildrenIfNecessary().\n\n";
+
+if (window.accessibilityController) {
+    // Test 1: Three-element aria-owns cycle. Querying children must terminate.
+    var t1a = accessibilityController.accessibleElementById("t1-a");
+    output += expect("typeof t1a.childrenCount", "'number'");
+
+    // Test 2: Mixed DOM + aria-owns. Querying t2-a's children traverses both
+    // its DOM child and its aria-owns target.
+    var t2a = accessibilityController.accessibleElementById("t2-a");
+    output += expect("typeof t2a.childrenCount", "'number'");
+
+    // Test 3: Self-owning aria-owns.
+    var t3self = accessibilityController.accessibleElementById("t3-self");
+    output += expect("typeof t3self.childrenCount", "'number'");
+
+    // Test 4: Trigger live-region update by mutating content. This sets
+    // m_subtreeDirty across the ancestry.
+    document.getElementById("t4-a").textContent = "a-mutated";
+    var t4a = accessibilityController.accessibleElementById("t4-a");
+    output += expect("typeof t4a.childrenCount", "'number'");
+
+    output += "PASS: did not stack overflow.\n";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash.html
+++ b/LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// Regression test for rdar://178478856: tearing down a cross-site iframe
+// while its WebProcess is still launching left a WebPage::Close async-reply
+// handler in AuxiliaryProcessProxy::m_pendingMessages. ~AuxiliaryProcessProxy
+// then cancelled it after ~WebProcessProxy had already destroyed
+// m_pagesPendingClose, and the lambda's still-live WeakPtr read freed memory.
+
+let count = 0;
+function churn() {
+    let f = document.createElement("iframe");
+    f.src = "http://localhost:8000/site-isolation/resources/frame-with-text.html";
+    document.body.appendChild(f);
+    // Remove on a microtask so the provisional frame's process is still
+    // launching when WebPageProxy::didDestroyFrame tears it down.
+    Promise.resolve().then(() => f.remove());
+
+    if (++count < 5)
+        setTimeout(churn, 0);
+    else
+        setTimeout(() => {
+            document.body.textContent = "PASS if no crash";
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 100);
+}
+onload = churn;
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS new Request(clone) preserves a ReadableStream body that came from clone()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.js
@@ -1,0 +1,22 @@
+// META: global=window,worker
+
+promise_test(async () => {
+    const stream = new ReadableStream({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode("hello"));
+            controller.close();
+        }
+    });
+
+    const r1 = new Request("https://example.com/", { method: "POST", body: stream, duplex: "half" });
+    const r2 = r1.clone();
+    assert_false(r2.bodyUsed, "clone should not be marked as used");
+    assert_not_equals(r2.body, null, "clone should have a body");
+
+    // Constructing a new Request from the clone should preserve the body.
+    const r3 = new Request(r2);
+    assert_not_equals(r3.body, null, "Request constructed from clone should have a body");
+
+    const text = await r3.text();
+    assert_equals(text, "hello", "body content should be preserved through clone() and new Request()");
+}, "new Request(clone) preserves a ReadableStream body that came from clone()");

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS new Request(clone) preserves a ReadableStream body that came from clone()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -359,7 +359,9 @@ FetchBody FetchBody::clone(JSDOMGlobalObject& globalObject)
         ASSERT(!clones.hasException());
         if (!clones.hasException()) {
             auto pair = clones.releaseReturnValue();
+            m_data = pair[0];
             m_readableStream = WTF::move(pair[0]);
+            clone.m_data = pair[1];
             clone.m_readableStream = WTF::move(pair[1]);
         }
     }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -2287,6 +2287,9 @@ void GStreamerMediaEndpoint::trackWasReplaced(const String& previousId, const St
         GRefPtr<GstCaps> caps;
         g_object_get(transceiver.get(), "codec-preferences", &caps.outPtr(), nullptr);
 
+        if (!caps)
+            return false;
+
         auto newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
         gst_caps_map_in_place(newCaps.get(), [](auto*, auto* structure, gpointer userData) -> gboolean {
             auto msid = gstStructureGetString(structure, "a-msid"_s);

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
@@ -88,6 +88,9 @@ void AudioNodeInput::disconnect(AudioNodeOutput* output)
     }
     
     // Otherwise, try to disconnect from disabled connections.
+    // Heap allocations are forbidden on the audio thread for performance reasons so we need to
+    // explicitly allow the following allocation(s).
+    DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
     if (m_disabledOutputs.remove(output)) {
         output->removeInput(this); // Note: it's important to return immediately after this since the node may be deleted.
         return;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5672,7 +5672,7 @@ bool AXObjectCache::addRelation(Element& origin, Element& target, AXRelation rel
     AXLOG(makeString("origin: "_s, origin.debugDescription(), " target: "_s, target.debugDescription(), " relation "_s, static_cast<uint8_t>(relation)));
 
     if (!validRelation(origin, target, relation)) {
-        AX_ASSERT_NOT_REACHED();
+        // Skip invalid relations (which can be created with legitimate markup, e.g. self-referential aria-owns.
         return false;
     }
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -765,11 +765,20 @@ void AccessibilityNodeObject::clearChildren()
 
 void AccessibilityNodeObject::updateOwnedChildrenIfNecessary()
 {
-    bool didRemoveChild = false;
     auto ownedObjects = this->ownedObjects();
     if (ownedObjects.isEmpty())
         return;
 
+    // Tracks the objects whose owned children are currently being resolved, so a re-entrant
+    // call for an object already on the stack can bail instead of recursing forever.
+    static NeverDestroyed<HashSet<const AccessibilityNodeObject*>> objectsCurrentlyResolvingOwnedChildren;
+    if (!objectsCurrentlyResolvingOwnedChildren->add(this).isNewEntry)
+        return;
+    auto removeOnExit = makeScopeExit([&] {
+        objectsCurrentlyResolvingOwnedChildren->remove(this);
+    });
+
+    bool didRemoveChild = false;
     for (const auto& child : ownedObjects) {
         if (m_children.removeFirst(child)) {
             // If the child already exists as a DOM child, but is also in the owned objects, then

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -87,6 +87,31 @@ void MessagePort::notifyMessageAvailable(const MessagePortIdentifier& identifier
     });
 }
 
+void MessagePort::notifyAllConnectionsClosed()
+{
+    ASSERT(isMainThread());
+    Vector<std::pair<ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<MessagePort>>> entries;
+    {
+        Locker locker { allMessagePortsLock };
+        entries.reserveInitialCapacity(allMessagePorts().size());
+        for (auto& [identifier, weakPort] : allMessagePorts()) {
+            if (auto contextIdentifier = portToContextIdentifier().getOptional(identifier))
+                entries.append({ *contextIdentifier, weakPort });
+        }
+    }
+
+    for (auto& [contextIdentifier, weakPort] : entries) {
+        ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakPort = WTF::move(weakPort)](auto&) {
+            RefPtr port = weakPort.get();
+            if (!port || port->m_isDetached)
+                return;
+            port->m_isDetached = true;
+            port->m_entangled = false;
+            port->removeAllEventListeners();
+        });
+    }
+}
+
 Ref<MessagePort> MessagePort::create(ScriptExecutionContext& scriptExecutionContext, const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
     Ref messagePort = adoptRef(*new MessagePort(scriptExecutionContext, local, remote));

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -73,6 +73,7 @@ public:
 
     WEBCORE_EXPORT static bool isMessagePortAliveForTesting(const MessagePortIdentifier&);
     WEBCORE_EXPORT static void notifyMessageAvailable(const MessagePortIdentifier&);
+    WEBCORE_EXPORT static void notifyAllConnectionsClosed();
 
     WEBCORE_EXPORT void messageAvailable();
     bool started() const { return m_started; }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3205,9 +3205,15 @@ void HTMLMediaElement::dispatchPlayPauseEventsIfNeedsQuirks()
     if (!protectedDocument()->quirks().needsAutoplayPlayPauseEvents())
         return;
 
+    if (m_isDispatchingAutoplayPlayPauseQuirkEvents)
+        return;
+
     ALWAYS_LOG(LOGIDENTIFIER);
-    scheduleEvent(eventNames().playingEvent);
-    scheduleEvent(eventNames().pauseEvent);
+    queueCancellableTaskKeepingObjectAlive(*this, TaskSource::MediaElement, m_asyncEventsCancellationGroup, [](auto& element) {
+        SetForScope dispatching(element.m_isDispatchingAutoplayPlayPauseQuirkEvents, true);
+        element.dispatchEvent(Event::create(eventNames().playingEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
+        element.dispatchEvent(Event::create(eventNames().pauseEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
+    });
 }
 
 void HTMLMediaElement::durationChanged()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1352,6 +1352,7 @@ private:
     ControlsState m_controlsState { ControlsState::None };
 
     AutoplayEventPlaybackState m_autoplayEventPlaybackState { AutoplayEventPlaybackState::None };
+    bool m_isDispatchingAutoplayPlayPauseQuirkEvents { false };
 
     String m_subtitleTrackLanguage;
     std::optional<String> m_languageOfPrimaryAudioTrack;

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -166,7 +166,7 @@ uint64_t Region::totalArea() const
     uint64_t totalArea = 0;
 
     for (auto& rect : rects())
-        totalArea += (rect.width() * rect.height());
+        totalArea += static_cast<uint64_t>(rect.width()) * rect.height();
 
     return totalArea;
 }

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -397,8 +397,12 @@ void WorkerMessagingProxy::workerThreadCreated(DedicatedWorkerThread& workerThre
 void WorkerMessagingProxy::workerObjectDestroyed()
 {
     m_workerObject = nullptr;
-    if (!m_scriptExecutionContextIdentifier)
+    if (!m_scriptExecutionContextIdentifier) {
+        m_mayBeDestroyed = true;
+        m_queuedEarlyTasks.clear();
+        deref();
         return;
+    }
 
     ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this, protectedThis = Ref { *this }](auto&) {
         m_mayBeDestroyed = true;
@@ -456,6 +460,8 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal()
     m_askedToTerminate = true;
 
     m_inspectorProxy->workerTerminated();
+
+    m_queuedEarlyTasks.clear();
 
     if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(m_scriptExecutionContext); workerGlobalScope && m_workerThread)
         workerGlobalScope->thread()->removeChildThread(Ref { *m_workerThread });

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -782,6 +782,9 @@ NetworkStorageSession* NetworkConnectionToWebProcess::storageSession()
 
 void NetworkConnectionToWebProcess::startDownload(DownloadID downloadID, const ResourceRequest& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain, const String& suggestedName, FromDownloadAttribute fromDownloadAttribute, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID)
 {
+    if (!request.firstPartyForCookies().isEmpty())
+        MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow);
+
     m_networkProcess->checkedDownloadManager()->startDownload(m_sessionID, downloadID, request, topOrigin, isNavigatingToAppBoundDomain, suggestedName, fromDownloadAttribute, frameID, pageID, webProcessIdentifier());
 }
 
@@ -793,6 +796,9 @@ void NetworkConnectionToWebProcess::loadCancelledDownloadRedirectRequestInFrame(
 void NetworkConnectionToWebProcess::convertMainResourceLoadToDownload(std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoadIdentifier, DownloadID downloadID, const ResourceRequest& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, const ResourceResponse& response, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain)
 {
     RELEASE_ASSERT(RunLoop::isMain());
+
+    if (!request.firstPartyForCookies().isEmpty())
+        MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow);
 
     if (!mainResourceLoadIdentifier) {
         m_networkProcess->checkedDownloadManager()->startDownload(m_sessionID, downloadID, request, topOrigin, isNavigatingToAppBoundDomain);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -74,6 +74,7 @@ using namespace WebCore;
 #define SWSERVERCONNECTION_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(ServiceWorker, "%p - WebSWServerConnection::" fmt, this, ##__VA_ARGS__)
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_contentConnection.get())
+#define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, value) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, m_contentConnection.get(), value)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSWServerConnection);
 
@@ -409,7 +410,8 @@ void WebSWServerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier d
 
 void WebSWServerConnection::scheduleJobInServer(ServiceWorkerJobData&& jobData)
 {
-    checkTopOrigin(jobData.topOrigin);
+    if (!checkTopOrigin(jobData.topOrigin))
+        return;
 
     ASSERT(!jobData.scopeURL.isNull());
     if (jobData.scopeURL.isNull()) {
@@ -483,7 +485,8 @@ void WebSWServerConnection::postMessageToServiceWorkerClient(ScriptExecutionCont
 
 void WebSWServerConnection::matchRegistration(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&& callback)
 {
-    checkTopOrigin(topOrigin);
+    if (!checkTopOrigin(topOrigin))
+        return;
 
     if (RefPtr registration = doRegistrationMatching(topOrigin, clientURL)) {
         callback(registration->data());
@@ -494,14 +497,16 @@ void WebSWServerConnection::matchRegistration(const SecurityOriginData& topOrigi
 
 void WebSWServerConnection::whenRegistrationReady(const WebCore::SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<WebCore::ServiceWorkerRegistrationData>&&)>&& callback)
 {
-    checkTopOrigin(topOrigin);
+    if (!checkTopOrigin(topOrigin))
+        return;
 
     SWServer::Connection::whenRegistrationReady(topOrigin, clientURL, WTF::move(callback));
 }
 
 void WebSWServerConnection::getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(const Vector<ServiceWorkerRegistrationData>&)>&& callback)
 {
-    checkTopOrigin(topOrigin);
+    if (!checkTopOrigin(topOrigin))
+        return;
 
     if (RefPtr server = this->server())
         callback(server->getRegistrations(topOrigin, clientURL));
@@ -512,7 +517,8 @@ void WebSWServerConnection::getRegistrations(const SecurityOriginData& topOrigin
 void WebSWServerConnection::registerServiceWorkerClient(WebCore::ClientOrigin&& clientOrigin, ServiceWorkerClientData&& data, const std::optional<ServiceWorkerRegistrationIdentifier>& controllingServiceWorkerRegistrationIdentifier, String&& userAgent)
 {
     MESSAGE_CHECK(data.identifier.processIdentifier() == identifier());
-    checkTopOrigin(clientOrigin.topOrigin);
+    if (!checkTopOrigin(clientOrigin.topOrigin))
+        return;
 
     registerServiceWorkerClientInternal(WTF::move(clientOrigin), WTF::move(data), controllingServiceWorkerRegistrationIdentifier, WTF::move(userAgent), SWServer::IsBeingCreatedClient::No);
 }
@@ -1015,15 +1021,16 @@ void WebSWServerConnection::reportNetworkUsageToWorkerClient(WebCore::ScriptExec
 }
 #endif
 
-void WebSWServerConnection::checkTopOrigin(const WebCore::SecurityOriginData& origin)
+bool WebSWServerConnection::checkTopOrigin(const WebCore::SecurityOriginData& origin)
 {
-    MESSAGE_CHECK(!origin.isNull());
+    MESSAGE_CHECK_WITH_RETURN_VALUE(!origin.isNull(), false);
     RefPtr networkConnectionToWebProcess = m_networkConnectionToWebProcess.get();
     if (!networkConnectionToWebProcess)
-        return;
+        return false;
 
     Ref networkProcess = networkConnectionToWebProcess->networkProcess();
-    MESSAGE_CHECK(networkProcess->allowsFirstPartyForCookies(networkConnectionToWebProcess->webProcessIdentifier(), WebCore::RegistrableDomain::uncheckedCreateFromHost(origin.host())) != NetworkProcess::AllowCookieAccess::Terminate);
+    MESSAGE_CHECK_WITH_RETURN_VALUE(networkProcess->allowsFirstPartyForCookies(networkConnectionToWebProcess->webProcessIdentifier(), WebCore::RegistrableDomain::uncheckedCreateFromHost(origin.host())) != NetworkProcess::AllowCookieAccess::Terminate, false);
+    return true;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -177,7 +177,7 @@ private:
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
 #endif
 
-    void checkTopOrigin(const WebCore::SecurityOriginData&);
+    bool checkTopOrigin(const WebCore::SecurityOriginData&);
 
     URL clientURLFromIdentifier(WebCore::ServiceWorkerOrClientIdentifier);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -362,6 +362,11 @@ WebProcessProxy::~WebProcessProxy()
     ASSERT(m_pageURLRetainCountMap.isEmpty());
     WEBPROCESSPROXY_RELEASE_LOG(Process, "destructor:");
 
+    // ~AuxiliaryProcessProxy() replies to pending messages after our members are gone; a reply
+    // handler that upgrades its still-live WeakPtr<WebProcessProxy> would then touch freed members
+    // (e.g. m_pagesPendingClose). Cancel them now, while our state is intact.
+    replyToPendingMessages();
+
     liveProcessesLRU().remove(*this);
 
     for (auto identifier : m_speechRecognitionServerMap.keys())

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -346,6 +346,7 @@ NetworkProcessProxy& WebsiteDataStore::networkProcess()
         Ref networkProcess = networkProcessForSession(m_sessionID);
         m_networkProcess = networkProcess.copyRef();
         networkProcess->addSession(*this, NetworkProcessProxy::SendParametersToNetworkProcess::Yes);
+        propagateSettingUpdates();
     }
 
     return *m_networkProcess;
@@ -2860,12 +2861,16 @@ void WebsiteDataStore::addPage(WebPageProxy& page)
 {
     m_pages.add(page);
 
+    propagateSettingUpdates();
+
     updateServiceWorkerInspectability();
 }
 
 void WebsiteDataStore::removePage(WebPageProxy& page)
 {
     m_pages.remove(page);
+
+    propagateSettingUpdates();
 
     updateServiceWorkerInspectability();
 }

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -129,7 +129,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
     if (WebProcess::singleton().isLockdownModeEnabled())
         WebPage::adjustSettingsForLockdownMode(page->settings(), m_preferencesStore ? &m_preferencesStore.value() : nullptr);
 
-    if (!initializationData.userAgent.isEmpty())
+    if (initializationData.userAgent.isEmpty())
         initializationData.userAgent = m_userAgent;
 
     if (!initializationData.clientIdentifier)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -71,18 +71,23 @@ void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePor
         m_inProcessPortMessages.add(port2, Vector<MessageWithMessagePorts> { });
     }
 
+    m_portsKnownToNetworkProcess.add(port1);
+    m_portsKnownToNetworkProcess.add(port2);
+
     protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::CreateNewMessagePortChannel { port1, port2 }, 0);
 }
 
 void WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
     m_inProcessPortMessages.add(local, Vector<MessageWithMessagePorts> { });
+    m_portsKnownToNetworkProcess.add(local);
 
     protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::EntangleLocalPortInThisProcessToRemote { local, remote }, 0);
 }
 
 void WebMessagePortChannelProvider::messagePortDisentangled(const MessagePortIdentifier& port)
 {
+    m_portsKnownToNetworkProcess.remove(port);
     protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::MessagePortDisentangled { port }, 0);
 }
 
@@ -93,14 +98,30 @@ void WebMessagePortChannelProvider::messagePortSentToRemote(const WebCore::Messa
         postMessageToRemote(WTF::move(message), port);
 }
 
+void WebMessagePortChannelProvider::networkProcessConnectionClosed()
+{
+    ASSERT(isMainRunLoop());
+
+    m_inProcessPortMessages.clear();
+    m_portsKnownToNetworkProcess.clear();
+    MessagePort::notifyAllConnectionsClosed();
+}
+
 void WebMessagePortChannelProvider::messagePortClosed(const MessagePortIdentifier& port)
 {
     m_inProcessPortMessages.remove(port);
+    m_portsKnownToNetworkProcess.remove(port);
     protectedNetworkProcessConnection()->send(Messages::NetworkConnectionToWebProcess::MessagePortClosed { port }, 0);
 }
 
 void WebMessagePortChannelProvider::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& completionHandler)
 {
+    // This attempt to takeAllMessagesForPort might asynchronously have come from a worker thread while
+    // all ports were being detached due to disconnection from the networking process.
+    // Gracefully fail in this case.
+    if (!m_portsKnownToNetworkProcess.contains(port))
+        return completionHandler({ }, [] { });
+
     protectedNetworkProcessConnection()->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::TakeAllMessagesForPort { port }, [completionHandler = WTF::move(completionHandler), port](Vector<WebCore::MessageWithMessagePorts>&& messages, std::optional<MessageBatchIdentifier> messageBatchIdentifier) mutable {
         if (!messageBatchIdentifier)
             return completionHandler({ }, [] { }); // IPC failure.

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -28,6 +28,7 @@
 #include <WebCore/MessagePortChannelProvider.h>
 #include <WebCore/MessagePortIdentifier.h>
 #include <WebCore/MessageWithMessagePorts.h>
+#include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
@@ -38,6 +39,7 @@ public:
     static WebMessagePortChannelProvider& singleton();
 
     void messagePortSentToRemote(const WebCore::MessagePortIdentifier&);
+    void networkProcessConnectionClosed();
 
     // Don't do anything in ref() / deref() since this class is a singleton.
     void ref() const { }
@@ -55,6 +57,7 @@ private:
     void postMessageToRemote(WebCore::MessageWithMessagePorts&&, const WebCore::MessagePortIdentifier& remoteTarget) final;
 
     HashMap<WebCore::MessagePortIdentifier, Vector<WebCore::MessageWithMessagePorts>> m_inProcessPortMessages;
+    HashSet<WebCore::MessagePortIdentifier> m_portsKnownToNetworkProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -230,7 +230,7 @@ bool WebCookieJar::cookiesEnabled(Document& document)
         return false;
 
     auto blockCookies = shouldBlockCookies(webFrame.get(), document.firstPartyForCookies(), document.cookieURL());
-    if (shouldBlockCookies(webFrame.get(), document.firstPartyForCookies(), document.cookieURL()) == BlockCookies::Yes)
+    if (blockCookies == BlockCookies::Yes)
         return false;
 
     if (blockCookies != BlockCookies::WillDecideInNetworkProcess)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1478,6 +1478,7 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     m_webLoaderStrategy->networkProcessCrashed();
     m_webSocketChannelManager.networkProcessCrashed();
     m_broadcastChannelRegistry->networkProcessCrashed();
+    WebMessagePortChannelProvider::singleton().networkProcessConnectionClosed();
 
 #if USE(LIBWEBRTC)
     if (m_libWebRTCNetwork)

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c
@@ -37,6 +37,7 @@
 #include "pas_free_granules.h"
 #include "pas_heap_lock.h"
 #include "pas_page_sharing_pool.h"
+#include "pas_race_test_hooks.h"
 #include "pas_segregated_heap.h"
 #include "pas_stream.h"
 
@@ -383,7 +384,7 @@ pas_page_sharing_pool_take_result pas_bitfit_directory_take_last_empty(
     const pas_bitfit_page_config* page_config;
     size_t num_granules;
 
-    last_empty_plus_one_value = pas_versioned_field_read(&directory->last_empty_plus_one);
+    last_empty_plus_one_value = pas_versioned_field_read_to_watch(&directory->last_empty_plus_one);
 
     page_config = pas_bitfit_page_config_kind_get_config(directory->config_kind);
     num_granules = page_config->base.page_size / page_config->base.granule_size;
@@ -539,10 +540,12 @@ pas_page_sharing_pool_take_result pas_bitfit_directory_take_last_empty(
         return pas_page_sharing_pool_take_success;
     }
 
+    pas_race_test_hook(pas_race_test_hook_bitfit_directory_take_last_empty_after_loop);
+
     pas_versioned_field_try_write(&directory->last_empty_plus_one,
                                   last_empty_plus_one_value,
                                   0);
-    
+
     return pas_page_sharing_pool_take_none_available;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
@@ -32,7 +32,8 @@ PAS_BEGIN_EXTERN_C;
 
 enum pas_race_test_hook_kind {
     pas_race_test_hook_local_allocator_stop_before_did_stop_allocating,
-    pas_race_test_hook_local_allocator_stop_before_unlock
+    pas_race_test_hook_local_allocator_stop_before_unlock,
+    pas_race_test_hook_bitfit_directory_take_last_empty_after_loop
 };
 
 typedef enum pas_race_test_hook_kind pas_race_test_hook_kind;
@@ -44,6 +45,8 @@ static inline const char* pas_race_test_hook_kind_get_string(pas_race_test_hook_
         return "local_allocator_stop_before_did_stop_allocating";
     case pas_race_test_hook_local_allocator_stop_before_unlock:
         return "local_allocator_stop_before_unlock";
+    case pas_race_test_hook_bitfit_directory_take_last_empty_after_loop:
+        return "bitfit_directory_take_last_empty_after_loop";
     }
     PAS_ASSERT_NOT_REACHED();
     return NULL;

--- a/Source/bmalloc/libpas/src/test/BitfitTests.cpp
+++ b/Source/bmalloc/libpas/src/test/BitfitTests.cpp
@@ -29,9 +29,15 @@
 
 #include "iso_heap.h"
 #include "iso_heap_innards.h"
+#include "pas_bitfit_directory.h"
 #include "pas_bitfit_heap.h"
 #include "pas_bitfit_size_class.h"
+#include "pas_deferred_decommit_log.h"
 #include "pas_heap.h"
+#include "pas_race_test_hooks.h"
+#include "pas_scavenger.h"
+#include "pas_versioned_field.h"
+#include <functional>
 #include <vector>
 
 using namespace std;
@@ -154,6 +160,75 @@ void testAllocateAlignedSmallerThanSizeClassAndSmallerThanLargestAvailable(
     assertSizeClasses(fillerObjectSize, firstSize);
 }
 
+#if PAS_ENABLE_TESTING
+function<void(pas_race_test_hook_kind)> hookCallback;
+
+void hookCallbackAdapter(pas_race_test_hook_kind kind)
+{
+    hookCallback(kind);
+}
+
+class InstallBitfitRaceHook : public TestScope {
+public:
+    InstallBitfitRaceHook()
+        : TestScope(
+            "install-bitfit-race-hook",
+            [] () {
+                pas_race_test_hook_callback_instance = hookCallbackAdapter;
+            })
+    {
+    }
+};
+
+void testTakeLastEmptyLastEmptyPlusOneWatchRace()
+{
+    pas_scavenger_suspend();
+
+    void* obj = iso_allocate_common_primitive(1056, pas_non_compact_allocation_mode);
+    CHECK(obj);
+
+    pas_bitfit_heap* bitfitHeap = pas_compact_atomic_bitfit_heap_ptr_load_non_null(
+        &iso_common_primitive_heap.segregated_heap.bitfit_heap);
+    pas_bitfit_directory* directory = nullptr;
+    pas_bitfit_page_config_variant variant;
+    for (PAS_EACH_BITFIT_PAGE_CONFIG_VARIANT_ASCENDING(variant)) {
+        pas_bitfit_directory* candidate = pas_bitfit_heap_get_directory(bitfitHeap, variant);
+        if (pas_bitfit_directory_size(candidate)) {
+            directory = candidate;
+            break;
+        }
+    }
+    CHECK(directory);
+    CHECK_GREATER_EQUAL(pas_bitfit_directory_size(directory), 1u);
+
+    pas_bitfit_directory_set_empty_bit_at_index(directory, 0, false);
+    directory->last_empty_plus_one = pas_versioned_field_create(1, 0);
+
+    hookCallback =
+        [directory] (pas_race_test_hook_kind kind) {
+            if (kind != pas_race_test_hook_bitfit_directory_take_last_empty_after_loop)
+                return;
+            pas_bitfit_directory_view_did_become_empty_at_index(directory, 0);
+        };
+
+    pas_deferred_decommit_log log;
+    pas_deferred_decommit_log_construct(&log, nullptr, 0, nullptr);
+    pas_page_sharing_pool_take_result result =
+        pas_bitfit_directory_take_last_empty(directory, &log, pas_lock_is_not_held);
+    pas_deferred_decommit_log_destruct(&log, pas_lock_is_not_held);
+
+    hookCallback = nullptr;
+
+    CHECK_EQUAL(result, pas_page_sharing_pool_take_none_available);
+
+    // The hook re-reported view[0] as empty after the scan but before the final try_write.
+    // If take_last_empty's read of last_empty_plus_one isn't watched, the hook's maximize()
+    // is a no-op, the try_write succeeds, and the directory ends with last_empty_plus_one == 0
+    // while empty_bits[0] is set: a permanently stranded page.
+    CHECK_EQUAL(directory->last_empty_plus_one.value, static_cast<uintptr_t>(1));
+}
+#endif // PAS_ENABLE_TESTING
+
 } // anonymous namespace
 
 #endif // PAS_ENABLE_ISO
@@ -162,8 +237,12 @@ void addBitfitTests()
 {
 #if PAS_ENABLE_ISO
     ForceBitfit forceBitfit;
-    
+
     ADD_TEST(testAllocateAlignedSmallerThanSizeClassAndSmallerThanLargestAvailable(
                  1056, 100, 0, 16, 1024, 100));
+#if PAS_ENABLE_TESTING
+    InstallBitfitRaceHook installBitfitRaceHook;
+    ADD_TEST(testTakeLastEmptyLastEmptyPlusOneWatchRace());
+#endif
 #endif // PAS_ENABLE_ISO
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp
@@ -267,4 +267,13 @@ TEST(RegionTests, IsValidShape2)
     ASSERT_TRUE(Shape::isValidShape(segments.span(), spans.span())) << r.dataForTesting();
 }
 
+TEST(RegionTests, TotalAreaDoesNotOverflowSignedInt)
+{
+    // 50000 * 50000 == 2,500,000,000, which exceeds INT_MAX (2,147,483,647).
+    // Region::totalArea computes width() * height() in int before promoting
+    // to uint64_t, so the multiplication wraps.
+    Region region(IntRect { 0, 0, 50000, 50000 });
+    EXPECT_EQ(region.totalArea(), 2'500'000'000ULL);
+}
+
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CustomUserAgent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CustomUserAgent.mm
@@ -275,4 +275,61 @@ TEST(CustomUserAgent, WebpagePreferencesCustomUserAgentAsSiteSpecificQuirksAppli
     EXPECT_WK_STREQ("User-Agent: QuirkUA", receivedUserAgentOnTarget.utf8().data());
 }
 
+// SharedWorker is hosted in a separate WebProcess. The page-side custom UA must
+// propagate through the network process and into that host process so the
+// worker observes it via navigator.userAgent. Regression test for
+// WebSharedWorkerContextManagerConnection's inverted user-agent fallback.
+//
+// Use WKWebpagePreferences._customUserAgent rather than WKWebView.customUserAgent
+// because the page-level customUserAgent is also pushed to remote-worker host
+// processes via WebProcessPool::updateRemoteWorkerUserAgent, which keeps the
+// host's m_userAgent in sync with the page UA and would mask the bug. The
+// per-navigation UA stops at the page's DocumentLoader, so the host's
+// m_userAgent stays as the standard UA and the buggy assignment becomes
+// observable.
+TEST(CustomUserAgent, SharedWorkerNavigatorUserAgent)
+{
+    constexpr auto mainPage = R"PAGE(
+<script>
+const worker = new SharedWorker("sw.js");
+worker.port.onmessage = e => window.webkit.messageHandlers.testHandler.postMessage(e.data);
+worker.port.start();
+</script>
+)PAGE"_s;
+
+    constexpr auto sharedWorkerScript = R"WORKER(
+onconnect = e => {
+    const port = e.ports[0];
+    port.postMessage(navigator.userAgent);
+    port.start();
+};
+)WORKER"_s;
+
+    HTTPServer server({
+        { "/"_s, { mainPage } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerScript } },
+    });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *navigationAction, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        preferences._customUserAgent = @"SharedWorkerCustomUA/1.0";
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    __block RetainPtr<NSString> reportedUserAgent;
+    __block bool gotMessage = false;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        reportedUserAgent = message;
+        gotMessage = true;
+    }];
+
+    [webView loadRequest:server.request()];
+    TestWebKitAPI::Util::run(&gotMessage);
+
+    EXPECT_WK_STREQ("SharedWorkerCustomUA/1.0", reportedUserAgent.get());
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MessagePortSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MessagePortSecurity.mm
@@ -108,9 +108,7 @@ worker.port.postMessage('get-port');
 
 TEST(MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)
 {
-    using namespace TestWebKitAPI;
-
-    HTTPServer server({
+    TestWebKitAPI::HTTPServer server({
         { "/sender"_s, { senderBytes } },
         { "/receiver"_s, { receiverBytes } },
         { "/worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerBytes } },
@@ -216,3 +214,225 @@ TEST(MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)
 }
 
 #endif // ENABLE(IPC_TESTING_API)
+
+// When a WebContent process detaches from its Networking process, then reattaches to a new one,
+// then tries to use stale message ports... It triggers a message check in the new Networking process.
+// This test verifies that a WebContent process with "stale" message ports clears record of them,
+// so that we cannot trigger this message check under normal operation.
+TEST(MessagePortSecurity, MessagePortsSurviveNetworkProcessRestart)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<!doctype html><script>"
+            "window.channel = new MessageChannel();"
+            "window.channel.port2.onmessage = function(e) { alert('received-' + e.data); };"
+            "</script>"_s } },
+        { "/ping"_s, { "ok"_s } },
+    });
+
+    RetainPtr<TestNavigationDelegate> navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webView setNavigationDelegate:navDelegate.get()];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:server.request("/main"_s)];
+    [navDelegate waitForDidFinishNavigation];
+
+    pid_t initialWebProcessPID = [webView _webProcessIdentifier];
+    pid_t initialNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_TRUE(!!initialWebProcessPID);
+    EXPECT_TRUE(!!initialNetworkProcessPID);
+
+    [webView evaluateJavaScript:@"channel.port1.postMessage('first');" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "received-first");
+
+    // Killing the Networking process should cause the WebContent process to handle the disconnect,
+    // invalidating its current ports. This will help it avoid being killed by failing a MESSAGE_CHECK
+    // in the new Networking process.
+    [[webView configuration].websiteDataStore _terminateNetworkProcess];
+
+    // Force a new Networking process to fire up and connect.
+    NSString *fetchJS = [NSString stringWithFormat:
+        @"fetch('%@/ping').then(r => r.text()).catch(e => 'err')",
+        server.origin().createNSString().get()];
+    __block bool fetchSettled = false;
+    [webView evaluateJavaScript:fetchJS completionHandler:^(id, NSError *) {
+        fetchSettled = true;
+    }];
+    TestWebKitAPI::Util::run(&fetchSettled);
+
+    pid_t reestablishedNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_NE(initialNetworkProcessPID, reestablishedNetworkProcessPID);
+
+    __block bool webContentTerminated = false;
+    navDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webContentTerminated = true;
+    };
+
+    // Posting on a stale leftover port should be an instant no-op - The port has been invalidated.
+    __block bool unexpectedAlert = false;
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *, WKFrameInfo *, void (^handler)(void)) {
+        unexpectedAlert = true;
+        handler();
+    };
+    [webView evaluateJavaScript:@"channel.port1.postMessage('stale');" completionHandler:nil];
+
+    // Let any in-flight tasks settle. If the bug is present (stale TakeAllMessagesForPort over the new
+    // connection), webContentTerminated would flip during this window when the MESSAGE_CHECK fails.
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    EXPECT_FALSE(webContentTerminated);
+    EXPECT_FALSE(unexpectedAlert);
+    EXPECT_EQ(initialWebProcessPID, [webView _webProcessIdentifier]);
+
+    // New MessageChannels should, of course, work again.
+    __block bool freshAlertReceived = false;
+    __block RetainPtr<NSString> freshAlertText;
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^handler)(void)) {
+        freshAlertText = message;
+        freshAlertReceived = true;
+        handler();
+    };
+
+    [webView evaluateJavaScript:
+        @"window.fresh = new MessageChannel();"
+        "window.fresh.port2.onmessage = function(e) { alert('fresh-' + e.data); };"
+        "window.fresh.port1.postMessage('hello');"
+        completionHandler:nil];
+
+    TestWebKitAPI::Util::runFor(&freshAlertReceived, 5_s);
+    EXPECT_TRUE(freshAlertReceived);
+    if (freshAlertReceived)
+        EXPECT_WK_STREQ(freshAlertText.get(), "fresh-hello");
+    EXPECT_FALSE(webContentTerminated);
+}
+
+TEST(MessagePortSecurity, MessagePortsSurviveNetworkProcessRestartWithSiteIsolation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<!doctype html><script>"
+            "window.channel = new MessageChannel();"
+            "</script>"_s } },
+        { "/ping"_s, { "ok"_s } },
+    });
+
+    RetainPtr<TestNavigationDelegate> navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"SiteIsolationEnabled"]) {
+            [[config preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+
+    RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webView setNavigationDelegate:navDelegate.get()];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:server.request("/main"_s)];
+    [navDelegate waitForDidFinishNavigation];
+
+    pid_t initialWebProcessPID = [webView _webProcessIdentifier];
+    pid_t initialNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_TRUE(!!initialWebProcessPID);
+    EXPECT_TRUE(!!initialNetworkProcessPID);
+
+    [[webView configuration].websiteDataStore _terminateNetworkProcess];
+
+    NSString *fetchJS = [NSString stringWithFormat:
+        @"fetch('%@/ping').then(r => r.text()).catch(e => 'err')",
+        server.origin().createNSString().get()];
+    __block bool fetchSettled = false;
+    [webView evaluateJavaScript:fetchJS completionHandler:^(id, NSError *) {
+        fetchSettled = true;
+    }];
+    TestWebKitAPI::Util::run(&fetchSettled);
+
+    pid_t reestablishedNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_NE(initialNetworkProcessPID, reestablishedNetworkProcessPID);
+
+    __block bool webContentTerminated = false;
+    navDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webContentTerminated = true;
+    };
+
+    [webView evaluateJavaScript:@"channel.port2.start();" completionHandler:nil];
+
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    EXPECT_FALSE(webContentTerminated);
+    EXPECT_EQ(initialWebProcessPID, [webView _webProcessIdentifier]);
+}
+
+TEST(MessagePortSecurity, WorkerMessagePortsSurviveNetworkProcessRestart)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/main"_s, { "<!doctype html><script>"
+            "window.worker = new Worker('/worker.js');"
+            "window.channel = new MessageChannel();"
+            "window.worker.onmessage = function(e) { alert('worker-' + e.data); };"
+            "window.worker.postMessage('init', [window.channel.port2]);"
+            "</script>"_s } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } },
+            "self.port = null;"
+            "self.onmessage = function(e) {"
+            "    if (e.data === 'init') {"
+            "        self.port = e.ports[0];"
+            // Intentionally don't start the port here. Starting it after the NetworkProcess
+            // restart is what exercises the racy TakeAllMessagesForPort path.
+            "        self.postMessage('ready');"
+            "    } else if (e.data === 'start-stale-port') {"
+            "        try {"
+            "            self.port.start();"
+            "            self.postMessage('start-ok');"
+            "        } catch (err) { self.postMessage('start-threw-' + err.message); }"
+            "    }"
+            "};"_s } },
+        { "/ping"_s, { "ok"_s } },
+    });
+
+    RetainPtr<TestNavigationDelegate> navDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegate = adoptNS([TestUIDelegate new]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webView setNavigationDelegate:navDelegate.get()];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:server.request("/main"_s)];
+    [navDelegate waitForDidFinishNavigation];
+
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "worker-ready");
+
+    pid_t initialWebProcessPID = [webView _webProcessIdentifier];
+    pid_t initialNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+
+    [[webView configuration].websiteDataStore _terminateNetworkProcess];
+
+    NSString *fetchJS = [NSString stringWithFormat:
+        @"fetch('%@/ping').then(r => r.text()).catch(e => 'err')",
+        server.origin().createNSString().get()];
+    __block bool fetchSettled = false;
+    [webView evaluateJavaScript:fetchJS completionHandler:^(id, NSError *) {
+        fetchSettled = true;
+    }];
+    TestWebKitAPI::Util::run(&fetchSettled);
+
+    pid_t reestablishedNetworkProcessPID = [[webView configuration].websiteDataStore _networkProcessIdentifier];
+    EXPECT_NE(initialNetworkProcessPID, reestablishedNetworkProcessPID);
+
+    __block bool webContentTerminated = false;
+    navDelegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
+        webContentTerminated = true;
+    };
+
+    [webView evaluateJavaScript:@"worker.postMessage('start-stale-port');" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "worker-start-ok");
+
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    EXPECT_FALSE(webContentTerminated);
+    EXPECT_EQ(initialWebProcessPID, [webView _webProcessIdentifier]);
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -4982,6 +4982,245 @@ TEST(Navigation, CookieTransformOnRedirect)
     EXPECT_EQ(transformCallbackCount, 2u);
 }
 
+#if ENABLE(OPT_IN_PARTITIONED_COOKIES)
+TEST(WKNavigation, PartitionedCookieSentOnTopLevelRedirect)
+{
+    using namespace TestWebKitAPI;
+    bool sawCookieOnRedirectTarget { false };
+    bool requestedRedirectTarget { false };
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        request.append(0);
+        if (path == "/page1"_s) {
+            co_await connection.awaitableSend(
+                "HTTP/1.1 302 Found\r\n"
+                "Location: https://example.com/page2\r\n"
+                "Set-Cookie: PF=value;Secure;HttpOnly;SameSite=None;Partitioned\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+        } else if (path == "/page2"_s) {
+            sawCookieOnRedirectTarget = contains(request.span(), "PF=value"_span);
+            co_await connection.awaitableSend(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+            requestedRedirectTarget = true;
+        }
+    } }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+
+    // Force the network session to be created while m_pages is empty. After
+    // this returns, the session has isOptInCookiePartitioningEnabled = false.
+    __block bool forcedNetworkProcess = false;
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *) {
+        forcedNetworkProcess = true;
+    }];
+    Util::run(&forcedNetworkProcess);
+
+    // Sanity check the broken bootstrap state: with no pages added yet, the
+    // data store should still be in the default mode (All) — not the upgraded
+    // AllExceptPartitioned that propagateSettingUpdates produces.
+    EXPECT_WK_STREQ(@"All", [dataStore _thirdPartyCookieBlockingModeForTesting]);
+
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page1"]]];
+    Util::run(&requestedRedirectTarget);
+
+    EXPECT_TRUE(sawCookieOnRedirectTarget);
+
+    EXPECT_WK_STREQ(@"AllExceptPartitioned", [dataStore _thirdPartyCookieBlockingModeForTesting]);
+
+    __block bool gotStoredCookies = false;
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ(cookies.count, 1u);
+        if (cookies.count) {
+            EXPECT_WK_STREQ(@"PF", cookies[0].name);
+            EXPECT_WK_STREQ(@"https://example.com", cookies[0].properties[@"StoragePartition"]);
+        }
+        gotStoredCookies = true;
+    }];
+    Util::run(&gotStoredCookies);
+}
+
+TEST(WKNavigation, PartitionedCookieSentWhenNetworkProcessExistsBeforePage)
+{
+    using namespace TestWebKitAPI;
+    bool sawCookieOnRedirectTarget { false };
+    bool requestedRedirectTarget { false };
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        request.append(0);
+        if (path == "/page1"_s) {
+            co_await connection.awaitableSend(
+                "HTTP/1.1 302 Found\r\n"
+                "Location: https://example.com/page2\r\n"
+                "Set-Cookie: PF=value;Secure;HttpOnly;SameSite=None;Partitioned\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+        } else if (path == "/page2"_s) {
+            sawCookieOnRedirectTarget = contains(request.span(), "PF=value"_span);
+            co_await connection.awaitableSend(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+            requestedRedirectTarget = true;
+        }
+    } }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+
+    // removeDataOfTypes drives WebsiteDataStore::removeData → networkProcess()
+    // lazy creator with empty m_pages. Unlike getAllCookies (which uses
+    // networkProcessIfExists), this genuinely creates the session here.
+    __block bool dataRemoved = false;
+    [dataStore removeDataOfTypes:[NSSet setWithObject:WKWebsiteDataTypeCookies] modifiedSince:[NSDate distantPast] completionHandler:^{
+        dataRemoved = true;
+    }];
+    Util::run(&dataRemoved);
+
+    // Sanity: the session was born with isOpt=false (no pages), and the
+    // post-addSession propagateSettingUpdates inside networkProcess() saw
+    // computeIsOptInCookiePartitioningEnabled() == false too — so the UIProcess
+    // mode is still at the lazy default. If this ever flips early, the test
+    // is no longer modeling the broken-bootstrap scenario.
+    EXPECT_WK_STREQ(@"All", [dataStore _thirdPartyCookieBlockingModeForTesting]);
+
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/page1"]]];
+    Util::run(&requestedRedirectTarget);
+
+    EXPECT_TRUE(sawCookieOnRedirectTarget);
+    EXPECT_WK_STREQ(@"AllExceptPartitioned", [dataStore _thirdPartyCookieBlockingModeForTesting]);
+
+    __block bool gotStoredCookies = false;
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        EXPECT_EQ(cookies.count, 1u);
+        if (cookies.count) {
+            EXPECT_WK_STREQ(@"PF", cookies[0].name);
+            EXPECT_WK_STREQ(@"https://example.com", cookies[0].properties[@"StoragePartition"]);
+        }
+        gotStoredCookies = true;
+    }];
+    Util::run(&gotStoredCookies);
+}
+
+TEST(WKNavigation, PartitionedCookieAfterRedirect)
+{
+    using namespace TestWebKitAPI;
+    bool sawPartitionedCookieOnSubresource { false };
+    bool sawNonPartitionedCookieOnSubresource { false };
+    bool requestedSubresource { false };
+
+    //   (1) example.org/ serves HTML with a JS-driven (client-side) redirect
+    //       to example.com/ — this triggers a top-level cross-site navigation,
+    //       which the client treats as a process swap.
+    //   (2) The redirect target is loaded in a provisional WebProcess
+    //   (3) The Partitioned cookie is set on the first response to example.com,
+    //       which is also the response that commits the provisional page.
+    //   (4) After commit, the original WebProcess is shut down because the swap
+    //       is from a client-side redirect (so the old page is not suspended/cached).
+    //       The bug under investigation is that this termination disables
+    //       setOptInCookiePartitioningEnabled across all NetworkSessions, dropping
+    //       the partition key from in-flight tasks.
+    //   (5) A subresource on example.com/ then loads from the new (committed)
+    //       process.
+    static constexpr auto initialPageHTML =
+        "<script>window.location = \"https://example.com/\";</script>"_s;
+
+    static constexpr auto committedPageBody =
+        "<!DOCTYPE html><img src=\"https://example.com/subresource\">"_s;
+
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> ConnectionTask { while (true) {
+        auto request = co_await connection.awaitableReceiveHTTPRequest();
+        auto path = HTTPServer::parsePath(request);
+        request.append(0);
+        if (contains(request.span(), "Host: example.org"_span) && path == "/"_s) {
+            co_await connection.awaitableSend(HTTPResponse({ { }, initialPageHTML }).serialize());
+        } else if (contains(request.span(), "Host: example.com"_span) && path == "/"_s) {
+            co_await connection.awaitableSend(makeString(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: text/html\r\n"
+                "Set-Cookie: testcookie=1; Path=/; Secure; SameSite=None; Max-Age=300\r\n"
+                "Set-Cookie: partitioned_cookie=p1; Path=/; Secure; SameSite=None; Partitioned; Max-Age=300\r\n"
+                "Content-Length: "_s, committedPageBody.length(), "\r\n"
+                "\r\n"_s, committedPageBody));
+        } else if (contains(request.span(), "Host: example.com"_span) && path == "/subresource"_s) {
+            sawNonPartitionedCookieOnSubresource = contains(request.span(), "testcookie=1"_span);
+            sawPartitionedCookieOnSubresource = contains(request.span(), "partitioned_cookie=p1"_span);
+            co_await connection.awaitableSend(
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: image/png\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"_s);
+            requestedSubresource = true;
+        }
+    } }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setHTTPSProxy:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server.port()]]];
+    RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+    RetainPtr viewConfiguration = adoptNS([WKWebViewConfiguration new]);
+    [viewConfiguration setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    [delegate allowAnyTLSCertificate];
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:viewConfiguration.get()]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.org/"]]];
+    Util::run(&requestedSubresource);
+
+    EXPECT_TRUE(sawNonPartitionedCookieOnSubresource);
+    EXPECT_TRUE(sawPartitionedCookieOnSubresource);
+
+    __block bool gotStoredCookies = false;
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        bool foundPartitioned = false;
+        bool foundNonPartitioned = false;
+        for (NSHTTPCookie *cookie in cookies) {
+            if ([cookie.name isEqualToString:@"partitioned_cookie"]) {
+                foundPartitioned = true;
+                EXPECT_WK_STREQ(cookie.properties[@"StoragePartition"], @"https://example.com");
+            } else if ([cookie.name isEqualToString:@"testcookie"]) {
+                foundNonPartitioned = true;
+                EXPECT_NULL(cookie.properties[@"StoragePartition"]);
+            }
+        }
+        EXPECT_TRUE(foundPartitioned);
+        EXPECT_TRUE(foundNonPartitioned);
+        gotStoredCookies = true;
+    }];
+    Util::run(&gotStoredCookies);
+}
+#endif // ENABLE(OPT_IN_PARTITIONED_COOKIES)
+
 TEST(WKNavigation, AllowResourceLoadFromBlockedPortWithCustomScheme)
 {
     using namespace TestWebKitAPI;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -836,6 +836,41 @@ TEST(WebpagePreferences, WebsitePoliciesAutoplayQuirks)
     [webView waitForMessage:@"playing"];
 }
 
+TEST(WebpagePreferences, WebsitePoliciesSynthesizedPauseEventFiresOnce)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+#if PLATFORM(IOS_FAMILY)
+    configuration.get().allowsInlineMediaPlayback = YES;
+    configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
+#endif
+    [configuration preferences].siteSpecificQuirksModeEnabled = YES;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr delegate = adoptNS([[AutoplayPoliciesDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    [delegate setAllowedAutoplayQuirksForURL:^_WKWebsiteAutoplayQuirk(NSURL *) {
+        return _WKWebsiteAutoplayQuirkSynthesizedPauseEvents;
+    }];
+    [delegate setAutoplayPolicyForURL:^(NSURL *) {
+        return _WKWebsiteAutoplayPolicyDeny;
+    }];
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"autoplay-quirk-pause-fires-once" withExtension:@"html"]];
+    [webView loadRequest:request];
+
+    __block bool done = false;
+    __block RetainPtr<NSString> receivedMessage;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        if ([message hasPrefix:@"pause-count:"]) {
+            receivedMessage = message;
+            done = true;
+        }
+    }];
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_WK_STREQ(@"pause-count:1", receivedMessage.get());
+}
+
 TEST(WebpagePreferences, WebsitePoliciesPerDocumentAutoplayBehaviorQuirks)
 {
     auto* configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/autoplay-quirk-pause-fires-once.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/autoplay-quirk-pause-fires-once.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+<script>
+var pauseCount = 0;
+
+function setup() {
+    var video = document.getElementById("video");
+    video.addEventListener("pause", function() {
+        pauseCount++;
+        // Simulate a site that retries play() on pause.
+        video.play().catch(function() { });
+    });
+    video.play().catch(function() {
+        // One-time result post after first play.
+        setTimeout(function() {
+            try {
+                window.webkit.messageHandlers.testHandler.postMessage("pause-count:" + pauseCount);
+            } catch(e) { }
+        }, 100);
+    });
+}
+</script>
+</head>
+<body onload="setup()">
+<video id="video" playsinline src="test.mp4"></video>
+</body>
+</html>


### PR DESCRIPTION
#### 0480a37c76c81dbfee40160990e3442f5cd5bf5c
<pre>
Cherry-pick 311277@main (5205050c09a9). <a href="https://bugs.webkit.org/show_bug.cgi?id=312253">https://bugs.webkit.org/show_bug.cgi?id=312253</a>

    Callers of WebSWServerConnection::checkTopOrigin should return early if check fails
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312253">https://bugs.webkit.org/show_bug.cgi?id=312253</a>
    <a href="https://rdar.apple.com/174495602">rdar://174495602</a>

    Reviewed by Chris Dumez.

    We make checkTopOrigin return false if a MESSAGE_CHECK fails and make callers of checkTopOrigin bail out if it returns false.

    * Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
    (WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
    * Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:

    Canonical link: <a href="https://commits.webkit.org/311277@main">https://commits.webkit.org/311277@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.778@webkitglib/2.52">https://commits.webkit.org/305877.778@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 22c6d14dfc28f504ff95012bf027fae54d8d9f5d
<pre>
Cherry-pick 312256@main (80cc99fb32cb). <a href="https://bugs.webkit.org/show_bug.cgi?id=313389">https://bugs.webkit.org/show_bug.cgi?id=313389</a>

    WorkerMessagingProxy objects leak after calling worker.terminate() from JavaScript
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313389">https://bugs.webkit.org/show_bug.cgi?id=313389</a>&gt;
    &lt;<a href="https://rdar.apple.com/175652847">rdar://175652847</a>&gt;

    Reviewed by Chris Dumez.

    Handle the case in `workerObjectDestroyed()` where
    `workerGlobalScopeDestroyedInternal()` has already run.  When
    that happens, the proxy&apos;s thread, context, and identifier are
    already cleaned up -- the only remaining work is releasing the
    initial construction ref via `deref()`.  Without this,
    `workerObjectDestroyed()` returns early on the nullopt
    identifier, leaving the ref permanently held.

    Also clear `m_queuedEarlyTasks` in
    `workerGlobalScopeDestroyedInternal()` because tasks queued
    before the worker thread is created capture `Ref { *this }`,
    forming a retain cycle through the proxy&apos;s own member vector
    that prevents destruction even after `deref()` is called.

    The leak was introduced in Bug 22723 (254597@main) which added
    the null-context early return to `workerObjectDestroyed()` and
    added `m_scriptExecutionContext = nullptr` to
    `workerGlobalScopeDestroyedInternal()` as part of implementing
    nested dedicated workers.

    Test using `run-webkit-tests --leaks` with:
    - workers/worker-set-delete-terminate-crash.html
    - workers/worker-terminate-crash.html

    * Source/WebCore/workers/WorkerMessagingProxy.cpp:
    (WebCore::WorkerMessagingProxy::workerObjectDestroyed):
    (WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):

    Canonical link: <a href="https://commits.webkit.org/312256@main">https://commits.webkit.org/312256@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.777@webkitglib/2.52">https://commits.webkit.org/305877.777@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c9159513d8793809cc2d30906b7e96f12c9b2d43
<pre>
Cherry-pick 312830@main (6e299de4c1ae). <a href="https://bugs.webkit.org/show_bug.cgi?id=314271">https://bugs.webkit.org/show_bug.cgi?id=314271</a>

    [libpas] Fix race in `pas_bitfit_directory_take_last_empty`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314271">https://bugs.webkit.org/show_bug.cgi?id=314271</a>

    Reviewed by Marcus Plutowski.

    pas_bitfit_directory_take_last_empty read last_empty_plus_one with
    pas_versioned_field_read instead of pas_versioned_field_read_to_watch,
    so the final pas_versioned_field_try_write could not detect a
    concurrent view_did_become_empty_at_index between the scan and the
    write. The try_write succeeded on a stale version and zeroed
    last_empty_plus_one with empty bits still set, stranding the page.
    The matching segregated-directory path already uses read_to_watch.

    Add a regression test that uses pas_race_test_hooks to inject the
    empty event between the scan and the write.

    * Source/bmalloc/libpas/src/libpas/pas_bitfit_directory.c:
    (pas_bitfit_directory_take_last_empty):
    * Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h:
    (pas_race_test_hook_kind_get_string):
    * Source/bmalloc/libpas/src/test/BitfitTests.cpp:
    (std::takeLastEmptyRaceHook):
    (std::testTakeLastEmptyLastEmptyPlusOneWatchRace):
    (addBitfitTests):

    Canonical link: <a href="https://commits.webkit.org/312830@main">https://commits.webkit.org/312830@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.776@webkitglib/2.52">https://commits.webkit.org/305877.776@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ff4bc7858b3e61f4fa9bcbd5ff011615562ce9f4
<pre>
Cherry-pick 314369@main (afa9356bdfb2). <a href="https://bugs.webkit.org/show_bug.cgi?id=316096">https://bugs.webkit.org/show_bug.cgi?id=316096</a>

    REGRESSION(314285@main): [GStreamer] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTransceiver-renegotiation.https.html crashes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316096">https://bugs.webkit.org/show_bug.cgi?id=316096</a>

    Reviewed by Claudio Saavedra.

    The transceiver codec-preferences can be un-set, so that should be checked before usage.

    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
    (WebCore::GStreamerMediaEndpoint::trackWasReplaced):

    Canonical link: <a href="https://commits.webkit.org/314369@main">https://commits.webkit.org/314369@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.775@webkitglib/2.52">https://commits.webkit.org/305877.775@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1f39a3c35acf07a422650fe1f81966c9638f2aa8
<pre>
Cherry-pick 314410@main (7ff2120302f0). <a href="https://bugs.webkit.org/show_bug.cgi?id=316093">https://bugs.webkit.org/show_bug.cgi?id=316093</a>

    webaudio/AudioBufferSource/audiobuffersource-playbackrate.html is a flaky crash
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316093">https://bugs.webkit.org/show_bug.cgi?id=316093</a>

    Reviewed by Philippe Normand and Chris Dumez.

    AudioDestinationNode::renderQuantum() runs the audio thread inside a
    ForbidMallocUseForCurrentThreadScope, which extends through
    handlePostRenderTasks() and the node-deletion bookkeeping it performs. The
    fallback in AudioNodeInput::disconnect() calls m_disabledOutputs.remove()
    without a DisableMallocRestrictionsForCurrentThreadScope; HashSet::remove()
    may shrink and rehash, allocating, and trips the assertion.

    AudioSummingJunction::removeOutput() and AudioNodeInput::disable() / enable()
    already wrap their hash-set mutations the same way; do the same for the
    disabled-list fallback in disconnect().

    * Source/WebCore/Modules/webaudio/AudioNodeInput.cpp:
    (WebCore::AudioNodeInput::disconnect):

    Canonical link: <a href="https://commits.webkit.org/314410@main">https://commits.webkit.org/314410@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.774@webkitglib/2.52">https://commits.webkit.org/305877.774@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e6197d2b43346da3a512830a0f412e44ec6a232d
<pre>
Cherry-pick 314426@main (9d6056753754). <a href="https://bugs.webkit.org/show_bug.cgi?id=316154">https://bugs.webkit.org/show_bug.cgi?id=316154</a>

    Fix use-after-free in ~WebProcessProxy() when replying to pending IPC messages
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316154">https://bugs.webkit.org/show_bug.cgi?id=316154</a>
    <a href="https://rdar.apple.com/178478856">rdar://178478856</a>

    Reviewed by Chris Dumez.

    When a WebProcessProxy is torn down while its process is still launching,
    ~AuxiliaryProcessProxy() calls replyToPendingMessages() after WebProcessProxy&apos;s
    own members have already been destroyed. Those reply handlers (e.g. the one queued
    by sendPageCloseMessage()) upgrade a WeakPtr&lt;WebProcessProxy&gt; that is still live —
    the WeakPtrFactory lives in a base class destroyed later — and read freed members
    such as m_pagesPendingClose, causing a heap-use-after-free.

    Reply to the pending messages at the top of ~WebProcessProxy(), while our members
    are still intact. The later base-class call then finds an empty queue and is a no-op.

    * LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash-expected.txt: Added.
    * LayoutTests/http/tests/site-isolation/remove-iframe-while-process-launching-crash.html: Added.
    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::~WebProcessProxy):

    Canonical link: <a href="https://commits.webkit.org/314426@main">https://commits.webkit.org/314426@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.773@webkitglib/2.52">https://commits.webkit.org/305877.773@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### eac069eefa82ab673c295a255926056728823d2e
<pre>
Cherry-pick 314442@main (5d8c7f0a38c9). <a href="https://bugs.webkit.org/show_bug.cgi?id=316159">https://bugs.webkit.org/show_bug.cgi?id=316159</a>

    FetchBody::clone() leaves m_data and m_readableStream desynchronized
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316159">https://bugs.webkit.org/show_bug.cgi?id=316159</a>

    Reviewed by Anne van Kesteren.

    When cloning a FetchBody whose body is a ReadableStream, only the
    m_readableStream field was updated to point at the new tee branches;
    m_data still held the original (now disturbed) stream on the source,
    and was left as the default nullptr variant on the clone. This broke
    the invariant established by FetchBody(Ref&lt;ReadableStream&gt;&amp;&amp;) that
    m_data and m_readableStream refer to the same stream, causing
    isReadableStream() and hasReadableStream() to disagree.

    The visible consequence is that constructing a new Request from a
    cloned Request silently dropped the body: FetchBody::createProxy()
    keys off isReadableStream(), which returned false on the clone, so
    the proxy short-circuited before piping the readable stream through.

    Set m_data alongside m_readableStream on both branches of the tee
    to keep the two fields in sync.

    This aligns our behavior with Chrome.

    Tests: imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.html
           imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker.html

    * LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any-expected.txt: Added.
    * LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.js: Added.
    (promise_test.async const):
    (promise_test):
    * LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker-expected.txt: Added.
    * LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/request-clone-readable-stream-body.any.worker.html: Added.
    * Source/WebCore/Modules/fetch/FetchBody.cpp:
    (WebCore::FetchBody::clone):

    Canonical link: <a href="https://commits.webkit.org/314442@main">https://commits.webkit.org/314442@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.772@webkitglib/2.52">https://commits.webkit.org/305877.772@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 406a3327db30ca4021b8d2608e18348594556cfb
<pre>
Cherry-pick 314550@main (28ea4d7f92e5). <a href="https://bugs.webkit.org/show_bug.cgi?id=316231">https://bugs.webkit.org/show_bug.cgi?id=316231</a>

    WebCookieJar contains duplicate shouldBlockCookies() call
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316231">https://bugs.webkit.org/show_bug.cgi?id=316231</a>
    <a href="https://rdar.apple.com/178655565">rdar://178655565</a>

    Reviewed by Charlie Wolfe.

    There is no need to recompute shouldBlockCookies. We can reuse the stored result.

    * Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
    (WebKit::WebCookieJar::cookiesEnabled):

    Canonical link: <a href="https://commits.webkit.org/314550@main">https://commits.webkit.org/314550@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.771@webkitglib/2.52">https://commits.webkit.org/305877.771@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 521b55ce447f0c74798387c5633c5dd576764c0d
<pre>
Cherry-pick 314583@main (e30ca29fe973). <a href="https://bugs.webkit.org/show_bug.cgi?id=314298">https://bugs.webkit.org/show_bug.cgi?id=314298</a>

    Add cookie access validation to startDownload() and convertMainResourceLoadToDownload() to prevent CSRF
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314298">https://bugs.webkit.org/show_bug.cgi?id=314298</a>
    <a href="https://rdar.apple.com/173378006">rdar://173378006</a>

    Reviewed by Alex Christensen.

    NetworkConnectionToWebProcess::startDownload() and
    NetworkConnectionToWebProcess::convertMainResourceLoadToDownload() do not
    validate the firstPartyForCookies in the requests sent to them by the web
    process. So a web process could send in a cross-site origin, leading to
    requests being sent to this cross-site origin that contain the cookies for
    this origin. So these requests would be seen as legitimate even though they
    did not come from the user. We fix this by adding message checks to confirm
    that the web process indeed has cookie access to the origin it is sending
    as the firstPartyForCookies.

    This breaks a number of tests. For example,
    TEST(_WKDownload, DownloadRequestOriginalURLDirectDownload), crashes at the
    ASSERT_NOT_REACHED(); in NetworkProcess::allowsFirstPartyForCookies because
    the web process hasn&apos;t been added to the map (Since the policy decision is
    PolicyAction::Download and that codepath doesn&apos;t add the web process to the
    map. So we modify the MESSAGE_CHECK to only occur if the passed in request
    contains a non-empty firstPartyForCookies. That way, we guard against an
    arbitrary domain being used.

    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
    (WebKit::NetworkConnectionToWebProcess::startDownload):
    (WebKit::NetworkConnectionToWebProcess::convertMainResourceLoadToDownload):

    Originally-landed-as: 305413.882@safari-7624-branch (12dccb08af3d). <a href="https://rdar.apple.com/173378006">rdar://173378006</a>
    Canonical link: <a href="https://commits.webkit.org/314583@main">https://commits.webkit.org/314583@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.770@webkitglib/2.52">https://commits.webkit.org/305877.770@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### fd9fc45e167ca00a6681945f23f6e59db8e3e6e7
<pre>
Cherry-pick 314573@main (67117c4975bb). <a href="https://bugs.webkit.org/show_bug.cgi?id=315221">https://bugs.webkit.org/show_bug.cgi?id=315221</a>

    MessagePorts a WebContent process already has should be invalidated if the Networking process disconnects
    <a href="https://rdar.apple.com/177440317">rdar://177440317</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315221">https://bugs.webkit.org/show_bug.cgi?id=315221</a>

    Reviewed by Basuke Suzuki.

    The scenario is:
    1 - A MessageChannel is created, and therefore registered with the networking process.
    2 - The Networking process disconnects (crash, jetsam, suspend, etc)
    3 - A new Networking process is fired up and connects to the old WebContent process
    4 - The WebContent process tries a message channel operation in the new Networking process on a port
        the new Networking process doesn&apos;t know about.

    <a href="https://commits.webkit.org/305413.547@safari-7624-branch">https://commits.webkit.org/305413.547@safari-7624-branch</a> added more aggressive MESSAGE_CHECKs to the
    networking process to protect against message port spoofs from compromised web content processes.

    The above scenario is WebKit in normal operation and unfortunately triggering those MESSAGE_CHECKs

    So this PR teaches web content processes to invalidate current message ports if the Networking process
    goes away. It handles normal message port operation, worker use, and works with site isolation.

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/MessagePortSecurity.mm

    * Source/WebCore/dom/MessagePort.cpp:
    (WebCore::MessagePort::notifyAllConnectionsClosed):
    * Source/WebCore/dom/MessagePort.h:
    * Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
    (WebKit::WebMessagePortChannelProvider::createNewMessagePortChannel):
    (WebKit::WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote):
    (WebKit::WebMessagePortChannelProvider::messagePortDisentangled):
    (WebKit::WebMessagePortChannelProvider::networkProcessConnectionClosed):
    (WebKit::WebMessagePortChannelProvider::messagePortClosed):
    (WebKit::WebMessagePortChannelProvider::takeAllMessagesForPort):
    * Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:
    * Source/WebKit/WebProcess/WebProcess.cpp:
    (WebKit::WebProcess::networkProcessConnectionClosed):
    * Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm:
    ((MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)):
    ((MessagePortSecurity, MessagePortsSurviveNetworkProcessRestart)):
    ((MessagePortSecurity, MessagePortsSurviveNetworkProcessRestartWithSiteIsolation)):
    ((MessagePortSecurity, WorkerMessagePortsSurviveNetworkProcessRestart)):

    Originally-landed-as: 305413.972@safari-7624-branch (b90cdae5a91d). <a href="https://rdar.apple.com/178741244">rdar://178741244</a>
    Canonical link: <a href="https://commits.webkit.org/314573@main">https://commits.webkit.org/314573@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.769@webkitglib/2.52">https://commits.webkit.org/305877.769@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8c84f914883d3389dea52e339f500a0e389d4e92
<pre>
Cherry-pick 314594@main (5eacd591f79b). <a href="https://bugs.webkit.org/show_bug.cgi?id=316188">https://bugs.webkit.org/show_bug.cgi?id=316188</a>

    Region::totalArea overflows when a single rect&apos;s area exceeds INT_MAX
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316188">https://bugs.webkit.org/show_bug.cgi?id=316188</a>

    Reviewed by Kimmo Kinnunen.

    Region::totalArea() accumulates rect.width() * rect.height() into a
    uint64_t. Both width() and height() return int, so the multiplication
    is performed in int and only the result is widened. Any rect whose
    area exceeds INT_MAX (e.g. 50000 x 50000 == 2,500,000,000) overflows
    the int multiplication before the assignment, then sign-extends into
    uint64_t and corrupts the running total.

    Cast one operand to uint64_t so the multiplication itself happens in
    64 bits. Add an API test that exercises the overflow case.

    Test: RegionTests.TotalAreaDoesNotOverflowSignedInt

    * Source/WebCore/platform/graphics/Region.cpp:
    (WebCore::Region::totalArea const):
    * Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp:
    (TestWebKitAPI::TEST(RegionTests, TotalAreaDoesNotOverflowSignedInt)):

    Canonical link: <a href="https://commits.webkit.org/314594@main">https://commits.webkit.org/314594@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.768@webkitglib/2.52">https://commits.webkit.org/305877.768@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b0b779d817465f425cec02e725370251f2536409
<pre>
Cherry-pick 314858@main (fbd2160cf1ac). <a href="https://bugs.webkit.org/show_bug.cgi?id=316637">https://bugs.webkit.org/show_bug.cgi?id=316637</a>

    SharedWorker&apos;s navigator.userAgent ignores per-navigation _customUserAgent
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316637">https://bugs.webkit.org/show_bug.cgi?id=316637</a>

    Reviewed by Youenn Fablet.

    WebSharedWorkerContextManagerConnection::launchSharedWorker() applied an
    inverted user-agent fallback:
    ```
          if (!initializationData.userAgent.isEmpty())
              initializationData.userAgent = m_userAgent;
    ```

    The intent (matching the parallel logic in WebSWContextManagerConnection&apos;s
    installServiceWorker, which uses `if (effectiveUserAgent.isNull())`) is to
    fall back to the host&apos;s m_userAgent only when the value supplied by the
    network process is empty. The condition was negated, so a non-empty
    page-supplied UA was overwritten by the host&apos;s default, while an empty UA
    was left empty.

    The page-level WKWebView.customUserAgent path masks the bug because
    WebProcessPool::updateRemoteWorkerUserAgent pushes that UA to every remote-
    worker host via Messages::WebSharedWorkerContextManagerConnection::SetUserAgent,
    keeping the host&apos;s m_userAgent in sync with the page UA so the buggy
    assignment becomes a no-op. The bug is observable through any UA path that
    does NOT round-trip through WebPageProxy::setUserAgent — most notably
    WKWebpagePreferences._customUserAgent (per-navigation), which is stored on
    the page&apos;s DocumentLoader and flows into WorkerScriptLoader::
    userAgentForSharedWorker() but never updates the host process. In that
    configuration the SharedWorker&apos;s navigator.userAgent reported the host&apos;s
    standard UA instead of the per-navigation override.

    Invert the condition so initializationData.userAgent is preserved when
    non-empty and only filled in from m_userAgent when empty.

    * Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
    (WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
    Fall back to m_userAgent only when initializationData.userAgent is empty.

    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm:
    (TEST(CustomUserAgent, SharedWorkerNavigatorUserAgent)):
    Add a regression test that uses WKWebpagePreferences._customUserAgent so
    the page UA diverges from the host&apos;s m_userAgent, and asserts that a
    SharedWorker created from that page observes the per-navigation UA via
    navigator.userAgent.

    Canonical link: <a href="https://commits.webkit.org/314858@main">https://commits.webkit.org/314858@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.767@webkitglib/2.52">https://commits.webkit.org/305877.767@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 194d83a90fe7ba39393b0eec9c1066b79ef596a5
<pre>
Cherry-pick 314865@main (5472527c2f96). <a href="https://bugs.webkit.org/show_bug.cgi?id=316542">https://bugs.webkit.org/show_bug.cgi?id=316542</a>

    AX: In rare circumstances, WebKit can loop infinitely downstream of updateOwnedChildrenIfNecessary(), causing stack overflow crashes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316542">https://bugs.webkit.org/show_bug.cgi?id=316542</a>
    <a href="https://rdar.apple.com/172763724">rdar://172763724</a>

    Reviewed by Dominic Mazzoni and Andres Gonzalez.

    For a long while now, we have observed rare stack overflow crashes
    originating from updateOwnedChildrenIfNecessary(). It&apos;s unclear how
    these crashes are ocurring, since existing function relationCausesCycle
    should (and does in all known situations) prevent an aria-owns
    relationship from being established if it would cause a cycle.

    The current theory is that these crashes happen when the tree is dirty and
    in the process of being rebuilt after dynamic DOM changes (which may introduce
    cycles that relationCausesCycle didn&apos;t and couldn&apos;t possibly have
    checked for at relations-creation time). But I haven&apos;t been able to
    construct markup that actually reproduces this, including the new layout
    test, which passes with and without the newly added guard (described below).

    The speculative fix taken by this commit is the addition of a per-traversal visited
    set in updateOwnedChildrenIfNecessary, breaking if we encounter a node we&apos;ve already seen.

    * LayoutTests/accessibility/aria-owns-crash-after-subtree-update-expected.txt: Added.
    * LayoutTests/accessibility/aria-owns-crash-after-subtree-update.html: Added.
    * Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
    (WebCore::AccessibilityNodeObject::updateOwnedChildrenIfNecessary):

    Canonical link: <a href="https://commits.webkit.org/314865@main">https://commits.webkit.org/314865@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.766@webkitglib/2.52">https://commits.webkit.org/305877.766@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3dfa3aa802ac3a4c05f6bbca536ac50549e770ca
<pre>
Cherry-pick 314984@main (412a8234329f). <a href="https://bugs.webkit.org/show_bug.cgi?id=316746">https://bugs.webkit.org/show_bug.cgi?id=316746</a>

    Prevent re-entrant calls to dispatchPlayPauseEventsIfNeedsQuirks()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316746">https://bugs.webkit.org/show_bug.cgi?id=316746</a>
    <a href="https://rdar.apple.com/179191475">rdar://179191475</a>

    Reviewed by Ryosuke Niwa.

    dispatchPlayPauseEventsIfNeedsQuirks() dispatches synthesized `playing` and `pause` events to satisfy sites whose JS
    player state machines rely on these events to detect that autoplay was prevented (SynthesizedPauseEvents), or to
    recover after being restored from the back/forward cache (<a href="https://rdar.apple.com/68938833">rdar://68938833</a>).

    The function was not re-entrant-safe because a common JS pattern is to call video.play() from a `pause` event handler to
    retry playback. When autoplay was blocked, the sequence was:
    1. setAutoplayEventPlaybackState(PreventedAutoplay) =&gt; dispatchPlayPauseEventsIfNeedsQuirks() // schedule playing +
    pause events
    2. `pause` event fires, JS handler calls video.play() // autoplay blocked again
    3. setAutoplayEventPlaybackState(PreventedAutoplay) =&gt; dispatchPlayPauseEventsIfNeedsQuirks()  // schedule playing +
    pause events again, and cause infinite loop

    This can produce hundreds of log entries per millisecond and could trigger logd&apos;s per-process quarantine on affected
    pages. To fix this, this patch adds a bool guard m_isDispatchingAutoplayPlayPauseQuirkEvents and consolidates two
    scheduleEvent() calls into a single queued task that ispatches both events synchronously via dispatchEvent(). A
    SetForScope sets the guard for the duration of the task, covering the entire JS execution window. Any re-entrant call to
    dispatchPlayPauseEventsIfNeedsQuirks() during that window — whether from the `playing` or the `pause` handler — returns
    immediately.

    API Test: WebpagePreferences.WebsitePoliciesSynthesizedPauseEventFiresOnce

    * Source/WebCore/html/HTMLMediaElement.cpp:
    (WebCore::HTMLMediaElement::dispatchPlayPauseEventsIfNeedsQuirks):
    * Source/WebCore/html/HTMLMediaElement.h:
    * Tools/TestWebKitAPI/Resources/cocoa/autoplay-quirk-pause-fires-once.html: Added.
    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm:
    (TEST(WebpagePreferences, WebsitePoliciesSynthesizedPauseEventFiresOnce)):

    Canonical link: <a href="https://commits.webkit.org/314984@main">https://commits.webkit.org/314984@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.765@webkitglib/2.52">https://commits.webkit.org/305877.765@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9bb8e6006c96b6ef224b0b7b836dbe50fd527674
<pre>
Cherry-pick 315043@main (39679d6a6e43). <a href="https://bugs.webkit.org/show_bug.cgi?id=316066">https://bugs.webkit.org/show_bug.cgi?id=316066</a>

    Partitioned cookies may not be sent on resource requests
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316066">https://bugs.webkit.org/show_bug.cgi?id=316066</a>
    <a href="https://rdar.apple.com/175507450">rdar://175507450</a>

    Reviewed by Charlie Wolfe.

    There is a problem with how we compute and synchronize across processes the
    preference&apos;s state that controls whether partitioned cookies are enabled. There
    is a case where we can erroneously disable partitioned cookies if we are in a
    situation where we don&apos;t have any WebPageProxy, but we have an active
    provisional load. That gap may result in some resource requests where a
    partitioned cookie is absent.

    The current behavior relies on a WebPageProxy existing. This patch resolves
    that issue, and a couple others, by calling propagateSettingUpdates() when a
    page is added or removed from a WebsiteDataStore, and immediately after a
    network process is created.

    * Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
    (WebKit::WebsiteDataStore::networkProcess):
    (WebKit::WebsiteDataStore::addPage):
    (WebKit::WebsiteDataStore::removePage):
    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm:
    (TEST(WKNavigation, PartitionedCookieSentOnTopLevelRedirect)):
    (TEST(WKNavigation, PartitionedCookieSentWhenNetworkProcessExistsBeforePage)):
    (TEST(WKNavigation, PartitionedCookieAfterRedirect)):

    Canonical link: <a href="https://commits.webkit.org/315043@main">https://commits.webkit.org/315043@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.764@webkitglib/2.52">https://commits.webkit.org/305877.764@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a171036e2812d50ff38db8b333d5097ef4822c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168707 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/42266 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35861 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178038 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126414 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170573 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/42643 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/42226 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131557 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126414 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171666 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/42643 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/35861 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111856 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/42643 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/42226 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26733 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/35861 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/42643 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35861 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180639 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/29958 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33369 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/42226 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139793 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/42278 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/35861 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139642 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/42967 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35861 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106694 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25813 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/42967 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114734 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201386 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/41470 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/35861 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54070 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/40867 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/41121 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/41012 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->