### PR TITLE
[Form Control Refresh] Animation/transition-origin background-color bleeds into native text controls

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -955,8 +955,6 @@ imported/w3c/web-platform-tests/html/canvas/element/manual/filters/tentative/can
 imported/w3c/web-platform-tests/html/canvas/element/manual/filters/tentative/canvas-filter-object-component-transfer.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/filters/tentative/canvas-filter-object-convolve-matrix.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/filters/tentative/canvas-filter-object-turbulence.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-animation-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-transition-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html [ Pass Failure ]
 
 # Cross-Origin-Embedder-Policy: credentialless is not supported.

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -3083,7 +3083,16 @@ static bool paintTextAreaOrTextField(const RenderElement& box, const PaintInfo& 
 #endif
 
     const auto styleColorOptions = box.styleColorOptions();
-    auto backgroundColor = style->visitedDependentBackgroundColor();
+
+    // Only honor the renderer's background-color for autofill (forced via an !important UA rule); otherwise
+    // animation/transition backgrounds would bleed into the native control (author backgrounds devolve it first).
+    auto isAutofilled = [&] {
+        RefPtr input = dynamicDowncast<HTMLInputElement>(box.element());
+        return input && (input->autofilled() || input->autofilledAndViewable() || input->autofilledAndObscured());
+    };
+    auto backgroundColor = isAutofilled()
+        ? style->visitedDependentBackgroundColor()
+        : RenderTheme::singleton().systemColor(CSSValueCanvas, styleColorOptions);
 #if PLATFORM(MAC)
     const auto prefersContrast = Theme::singleton().userPrefersContrast();
     auto borderColor = prefersContrast ? highContrastOutlineColor(styleColorOptions) : RenderTheme::singleton().systemColor(CSSValueAppleSystemContainerBorder, styleColorOptions);


### PR DESCRIPTION
#### 6ac3492ed13061b84f6985de795ac43ec83fc867
<pre>
[Form Control Refresh] Animation/transition-origin background-color bleeds into native text controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=317093">https://bugs.webkit.org/show_bug.cgi?id=317093</a>
<a href="https://rdar.apple.com/179649974">rdar://179649974</a>

Reviewed by NOBODY (OOPS!).

WebKit restricts the appearance-disabling decision to the Author Origin
(disableNativeAppearanceIfNeeded), so a background-color coming from the animation or
transition origin does not devolve a form control and it stays a native widget. Under Form
Control Refresh, however, paintTextAreaOrTextField() filled the native control with the
renderer&apos;s visitedDependentBackgroundColor(). Since the renderer&apos;s style is the animated
style, an animation/transition-origin background (e.g. a @keyframes or transition to red)
leaked into the native control.

That style read was added so the autofill background (a UA !important rule in html.css)
would appear on native controls. Restore the platform Canvas color as the default fill and
read the style&apos;s background-color only when the control is autofilled, which keeps the
autofill behavior while ignoring author/animation/transition backgrounds (author backgrounds
never reach this path because they devolve the control first).

* LayoutTests/TestExpectations: Progressions
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::paintTextAreaOrTextField):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ac3492ed13061b84f6985de795ac43ec83fc867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177666 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126039 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1990821-c4ff-4023-baa4-a8c984583f11) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41852 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131010 "Found 2 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-animation-002.html imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-transition-003.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92106 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c3e32f5-1e5a-493a-bcb2-d8618cecef5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111522 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e33b72c-6ee6-4d52-8aa5-933a1c7b20e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32464 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31166 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26362 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142450 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180266 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32990 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30690 "8 flakes 3 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139447 "Found 2 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-animation-002.html imported/w3c/web-platform-tests/html/rendering/widgets/appearance/appearance-transition-003.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139310 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42595 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150763 "Exiting early after 10 failures. 10 tests run. 2 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106132 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34601 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27661 "6 flakes 4 failures") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114355 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40496 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5746 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40747 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->