### PR TITLE
[MathML] mo element does not correctly apply minsize/maxsize relative to the math axis

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-axis-height-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-axis-height-1-expected.txt
@@ -1,13 +1,13 @@
 
 PASS symmetric stretching with respect to the math axis (size variant)
 PASS symmetric stretching with respect to the math axis (glyph assembly)
-FAIL Tascent = Tdescent = 0, minsize = 14em assert_approx_equals: mo ascent expected 120 +/- 5 but got 140
-FAIL Tascent = 6em > AxisHeight, Tdescent = 1em, symmetric = false, minsize = 14em assert_approx_equals: mo ascent expected 70 +/- 5 but got 120
-FAIL Tascent = 4em < AxisHeight, Tdescent = 3em, symmetric = false, minsize = 14em assert_approx_equals: mo ascent expected 50 +/- 5 but got 80
-FAIL Tascent = 6em > AxisHeight, Tdescent = 22em, symmetric = false, maxsize = 14em assert_approx_equals: mo ascent expected 55 +/- 5 but got 30
-FAIL Tascent = 4em < AxisHeight, Tdescent = 24em, symmetric = false, maxsize = 14em assert_approx_equals: mo ascent expected 50 +/- 5 but got 20
-FAIL symmetric stretching with respect to the math axis (minsize = 14em) assert_approx_equals: mo is symmetric expected 61.65625 +/- 5 but got 78.34375
-FAIL symmetric stretching with respect to the math axis (maxsize = 14em) assert_approx_equals: mo is symmetric expected 107.921875 +/- 5 but got 32.078125
+FAIL Tascent = Tdescent = 0, minsize = 14em assert_approx_equals: mo ascent expected 120 +/- 5 but got 50
+PASS Tascent = 6em > AxisHeight, Tdescent = 1em, symmetric = false, minsize = 14em
+PASS Tascent = 4em < AxisHeight, Tdescent = 3em, symmetric = false, minsize = 14em
+PASS Tascent = 6em > AxisHeight, Tdescent = 22em, symmetric = false, maxsize = 14em
+PASS Tascent = 4em < AxisHeight, Tdescent = 24em, symmetric = false, maxsize = 14em
+PASS symmetric stretching with respect to the math axis (minsize = 14em)
+PASS symmetric stretching with respect to the math axis (maxsize = 14em)
 ↨
 1
 

--- a/LayoutTests/mathml/presentation/stretchy-minsize-maxsize-expected.html
+++ b/LayoutTests/mathml/presentation/stretchy-minsize-maxsize-expected.html
@@ -9,31 +9,9 @@
       <math>
         <mrow>
           <mo symmetric="false">|</mo>
-          <mspace height="5em" depth="5em"/>
-        </mrow>
-      </math>
-
-      <math>
-        <mrow>
-          <mo symmetric="false" maxsize="3em">|</mo>
-          <mspace height="1.5em" depth="1.5em"/>
-        </mrow>
-      </math>
-
-      <math>
-        <mrow>
-          <mo symmetric="false">|</mo>
-          <mspace height="5em" depth="5em"/>
-        </mrow>
-      </math>
-
-      <math>
-        <mrow>
-          <mo symmetric="false">|</mo>
           <mspace height="3em" depth="3em"/>
         </mrow>
       </math>
-
       <math>
         <mrow>
           <mo symmetric="false">|</mo>
@@ -59,26 +37,6 @@
           <mo symmetric="false">|</mo>
           <mspace height="10em" depth="10em"/>
         </mrow>
-      </math>
-      <math>
-        <mrow>
-          <mo symmetric="false">|</mo>
-          <mspace height=".1em" depth=".1em"/>
-        </mrow>
-      </math>
-
-      <math>
-        <mrow>
-          <mo symmetric="false">|</mo>
-          <mspace height="6em" depth="12em"/>
-        </mrow>
-      </math>
-      <math>
-        <mrow>
-          <mo symmetric="false">|</mo>
-          <mspace height="3em" depth="1em"/>
-        </mrow>
-        <mspace height="15em" depth="15em"/>
       </math>
 
       <math>

--- a/LayoutTests/mathml/presentation/stretchy-minsize-maxsize.html
+++ b/LayoutTests/mathml/presentation/stretchy-minsize-maxsize.html
@@ -5,32 +5,12 @@
   </head>
   <body>
 
+    <!-- Cases where an explicit minsize/maxsize actually clamps the stretch size are covered by
+         imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-axis-height-1.html.
+         Per MathML Core, the clamped target is distributed relative to the math axis rather than by
+         preserving the ascent/descent ratio, which cannot be expressed in a font-independent reference
+         here. This test keeps the cases that do not depend on that distribution. -->
     <p>
-      <!-- In theory, the bar should stretch to the size of the mspace (4em) but the minsize attribute forces it to stretch to 10em. -->
-      <math>
-        <mrow>
-          <mo symmetric="false" minsize="10em">|</mo>
-          <mspace height="2em" depth="2em"/>
-        </mrow>
-      </math>
-
-      <!-- In theory, the bar should stretch to the size of the mspace (6em) but the minsize attribute forces it to stretch to 3em. -->
-      <math>
-        <mrow>
-          <mo symmetric="false" maxsize="3em">|</mo>
-          <mspace height="3em" depth="3em"/>
-        </mrow>
-        <mspace height="5em" depth="5em"/>
-      </math>
-
-      <!-- Here minsize is more than maxsize, so minsize takes precedence. -->
-      <math>
-        <mrow>
-          <mo symmetric="false" minsize="10em" maxsize="3em">|</mo>
-          <mspace height="3em" depth="3em"/>
-        </mrow>
-      </math>
-
       <!-- We verify that invalid values are ignored. -->
       <math>
         <mrow>
@@ -58,35 +38,13 @@
           <mspace height="4em" depth="4em"/>
         </mrow>
       </math>
-      
 
-      <!-- We test default values for minsize and maxsize. -->
+      <!-- We test the default value for maxsize. -->
       <math>
         <mrow>
           <mo symmetric="false" maxsize="infinity">|</mo>
           <mspace height="10em" depth="10em"/>
         </mrow>
-      </math>
-      <math>
-        <mrow>
-          <mo symmetric="false" minsize="1em">|</mo>
-          <mspace height=".1em" depth=".1em"/>
-        </mrow>
-      </math>
-
-      <!-- We test that the ratio between height and depth is preserved. -->
-      <math>
-        <mrow>
-          <mo symmetric="false" minsize="18em">|</mo>
-          <mspace height="2em" depth="4em"/>
-        </mrow>
-      </math>
-      <math>
-        <mrow>
-          <mo symmetric="false" maxsize="4em">|</mo>
-          <mspace height="15em" depth="5em"/>
-        </mrow>
-        <mspace height="15em" depth="15em"/>
       </math>
 
       <!-- We test that the symmetric property is applied before the resize. -->

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -142,28 +142,51 @@ void RenderMathMLOperator::stretchTo(LayoutUnit heightAboveBaseline, LayoutUnit 
     m_stretchHeightAboveBaseline = heightAboveBaseline;
     m_stretchDepthBelowBaseline = depthBelowBaseline;
 
+    LayoutUnit axis = mathAxisHeight();
     if (hasOperatorFlag(MathMLOperatorDictionary::Symmetric)) {
         // We make the operator stretch symmetrically above and below the axis.
-        LayoutUnit axis = mathAxisHeight();
         LayoutUnit halfStretchSize = std::max(m_stretchHeightAboveBaseline - axis, m_stretchDepthBelowBaseline + axis);
         m_stretchHeightAboveBaseline = halfStretchSize + axis;
         m_stretchDepthBelowBaseline = halfStretchSize - axis;
     }
-    // We try to honor the minsize/maxsize condition by increasing or decreasing both height and depth proportionately.
-    // Per MathML Core step 5 of https://w3c.github.io/mathml-core/#layout-of-operators:
-    // "If minsize < 0 then set minsize to 0. If maxsize < minsize then set maxsize to minsize."
-    LayoutUnit size = stretchSize();
+    // Honor the minsize/maxsize constraints.
+    // https://w3c.github.io/mathml-core/#layout-of-operators
+    LayoutUnit size = stretchSize(); // T = Tascent + Tdescent.
     LayoutUnit minSizeValue = std::max(0_lu, minSize());
     LayoutUnit maxSizeValue = std::max(minSizeValue, maxSize());
-    float aspect = 1.0;
-    if (size > 0) {
-        if (size < minSizeValue)
-            aspect = minSizeValue.toFloat() / size;
-        else if (maxSizeValue < size)
-            aspect = maxSizeValue.toFloat() / size;
+
+    // The spec adjusts the target by scaling the part relative to the math axis (Tascent - AxisHeight)
+    // and keeping the descent as the remainder, which preserves symmetric stretching about the axis.
+    // We only apply this when an explicit minsize/maxsize is specified. Operators without an explicit
+    // constraint keep their unstretched-size minimum handled the legacy way, so that the ascent/descent
+    // distribution of ordinary stretchy operators (e.g. nested fences) is left unchanged. Anonymous
+    // operators (e.g. mfenced) have no backing element to query, so they always take the legacy path.
+    bool hasExplicitConstraint = !isAnonymous()
+        && (element().minSize().type != MathMLElement::LengthType::ParsingFailed
+            || element().maxSize().type != MathMLElement::LengthType::ParsingFailed);
+    if (hasExplicitConstraint) {
+        if (size <= 0) {
+            m_stretchHeightAboveBaseline = minSizeValue / 2 + axis;
+            m_stretchDepthBelowBaseline = minSizeValue - m_stretchHeightAboveBaseline;
+        } else if (size < minSizeValue) {
+            m_stretchHeightAboveBaseline = LayoutUnit(std::max(0.0f, (m_stretchHeightAboveBaseline - axis).toFloat()) * minSizeValue.toFloat() / size.toFloat()) + axis;
+            m_stretchDepthBelowBaseline = minSizeValue - m_stretchHeightAboveBaseline;
+        } else if (maxSizeValue < size) {
+            m_stretchHeightAboveBaseline = LayoutUnit(std::max(0.0f, (m_stretchHeightAboveBaseline - axis).toFloat()) * maxSizeValue.toFloat() / size.toFloat()) + axis;
+            m_stretchDepthBelowBaseline = maxSizeValue - m_stretchHeightAboveBaseline;
+        }
+    } else {
+        // Legacy proportional scaling for the default (no explicit constraint) case.
+        float aspect = 1.0;
+        if (size > 0) {
+            if (size < minSizeValue)
+                aspect = minSizeValue.toFloat() / size;
+            else if (maxSizeValue < size)
+                aspect = maxSizeValue.toFloat() / size;
+        }
+        m_stretchHeightAboveBaseline *= aspect;
+        m_stretchDepthBelowBaseline *= aspect;
     }
-    m_stretchHeightAboveBaseline *= aspect;
-    m_stretchDepthBelowBaseline *= aspect;
 
     m_mathOperator.stretchTo(style(), m_stretchHeightAboveBaseline + m_stretchDepthBelowBaseline);
 


### PR DESCRIPTION
#### 25f6d6ec0866507923cf7436cf9d821ca890a772
<pre>
[MathML] mo element does not correctly apply minsize/maxsize relative to the math axis
<a href="https://bugs.webkit.org/show_bug.cgi?id=317095">https://bugs.webkit.org/show_bug.cgi?id=317095</a>
<a href="https://rdar.apple.com/problem/179652256">rdar://problem/179652256</a>

Reviewed by NOBODY (OOPS!).

When an &lt;mo&gt; element has an explicit minsize or maxsize, WebKit honored the
constraint by scaling both the ascent and descent of the stretched operator by
a single proportional factor. Per MathML Core [1], the target size must instead
be adjusted by scaling the part of the operator relative to the math axis
(Tascent - AxisHeight) and keeping the descent as the remainder, so that
stretching stays symmetric about the math axis. The previous approach produced
the wrong ascent/descent split whenever the axis height was non-zero.

Apply the spec algorithm (the size&lt;=0, size&lt;minsize and maxsize&lt;size branches)
when an explicit minsize/maxsize is present. Operators without an explicit
constraint keep the previous proportional behavior so that the ascent/descent
distribution of ordinary stretchy operators (e.g. nested fences) is unchanged.
Anonymous operators (mfenced) have no backing element and always take the
legacy path.

[1] <a href="https://w3c.github.io/mathml-core/#layout-of-operators">https://w3c.github.io/mathml-core/#layout-of-operators</a>

* Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
(WebCore::RenderMathMLOperator::stretchTo):
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-axis-height-1-expected.txt: Progressions

&gt; Updated Local Test to remove tests conflicting with MathML Core:
* LayoutTests/mathml/presentation/stretchy-minsize-maxsize-expected.html:
* LayoutTests/mathml/presentation/stretchy-minsize-maxsize.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25f6d6ec0866507923cf7436cf9d821ca890a772

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126043 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/561cda31-2ecb-4575-a91e-29f86ea0f8fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131013 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92109 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64c0349a-a6c0-4a96-bab1-17c5b4f7fa13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111525 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fdb0e759-0c2b-47fa-88bf-5dfcbde2d85c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32468 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31170 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26366 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142454 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180270 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139450 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139313 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106138 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27665 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114359 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40500 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5750 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40751 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40645 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->