### PR TITLE
[JSC][B3] Implement CSE without using B3::Variable

### DIFF
--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -28,18 +28,22 @@
 
 #if ENABLE(B3_JIT)
 
+#include "B3BasicBlockInlines.h"
 #include "B3BlockWorklist.h"
+#include "B3BreakCriticalEdges.h"
 #include "B3Dominators.h"
 #include "B3HeapRange.h"
 #include "B3InsertionSetInlines.h"
 #include "B3MemoryValue.h"
 #include "B3MemoryValueInlines.h"
+#include "B3NaturalLoops.h"
 #include "B3PhaseScope.h"
 #include "B3ProcedureInlines.h"
 #include "B3PureCSE.h"
+#include "B3SSACalculator.h"
+#include "B3UpsilonValue.h"
 #include "B3ValueInlines.h"
 #include "B3ValueKeyInlines.h"
-#include "B3VariableValue.h"
 #include "B3WasmArrayElementValue.h"
 #include "B3WasmArrayGetValue.h"
 #include "B3WasmArraySetValue.h"
@@ -48,6 +52,7 @@
 #include "B3WasmStructSetValue.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/HashMap.h>
+#include <wtf/IndexSet.h>
 #include <wtf/ListDump.h>
 #include <wtf/RangeSet.h>
 #include <wtf/Scope.h>
@@ -72,6 +77,18 @@ static constexpr bool verbose = false;
 using MemoryMatches = Vector<MemoryValue*, 1>;
 using WasmStructMatches = Vector<WasmStructFieldValue*, 1>;
 using WasmArrayMatches = Vector<WasmArrayElementValue*, 1>;
+
+// Only these node kinds can ever become a key in CSE::m_sets (they are the
+// dominating matches: MemoryValue / WasmStructFieldValue / WasmArrayElementValue).
+// Used to skip the per-value m_sets hash lookup in finalize() and to assert at
+// the add site.
+inline bool canHaveSets(Value* value)
+{
+    Opcode opcode = value->opcode();
+    return isMemoryAccess(opcode)
+        || opcode == WasmStructGet || opcode == WasmStructSet
+        || opcode == WasmArrayGet || opcode == WasmArraySet;
+}
 
 class MemoryValueMap {
 public:
@@ -291,8 +308,6 @@ class CSE {
 public:
     CSE(Procedure& proc)
         : m_proc(proc)
-        , m_dominators(proc.dominators())
-        , m_impureBlockData(proc.size())
         , m_insertionSet(proc)
     {
     }
@@ -301,7 +316,13 @@ public:
     {
         dataLogIf(B3EliminateCommonSubexpressionsInternal::verbose, "B3 before CSE:\n", m_proc);
 
+        // Direct Upsilon insertion needs no critical edges.
+        breakCriticalEdges(m_proc);
+
         m_proc.resetValueOwners();
+        m_dominators = &m_proc.dominators();
+        m_impureBlockData = IndexMap<BasicBlock*, ImpureBlockData>(m_proc.size());
+        m_ssa = makeUnique<SSACalculator>(m_proc);
 
         // Summarize the impure effects of each block, and the impure values available at the end of
         // each block. This doesn't edit code yet.
@@ -361,9 +382,36 @@ public:
         }
 
         // Perform CSE. This edits code.
-        Vector<BasicBlock*> postOrder = m_proc.blocksInPostOrder();
-        for (unsigned i = postOrder.size(); i--;) {
-            m_block = postOrder[i];
+        performCSE(nullptr);
+
+        // Re-sweep loop blocks once to catch some additional cases. In reverse-post-order the loop body hasn't been
+        // processed when we visit the header, so back-edge queries from the header miss matches that show up after the body is processed.
+        NaturalLoops& loops = m_proc.naturalLoops();
+        if (loops.numLoops()) {
+            IndexSet<BasicBlock*> loopBlocks;
+            for (unsigned i = 0; i < loops.numLoops(); ++i) {
+                const auto& loop = loops.loop(i);
+                loopBlocks.add(loop.header());
+                for (unsigned j = 0; j < loop.size(); ++j)
+                    loopBlocks.add(loop.at(j));
+            }
+            performCSE(&loopBlocks);
+        }
+
+        finalize();
+
+        dataLogIf(B3EliminateCommonSubexpressionsInternal::verbose, "B3 after CSE:\n", m_proc);
+
+        return m_changed;
+    }
+
+private:
+    void performCSE(const IndexSet<BasicBlock*>* filter)
+    {
+        for (auto* block : m_proc.blocksInPostOrder() | std::views::reverse) {
+            m_block = block;
+            if (filter && !filter->contains(m_block))
+                continue;
             dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "Looking at ", *m_block, ":");
 
             m_data = ImpureBlockData();
@@ -374,32 +422,82 @@ public:
             m_insertionSet.execute(m_block);
             m_impureBlockData[m_block] = m_data;
         }
+    }
 
-        // The previous pass might have requested that we insert code in some basic block other than
-        // the one that it was looking at. This inserts them.
-        for (BasicBlock* block : m_proc) {
-            for (unsigned valueIndex = 0; valueIndex < block->size(); ++valueIndex) {
-                auto iter = m_sets.find(block->at(valueIndex));
-                if (iter == m_sets.end())
-                    continue;
+    void finalize()
+    {
+        if (m_pendingResolutions.isEmpty()) {
+            ASSERT(m_sets.isEmpty());
+            return;
+        }
 
-                for (Value* value : iter->value)
-                    m_insertionSet.insertValue(valueIndex + 1, value);
+        m_ssa->computePhis(
+            [&] (SSACalculator::Variable* var, BasicBlock*) -> Value* {
+                const auto& resolution = m_pendingResolutions[var->index()];
+                return m_proc.add<Value>(Phi, resolution.placeholder->type(), resolution.placeholder->origin());
+            });
+
+        for (BasicBlock* block : m_proc.blocksInPreOrder()) {
+            for (SSACalculator::Def* phiDef : m_ssa->phisForBlock(block))
+                m_insertionSet.insertValue(0, phiDef->value());
+
+            if (m_blocksWithSets.contains(block)) {
+                for (unsigned valueIndex = 0; valueIndex < block->size(); ++valueIndex) {
+                    Value* value = block->at(valueIndex);
+                    if (!canHaveSets(value))
+                        continue;
+                    auto iter = m_sets.find(value);
+                    if (iter == m_sets.end())
+                        continue;
+                    for (Value* extra : iter->value)
+                        m_insertionSet.insertValue(valueIndex + 1, extra);
+                }
             }
+
+            if (block->size()) {
+                unsigned upsilonIndex = block->size() - 1;
+                Origin upsilonOrigin = block->last()->origin();
+                for (BasicBlock* successor : block->successorBlocks()) {
+                    for (SSACalculator::Def* phiDef : m_ssa->phisForBlock(successor)) {
+                        SSACalculator::Variable* var = phiDef->variable();
+                        SSACalculator::Def* reaching = m_ssa->reachingDefAtTail(block, var);
+                        Value* upsilonChild;
+                        if (reaching)
+                            upsilonChild = reaching->value()->foldIdentity();
+                        else {
+                            // Predecessor reaches the Phi on a path with no def.
+                            upsilonChild = m_insertionSet.insertBottom(upsilonIndex, upsilonOrigin, m_pendingResolutions[var->index()].placeholder->type());
+                        }
+                        m_insertionSet.insert<UpsilonValue>(upsilonIndex, upsilonOrigin, upsilonChild, phiDef->value());
+                    }
+                }
+            }
+
             m_insertionSet.execute(block);
         }
 
-        dataLogIf(B3EliminateCommonSubexpressionsInternal::verbose, "B3 after CSE:\n", m_proc);
-
-        return m_changed;
+        for (auto& resolution : m_pendingResolutions) {
+            Value* reachingValue = nullptr;
+            for (SSACalculator::Def* phiDef : m_ssa->phisForBlock(resolution.useBlock)) {
+                if (phiDef->variable() == resolution.var) {
+                    reachingValue = phiDef->value();
+                    break;
+                }
+            }
+            if (!reachingValue) {
+                SSACalculator::Def* def = m_ssa->reachingDefAtHead(resolution.useBlock, resolution.var);
+                ASSERT(def);
+                reachingValue = def->value();
+            }
+            resolution.placeholder->replaceWithIdentity(reachingValue->foldIdentity());
+        }
     }
-    
-private:
+
     void process()
     {
         m_value->performSubstitution();
 
-        if (m_pureCSE.process(m_value, m_dominators)) {
+        if (m_pureCSE.process(m_value, *m_dominators)) {
             ASSERT(!m_value->effects().readsPinned || !m_data.writesPinned);
             ASSERT(!m_value->effects().writes);
             ASSERT(!m_value->effects().writesPinned);
@@ -415,7 +513,7 @@ private:
             Kind altKind = m_value->kind();
             altKind.setTraps(!altKind.traps());
             ValueKey altKey(altKind, m_value->type(), m_value->child(0));
-            if (Value* match = m_pureCSE.findMatch(altKey, m_block, m_dominators)) {
+            if (Value* match = m_pureCSE.findMatch(altKey, m_block, *m_dominators)) {
                 m_value->replaceWithIdentity(match);
                 m_changed = true;
                 return;
@@ -852,7 +950,7 @@ private:
 
         if (matches.size() == 1) {
             MemoryValue* dominatingMatch = matches[0];
-            RELEASE_ASSERT(m_dominators.dominates(dominatingMatch->owner, m_block));
+            RELEASE_ASSERT(m_dominators->dominates(dominatingMatch->owner, m_block));
             
             dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Eliminating using ", *dominatingMatch);
             Vector<Value*> extraValues;
@@ -869,32 +967,32 @@ private:
             return true;
         }
 
-        // FIXME: It would be way better if this phase just did SSA calculation directly.
-        // Right now we're relying on the fact that CSE's position in the phase order is
-        // almost right before SSA fixup.
 
-        Variable* variable = m_proc.addVariable(m_value->type());
+        // addBottom creates a fresh Const; InsertionSet::insertBottom would
+        // alias placeholders of the same type within one block.
+        SSACalculator::Variable* var = m_ssa->newVariable();
+        Value* placeholder = m_proc.addBottom(m_value->origin(), m_value->type());
+        m_insertionSet.insertValue(m_index, placeholder);
+        dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Inserting placeholder for value: ", *placeholder);
+        m_value->replaceWithIdentity(placeholder);
 
-        VariableValue* get = m_insertionSet.insert<VariableValue>(
-            m_index, Get, m_value->origin(), variable);
-        dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Inserting get of value: ", *get);
-        m_value->replaceWithIdentity(get);
-            
         for (MemoryValue* match : matches) {
-            Vector<Value*>& sets = m_sets.add(match, Vector<Value*>()).iterator->value;
-
-            Value* value = replace(match, sets);
+            ASSERT(canHaveSets(match));
+            m_blocksWithSets.add(match->owner);
+            auto& extras = m_sets.add(match, Vector<Value*>()).iterator->value;
+            Value* value = replace(match, extras);
             if (!value) {
                 if (match->isStore())
                     value = match->child(0);
                 else
                     value = match;
             }
-                
-            Value* set = m_proc.add<VariableValue>(Set, m_value->origin(), variable, value);
-            sets.append(set);
+
+            m_ssa->newDef(var, match->owner, value);
         }
 
+        m_pendingResolutions.append({ placeholder, m_block, var });
+        ASSERT(var->index() == m_pendingResolutions.size() - 1);
         return true;
     }
 
@@ -981,7 +1079,7 @@ private:
 
         Value* candidateReplacement = nullptr;
         BasicBlock* dominator = nullptr;
-        m_dominators.forAllStrictDominatorsOf(m_block, [&] (BasicBlock* block) {
+        m_dominators->forAllStrictDominatorsOf(m_block, [&] (BasicBlock* block) {
             if (candidateReplacement)
                 return;
 
@@ -1098,7 +1196,7 @@ private:
         auto fieldType = structType->field(fieldIndex).type;
         auto structGetOrigin = structGet->origin();
 
-        auto replace = [&](Value* dominatingMatch, Vector<Value*, 16>& extraValues) -> Value* {
+        auto replace = [&](Value* dominatingMatch, Vector<Value*>& extraValues) -> Value* {
             if (auto* structSet = dominatingMatch->as<WasmStructSetValue>()) {
                 Value* storedValue = structSet->child(1);
 
@@ -1131,13 +1229,13 @@ private:
 
         if (matches.size() == 1) {
             auto* dominatingMatch = matches[0];
-            RELEASE_ASSERT(m_dominators.dominates(dominatingMatch->owner, m_block));
+            RELEASE_ASSERT(m_dominators->dominates(dominatingMatch->owner, m_block));
 
             dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Eliminating using ", *dominatingMatch);
 
             // Handle store-to-load forwarding from WasmStructSet
 
-            Vector<Value*, 16> extraValues;
+            Vector<Value*> extraValues;
             auto* value = replace(dominatingMatch, extraValues);
             ASSERT(value);
             for (auto* extraValue : extraValues)
@@ -1146,23 +1244,23 @@ private:
             return true;
         }
 
-        // Multiple matches from different paths - need SSA fixup with Variable
-        Variable* variable = m_proc.addVariable(m_value->type());
-
-        VariableValue* get = m_insertionSet.insert<VariableValue>(m_index, Get, m_value->origin(), variable);
-        dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Inserting get of value: ", *get);
-        m_value->replaceWithIdentity(get);
+        SSACalculator::Variable* var = m_ssa->newVariable();
+        Value* placeholder = m_proc.addBottom(m_value->origin(), m_value->type());
+        m_insertionSet.insertValue(m_index, placeholder);
+        dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Inserting placeholder for value: ", *placeholder);
+        m_value->replaceWithIdentity(placeholder);
 
         for (auto* match : matches) {
-            Vector<Value*>& sets = m_sets.add(match, Vector<Value*>()).iterator->value;
-            Vector<Value*, 16> extraValues;
-            auto* value = replace(match, extraValues);
+            ASSERT(canHaveSets(match));
+            m_blocksWithSets.add(match->owner);
+            Vector<Value*>& extras = m_sets.add(match, Vector<Value*>()).iterator->value;
+            auto* value = replace(match, extras);
             ASSERT(value);
-            sets.appendVector(extraValues);
-            Value* set = m_proc.add<VariableValue>(Set, m_value->origin(), variable, value);
-            sets.append(set);
+            m_ssa->newDef(var, match->owner, value);
         }
 
+        m_pendingResolutions.append({ placeholder, m_block, var });
+        ASSERT(var->index() == m_pendingResolutions.size() - 1);
         return true;
     }
 
@@ -1328,7 +1426,7 @@ private:
         auto elementType = arrayType->elementType().type;
         auto arrayGetOrigin = arrayGet->origin();
 
-        auto replace = [&](Value* dominatingMatch, Vector<Value*, 16>& extraValues) -> Value* {
+        auto replace = [&](Value* dominatingMatch, Vector<Value*>& extraValues) -> Value* {
             if (auto* arraySet = dominatingMatch->as<WasmArraySetValue>()) {
                 Value* storedValue = arraySet->child(2);
                 Value* forwardedValue = storedValue;
@@ -1359,9 +1457,9 @@ private:
 
         if (matches.size() == 1) {
             auto* dominatingMatch = matches[0];
-            RELEASE_ASSERT(m_dominators.dominates(dominatingMatch->owner, m_block));
+            RELEASE_ASSERT(m_dominators->dominates(dominatingMatch->owner, m_block));
 
-            Vector<Value*, 16> extraValues;
+            Vector<Value*> extraValues;
             auto* value = replace(dominatingMatch, extraValues);
             ASSERT(value);
             for (auto* extraValue : extraValues)
@@ -1370,20 +1468,23 @@ private:
             return true;
         }
 
-        Variable* variable = m_proc.addVariable(m_value->type());
-        VariableValue* get = m_insertionSet.insert<VariableValue>(m_index, Get, m_value->origin(), variable);
-        m_value->replaceWithIdentity(get);
+        SSACalculator::Variable* var = m_ssa->newVariable();
+        Value* placeholder = m_proc.addBottom(m_value->origin(), m_value->type());
+        m_insertionSet.insertValue(m_index, placeholder);
+        dataLogLnIf(B3EliminateCommonSubexpressionsInternal::verbose, "    Inserting placeholder for value: ", *placeholder);
+        m_value->replaceWithIdentity(placeholder);
 
         for (auto* match : matches) {
-            Vector<Value*>& sets = m_sets.add(match, Vector<Value*>()).iterator->value;
-            Vector<Value*, 16> extraValues;
-            auto* value = replace(match, extraValues);
+            ASSERT(canHaveSets(match));
+            m_blocksWithSets.add(match->owner);
+            Vector<Value*>& extras = m_sets.add(match, Vector<Value*>()).iterator->value;
+            auto* value = replace(match, extras);
             ASSERT(value);
-            sets.appendVector(extraValues);
-            Value* set = m_proc.add<VariableValue>(Set, m_value->origin(), variable, value);
-            sets.append(set);
+            m_ssa->newDef(var, match->owner, value);
         }
 
+        m_pendingResolutions.append({ placeholder, m_block, var });
+        ASSERT(var->index() == m_pendingResolutions.size() - 1);
         return true;
     }
 
@@ -1476,20 +1577,33 @@ private:
 
     Procedure& m_proc;
 
-    Dominators& m_dominators;
+    Dominators* m_dominators { nullptr };
     PureCSE m_pureCSE;
-    
+
     IndexMap<BasicBlock*, ImpureBlockData> m_impureBlockData;
 
     ImpureBlockData m_data;
 
-    BasicBlock* m_block;
-    unsigned m_index;
-    Value* m_value;
+    BasicBlock* m_block { nullptr };
+    unsigned m_index { 0 };
+    Value* m_value { nullptr };
 
+    // Match -> extra fixup values (e.g. BitAnd masks for packed Wasm types),
+    // flushed at match site during finalize().
     UncheckedKeyHashMap<Value*, Vector<Value*>> m_sets;
+    // Blocks that own at least one m_sets key, so finalize() can skip whole blocks.
+    IndexSet<BasicBlock*> m_blocksWithSets;
 
     InsertionSet m_insertionSet;
+
+    std::unique_ptr<SSACalculator> m_ssa;
+
+    struct PendingResolution {
+        Value* placeholder;
+        BasicBlock* useBlock;
+        SSACalculator::Variable* var;
+    };
+    Vector<PendingResolution> m_pendingResolutions;
 
     bool m_changed { false };
 };

--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -86,8 +86,7 @@ void generateToAir(Procedure& procedure)
         reduceStrength(procedure, ReduceStrengthPass::Initial);
         if (Options::useB3HoistLoopInvariantValues())
             hoistLoopInvariantValues(procedure);
-        if (eliminateCommonSubexpressions(procedure))
-            eliminateCommonSubexpressions(procedure);
+        eliminateCommonSubexpressions(procedure);
         eliminateDeadCode(procedure);
         inferSwitches(procedure);
         if (Options::useB3TailDup())

--- a/Source/JavaScriptCore/b3/B3PureCSE.cpp
+++ b/Source/JavaScriptCore/b3/B3PureCSE.cpp
@@ -80,6 +80,9 @@ bool PureCSE::process(Value* value, Dominators& dominators)
     Matches& matches = m_map.add(key, Matches()).iterator->value;
 
     for (Value* match : matches) {
+        // CSE may revisit blocks (loop re-sweep); avoid self-replacement.
+        if (match == value)
+            return false;
         // Value is invalidated.
         if (!match->owner)
             continue;

--- a/Source/JavaScriptCore/b3/B3SSACalculator.cpp
+++ b/Source/JavaScriptCore/b3/B3SSACalculator.cpp
@@ -29,8 +29,11 @@
 #if ENABLE(B3_JIT)
 
 #include <wtf/CommaPrinter.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace B3 {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SSACalculator);
 
 void SSACalculator::Variable::dump(PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3SSACalculator.h
+++ b/Source/JavaScriptCore/b3/B3SSACalculator.h
@@ -32,6 +32,7 @@
 #include <wtf/Bag.h>
 #include <wtf/IndexMap.h>
 #include <wtf/SegmentedVector.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
 
@@ -39,6 +40,7 @@ namespace JSC { namespace B3 {
 // DFG::SSACalculator.
 
 class SSACalculator {
+    WTF_MAKE_TZONE_ALLOCATED(SSACalculator);
 public:
     SSACalculator(Procedure&);
     ~SSACalculator();

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1402,6 +1402,9 @@ void addLoadTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
 void addTupleTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
 
 void testCSEStoreWithLoop();
+void testCSELoadAfterStoreDiamond(bool flag);
+void testCSELoadAcrossLoopBackEdge(unsigned count);
+void testCSELoopHeaderLoadFromBackEdgeStore(unsigned count);
 
 bool shouldRun(const TestConfig*, const char* testName);
 

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -86,6 +86,142 @@ void testCSEStoreWithLoop()
     CHECK_EQ(num, 5);
 }
 
+void testCSELoadAfterStoreDiamond(bool flag)
+{
+    // Two predecessors each store a distinct value to the same address, then a
+    // load at the merge point reads it. CSE has more than one reaching store, so
+    // it must build a Phi of the stored values and forward the load to it (rather
+    // than re-reading memory). This exercises the multi-match Phi/Upsilon path.
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    BasicBlock* done = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* condition = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR1);
+    root->appendNewControlValue(proc, Branch, Origin(), condition, FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    Value* fortyTwo = thenCase->appendIntConstant(proc, Origin(), Int64, 42);
+    thenCase->appendNew<MemoryValue>(proc, Store, Origin(), fortyTwo, address);
+    thenCase->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(done));
+
+    Value* seven = elseCase->appendIntConstant(proc, Origin(), Int64, 7);
+    elseCase->appendNew<MemoryValue>(proc, Store, Origin(), seven, address);
+    elseCase->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(done));
+
+    Value* loaded = done->appendNew<MemoryValue>(proc, Load, Int64, Origin(), address);
+    done->appendNewControlValue(proc, Return, Origin(), loaded);
+
+    auto code = compileProc(proc);
+    int64_t storage = -1;
+    int64_t result = invoke<int64_t>(*code, std::bit_cast<intptr_t>(&storage), flag ? 1 : 0);
+    CHECK_EQ(result, flag ? 42 : 7);
+    // The store still wrote through to memory regardless of forwarding.
+    CHECK_EQ(storage, flag ? 42 : 7);
+}
+
+void testCSELoadAcrossLoopBackEdge(unsigned count)
+{
+    // The load and one of its reaching stores live in the same block (the loop
+    // body), but the store is logically *after* the load on the next iteration,
+    // reached via the back edge. So the load's def-block equals its use-block,
+    // yet the in-block store must not be forwarded directly: it has to flow
+    // through a loop-header Phi. This is the loop analogue of the old Get/Set
+    // interleaving in one block.
+    //
+    //   *p = 1
+    //   for (i = 0; i < count; ++i) {
+    //       acc = load(p)   // reaches: header store (1) and body store below
+    //       store(acc + 1, p)
+    //   }
+    //   return load(p)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* loop = proc.addBlock();
+    BasicBlock* done = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* tripCount = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR1);
+    Value* one = root->appendIntConstant(proc, Origin(), Int64, 1);
+    Value* zero = root->appendIntConstant(proc, Origin(), Int64, 0);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), one, address);
+    UpsilonValue* initialCounter = root->appendNew<UpsilonValue>(proc, Origin(), zero);
+    root->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(loop));
+
+    Value* counter = loop->appendNew<Value>(proc, Phi, Int64, Origin());
+    initialCounter->setPhi(counter);
+    Value* loaded = loop->appendNew<MemoryValue>(proc, Load, Int64, Origin(), address);
+    Value* incremented = loop->appendNew<Value>(proc, Add, Origin(), loaded, one);
+    loop->appendNew<MemoryValue>(proc, Store, Origin(), incremented, address);
+    Value* nextCounter = loop->appendNew<Value>(proc, Add, Origin(), counter, one);
+    loop->appendNew<UpsilonValue>(proc, Origin(), nextCounter)->setPhi(counter);
+    loop->appendNewControlValue(proc, Branch, Origin(),
+        loop->appendNew<Value>(proc, LessThan, Origin(), nextCounter, tripCount),
+        FrequentedBlock(loop), FrequentedBlock(done));
+
+    Value* result = done->appendNew<MemoryValue>(proc, Load, Int64, Origin(), address);
+    done->appendNewControlValue(proc, Return, Origin(), result);
+
+    auto code = compileProc(proc);
+    int64_t storage = -1;
+    int64_t value = invoke<int64_t>(*code, std::bit_cast<intptr_t>(&storage), static_cast<int64_t>(count));
+    int64_t expected = 1 + std::max(1u, count);
+    CHECK_EQ(value, expected);
+    CHECK_EQ(storage, expected);
+}
+
+void testCSELoopHeaderLoadFromBackEdgeStore(unsigned count)
+{
+    // The redundant load sits in the loop *header*, but one of its reaching
+    // stores lives in a separate *body* block reached via the back edge. In
+    // reverse-post-order the header is processed before the body, so on the
+    // first sweep the header's backward query can't yet see the post-edit body
+    // summary. This is exactly the case the loop re-sweep exists to catch; the
+    // test pins down that it stays correct regardless of which sweep fires.
+    //
+    //   *p = 1
+    //   for (i = 0; i < count; ++i)   // header: acc = load(p)
+    //       *p = acc + 1              // body (separate block)
+    //   return load(p)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* header = proc.addBlock();
+    BasicBlock* body = proc.addBlock();
+    BasicBlock* done = proc.addBlock();
+
+    Value* address = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR0);
+    Value* tripCount = root->appendNew<ArgumentRegValue>(proc, Origin(), GPRInfo::argumentGPR1);
+    Value* one = root->appendIntConstant(proc, Origin(), Int64, 1);
+    Value* zero = root->appendIntConstant(proc, Origin(), Int64, 0);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), one, address);
+    UpsilonValue* initialCounter = root->appendNew<UpsilonValue>(proc, Origin(), zero);
+    root->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(header));
+
+    Value* counter = header->appendNew<Value>(proc, Phi, Int64, Origin());
+    initialCounter->setPhi(counter);
+    Value* loaded = header->appendNew<MemoryValue>(proc, Load, Int64, Origin(), address);
+    header->appendNewControlValue(proc, Branch, Origin(),
+        header->appendNew<Value>(proc, LessThan, Origin(), counter, tripCount),
+        FrequentedBlock(body), FrequentedBlock(done));
+
+    Value* incremented = body->appendNew<Value>(proc, Add, Origin(), loaded, one);
+    body->appendNew<MemoryValue>(proc, Store, Origin(), incremented, address);
+    Value* nextCounter = body->appendNew<Value>(proc, Add, Origin(), counter, one);
+    body->appendNew<UpsilonValue>(proc, Origin(), nextCounter)->setPhi(counter);
+    body->appendNewControlValue(proc, Jump, Origin(), FrequentedBlock(header));
+
+    Value* result = done->appendNew<MemoryValue>(proc, Load, Int64, Origin(), address);
+    done->appendNewControlValue(proc, Return, Origin(), result);
+
+    auto code = compileProc(proc);
+    int64_t storage = -1;
+    int64_t value = invoke<int64_t>(*code, std::bit_cast<intptr_t>(&storage), static_cast<int64_t>(count));
+    int64_t expected = static_cast<int64_t>(count) + 1;
+    CHECK_EQ(value, expected);
+    CHECK_EQ(storage, expected);
+}
+
 void testLoadPreIndex32()
 {
     if (Options::defaultB3OptLevel() < 2)
@@ -4436,6 +4572,14 @@ void addShrTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& ta
 #if !CPU(ARM)
     RUN(testCSEStoreWithLoop());
 #endif
+    RUN(testCSELoadAfterStoreDiamond(true));
+    RUN(testCSELoadAfterStoreDiamond(false));
+    RUN(testCSELoadAcrossLoopBackEdge(0));
+    RUN(testCSELoadAcrossLoopBackEdge(1));
+    RUN(testCSELoadAcrossLoopBackEdge(5));
+    RUN(testCSELoopHeaderLoadFromBackEdgeStore(0));
+    RUN(testCSELoopHeaderLoadFromBackEdgeStore(1));
+    RUN(testCSELoopHeaderLoadFromBackEdgeStore(5));
 
     RUN(testLoadPreIndex32());
     RUN(testLoadPreIndex64());


### PR DESCRIPTION
#### 3cded5952709c2ca6085385defbdafb85a4df3e0
<pre>
[JSC][B3] Implement CSE without using B3::Variable
<a href="https://bugs.webkit.org/show_bug.cgi?id=317099">https://bugs.webkit.org/show_bug.cgi?id=317099</a>
<a href="https://rdar.apple.com/179662935">rdar://179662935</a>

Reviewed by Yijia Huang.

This patch removes B3::Variable use in B3 CSE phase. This resolves
long-standing FIXME in this phase, using SSA Calculator directly instead
of B3 Variable.

The mapping is simple.

1. And &quot;Get&quot; and &quot;Set&quot; defines a new SSA Variable for each set of them.
   And we Def and Use the variable. Def is corresponding to &quot;Set&quot; and
   Use is corresponding to &quot;Get&quot;.
2. Instead of emitting &quot;Get&quot;, we emit a placeholder. Which will be later
   replaced with the actually resolved value.
3. At the finalization, we compute SSA. This produces where we should
   insert Phis. And inserting Phis to them. Also, insert Upsilon where
   we need to insert. That&apos;s aligned to B3 FixSSA phase.
4. Finally, placeholder inserted in (2) is replaced with the resolved
   value, which can be a direct value, or phi inserted in (3).

* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3PureCSE.cpp:
(JSC::B3::PureCSE::process):
* Source/JavaScriptCore/b3/B3SSACalculator.cpp:
* Source/JavaScriptCore/b3/B3SSACalculator.h:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testCSELoadAfterStoreDiamond):
(testCSELoadAcrossLoopBackEdge):
(testCSELoopHeaderLoadFromBackEdgeStore):
(addShrTests):

Canonical link: <a href="https://commits.webkit.org/315406@main">https://commits.webkit.org/315406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e6cb146e2234b57e132615904c217e2a515c074

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126505 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131434 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111938 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32875 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31588 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26824 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/127 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180730 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30049 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139882 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42369 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139726 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43058 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28081 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106810 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25738 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Yijia Huang; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35008 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114825 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201477 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41561 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6169 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54084 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40958 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41212 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41103 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->