### PR TITLE
Inconsistent straight quotes ("%@") and curly apostrophe (extension’s) in same string (2 strings).

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -926,7 +926,7 @@
 "Local documents on your computer" = "Local documents on your computer";
 
 /* Lockdown Mode alert title */
-"Lockdown Mode is Turned On For “%@“" = "Lockdown Mode is Turned On For “%@“";
+"Lockdown Mode is Turned On For “%@”" = "Lockdown Mode is Turned On For “%@”";
 
 /* Title for Look Up action button */
 "Look Up" = "Look Up";
@@ -1003,8 +1003,8 @@
 /* WKWebExtensionErrorInvalidBackgroundContent description for missing background service_worker or scripts keys */
 "Manifest `background` entry has missing or empty required `service_worker` or `scripts` key for `preferred_environment` of `service_worker`." = "Manifest `background` entry has missing or empty required `service_worker` or `scripts` key for `preferred_environment` of `service_worker`.";
 
-/* WKWebExtensionErrorInvalidContentScripts description for missing or empty 'js' and 'css' arrays */
-"Manifest `content_scripts` entry has missing or empty 'js' and 'css' arrays." = "Manifest `content_scripts` entry has missing or empty 'js' and 'css' arrays.";
+/* WKWebExtensionErrorInvalidContentScripts description for missing or empty `js` and `css` arrays */
+"Manifest `content_scripts` entry has missing or empty `js` and `css` arrays." = "Manifest `content_scripts` entry has missing or empty `js` and `css` arrays.";
 
 /* WKWebExtensionErrorInvalidContentScripts description for missing matches entry */
 "Manifest `content_scripts` entry has no specified `matches` entry." = "Manifest `content_scripts` entry has no specified `matches` entry.";
@@ -1645,20 +1645,20 @@
 /* accessibility role description for a URL field. */
 "URL field" = "URL field";
 
-/* WKWebExtensionErrorResourceNotFound description with file name */
-"Unable to find \"%@\" in the extension’s resources." = "Unable to find \"%@\" in the extension’s resources.";
-
-/* WKWebExtensionErrorResourceNotFound description with invalid file path */
-"Unable to find \"%@\" in the extension’s resources. It is an invalid path." = "Unable to find \"%@\" in the extension’s resources. It is an invalid path.";
-
-/* WKWebExtensionErrorResourceNotFound description with file name */
-"Unable to find \"%s\" in the extension’s resources." = "Unable to find \"%s\" in the extension’s resources.";
-
-/* WKWebExtensionErrorResourceNotFound description with invalid file path */
-"Unable to find \"%s\" in the extension’s resources. It is an invalid path." = "Unable to find \"%s\" in the extension’s resources. It is an invalid path.";
-
 /* Error description for missing default_locale */
 "Unable to find `default_locale` in “_locales” folder." = "Unable to find `default_locale` in “_locales” folder.";
+
+/* WKWebExtensionErrorResourceNotFound description with file name */
+"Unable to find “%@” in the extension’s resources." = "Unable to find “%@” in the extension’s resources.";
+
+/* WKWebExtensionErrorResourceNotFound description with invalid file path */
+"Unable to find “%@” in the extension’s resources. It is an invalid path." = "Unable to find “%@” in the extension’s resources. It is an invalid path.";
+
+/* WKWebExtensionErrorResourceNotFound description with file name */
+"Unable to find “%s” in the extension’s resources." = "Unable to find “%s” in the extension’s resources.";
+
+/* WKWebExtensionErrorResourceNotFound description with invalid file path */
+"Unable to find “%s” in the extension’s resources. It is an invalid path." = "Unable to find “%s” in the extension’s resources. It is an invalid path.";
 
 /* WKWebExtensionErrorInvalidDeclarativeNetRequest description */
 "Unable to parse `declarativeNetRequest` rules because of an unexpected error." = "Unable to parse `declarativeNetRequest` rules because of an unexpected error.";
@@ -1673,7 +1673,7 @@
 "Unable to parse manifest: %s" = "Unable to parse manifest: %s";
 
 /* WKWebExtensionErrorInvalidResourceCodeSignature description with file name */
-"Unable to validate \"%@\" with the extension’s code signature. It likely has been modified since the extension was built." = "Unable to validate \"%@\" with the extension’s code signature. It likely has been modified since the extension was built.";
+"Unable to validate “%@” with the extension’s code signature. It likely has been modified since the extension was built." = "Unable to validate “%@” with the extension’s code signature. It likely has been modified since the extension was built.";
 
 /* Unacceptable TLS certificate error */
 "Unacceptable TLS certificate" = "Unacceptable TLS certificate";
@@ -2227,6 +2227,9 @@
 /* Message for requesting access to the device motion and orientation */
 "“%@” Would Like to Access Motion and Orientation" = "“%@” Would Like to Access Motion and Orientation";
 
+/* Full Screen Warning Banner Content Text */
+"“%@” is in full screen.\nSwipe down to exit." = "“%@” is in full screen.\nSwipe down to exit.";
+
 /* Allow the specified bundle to sign in to the specified website */
 "“%@” would like to sign in to “%@”." = "“%@” would like to sign in to “%@”.";
 
@@ -2235,9 +2238,6 @@
 
 /* Prompt for a webpage to request location access. The parameter is the domain for the webpage. */
 "“%@” would like to use your current location." = "“%@” would like to use your current location.";
-
-/* Full Screen Warning Banner Content Text */
-"”%@” is in full screen.\nSwipe down to exit." = "”%@” is in full screen.\nSwipe down to exit.";
 
 /* Option in segmented control for choosing list type in text editing */
 "•" = "•";

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -251,7 +251,7 @@ Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(c
     auto *resourceURL = resourceFileURLForPath(path).createNSURL().get();
     if (!resourceURL) {
         if (suppressErrors == SuppressNotFoundErrors::No)
-            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_CFSTRING("Unable to find \"%@\" in the extension’s resources. It is an invalid path.", "WKWebExtensionErrorResourceNotFound description with invalid file path", bridge_cast(cocoaPath))));
+            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_CFSTRING("Unable to find “%@” in the extension’s resources. It is an invalid path.", "WKWebExtensionErrorResourceNotFound description with invalid file path", bridge_cast(cocoaPath))));
         return makeUnexpected(nullptr);
     }
 
@@ -259,14 +259,14 @@ Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(c
     NSData *resultData = [NSData dataWithContentsOfURL:resourceURL options:NSDataReadingMappedIfSafe error:&fileReadError];
     if (!resultData) {
         if (suppressErrors == SuppressNotFoundErrors::No)
-            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_CFSTRING("Unable to find \"%@\" in the extension’s resources.", "WKWebExtensionErrorResourceNotFound description with file name", bridge_cast(cocoaPath)), API::Error::create(fileReadError)));
+            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_CFSTRING("Unable to find “%@” in the extension’s resources.", "WKWebExtensionErrorResourceNotFound description with file name", bridge_cast(cocoaPath)), API::Error::create(fileReadError)));
         return makeUnexpected(nullptr);
     }
 
 #if PLATFORM(MAC)
     NSError *validationError;
     if (!validateResourceData(resourceURL, resultData, &validationError)) {
-        return makeUnexpected(createError(Error::InvalidResourceCodeSignature, WEB_UI_FORMAT_CFSTRING("Unable to validate \"%@\" with the extension’s code signature. It likely has been modified since the extension was built.", "WKWebExtensionErrorInvalidResourceCodeSignature description with file name", bridge_cast(cocoaPath)), API::Error::create(validationError)));
+        return makeUnexpected(createError(Error::InvalidResourceCodeSignature, WEB_UI_FORMAT_CFSTRING("Unable to validate “%@” with the extension’s code signature. It likely has been modified since the extension was built.", "WKWebExtensionErrorInvalidResourceCodeSignature description with file name", bridge_cast(cocoaPath)), API::Error::create(validationError)));
     }
 #endif
 

--- a/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
+++ b/Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp
@@ -106,14 +106,14 @@ Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(c
     auto resourceURL = resourceFileURLForPath(path);
     if (resourceURL.isEmpty()) {
         if (suppressErrors == SuppressNotFoundErrors::No)
-            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_STRING("Unable to find \"%s\" in the extension’s resources. It is an invalid path.", "WKWebExtensionErrorResourceNotFound description with invalid file path", path.utf8().data())));
+            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_STRING("Unable to find “%s” in the extension’s resources. It is an invalid path.", "WKWebExtensionErrorResourceNotFound description with invalid file path", path.utf8().data())));
         return makeUnexpected(nullptr);
     }
 
     auto rawData = FileSystem::readEntireFile(resourceURL.fileSystemPath());
     if (!rawData.has_value()) {
         if (suppressErrors == SuppressNotFoundErrors::No)
-            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_STRING("Unable to find \"%s\" in the extension’s resources.", "WKWebExtensionErrorResourceNotFound description with file name", path.utf8().data())));
+            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_STRING("Unable to find “%s” in the extension’s resources.", "WKWebExtensionErrorResourceNotFound description with file name", path.utf8().data())));
         return makeUnexpected(nullptr);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
@@ -966,7 +966,7 @@ TEST(WKWebExtensionContext, LoadNonExistentImage)
 
     auto *error = manager.get().context.errors.firstObject;
     EXPECT_EQ(error.code, WKWebExtensionErrorResourceNotFound);
-    EXPECT_NS_EQUAL(error.localizedDescription, @"Unable to find \"non-existent-image.png\" in the extension’s resources. It is an invalid path.");
+    EXPECT_NS_EQUAL(error.localizedDescription, @"Unable to find “non-existent-image.png” in the extension’s resources. It is an invalid path.");
 }
 
 TEST(WKWebExtensionContext, TopLevelThrowInModuleBackground)


### PR DESCRIPTION
#### 85d58e7ee257b076ed23282b7356a9f220e749d9
<pre>
Inconsistent straight quotes (&quot;%@&quot;) and curly apostrophe (extension’s) in same string (2 strings).
<a href="https://webkit.org/b/317101">https://webkit.org/b/317101</a>
<a href="https://rdar.apple.com/177876427">rdar://177876427</a>

Reviewed by Brian Weinstein.

Change straight quotes to curly quotes for both Web Extension errors for Cocoa and GTK ports.
Ran `update-webkit-localizable-strings` to regenerate Localizable.strings.

* Source/WebCore/en.lproj/Localizable.strings: Updated with script.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceDataForPath): Fixed quotes.
* Source/WebKit/UIProcess/Extensions/glib/WebExtensionGLib.cpp:
(WebKit::WebExtension::resourceDataForPath): Ditto.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST(WKWebExtensionContext, LoadNonExistentImage)): Updated string.

Canonical link: <a href="https://commits.webkit.org/315224@main">https://commits.webkit.org/315224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3942e5c3b0d3082e54a1cc44ce82c86a418b21a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126134 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e330ec1-79c6-420f-9354-1f16b8f6af68) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131090 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d4c63b3-4d40-4dd4-9a1c-e7c65fdde862) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111601 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6585d72c-aa63-484b-ba1b-98c60523ce42) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32538 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31243 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26457 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142524 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180361 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139524 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139388 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42690 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106320 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25653 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34677 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27737 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114450 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40591 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5821 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40736 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->