### PR TITLE
[Win] Garden five layout-test failures (Site Isolation, WebGL, WebSocket, IDNA)

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
 <meta charset="utf-8">

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1089,6 +1089,11 @@ http/tests/ssl/curl/certificate-and-authentication.html [ Failure ]
 # Needs site isolation drawing implementation
 http/tests/site-isolation [ Skip ]
 
+# Requires Site Isolation (SiteIsolationEnabled, a WebKit2-only feature), which
+# the Windows port does not yet support (see the http/tests/site-isolation skip
+# above). Without it the test crashes the GPU process, so skip it.
+fast/events/site-isolation [ Skip ]
+
 webkit.org/b/68278  http/tests/history/back-with-fragment-change.py [ Failure Pass ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
@@ -1892,6 +1897,11 @@ webgl/1.0.x/conformance/textures/misc/png-image-types.html [ Failure ]
 webgl/2.0.y/conformance/textures/misc/png-image-types.html [ Failure ]
 webgl/2.0.y/conformance2/glsl3/switch-case.html [ Failure ]
 webgl/2.0.y/conformance2/glsl3/texture-bias.html [ Failure ]
+
+# Relies on Cocoa IOSurface copy-on-write semantics and full OffscreenCanvas+WebGL
+# support, neither of which the Skia-based Windows port has. Fails the same way on
+# glib (which marks it [ Failure ] as well).
+webgl/webgl-modify-after-drawimage.html [ Failure ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # Unknown category

--- a/LayoutTests/platform/win/http/tests/websocket/tests/hybi/handshake-ok-with-http-version-beyond-1_1-expected.txt
+++ b/LayoutTests/platform/win/http/tests/websocket/tests/hybi/handshake-ok-with-http-version-beyond-1_1-expected.txt
@@ -1,0 +1,10 @@
+Test http version parsing and validation. HTTP version 1.1 and above should be accepted for WebSockets.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+FAIL The following URL should have caused an error: ws://localhost:8880/websocket/tests/hybi/handshake-ok-with-http-version-beyond-1_1?01.00
+FAIL At least one test failed.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/url/IdnaTestV2.any-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/url/IdnaTestV2.any-expected.txt
@@ -1823,7 +1823,7 @@ PASS ToASCII("１꫶Ss𑲥｡ᷘ") V6
 PASS ToASCII("xn--3j78f.xn--mkb20b") V7
 PASS ToASCII("𲤱⒛⾳．ꡦ⒈") V7
 FAIL ToASCII("𲤱20.音.ꡦ1.") A4_2 (ignored) "https://𲤱20.音.ꡦ1./x" cannot be parsed as a URL.
-FAIL ToASCII("xn--20-9802c.xn--0w5a.xn--1-eg4e.") A4_2 (ignored) "https://xn--20-9802c.xn--0w5a.xn--1-eg4e./x" cannot be parsed as a URL.
+PASS ToASCII("xn--20-9802c.xn--0w5a.xn--1-eg4e.") A4_2 (ignored)
 PASS ToASCII("xn--dth6033bzbvx.xn--tsh9439b") V7
 PASS ToASCII("Ⴕ。۰≮ß݅")
 PASS ToASCII("Ⴕ。۰≮ß݅")
@@ -1910,7 +1910,7 @@ PASS ToASCII("𲮚９ꍩ៓．‍ß") C2
 PASS ToASCII("𲮚9ꍩ៓.‍ß") C2
 PASS ToASCII("𲮚9ꍩ៓.‍SS") C2
 PASS ToASCII("𲮚9ꍩ៓.‍ss") C2
-FAIL ToASCII("xn--9-i0j5967eg3qz.ss") "https://xn--9-i0j5967eg3qz.ss/x" cannot be parsed as a URL.
+PASS ToASCII("xn--9-i0j5967eg3qz.ss")
 FAIL ToASCII("𲮚9ꍩ៓.ss") "https://𲮚9ꍩ៓.ss/x" cannot be parsed as a URL.
 FAIL ToASCII("𲮚9ꍩ៓.SS") "https://𲮚9ꍩ៓.SS/x" cannot be parsed as a URL.
 PASS ToASCII("xn--9-i0j5967eg3qz.xn--ss-l1t") C2


### PR DESCRIPTION
#### 9981b18ea8799b70e92631f0501662c018fb1446
<pre>
[Win] Garden five layout-test failures (Site Isolation, WebGL, WebSocket, IDNA)
<a href="https://bugs.webkit.org/show_bug.cgi?id=317178">https://bugs.webkit.org/show_bug.cgi?id=317178</a>

Unreviewed test gardening.

Each test fails on the Windows port for a port-specific reason; verified by
running each against a local Release build.

* LayoutTests/http/tests/websocket/tests/hybi/inspector/handshake-error.html:
    Route JS console logging to stderr (dumpJSConsoleLogInStdErr), matching the
    sibling handshake-fail tests. The &quot;WebSocket connection ... failed: 403&quot;
    console message is emitted by the inspected page on a path that is not
    synchronized with the inspector test-completion path, so under bot timing it
    intermittently lands in the compared output and causes a text diff; the three
    inspector assertions themselves always pass.

* LayoutTests/platform/win/TestExpectations:

  - fast/events/site-isolation [ Skip ]
    Needs Site Isolation (SiteIsolationEnabled), a WebKit2-only feature the
    Windows port does not yet support (like the existing http/tests/site-isolation
    skip). Without it the test crashes the GPU process.

  - webgl/webgl-modify-after-drawimage.html [ Failure ]
    Relies on Cocoa IOSurface copy-on-write semantics and full OffscreenCanvas +
    WebGL support that the Skia-based Windows port lacks; fails identically on
    glib, which also marks it [ Failure ].

* LayoutTests/platform/win/http/tests/websocket/tests/hybi/handshake-ok-with-http-version-beyond-1_1-expected.txt: Added.
    The curl WebSocket handshake parser accepts HTTP/01.00 at a 101 response
    where it should reject it (RFC 6455 requires &gt;= 1.1), so the ?01.00 case
    opens instead of erroring. Recording the current Windows result; the other
    ten cases pass.

* LayoutTests/platform/win/imported/w3c/web-platform-tests/url/IdnaTestV2.any-expected.txt:
    Rebaselined. The bundled ICU (77.1) now passes two UTS-46 subtests
    (xn--20-9802c.xn--0w5a.xn--1-eg4e. and xn--9-i0j5967eg3qz.ss) that the
    previous baseline recorded as failing.

Canonical link: <a href="https://commits.webkit.org/315429@main">https://commits.webkit.org/315429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02b320e838545d81b45061be7fa9895a0bcad9ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131207 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92287 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31356 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26580 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180484 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139648 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42124 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151366 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139506 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42812 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106473 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25752 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34786 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41316 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6356 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->