### PR TITLE
[JSC] Use counting sort for `Array#sort`

### DIFF
--- a/JSTests/stress/array-default-sort-radix-edge-cases.js
+++ b/JSTests/stress/array-default-sort-radix-edge-cases.js
@@ -1,0 +1,173 @@
+// Default (no-comparator) Array.prototype.sort must order elements like a comparator comparing
+// String(a) vs String(b) in code-unit order. Comparing serialized results (not identity) keeps
+// the legitimate instability of equal strings from causing false failures.
+
+function ser(arr) {
+    let parts = [];
+    for (let i = 0; i < arr.length; i++)
+        parts.push((i in arr) ? ("|" + String(arr[i])) : "|<hole>");
+    return parts.join("");
+}
+
+function refCmp(a, b) {
+    let sa = String(a), sb = String(b);
+    return sa < sb ? -1 : (sa > sb ? 1 : 0);
+}
+
+// slice() preserves holes and undefined, so each operation gets an independent copy
+// of the same input (objects are shared by reference, which is fine here).
+let failures = 0;
+function check(arr, label) {
+    let a = arr.slice();
+    let lenBefore = a.length;
+    let sorted = a.sort();
+    if (sorted !== a)
+        throw new Error(label + ": sort() must return the same array");
+    if (a.length !== lenBefore)
+        throw new Error(label + ": length changed " + lenBefore + " -> " + a.length);
+    let expected = arr.slice().sort(refCmp);
+    if (ser(a) !== ser(expected)) {
+        failures++;
+        if (failures <= 8) {
+            print("ORDER FAIL [" + label + "]");
+            print("  got: " + ser(a).slice(0, 200));
+            print("  exp: " + ser(expected).slice(0, 200));
+        }
+    }
+    // toSorted must not mutate the receiver, and must order like refCmp's toSorted.
+    // (toSorted reads holes as undefined, unlike in-place sort which keeps trailing holes,
+    // so it is compared against refCmp's toSorted rather than against sort.)
+    let src = arr.slice();
+    let copy = src.slice();
+    let ts = src.toSorted();
+    if (ser(src) !== ser(copy))
+        throw new Error(label + ": toSorted mutated the receiver");
+    if (ser(ts) !== ser(arr.slice().toSorted(refCmp))) {
+        failures++;
+        if (failures <= 8) {
+            print("TOSORTED FAIL [" + label + "]");
+            print("  got: " + ser(ts).slice(0, 200));
+            print("  exp: " + ser(arr.slice().toSorted(refCmp)).slice(0, 200));
+        }
+    }
+}
+
+// --- Boundary around the radix threshold (32) and the depth cap (32 code units). ---
+for (let n = 0; n <= 40; n++) {
+    check(Array.from({ length: n }, (_, i) => (i * 2654435761) % 97), "numbers n=" + n);
+    check(Array.from({ length: n }, (_, i) => "s" + ((i * 40503) % 13)), "shortstr n=" + n);
+}
+
+// --- All identical strings (everything funnels into one bucket, then terminal bucket 0). ---
+for (let n of [1, 31, 32, 33, 100, 500]) {
+    check(Array.from({ length: n }, () => "same"), "identical-short n=" + n);
+    check(Array.from({ length: n }, () => "x".repeat(40)), "identical-deep n=" + n); // >32 code units -> depth cap
+}
+
+// --- Empty strings, and prefixes of varying length (terminal buckets at many depths). ---
+check(["", "a", "ab", "abc", "a", "", "abcd", "ab", "abc", "abce", "abcz", "abca"], "prefix-ladder");
+(() => {
+    let a = [];
+    let words = ["", "a", "aa", "aaa", "aaaa", "ab", "aba", "abb", "b", "ba", "bb", "z", ""];
+    for (let i = 0; i < 50; i++) a.push(words[(i * 7) % words.length]);
+    check(a, "prefix-ladder-big");
+})();
+
+// --- Code-unit boundaries: NUL (byte 0), 0xFF/0x100 (high/low byte split), 0xFFFF. ---
+check([" ", "  ", "", "", " a", "a"], "nul-bytes");
+(() => {
+    let a = [];
+    for (let i = 0; i < 60; i++) {
+        // alternate code units that differ only in low byte vs only in high byte
+        let cu = (i % 2) ? (0x0100 + (i % 5)) : (0x0001 + (i % 5) * 0x0100);
+        a.push(String.fromCharCode(cu) + String.fromCharCode(0x00FF + (i % 3)));
+    }
+    check(a, "high-low-byte-split");
+})();
+check(["￿", "￾", "Ā", "ÿ", "", "", "￿ ", "￿"], "wide-code-units");
+
+// --- Surrogate code units / non-BMP: default sort is code-unit order, not code-point order. ---
+check(["\uD800", "\uDFFF", "퟿", "", "𐀀", "􏿿", "a", "￿"], "surrogates");
+(() => {
+    let a = [];
+    for (let i = 0; i < 50; i++) a.push(String.fromCodePoint(0x1F600 + (i % 7)) + String.fromCharCode(97 + (i % 4)));
+    check(a, "non-bmp");
+})();
+
+// --- Numbers stringified: negatives, decimals, -0, Infinity, NaN. ---
+check([10, 9, 100, 1, 20, 2, 3, 30, 0, -1, -10, -2, 11, 21, 101, 110, 12, 13, 14, 15, 16, 17, 18, 19, 22, 23, 24, 25, 26, 27, 28, 29, 31, 32, 33], "number-string-order");
+check([Infinity, -Infinity, NaN, 0, -0, 1.5, 1.25, 1.125, 1e21, 1e-7, 0.1, 0.2, 100, 99, 9, NaN, Infinity], "special-numbers");
+
+// --- undefined and holes placement (must be: values, then undefined, then holes). ---
+check([3, undefined, 1, undefined, 2], "undefined-mix");
+(() => { let a = [5, 4, 3, 2, 1]; a[10] = 0; a[20] = 9; check(a, "sparse-holes"); })();
+(() => { let a = new Array(40); for (let i = 0; i < 40; i += 2) a[i] = (i * 13) % 50; a[5] = undefined; a[7] = undefined; check(a, "holes-and-undefined-big"); })();
+
+// --- Mixed types in one array (all funnel through ToString). ---
+check([true, false, null, 1, "1", "true", {}, [1, 2], "a", 0, "0", "", "[object Object]"], "mixed-types");
+(() => {
+    let a = [];
+    for (let i = 0; i < 60; i++) {
+        let r = i % 6;
+        a.push(r === 0 ? i : r === 1 ? String(i) : r === 2 ? (i % 2 === 0) : r === 3 ? { x: i } : r === 4 ? [i] : null);
+    }
+    check(a, "mixed-types-big");
+})();
+
+// --- Deep shared prefix beyond the 32 code-unit depth cap (ordering must still be correct). ---
+(() => {
+    let a = [];
+    let base = "Z".repeat(40);
+    for (let i = 0; i < 80; i++) a.push(base + ((i * 31) % 17) + "tail");
+    check(a, "deep-prefix-ordering");
+})();
+
+// --- Randomized differential across alphabets and sizes (deterministic seed). ---
+let seed = 0x9e3779b9 >>> 0;
+function rnd() {
+    seed ^= seed << 13; seed >>>= 0;
+    seed ^= seed >> 17;
+    seed ^= seed << 5; seed >>>= 0;
+    return seed >>> 0;
+}
+for (let trial = 0; trial < 4000; trial++) {
+    let n = rnd() % 400;
+    let mode = rnd() % 5;
+    let a = new Array(n);
+    for (let i = 0; i < n; i++) {
+        if (mode === 0) a[i] = rnd() % 1000000;                       // numbers, small distinct prefix
+        else if (mode === 1) { let len = rnd() % 8, s = ""; for (let j = 0; j < len; j++) s += String.fromCharCode(97 + rnd() % 4); a[i] = s; } // tiny alphabet, many collisions
+        else if (mode === 2) { let len = 1 + rnd() % 6, s = ""; for (let j = 0; j < len; j++) s += String.fromCharCode(32 + rnd() % 200); a[i] = s; } // wide alphabet, BMP
+        else if (mode === 3) { let len = rnd() % 5, s = ""; for (let j = 0; j < len; j++) s += String.fromCharCode(0xD800 + rnd() % 0x800); a[i] = s; } // raw surrogate code units
+        else { let r = rnd() % 4; a[i] = r === 0 ? (rnd() % 50) : r === 1 ? String.fromCharCode(97 + rnd() % 5) : r === 2 ? undefined : null; } // mixed incl undefined
+    }
+    check(a, "rand trial=" + trial + " mode=" + mode + " n=" + n);
+}
+
+// --- Stability where the radix path guarantees it (shallow keys, n >= 32). ---
+// Distinct objects whose ToString collides on short keys keep insertion order: equal-key
+// runs are scattered stably and identical strings land in the terminal bucket in order.
+function checkStability(n, distinctKeys, label) {
+    let a = [];
+    for (let i = 0; i < n; i++) {
+        let key = "k" + (rnd() % distinctKeys);
+        let o = { id: i, key };
+        o.toString = function () { return this.key; };
+        a.push(o);
+    }
+    let expected = a.slice().sort((x, y) => x.key < y.key ? -1 : x.key > y.key ? 1 : x.id - y.id);
+    let got = a.slice().sort();
+    for (let i = 0; i < n; i++) {
+        if (got[i] !== expected[i]) {
+            failures++;
+            if (failures <= 8) print("STABILITY FAIL [" + label + "] at i=" + i);
+            return;
+        }
+    }
+}
+for (let trial = 0; trial < 600; trial++)
+    checkStability(32 + rnd() % 400, 1 + rnd() % 8, "stab trial=" + trial);
+
+if (failures)
+    throw new Error(failures + " failure(s) in default-sort radix edge cases");
+print("PASS: default-sort radix edge cases");

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -44,9 +44,9 @@
 #include "StringRecursionChecker.h"
 #include "VMEntryScopeInlines.h"
 #include <algorithm>
+#include <array>
 #include <wtf/Assertions.h>
 #include <wtf/MathExtras.h>
-#include <wtf/StdMap.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -813,6 +813,10 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncSlice, (JSGlobalObject* globalObject, Cal
 using SortJSValueVector = MarkedArgumentBufferWithSize<64>;
 using SortEntryVector = Vector<std::tuple<JSValue, String>>;
 
+static constexpr unsigned radixSortThreshold = 32;
+static constexpr unsigned maxRadixByteDepth = 64;
+static constexpr unsigned radixBucketCount = 257;
+
 static ALWAYS_INLINE std::tuple<uint64_t, IndexingType, std::span<EncodedJSValue>> sortCompact(JSGlobalObject* globalObject, JSObject* thisObject, uint64_t length, SortJSValueVector& compactedRoot)
 {
     VM& vm = globalObject->vm();
@@ -903,32 +907,66 @@ static ALWAYS_INLINE std::tuple<uint64_t, IndexingType, std::span<EncodedJSValue
     return std::tuple { undefinedCount, ArrayWithContiguous, std::span { compactedRoot.data(), compactedRoot.size() } };
 }
 
-static unsigned sortBucketSort(std::span<EncodedJSValue> sorted, unsigned dst, SortEntryVector& bucket, unsigned depth)
+static void sortBucketSort(std::span<std::tuple<JSValue, String>> entries, std::span<std::tuple<JSValue, String>> scratch, unsigned byteIndex)
 {
-    if (bucket.size() < 32 || depth > 32) {
-        std::ranges::sort(bucket, WTF::codePointCompareLessThan, [](const auto& element) {
+    size_t size = entries.size();
+    if (size < radixSortThreshold || byteIndex > maxRadixByteDepth) {
+        std::ranges::stable_sort(entries, WTF::codePointCompareLessThan, [](const auto& element) {
             return std::get<1>(element);
         });
-        for (auto& entry : bucket)
-            sorted[dst++] = JSValue::encode(std::get<0>(entry));
-        return dst;
+        return;
     }
 
-    StdMap<char16_t, SortEntryVector> buckets;
-    for (const auto& entry : bucket) {
-        if (std::get<1>(entry).length() == depth) {
-            sorted[dst++] = JSValue::encode(std::get<0>(entry));
-            continue;
+    auto keyOf = [&](const std::tuple<JSValue, String>& entry) -> unsigned {
+        const String& string = std::get<1>(entry);
+        if (byteIndex >= (static_cast<size_t>(string.length()) << 1))
+            return 0;
+        char16_t codeUnit = string.codeUnitAt(byteIndex >> 1);
+        // High byte first, so byte order matches the code-unit order the default comparator needs.
+        uint8_t byte = (byteIndex & 1) ? (codeUnit & 0xFF) : (codeUnit >> 8);
+        return static_cast<unsigned>(byte) + 1;
+    };
+
+    std::array<unsigned, radixBucketCount> counts { };
+    unsigned minBucket = radixBucketCount - 1;
+    unsigned maxBucket = 0;
+    for (const auto& entry : entries) {
+        unsigned key = keyOf(entry);
+        if (!counts[key]) {
+            minBucket = std::min(minBucket, key);
+            maxBucket = std::max(maxBucket, key);
         }
-
-        char16_t character = std::get<1>(entry).codeUnitAt(depth);
-        buckets.insert(std::pair { character, SortEntryVector { } }).first->second.append(entry);
+        ++counts[key];
     }
 
-    for (auto& entries : buckets)
-        dst = sortBucketSort(sorted, dst, entries.second, depth + 1);
+    // One bucket: nothing to reorder. Bucket 0 means every string already ended, so they are done.
+    if (minBucket == maxBucket) {
+        if (minBucket)
+            sortBucketSort(entries, scratch, byteIndex + 1);
+        return;
+    }
 
-    return dst;
+    std::array<unsigned, radixBucketCount> cursors;
+    unsigned running = 0;
+    for (unsigned i = minBucket; i <= maxBucket; ++i) {
+        cursors[i] = running;
+        running += counts[i];
+    }
+
+    for (auto& entry : entries) {
+        unsigned key = keyOf(entry);
+        scratch[cursors[key]++] = WTF::move(entry);
+    }
+    for (size_t i = 0; i < size; ++i)
+        entries[i] = WTF::move(scratch[i]);
+
+    unsigned offset = 0;
+    for (unsigned i = minBucket; i <= maxBucket; ++i) {
+        unsigned count = counts[i];
+        if (i && count > 1)
+            sortBucketSort(entries.subspan(offset, count), scratch.first(count), byteIndex + 1);
+        offset += count;
+    }
 }
 
 static ALWAYS_INLINE std::span<EncodedJSValue> sortStableSort(JSGlobalObject* globalObject, std::span<EncodedJSValue> compacted, std::span<EncodedJSValue> workingSet, JSObject* comparator)
@@ -1043,14 +1081,24 @@ static ALWAYS_INLINE void sortImpl(JSGlobalObject* globalObject, JSObject* thisO
     std::span<EncodedJSValue> dest;
     if (isStringSort) {
         SortEntryVector entries; // Keep in mind that all JSValues are also stored in SortJSValueVector (compacted). Thus, we do not need to keep them marked here.
-        entries.reserveInitialCapacity(compacted.size());
+        if (!entries.tryReserveInitialCapacity(compacted.size())) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return;
+        }
         for (EncodedJSValue encodedValue : compacted) {
             JSValue value = JSValue::decode(encodedValue);
             String string = value.toWTFString(globalObject);
             RETURN_IF_EXCEPTION(scope, void());
             entries.append(std::tuple { value, WTF::move(string) });
         }
-        sortBucketSort(sorted, 0, entries, 0);
+        SortEntryVector scratchEntries;
+        if (entries.size() >= radixSortThreshold && !scratchEntries.tryGrow(entries.size())) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return;
+        }
+        sortBucketSort(entries.mutableSpan(), scratchEntries.mutableSpan(), 0);
+        for (size_t index = 0; index < entries.size(); ++index)
+            sorted[index] = JSValue::encode(std::get<0>(entries[index]));
         dest = sorted;
     } else {
         dest = sortStableSort(globalObject, compacted, sorted, asObject(comparatorValue));


### PR DESCRIPTION
#### 68038d8089eb74f8ec85c7866b01d7193fcb5cb2
<pre>
[JSC] Use counting sort for `Array#sort`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317103">https://bugs.webkit.org/show_bug.cgi?id=317103</a>

Reviewed by NOBODY (OOPS!).

The default (no-comparator) sort radix-sorts elements by their stringified form.
Replace the per-node StdMap&lt;char16_t, Vector&gt; partitioning, which allocated a
tree node per distinct character and a Vector per bucket, with an in-place
counting sort over the UTF-16 byte stream using a single reused scratch buffer.

Ordering and stability are unchanged; the only heap allocation is that one
buffer, now allocated via the try* APIs so huge arrays throw OutOfMemoryError
instead of crashing.

                                           TipOfTree                  Patched

array-prototype-sort-large-array        21.2890+-0.0402     ^      7.5080+-0.0241        ^ definitely 2.8355x faster
array-prototype-sort-medium-array       45.5706+-0.0895     ^     45.0925+-0.0940        ^ definitely 1.0106x faster
array-prototype-sort-small-array        14.4684+-0.0425     ?     14.5349+-0.0347        ?

Test: JSTests/stress/array-default-sort-radix-edge-cases.js

* JSTests/stress/array-default-sort-radix-edge-cases.js: Added.
(ser):
(refCmp):
(check):
(rnd):
(trial.i.else):
(o.toString):
(checkStability):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::sortBucketSort):
(JSC::sortImpl):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68038d8089eb74f8ec85c7866b01d7193fcb5cb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127120 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131963 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92897 "2 flakes 10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32102 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27464 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/688 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181365 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30663 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140416 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42986 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140252 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43675 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28646 "Too many flaky failures: http/tests/contentextensions/sync-xhr-blocked.html, http/tests/media/track-in-band-hls-metadata-removecue-non-datacue-crash.html, http/tests/misc/percent-sign-in-form-field-name.html, http/tests/navigation/post-redirect-get-reload.py, http/tests/resourceLoadStatistics/grandfathering.html, http/tests/security/cached-svg-image-with-css-cross-domain.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/object-redirect-blocked2.html, http/tests/security/mixedContent/insecure-xhr-in-main-frame.html, http/tests/site-isolation/frame-index.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107747 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35524 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115440 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202087 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42185 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6735 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54196 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41578 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->