### PR TITLE
pictureInPictureElement getter inverts the shadow-host connectivity check

### DIFF
--- a/LayoutTests/media/picture-in-picture/picture-in-picture-api-shadow-root-element-expected.txt
+++ b/LayoutTests/media/picture-in-picture/picture-in-picture-api-shadow-root-element-expected.txt
@@ -1,0 +1,21 @@
+This tests that when a video inside a shadow tree is in Picture-in-Picture, a page can find it through its shadow root's pictureInPictureElement property instead of always getting null.
+RUN(internals.settings.setAllowsPictureInPictureMediaPlayback(true))
+RUN(internals.setMockVideoPresentationModeEnabled(true))
+RUN(video.src = findMediaFile("video", "../content/test"))
+EVENT(canplaythrough)
+* Nothing is in Picture-in-Picture yet, so every getter returns null.
+EXPECTED (document.pictureInPictureElement == 'null') OK
+EXPECTED (outerRoot.pictureInPictureElement == 'null') OK
+EXPECTED (innerRoot.pictureInPictureElement == 'null') OK
+EVENT(enterpictureinpicture)
+* The video inside the nested shadow roots is in Picture-in-Picture.
+EXPECTED (document.pictureInPictureElement.id == 'outerHost') OK
+EXPECTED (outerRoot.pictureInPictureElement.id == 'innerHost') OK
+EXPECTED (innerRoot.pictureInPictureElement.id == 'video') OK
+EVENT(leavepictureinpicture)
+* After exiting Picture-in-Picture, every getter returns null again.
+EXPECTED (document.pictureInPictureElement == 'null') OK
+EXPECTED (outerRoot.pictureInPictureElement == 'null') OK
+EXPECTED (innerRoot.pictureInPictureElement == 'null') OK
+END OF TEST
+

--- a/LayoutTests/media/picture-in-picture/picture-in-picture-api-shadow-root-element.html
+++ b/LayoutTests/media/picture-in-picture/picture-in-picture-api-shadow-root-element.html
@@ -1,0 +1,63 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../video-test.js"></script>
+    <script src="../media-file.js"></script>
+    <script>
+        window.addEventListener('load', async event => {
+            if (!window.internals) {
+                failTest('This test requires window.internals.');
+                return;
+            }
+
+            run('internals.settings.setAllowsPictureInPictureMediaPlayback(true)');
+            run('internals.setMockVideoPresentationModeEnabled(true)');
+
+            window.outerHost = document.createElement('div');
+            outerHost.id = 'outerHost';
+            window.outerRoot = outerHost.attachShadow({ mode: 'open' });
+
+            window.innerHost = document.createElement('div');
+            innerHost.id = 'innerHost';
+            outerRoot.appendChild(innerHost);
+            window.innerRoot = innerHost.attachShadow({ mode: 'open' });
+
+            video = document.createElement('video');
+            video.id = 'video';
+            innerRoot.appendChild(video);
+
+            document.body.appendChild(outerHost);
+
+            run('video.src = findMediaFile("video", "../content/test")');
+            await waitFor(video, 'canplaythrough');
+
+            consoleWrite('* Nothing is in Picture-in-Picture yet, so every getter returns null.');
+            testExpected('document.pictureInPictureElement', null);
+            testExpected('outerRoot.pictureInPictureElement', null);
+            testExpected('innerRoot.pictureInPictureElement', null);
+
+            runWithKeyDown(() => { video.requestPictureInPicture(); });
+            await waitFor(video, 'enterpictureinpicture');
+
+            consoleWrite('* The video inside the nested shadow roots is in Picture-in-Picture.');
+            testExpected('document.pictureInPictureElement.id', 'outerHost');
+            testExpected('outerRoot.pictureInPictureElement.id', 'innerHost');
+            testExpected('innerRoot.pictureInPictureElement.id', 'video');
+
+            document.exitPictureInPicture();
+            await waitFor(video, 'leavepictureinpicture');
+
+            consoleWrite('* After exiting Picture-in-Picture, every getter returns null again.');
+            testExpected('document.pictureInPictureElement', null);
+            testExpected('outerRoot.pictureInPictureElement', null);
+            testExpected('innerRoot.pictureInPictureElement', null);
+
+            endTest();
+        });
+    </script>
+</head>
+<body>
+    <div>This tests that when a video inside a shadow tree is in Picture-in-Picture, a page can find it through its shadow root's pictureInPictureElement property instead of always getting null.</div>
+</body>
+</html>

--- a/Source/WebCore/Modules/pictureinpicture/DocumentOrShadowRootPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/DocumentOrShadowRootPictureInPicture.cpp
@@ -39,7 +39,7 @@ Element* DocumentOrShadowRootPictureInPicture::pictureInPictureElement(TreeScope
 {
     // The pictureInPictureElement attribute’s getter must run these steps:
     // 1. If this is a shadow root and its host is not connected, return null and abort these steps.
-    if (auto* shadowHost = treeScope.rootNode().shadowHost(); shadowHost && shadowHost->isConnected())
+    if (auto* shadowHost = treeScope.rootNode().shadowHost(); shadowHost && !shadowHost->isConnected())
         return nullptr;
 
     // 2. Let candidate be the result of retargeting Picture-in-Picture element against this.


### PR DESCRIPTION
#### b0e1708f1a65643898b96480da8f3854e8b197ac
<pre>
pictureInPictureElement getter inverts the shadow-host connectivity check
<a href="https://bugs.webkit.org/show_bug.cgi?id=317104">https://bugs.webkit.org/show_bug.cgi?id=317104</a>
<a href="https://rdar.apple.com/179675087">rdar://179675087</a>

Reviewed by Jean-Yves Avenard.

This should return null when the shadow root&apos;s host is NOT connected, but the code returned null
when the host is connected, so the getter returned the wrong result for shadow roots (null for the
normal connected case).

Test: media/picture-in-picture/picture-in-picture-api-shadow-root-element.html
* LayoutTests/media/picture-in-picture/picture-in-picture-api-shadow-root-element-expected.txt: Added.
* LayoutTests/media/picture-in-picture/picture-in-picture-api-shadow-root-element.html: Added.
* Source/WebCore/Modules/pictureinpicture/DocumentOrShadowRootPictureInPicture.cpp:
(WebCore::DocumentOrShadowRootPictureInPicture::pictureInPictureElement):

Canonical link: <a href="https://commits.webkit.org/315403@main">https://commits.webkit.org/315403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65223d560c91198f3e03e95159e81915bc8edbcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126077 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c466dd19-ecf7-46e1-a9d7-caa0e3c1f11c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131039 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92134 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0df822bd-6969-40b1-9ed3-697f5a82ccd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111550 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29be1d0c-4f8d-4530-94ea-8d94a8e2cced) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31196 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26400 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180304 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33028 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35357 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139474 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139338 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42633 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27689 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106201 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25735 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34631 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114393 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41137 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5774 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40534 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40785 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->