### PR TITLE
Make notifyTimeReachedAndStall return a MediaTimePromise

### DIFF
--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -163,8 +163,8 @@ public:
     virtual bool timeIsProgressing() const = 0;
     virtual void notifyEffectiveRateChanged(Function<void(double)>&&) { }
     virtual MediaTime currentTime() const = 0;
-    virtual void notifyTimeReachedAndStall(const MediaTime&, Function<void(const MediaTime&)>&&) { }
-    virtual void cancelTimeReachedAction() { }
+    virtual Ref<MediaTimePromise> notifyTimeReachedAndStall(const MediaTime&) = 0;
+    virtual void cancelTimeReachedAction() = 0;
     virtual void performTaskAtTime(const MediaTime&, Function<void(const MediaTime&)>&&) { }
     virtual void setTimeObserver(Seconds, Function<void(const MediaTime&)>&&) { }
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -84,7 +84,7 @@ public:
 
     bool timeIsProgressing() const final;
     MediaTime currentTime() const final;
-    void notifyTimeReachedAndStall(const MediaTime&, Function<void(const MediaTime&)>&&) final;
+    Ref<MediaTimePromise> notifyTimeReachedAndStall(const MediaTime&) final;
     void cancelTimeReachedAction() final;
     void performTaskAtTime(const MediaTime&, Function<void(const MediaTime&)>&&) final;
     void setTimeObserver(Seconds, Function<void(const MediaTime&)>&&) final;
@@ -289,6 +289,7 @@ private:
     Function<void(const MediaTime&, FloatSize)> m_sizeChangedCallback;
 
     RetainPtr<id> m_currentTimeObserver;
+    std::optional<MediaTimePromise::Producer> m_stallProducer;
     RetainPtr<id> m_performTaskObserver;
     RetainPtr<id> m_timeChangedObserver;
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -519,24 +519,26 @@ void AudioVideoRendererAVFObjC::stall()
     setSynchronizerRate(0, { });
 }
 
-void AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const MediaTime& timeBoundary, Function<void(const MediaTime&)>&& callback)
+Ref<MediaTimePromise> AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const MediaTime& timeBoundary)
 {
     cancelTimeReachedAction();
 
     if (timeBoundary <= currentTime()) {
-        ALWAYS_LOG(LOGIDENTIFIER, "boundary ", timeBoundary, " is behind currentTime ", currentTime(), "; stalling and firing callback immediately");
+        ALWAYS_LOG(LOGIDENTIFIER, "boundary ", timeBoundary, " is behind currentTime ", currentTime(), "; stalling and resolving immediately");
         stall();
-        callback(timeBoundary);
-        return;
+        return MediaTimePromise::createAndResolve(timeBoundary);
     }
 
-    RetainPtr<NSArray> times = @[[NSValue valueWithCMTime:PAL::toCMTime(timeBoundary)]];
+    ASSERT(!m_stallProducer);
+    m_stallProducer.emplace();
+    Ref promise = m_stallProducer->promise();
 
     auto logSiteIdentifier = LOGIDENTIFIER;
     DEBUG_LOG(logSiteIdentifier, timeBoundary);
     UNUSED_PARAM(logSiteIdentifier);
 
-    m_currentTimeObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times.get() queue:mainDispatchQueueSingleton() usingBlock:makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }, timeBoundary, logSiteIdentifier, callback = WTF::move(callback)]() mutable {
+    RetainPtr<NSArray> times = @[[NSValue valueWithCMTime:PAL::toCMTime(timeBoundary)]];
+    m_currentTimeObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times.get() queue:mainDispatchQueueSingleton() usingBlock:makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }, timeBoundary, logSiteIdentifier]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -548,12 +550,16 @@ void AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const MediaTime& timeB
         [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(timeBoundary)];
         protectedThis->m_lastSetSyncRate = 0;
 
-        callback(timeBoundary);
+        if (auto producer = std::exchange(protectedThis->m_stallProducer, std::nullopt))
+            producer->resolve(timeBoundary);
     }).get()];
+    return promise;
 }
 
 void AudioVideoRendererAVFObjC::cancelTimeReachedAction()
 {
+    if (auto producer = std::exchange(m_stallProducer, std::nullopt))
+        producer->reject(PlatformMediaError::Cancelled);
     if (RetainPtr observer = std::exchange(m_currentTimeObserver, nullptr))
         [m_synchronizer removeTimeObserver:observer.get()];
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -360,6 +360,7 @@ private:
     const Ref<NativePromiseRequest> m_waitForTargetRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
     const Ref<NativePromiseRequest> m_rendererPrepareSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
     const Ref<NativePromiseRequest> m_rendererFinishSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
+    const Ref<NativePromiseRequest> m_stallRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     ThreadSafeWeakPtr<CDMSessionAVContentKeySession> m_session;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -107,6 +107,7 @@ MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(Media
     , m_waitForTargetRequest(NativePromiseRequest::create())
     , m_rendererPrepareSeekRequest(NativePromiseRequest::create())
     , m_rendererFinishSeekRequest(NativePromiseRequest::create())
+    , m_stallRequest(NativePromiseRequest::create())
     , m_networkState(MediaPlayer::NetworkState::Empty)
     , m_pageIsVisible { player.pageIsVisible() }
     , m_viewportVisibility { player.viewportVisibility() }
@@ -136,6 +137,9 @@ MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC()
     // callbacks (such as the error callback calling setNetworkState(),
     // which accesses the already-destroyed m_logger).
     weakPtrFactory().revokeAll();
+
+    if (m_stallRequest->hasCallback())
+        protect(m_stallRequest)->disconnect();
 
     cancelPendingSeek();
     m_seekTimer.stop();
@@ -759,38 +763,42 @@ void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
 void MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime(const MediaTime& time)
 {
     assertIsMainThread();
+    if (m_stallRequest->hasCallback())
+        protect(m_stallRequest)->disconnect();
     m_renderer->cancelTimeReachedAction();
 
     auto logSiteIdentifier = LOGIDENTIFIER;
     UNUSED_PARAM(logSiteIdentifier);
-    auto stallReachedCallback = [weakThis = WeakPtr { *this }, logSiteIdentifier](const MediaTime& stallTime) {
-        ensureOnMainThread([weakThis, logSiteIdentifier, stallTime] {
-            RefPtr protectedThis = weakThis.get();
-            if (!protectedThis)
-                return;
-            if (protect(protectedThis->m_mediaSourcePrivate)->hasFutureTime(stallTime) && protectedThis->shouldBePlaying()) {
-                ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "Data now available at ", stallTime, " resuming");
-                protectedThis->dispatchToRendererQueue([](auto& renderer) {
-                    renderer.play(); // New data was added, resume. Can't happen in practice, action would have been cancelled once buffered changed.
-                });
-                return;
-            }
-            MediaTime now = protectedThis->currentTime();
-            ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now = ", now);
+    auto onStallReached = [weakThis = WeakPtr { *this }, logSiteIdentifier](MediaTimePromise::Result&& result) {
+        assertIsMainThread();
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
 
-            if (protectedThis->seeking())
-                return; // seek owns state transitions
-            if (now >= protectedThis->duration())
-                protectedThis->pause();
-            protectedThis->timeChanged();
-        });
+        if (protectedThis->m_stallRequest->hasCallback())
+            protect(protectedThis->m_stallRequest)->complete();
+
+        if (!result)
+            return;
+
+        // The Request was tracked, so reaching this point means the cap really fired and
+        // hasn't been superseded by a newer resetStallForTime — bufferedChanged would have
+        // disconnected the Request before reinstalling. No need to re-check hasFutureTime.
+        MediaTime now = protectedThis->currentTime();
+        ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now = ", now);
+
+        if (protectedThis->seeking())
+            return; // seek owns state transitions
+        if (now >= protectedThis->duration())
+            protectedThis->pause();
+        protectedThis->timeChanged();
     };
 
     if (time >= duration()) {
         ALWAYS_LOG(LOGIDENTIFIER, "playhead ", time, " is at or past duration ", duration(), "; stalling");
         if (shouldBePlaying())
             stall();
-        stallReachedCallback(time);
+        onStallReached(time);
         return;
     }
 
@@ -814,7 +822,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime(const MediaTime& ti
     }
 
     ALWAYS_LOG(LOGIDENTIFIER, "will stall playback at time: ", stallAtTime);
-    m_renderer->notifyTimeReachedAndStall(stallAtTime, WTF::move(stallReachedCallback));
+    m_renderer->notifyTimeReachedAndStall(stallAtTime)->whenSettled(RunLoop::mainSingleton(), WTF::move(onStallReached))->track(m_stallRequest);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setLayerRequiresFlush()

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -397,6 +397,7 @@ private:
     std::atomic<bool> m_hasPendingSeek { false };
     std::optional<GenericPromise::AutoRejectProducer> m_waitForTimeBufferedPromise WTF_GUARDED_BY_CAPABILITY(runningQueue());
     Ref<NativePromiseRequest> m_rendererSeekRequest;
+    Ref<NativePromiseRequest> m_stallRequest;
     std::atomic<bool> m_seeking { false };
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel WTF_GUARDED_BY_CAPABILITY(mainThread);

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -102,6 +102,7 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer& player)
     , m_logIdentifier(player.mediaPlayerLogIdentifier())
     , m_seekTimer(*this, &MediaPlayerPrivateWebM::seekInternal)
     , m_rendererSeekRequest(NativePromiseRequest::create())
+    , m_stallRequest(NativePromiseRequest::create())
     , m_playerIdentifier(MediaPlayerIdentifier::generate())
     , m_renderer(createRenderer(*this, player.clientIdentifier(), m_playerIdentifier))
     , m_runningQueue(hasPlatformStrategies() && platformStrategies()->mediaStrategy()->hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier::CocoaWebM) ? m_appendQueue.get() : WorkQueue::mainSingleton())
@@ -137,9 +138,11 @@ MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM() WTF_IGNORES_THREAD_SAFETY_ANAL
     // cancelPendingSeek() requires being on m_runningQueue because disconnecting a
     // NativePromiseRequest requires being on the queue the callback was registered on.
     // Move the seek request out and dispatch to that queue.
-    m_runningQueue->dispatch([seekRequest = std::exchange(m_rendererSeekRequest, NativePromiseRequest::create())]() mutable {
+    m_runningQueue->dispatch([seekRequest = std::exchange(m_rendererSeekRequest, NativePromiseRequest::create()), stallRequest = std::exchange(m_stallRequest, NativePromiseRequest::create())]() mutable {
         if (seekRequest->hasCallback())
             seekRequest->disconnect();
+        if (stallRequest->hasCallback())
+            stallRequest->disconnect();
     });
 
     // clearTracks() and cancelLoad() access running-queue-guarded members on the main thread.
@@ -995,15 +998,28 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
     if (duration == m_duration)
         return;
 
-    m_renderer->notifyTimeReachedAndStall(duration, [weakThis = ThreadSafeWeakPtr { *this }](const MediaTime&) {
+    if (m_stallRequest->hasCallback())
+        protect(m_stallRequest)->disconnect();
+
+    m_renderer->cancelTimeReachedAction();
+
+    m_renderer->notifyTimeReachedAndStall(duration)->whenSettled(runningQueue(), [weakThis = ThreadSafeWeakPtr { *this }](MediaTimePromise::Result&& result) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        protect(protectedThis->m_stallRequest)->complete();
+        if (!result)
+            return;
         ensureOnMainThread([weakThis] {
-            if (RefPtr protectedThis = weakThis.get()) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            if (protectedThis->currentTime() >= protectedThis->duration())
                 protectedThis->m_renderer->pause();
-                if (RefPtr player = protectedThis->m_player.get())
-                    player->timeChanged();
-            }
+            if (RefPtr player = protectedThis->m_player.get())
+                player->timeChanged();
         });
-    });
+    })->track(m_stallRequest);
 
     m_duration = WTF::move(duration);
     ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, durationCopy = m_duration] {

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -316,15 +316,13 @@ void RemoteAudioVideoRendererProxyManager::enqueueSample(RemoteAudioVideoRendere
     completionHandler(false);
 }
 
-void RemoteAudioVideoRendererProxyManager::notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& time)
+void RemoteAudioVideoRendererProxyManager::notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& time, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&& completionHandler)
 {
-    RefPtr renderer = rendererFor(identifier);
-    if (!renderer)
+    if (RefPtr renderer = rendererFor(identifier)) {
+        renderer->notifyTimeReachedAndStall(time)->whenSettled(RunLoop::mainSingleton(), WTF::move(completionHandler));
         return;
-    renderer->notifyTimeReachedAndStall(time, [weakThis = WeakPtr { *this }, identifier](auto& time) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StallTimeReached(time, protectedThis->stateFor(identifier)));
-    });
+    }
+    completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
 }
 
 void RemoteAudioVideoRendererProxyManager::cancelTimeReachedAction(RemoteAudioVideoRendererIdentifier identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -102,7 +102,7 @@ private:
     void enqueueSample(RemoteAudioVideoRendererIdentifier, TrackIdentifier, WebCore::MediaSamplesBlock&&, std::optional<MediaTime>, CompletionHandler<void(bool)>&&);
     void requestMediaDataWhenReady(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
 
-    void notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier, const MediaTime&);
+    void notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
     void cancelTimeReachedAction(RemoteAudioVideoRendererIdentifier);
     void performTaskAtTime(RemoteAudioVideoRendererIdentifier, const MediaTime&);
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -44,7 +44,7 @@ messages -> RemoteAudioVideoRendererProxyManager {
     EnqueueSample(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier, WebCore::MediaSamplesBlock block, std::optional<MediaTime> upcomingMinimumTime) -> (bool readyForMoreData);
     RequestMediaDataWhenReady(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::SamplesRendererTrackIdentifier trackIdentifier)
 
-    NotifyTimeReachedAndStall(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime time)
+    NotifyTimeReachedAndStall(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime time) -> (Expected<MediaTime, WebCore::PlatformMediaError> result)
     CancelTimeReachedAction(WebKit::RemoteAudioVideoRendererIdentifier identifier)
     PerformTaskAtTime(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime time)
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -86,6 +86,7 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
     : m_gpuProcessConnection(connection)
     , m_receiver(MessageReceiver::create(*this))
     , m_identifier(identifier)
+    , m_stallRequest(NativePromiseRequest::create())
     , m_prepareSeekRequest(NativePromiseRequest::create())
     , m_finishSeekRequest(NativePromiseRequest::create())
 #if PLATFORM(COCOA)
@@ -139,7 +140,7 @@ AudioVideoRendererRemote::~AudioVideoRendererRemote() WTF_IGNORES_THREAD_SAFETY_
     m_videoLayerManager->didDestroyVideoLayer();
 #endif
 
-    ensureOnDispatcher([prepareSeekRequest = WTF::move(m_prepareSeekRequest), prepareSeekPromise = WTF::move(m_prepareSeekPromise), finishSeekRequest = WTF::move(m_finishSeekRequest), finishSeekPromise = WTF::move(m_finishSeekPromise)]() mutable {
+    ensureOnDispatcher([prepareSeekRequest = WTF::move(m_prepareSeekRequest), prepareSeekPromise = WTF::move(m_prepareSeekPromise), finishSeekRequest = WTF::move(m_finishSeekRequest), finishSeekPromise = WTF::move(m_finishSeekPromise), stallRequest = WTF::move(m_stallRequest), stallProducer = WTF::move(m_stallProducer)]() mutable {
         if (prepareSeekRequest->hasCallback())
             prepareSeekRequest->disconnect();
         if (auto promise = std::exchange(prepareSeekPromise, std::nullopt))
@@ -148,6 +149,10 @@ AudioVideoRendererRemote::~AudioVideoRendererRemote() WTF_IGNORES_THREAD_SAFETY_
             finishSeekRequest->disconnect();
         if (auto promise = std::exchange(finishSeekPromise, std::nullopt))
             promise->reject();
+        if (stallRequest->hasCallback())
+            stallRequest->disconnect();
+        if (auto producer = std::exchange(stallProducer, std::nullopt))
+            producer->reject(PlatformMediaError::Cancelled);
     });
 
     if (RefPtr gpuProcessConnection = m_gpuProcessConnection.get(); gpuProcessConnection && !m_shutdown) {
@@ -747,23 +752,35 @@ MediaTime AudioVideoRendererRemote::currentTime() const
     return t;
 }
 
-void AudioVideoRendererRemote::notifyTimeReachedAndStall(const MediaTime& time, Function<void(const MediaTime&)>&& callback)
+Ref<MediaTimePromise> AudioVideoRendererRemote::notifyTimeReachedAndStall(const MediaTime& time)
 {
-    auto now = currentTime();
-    if (time <= now) {
-        ALWAYS_LOG(LOGIDENTIFIER, "boundary ", time, " is behind currentTime ", now, "; stalling and firing callback immediately");
-        stall();
-        callback(time);
-        return;
-    }
     {
         Locker locker { m_lock };
         m_stallCap = time;
     }
-    ensureOnDispatcherWithConnection([time, callback = WTF::move(callback)](auto& renderer, auto& connection) mutable {
+    return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<MediaTimePromise> {
         assertIsCurrent(queueSingleton());
-        renderer.m_timeReachedAndStallCallback = WTF::move(callback);
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::NotifyTimeReachedAndStall(renderer.m_identifier, time), 0);
+        if (m_stallRequest->hasCallback())
+            protect(m_stallRequest)->disconnect();
+        if (auto previous = std::exchange(m_stallProducer, std::nullopt))
+            previous->reject(PlatformMediaError::Cancelled);
+
+        RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
+        if (!isGPURunning() || !gpuProcessConnection)
+            return MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
+
+        m_stallProducer.emplace();
+        Ref promise = m_stallProducer->promise();
+        gpuProcessConnection->connection().sendWithPromisedReply<MediaPromiseConverter>(Messages::RemoteAudioVideoRendererProxyManager::NotifyTimeReachedAndStall(m_identifier, time), 0)->whenSettled(queueSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](MediaTimePromise::Result&& result) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            assertIsCurrent(queueSingleton());
+            protect(protectedThis->m_stallRequest)->complete();
+            if (auto producer = std::exchange(protectedThis->m_stallProducer, std::nullopt))
+                producer->settle(WTF::move(result));
+        })->track(m_stallRequest);
+        return promise;
     });
 }
 
@@ -775,7 +792,10 @@ void AudioVideoRendererRemote::cancelTimeReachedAction()
     }
     ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
         assertIsCurrent(queueSingleton());
-        renderer.m_timeReachedAndStallCallback = { };
+        if (renderer.m_stallRequest->hasCallback())
+            protect(renderer.m_stallRequest)->disconnect();
+        if (auto producer = std::exchange(renderer.m_stallProducer, std::nullopt))
+            producer->reject(PlatformMediaError::Cancelled);
         connection.send(Messages::RemoteAudioVideoRendererProxyManager::CancelTimeReachedAction(renderer.m_identifier), 0);
     });
 }
@@ -1184,16 +1204,6 @@ void AudioVideoRendererRemote::MessageReceiver::effectiveRateChanged(RemoteAudio
                 effectiveRate = parent->m_sharedTimebaseReader->currentRate();
         }
         parent->m_effectiveRateChangedCallback(effectiveRate);
-    }
-}
-
-void AudioVideoRendererRemote::MessageReceiver::stallTimeReached(MediaTime time, RemoteAudioVideoRendererState state)
-{
-    if (RefPtr parent = m_parent.get()) {
-        assertIsCurrent(queueSingleton());
-        parent->updateCacheState(state);
-        if (parent->m_timeReachedAndStallCallback)
-            parent->m_timeReachedAndStallCallback(time);
     }
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -90,7 +90,6 @@ public:
         void sizeChanged(MediaTime, WebCore::FloatSize, RemoteAudioVideoRendererState);
         void trackNeedsReenqueuing(WebCore::SamplesRendererTrackIdentifier, MediaTime, RemoteAudioVideoRendererState);
         void effectiveRateChanged(RemoteAudioVideoRendererState);
-        void stallTimeReached(MediaTime, RemoteAudioVideoRendererState);
         void taskTimeReached(MediaTime, RemoteAudioVideoRendererState);
         void errorOccurred(WebCore::PlatformMediaError);
         void readyForMoreMediaData(WebCore::SamplesRendererTrackIdentifier);
@@ -169,7 +168,7 @@ private:
     bool timeIsProgressing() const final;
     void notifyEffectiveRateChanged(Function<void(double)>&&) final;
     MediaTime currentTime() const final;
-    void notifyTimeReachedAndStall(const MediaTime&, Function<void(const MediaTime&)>&&) final;
+    Ref<WebCore::MediaTimePromise> notifyTimeReachedAndStall(const MediaTime&) final;
     void cancelTimeReachedAction() final;
     void performTaskAtTime(const MediaTime&, Function<void(const MediaTime&)>&&) final;
 
@@ -271,7 +270,8 @@ private:
     Function<void(const MediaTime&, WebCore::FloatSize)> m_sizeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Function<void(const MediaTime&)> m_currentTimeDidChangeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Function<void(double)> m_effectiveRateChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Function<void(const MediaTime&)> m_timeReachedAndStallCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    std::optional<WebCore::MediaTimePromise::Producer> m_stallProducer WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    Ref<NativePromiseRequest> m_stallRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Function<void(const MediaTime&)> m_performTaskAtTimeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     MediaTime m_performTaskAtTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Function<void(const MediaTime&, WebCore::FloatSize)> m_videoLayerSizeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
@@ -38,7 +38,6 @@ messages -> AudioVideoRendererRemoteMessageReceiver {
     SizeChanged(MediaTime time, WebCore::FloatSize size, struct WebKit::RemoteAudioVideoRendererState state)
     TrackNeedsReenqueuing(WebCore::SamplesRendererTrackIdentifier identifier, MediaTime time, struct WebKit::RemoteAudioVideoRendererState state)
     EffectiveRateChanged(struct WebKit::RemoteAudioVideoRendererState state)
-    StallTimeReached(MediaTime time, struct WebKit::RemoteAudioVideoRendererState state)
     TaskTimeReached(MediaTime time, struct WebKit::RemoteAudioVideoRendererState state)
     ErrorOccurred(WebCore::PlatformMediaError error)
     StateUpdate(struct WebKit::RemoteAudioVideoRendererState state)


### PR DESCRIPTION
#### 8832caecee747939ab5236aee3174fafd8f1506d
<pre>
Make notifyTimeReachedAndStall return a MediaTimePromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=317112">https://bugs.webkit.org/show_bug.cgi?id=317112</a>
<a href="https://rdar.apple.com/problem/179681528">rdar://problem/179681528</a>

Reviewed by Jer Noble.

The previous interface — a fire-and-forget call paired with a separately
registered callback — could not maintain a 1:1 mapping between calls and
their notifications. The callback was invoked when the underlying boundary
time observer fired, but cancelTimeReachedAction / notifyTimeReachedAndStall
could replace the observer at any time:

1. notifyTimeReachedAndStall(t1) registers an observer at t1.
2. The synchronizer crosses t1, the observer block dispatches a stall
    notification.
3. While the notification is in flight (cross-process IPC for the
    remote case, or a queued main-thread block for the in-process case),
    the caller invokes notifyTimeReachedAndStall(t2). The producer for
    t1 is replaced by one for t2 before the in-flight notification
    resolves.
4. The notification for t1 is delivered against the producer registered
    for t2 — a stall is reported at the wrong time, or the t2 observer
    is silently dropped.

Convert the API to return Ref&lt;MediaTimePromise&gt;. Each call now owns its
own producer; later calls implicitly cancel the prior promise (rejecting
it with PlatformMediaError::Cancelled) before installing a new one. The
boundary observer captures and resolves a specific producer, so a stale
notification can never resolve a newer call&apos;s promise. The IPC variant
collapses StallTimeReached into the reply of the originating message,
ensuring the in-flight reply is the only resolution path and that
cancellation tears it down deterministically.

This fixes an intermittent failure observed when running
imported/w3c/web-platform-tests/media-source/mediasource-duration.html

Covered by existing tests.

* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
(WebCore::TracksRendererManager::notifyTimeReachedAndStall):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::notifyTimeReachedAndStall):
(WebCore::AudioVideoRendererAVFObjC::cancelTimeReachedAction):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::setDuration):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::notifyTimeReachedAndStall):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::AudioVideoRendererRemote):
(WebKit::AudioVideoRendererRemote::notifyTimeReachedAndStall):
(WebKit::AudioVideoRendererRemote::cancelTimeReachedAction):
(WebKit::AudioVideoRendererRemote::MessageReceiver::stallTimeReached): Deleted.
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in:

Canonical link: <a href="https://commits.webkit.org/315262@main">https://commits.webkit.org/315262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca2ec6ccf428ba3ebf5b34a51a6764ef9fb2de71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42100 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35689 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177873 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18b2b155-daf1-4d15-92dc-6a7bd5750178) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42062 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c8f2263-670f-40e0-a1d5-73ba917de362) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171502 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111708 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d52def23-ffd5-4eec-b330-33a7ccfbc929) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26568 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180472 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/30874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42112 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/139494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37556 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42800 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/150946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34776 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41304 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40701 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/5930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40952 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40846 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->