### PR TITLE
Use CMTimebaseGetEffectiveRate in place of CMTimebaseGetRate in AudioVideoRendererAVFObjC

### DIFF
--- a/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
+++ b/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
@@ -85,7 +85,7 @@ EffectiveRateChangedListener::~EffectiveRateChangedListener()
 
 void EffectiveRateChangedListener::effectiveRateChanged()
 {
-    m_callback(PAL::CMTimebaseGetRate(m_timebase.get()));
+    m_callback(PAL::CMTimebaseGetEffectiveRate(m_timebase.get()));
 }
 
 void EffectiveRateChangedListener::stop()

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -510,7 +510,7 @@ double AudioVideoRendererAVFObjC::effectiveRate() const
     if (m_startupGateObserver)
         return 0;
     // False positive see webkit.org/b/298024
-    SUPPRESS_UNRETAINED_ARG return PAL::CMTimebaseGetRate([m_synchronizer timebase]);
+    SUPPRESS_UNRETAINED_ARG return PAL::CMTimebaseGetEffectiveRate([m_synchronizer timebase]);
 }
 
 void AudioVideoRendererAVFObjC::stall()
@@ -711,7 +711,7 @@ void AudioVideoRendererAVFObjC::releaseStartupGateAndForwardRate()
 {
     ASSERT(isMainThread());
     cancelStartupGateObserver();
-    SUPPRESS_UNRETAINED_ARG double liveRate = PAL::CMTimebaseGetRate([m_synchronizer timebase]);
+    SUPPRESS_UNRETAINED_ARG double liveRate = PAL::CMTimebaseGetEffectiveRate([m_synchronizer timebase]);
     m_lastForwardedEffectiveRate = liveRate;
     if (m_effectiveRateChangedCallback)
         m_effectiveRateChangedCallback(liveRate);


### PR DESCRIPTION
#### d015de0a46553854edcb83b42a9e402c51570303
<pre>
Use CMTimebaseGetEffectiveRate in place of CMTimebaseGetRate in AudioVideoRendererAVFObjC
<a href="https://bugs.webkit.org/show_bug.cgi?id=317113">https://bugs.webkit.org/show_bug.cgi?id=317113</a>
<a href="https://rdar.apple.com/179682195">rdar://179682195</a>

Reviewed by Youenn Fablet.

No change in observable behaviour, the effectiveRate isn&apos;t JS exported
but is used to estimate the time progression in the web content.
CMTimebaseGetEffectiveRate is the API to use to retrieve the timebase effective rate
CMTimebaseGetRate only returns the current rate we set.

* Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm:
(WebCore::EffectiveRateChangedListener::effectiveRateChanged):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::effectiveRate const):
(WebCore::AudioVideoRendererAVFObjC::releaseStartupGateAndForwardRate):

Canonical link: <a href="https://commits.webkit.org/315210@main">https://commits.webkit.org/315210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31cdd5d2ae80a63b5ab6b89d0287e05e9f214d75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126102 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2f5d9d8-3d1e-489f-8c36-24a6152f1f57) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0af302fe-0f90-4c5f-921b-5acdd0ca7433) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3234fc6d-4e73-4987-aa6c-719e156960a1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31215 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26425 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142499 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180329 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33053 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139496 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41970 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35376 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139360 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37526 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42658 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106256 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34651 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27709 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114418 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40559 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5794 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40810 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->