### PR TITLE
[TestWebKitAPI] Fix unified source build with CMake + internal SDK

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/MediaRemoteSoftLink.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/MediaRemoteSoftLink.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef __cplusplus
+
+#pragma once
+
+#include <pal/spi/mac/MediaRemoteSPI.h>
+#include <wtf/SoftLinking.h>
+#include <wtf/cocoa/SoftLinking.h>
+
+SOFT_LINK_FRAMEWORK_FOR_HEADER(TestWebKitAPI, MediaRemote)
+
+SOFT_LINK_CONSTANT_FOR_HEADER(TestWebKitAPI, MediaRemote, kMRMediaRemoteNowPlayingApplicationDidChangeNotification, CFStringRef)
+#define kMRMediaRemoteNowPlayingApplicationDidChangeNotification get_MediaRemote_kMRMediaRemoteNowPlayingApplicationDidChangeNotificationSingleton()
+
+SOFT_LINK_CONSTANT_FOR_HEADER(TestWebKitAPI, MediaRemote, kMRMediaRemoteNowPlayingApplicationPIDUserInfoKey, CFStringRef)
+#define kMRMediaRemoteNowPlayingApplicationPIDUserInfoKey get_MediaRemote_kMRMediaRemoteNowPlayingApplicationPIDUserInfoKeySingleton()
+
+SOFT_LINK_CONSTANT_FOR_HEADER(TestWebKitAPI, MediaRemote, kMRMediaRemoteOptionPlaybackPosition, CFStringRef)
+#define kMRMediaRemoteOptionPlaybackPosition get_MediaRemote_kMRMediaRemoteOptionPlaybackPositionSingleton()
+
+SOFT_LINK_CONSTANT_FOR_HEADER(TestWebKitAPI, MediaRemote, kMRMediaRemoteOptionSkipInterval, CFStringRef)
+#define kMRMediaRemoteOptionSkipInterval get_MediaRemote_kMRMediaRemoteOptionSkipIntervalSingleton()
+
+SOFT_LINK_FUNCTION_FOR_HEADER(TestWebKitAPI, MediaRemote, MRMediaRemoteGetLocalOrigin, MROriginRef, (), ());
+#define MRMediaRemoteGetLocalOrigin softLink_MediaRemote_MRMediaRemoteGetLocalOrigin
+
+SOFT_LINK_FUNCTION_FOR_HEADER(TestWebKitAPI, MediaRemote, MRMediaRemoteGetNowPlayingClient, void, (dispatch_queue_t queue, void(^completion)(MRNowPlayingClientRef, CFErrorRef)), (queue, completion))
+#define MRMediaRemoteGetNowPlayingClient softLink_MediaRemote_MRMediaRemoteGetNowPlayingClient
+
+SOFT_LINK_FUNCTION_FOR_HEADER(TestWebKitAPI, MediaRemote, MRMediaRemoteGetSupportedCommandsForOrigin, void, (MROriginRef origin, dispatch_queue_t queue, void(^completion)(CFArrayRef commands)), (origin, queue, completion));
+#define MRMediaRemoteGetSupportedCommandsForOrigin softLink_MediaRemote_MRMediaRemoteGetSupportedCommandsForOrigin
+
+SOFT_LINK_FUNCTION_FOR_HEADER(TestWebKitAPI, MediaRemote, MRMediaRemoteSendCommandToApp, Boolean, (MRMediaRemoteCommand command, CFDictionaryRef options, MROriginRef origin, CFStringRef appDisplayID, MRSendCommandAppOptions appOptions, dispatch_queue_t replyQ, void(^completion)(MRSendCommandError err, CFArrayRef handlerReturnStatuses)), (command, options, origin, appDisplayID, appOptions, replyQ, completion));
+#define MRMediaRemoteSendCommandToApp softLink_MediaRemote_MRMediaRemoteSendCommandToApp
+
+SOFT_LINK_FUNCTION_FOR_HEADER(TestWebKitAPI, MediaRemote, MRMediaRemoteSetWantsNowPlayingNotifications, void, (bool wantsNotifications), (wantsNotifications))
+#define MRMediaRemoteSetWantsNowPlayingNotifications softLink_MediaRemote_MRMediaRemoteSetWantsNowPlayingNotifications
+
+SOFT_LINK_FUNCTION_FOR_HEADER(TestWebKitAPI, MediaRemote, MRNowPlayingClientGetProcessIdentifier, pid_t, (MRNowPlayingClientRef client), (client))
+#define MRNowPlayingClientGetProcessIdentifier softLink_MediaRemote_MRNowPlayingClientGetProcessIdentifier
+
+#endif // __cplusplus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/MediaRemoteSoftLink.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/MediaRemoteSoftLink.mm
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "MediaRemoteSoftLink.h"
+
+SOFT_LINK_FRAMEWORK_FOR_SOURCE(TestWebKitAPI, MediaRemote)
+
+SOFT_LINK_CONSTANT_FOR_SOURCE(TestWebKitAPI, MediaRemote, kMRMediaRemoteNowPlayingApplicationDidChangeNotification, CFStringRef)
+SOFT_LINK_CONSTANT_FOR_SOURCE(TestWebKitAPI, MediaRemote, kMRMediaRemoteNowPlayingApplicationPIDUserInfoKey, CFStringRef)
+SOFT_LINK_CONSTANT_FOR_SOURCE(TestWebKitAPI, MediaRemote, kMRMediaRemoteOptionPlaybackPosition, CFStringRef)
+SOFT_LINK_CONSTANT_FOR_SOURCE(TestWebKitAPI, MediaRemote, kMRMediaRemoteOptionSkipInterval, CFStringRef)
+SOFT_LINK_FUNCTION_FOR_SOURCE(TestWebKitAPI, MediaRemote, MRMediaRemoteGetLocalOrigin, MROriginRef, (), ());
+SOFT_LINK_FUNCTION_FOR_SOURCE(TestWebKitAPI, MediaRemote, MRMediaRemoteGetNowPlayingClient, void, (dispatch_queue_t queue, void(^completion)(MRNowPlayingClientRef, CFErrorRef)), (queue, completion))
+SOFT_LINK_FUNCTION_FOR_SOURCE(TestWebKitAPI, MediaRemote, MRMediaRemoteGetSupportedCommandsForOrigin, void, (MROriginRef origin, dispatch_queue_t queue, void(^completion)(CFArrayRef commands)), (origin, queue, completion));
+SOFT_LINK_FUNCTION_FOR_SOURCE(TestWebKitAPI, MediaRemote, MRMediaRemoteSendCommandToApp, Boolean, (MRMediaRemoteCommand command, CFDictionaryRef options, MROriginRef origin, CFStringRef appDisplayID, MRSendCommandAppOptions appOptions, dispatch_queue_t replyQ, void(^completion)(MRSendCommandError err, CFArrayRef handlerReturnStatuses)), (command, options, origin, appDisplayID, appOptions, replyQ, completion));
+SOFT_LINK_FUNCTION_FOR_SOURCE(TestWebKitAPI, MediaRemote, MRMediaRemoteSetWantsNowPlayingNotifications, void, (bool wantsNotifications), (wantsNotifications))
+SOFT_LINK_FUNCTION_FOR_SOURCE(TestWebKitAPI, MediaRemote, MRNowPlayingClientGetProcessIdentifier, pid_t, (MRNowPlayingClientRef client), (client))

--- a/Tools/TestWebKitAPI/Helpers/cocoa/ScreenTimeExtras.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/ScreenTimeExtras.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(SCREEN_TIME)
+
+#import <ScreenTime/STWebpageController.h>
+
+@interface STWebpageController ()
+@property (setter=setURLIsBlocked:) BOOL URLIsBlocked;
+@end
+
+#endif

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -36,6 +36,7 @@ Helpers/cocoa/DecomposedAttributedText.mm @nonARC
 Helpers/cocoa/DragAndDropSimulator.mm @nonARC
 Helpers/cocoa/HostWindowManager.mm @nonARC
 Helpers/cocoa/ImageAnalysisTestingUtilities.mm @nonARC
+Helpers/cocoa/MediaRemoteSoftLink.mm @nonARC
 Helpers/cocoa/ModelLoadingMessageHandler.mm @nonARC
 Helpers/cocoa/NSItemProviderAdditions.mm @nonARC
 Helpers/cocoa/PlatformUtilitiesCocoa.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
@@ -47,14 +47,14 @@
 
 #if USE(APPKIT)
 
-static NSData *readRTFDataFromPasteboard()
+static NSData *readRTFDDataFromPasteboard()
 {
     return [[NSPasteboard generalPasteboard] dataForType:NSPasteboardTypeRTFD];
 }
 
 #else
 
-static NSData *readRTFDataFromPasteboard()
+static NSData *readRTFDDataFromPasteboard()
 {
     id value = [[UIPasteboard generalPasteboard] valueForPasteboardType:UTTypeFlatRTFD.identifier];
     ASSERT([value isKindOfClass:[NSData class]]);
@@ -723,7 +723,7 @@ TEST(AdaptiveImageGlyph, CopyRTF)
     [webView selectAll:nil];
     [webView _synchronouslyExecuteEditCommand:@"Copy" argument:nil];
 
-    NSData *rtfData = readRTFDataFromPasteboard();
+    NSData *rtfData = readRTFDDataFromPasteboard();
     EXPECT_NOT_NULL(rtfData);
 
     RetainPtr attributedString = adoptNS([[NSAttributedString alloc] initWithData:rtfData options:@{ } documentAttributes:nil error:nullptr]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm
@@ -224,7 +224,7 @@ TEST(Badging, APIWindow)
     EXPECT_EQ(badgeDelegate.get().appBadgeIndex, 5);
 }
 
-static constexpr auto workerMainBytes = R"TESTRESOURCE(
+static constexpr auto badgingWorkerMainBytes = R"TESTRESOURCE(
 <script>
 window.worker = new Worker('worker.js');
 worker.onerror = (event) => {
@@ -236,7 +236,7 @@ worker.onmessage = (event) => {
 </script>
 )TESTRESOURCE"_s;
 
-static constexpr auto workerBytes = R"TESTRESOURCE(
+static constexpr auto badingWorkerBytes = R"TESTRESOURCE(
 self.onmessage = (event) => {
     if (event.data != 'updateBadge')
         return;
@@ -253,8 +253,8 @@ self.postMessage('RUNNING');
 TEST(Badging, DedicatedWorker)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { workerMainBytes } },
-        { "/worker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, workerBytes } }
+        { "/"_s, { badgingWorkerMainBytes } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, badingWorkerBytes } }
     });
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaMutedState.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaMutedState.mm
@@ -34,7 +34,7 @@
 #import <wtf/RetainPtr.h>
 
 static void *audioStateObserverChangeKVOContext = &audioStateObserverChangeKVOContext;
-static bool stateDidChange;
+static bool audioStateDidChange;
 
 @interface AudioStateObserver : NSObject
 - (instancetype)initWithWebView:(TestWKWebView *)webView;
@@ -64,7 +64,7 @@ static bool stateDidChange;
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if (context == audioStateObserverChangeKVOContext) {
-        stateDidChange = true;
+        audioStateDidChange = true;
         return;
     }
 
@@ -105,9 +105,9 @@ TEST(WKWebView, MediaMuted)
 
     EXPECT_EQ([webView _mediaMutedState], _WKMediaNoneMuted);
 
-    stateDidChange = false;
+    audioStateDidChange = false;
     [webView evaluateJavaScript:@"document.querySelector('video').play()" completionHandler:nil];
-    TestWebKitAPI::Util::run(&stateDidChange);
+    TestWebKitAPI::Util::run(&audioStateDidChange);
 
     EXPECT_EQ([webView _mediaMutedState], _WKMediaNoneMuted);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaSession.mm
@@ -29,6 +29,7 @@
 
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
+#import "Helpers/cocoa/MediaRemoteSoftLink.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -45,29 +46,6 @@
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
-
-SOFT_LINK_PRIVATE_FRAMEWORK(MediaRemote)
-
-SOFT_LINK(MediaRemote, MRMediaRemoteSendCommandToApp, Boolean, (MRMediaRemoteCommand command, CFDictionaryRef options, MROriginRef origin, CFStringRef appDisplayID, MRSendCommandAppOptions appOptions, dispatch_queue_t replyQ, void(^completion)(MRSendCommandError err, CFArrayRef handlerReturnStatuses)), (command, options, origin, appDisplayID, appOptions, replyQ, completion));
-#define MRMediaRemoteSendCommandToApp softLinkMRMediaRemoteSendCommandToApp
-
-SOFT_LINK(MediaRemote, MRMediaRemoteGetLocalOrigin, MROriginRef, (), ());
-#define MRMediaRemoteGetLocalOrigin softLinkMRMediaRemoteGetLocalOrigin
-
-SOFT_LINK(MediaRemote, MRMediaRemoteGetSupportedCommandsForOrigin, void, (MROriginRef origin, dispatch_queue_t queue, void(^completion)(CFArrayRef commands)), (origin, queue, completion));
-#define MRMediaRemoteGetSupportedCommandsForOrigin softLinkMRMediaRemoteGetSupportedCommandsForOrigin
-
-SOFT_LINK(MediaRemote, MRMediaRemoteGetNowPlayingClient, void, (dispatch_queue_t queue, void(^completion)(MRNowPlayingClientRef, CFErrorRef)), (queue, completion))
-#define MRMediaRemoteGetNowPlayingClient softLinkMRMediaRemoteGetNowPlayingClient
-
-SOFT_LINK(MediaRemote, MRNowPlayingClientGetProcessIdentifier, pid_t, (MRNowPlayingClientRef client), (client))
-#define MRNowPlayingClientGetProcessIdentifier softLinkMRNowPlayingClientGetProcessIdentifier
-
-SOFT_LINK_CONSTANT(MediaRemote, kMRMediaRemoteOptionSkipInterval, CFStringRef)
-#define kMRMediaRemoteOptionSkipInterval getkMRMediaRemoteOptionSkipIntervalSingleton()
-
-SOFT_LINK_CONSTANT(MediaRemote, kMRMediaRemoteOptionPlaybackPosition, CFStringRef)
-#define kMRMediaRemoteOptionPlaybackPosition getkMRMediaRemoteOptionPlaybackPositionSingleton()
 
 #if !USE(APPLE_INTERNAL_SDK)
 @interface MRCommandInfo : NSObject

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NowPlaying.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NowPlaying.mm
@@ -28,6 +28,7 @@
 #if !PLATFORM(IOS_FAMILY_SIMULATOR)
 
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/cocoa/MediaRemoteSoftLink.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -40,17 +41,7 @@
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/WTFString.h>
 
-SOFT_LINK_PRIVATE_FRAMEWORK(MediaRemote)
-SOFT_LINK(MediaRemote, MRMediaRemoteSetWantsNowPlayingNotifications, void, (bool wantsNotifications), (wantsNotifications))
-SOFT_LINK(MediaRemote, MRMediaRemoteGetNowPlayingClient, void, (dispatch_queue_t queue, void(^completion)(MRNowPlayingClientRef, CFErrorRef)), (queue, completion))
-SOFT_LINK(MediaRemote, MRNowPlayingClientGetProcessIdentifier, pid_t, (MRNowPlayingClientRef client), (client))
-SOFT_LINK_CONSTANT(MediaRemote, kMRMediaRemoteNowPlayingApplicationDidChangeNotification, CFStringRef)
-SOFT_LINK_CONSTANT(MediaRemote, kMRMediaRemoteNowPlayingApplicationPIDUserInfoKey, CFStringRef)
-#define MRMediaRemoteSetWantsNowPlayingNotifications softLinkMRMediaRemoteSetWantsNowPlayingNotifications
-#define MRMediaRemoteGetNowPlayingClient softLinkMRMediaRemoteGetNowPlayingClient
-#define MRNowPlayingClientGetProcessIdentifier softLinkMRNowPlayingClientGetProcessIdentifier
-#define kMRMediaRemoteNowPlayingApplicationDidChangeNotification getkMRMediaRemoteNowPlayingApplicationDidChangeNotificationSingleton()
-#define kMRMediaRemoteNowPlayingApplicationPIDUserInfoKey getkMRMediaRemoteNowPlayingApplicationPIDUserInfoKeySingleton()
+namespace TestWebKitAPI {
 
 static bool userInfoHasNowPlayingApplicationPID(CFDictionaryRef userInfo, int32_t pid)
 {
@@ -276,5 +267,7 @@ TEST_F(NowPlayingTest, VideoElementWithoutAudioPlayWithUserGesture)
 
     ASSERT_NE(webViewPid(), getNowPlayingClientPid());
 }
+
+} // namespace TestWebKitAPI
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenTime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenTime.mm
@@ -32,6 +32,7 @@
 #import "InstanceMethodSwizzler.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
+#import "Helpers/cocoa/ScreenTimeExtras.h"
 #import "Helpers/cocoa/TestCocoa.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
@@ -53,8 +54,8 @@
 static void *blockedStateObserverChangeKVOContext = &blockedStateObserverChangeKVOContext;
 static bool stateDidChange = false;
 static bool receivedLoadMessage = false;
-static bool hasVideoInPictureInPictureValue = false;
-static bool hasVideoInPictureInPictureCalled = false;
+static bool st_hasVideoInPictureInPictureValue = false;
+static bool st_hasVideoInPictureInPictureCalled = false;
 
 static RetainPtr<TestWKWebView> webViewForScreenTimeTests(WKWebViewConfiguration *configuration = nil, BOOL addToWindow = YES)
 {
@@ -106,10 +107,6 @@ static void testSuppressUsageRecordingWithDataStore(RetainPtr<WKWebsiteDataStore
 
     EXPECT_EQ(suppressUsageRecordingExpectation, suppressUsageRecording);
 }
-
-@interface STWebpageController ()
-@property (setter=setURLIsBlocked:) BOOL URLIsBlocked;
-@end
 
 @interface STWebHistory ()
 @property (readonly, copy) STWebHistoryProfileIdentifier profileIdentifier;
@@ -565,8 +562,8 @@ TEST(ScreenTime, URLIsPlayingVideo)
 
 - (void)_webView:(WKWebView *)webView hasVideoInPictureInPictureDidChange:(BOOL)hasVideoInPictureInPicture
 {
-    hasVideoInPictureInPictureValue = hasVideoInPictureInPicture;
-    hasVideoInPictureInPictureCalled = true;
+    st_hasVideoInPictureInPictureValue = hasVideoInPictureInPicture;
+    st_hasVideoInPictureInPictureCalled = true;
 }
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
@@ -612,8 +609,8 @@ TEST(ScreenTime, URLIsPictureInPicture)
     TestWebKitAPI::Util::run(&receivedLoadMessage);
     TestWebKitAPI::Util::run(&childRestrictionsDone);
 
-    hasVideoInPictureInPictureValue = false;
-    hasVideoInPictureInPictureCalled = false;
+    st_hasVideoInPictureInPictureValue = false;
+    st_hasVideoInPictureInPictureCalled = false;
 
     while (![webView _canTogglePictureInPicture])
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
@@ -621,8 +618,8 @@ TEST(ScreenTime, URLIsPictureInPicture)
     ASSERT_FALSE([webView _isPictureInPictureActive]);
     [webView _togglePictureInPicture];
 
-    TestWebKitAPI::Util::run(&hasVideoInPictureInPictureCalled);
-    EXPECT_TRUE(hasVideoInPictureInPictureValue);
+    TestWebKitAPI::Util::run(&st_hasVideoInPictureInPictureCalled);
+    EXPECT_TRUE(st_hasVideoInPictureInPictureValue);
     EXPECT_TRUE([[webView _screenTimeWebpageController] URLIsPictureInPicture]);
 
     // Wait for PIPAgent to launch, or it won't call -pipDidClose: callback.
@@ -631,12 +628,12 @@ TEST(ScreenTime, URLIsPictureInPicture)
     ASSERT_TRUE([webView _isPictureInPictureActive]);
     ASSERT_TRUE([webView _canTogglePictureInPicture]);
 
-    hasVideoInPictureInPictureCalled = false;
+    st_hasVideoInPictureInPictureCalled = false;
 
     [webView _togglePictureInPicture];
 
-    TestWebKitAPI::Util::run(&hasVideoInPictureInPictureCalled);
-    EXPECT_FALSE(hasVideoInPictureInPictureValue);
+    TestWebKitAPI::Util::run(&st_hasVideoInPictureInPictureCalled);
+    EXPECT_FALSE(st_hasVideoInPictureInPictureValue);
     EXPECT_FALSE([[webView _screenTimeWebpageController] URLIsPictureInPicture]);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -26,17 +26,18 @@
 #import "config.h"
 
 #import "ClassMethodSwizzler.h"
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import "Helpers/Utilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/PDFTestHelpers.h"
-#import "InstanceMethodSwizzler.h"
-#import "Helpers/PlatformUtilities.h"
-#import "SafeBrowsingSPI.h"
 #import "Helpers/cocoa/SafeBrowsingTestUtilities.h"
-#import "Helpers/Test.h"
+#import "Helpers/cocoa/ScreenTimeExtras.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
-#import "Helpers/Utilities.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import "InstanceMethodSwizzler.h"
+#import "SafeBrowsingSPI.h"
 #import <WebKit/WKContentWorldPrivate.h>
 #import <WebKit/WKFrameInfoPrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
@@ -65,14 +66,6 @@
 #define TestWebKitAPI_SSBLookupContext_SoftLinked
 SOFT_LINK_PRIVATE_FRAMEWORK(SafariSafeBrowsing);
 SOFT_LINK_CLASS(SafariSafeBrowsing, SSBLookupContext);
-#endif
-
-#if ENABLE(SCREEN_TIME)
-
-@interface STWebpageController ()
-@property (setter=setURLIsBlocked:) BOOL URLIsBlocked;
-@end
-
 #endif
 
 @class WKTextExtractionItem;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SkipAdInPictureInPicture.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SkipAdInPictureInPicture.mm
@@ -44,7 +44,7 @@ SOFT_LINK_CLASS(PIP, PIPPanel)
 SOFT_LINK_CLASS(PIP, PIPPrerollAttributes)
 SOFT_LINK_CLASS(PIP, PIPViewController)
 
-static bool didEnterPiP = false;
+static bool _didEnterPiP = false;
 
 @interface SkipAdInPiPFullscreenDelegate : NSObject <WKUIDelegate>
 @end
@@ -54,7 +54,7 @@ static bool didEnterPiP = false;
 - (void)_webView:(WKWebView *)webView hasVideoInPictureInPictureDidChange:(BOOL)value
 {
     if (value)
-        didEnterPiP = true;
+        _didEnterPiP = true;
 }
 
 @end
@@ -78,12 +78,12 @@ TEST(SkipAdInPictureInPicture, VideoHasAd)
 
     [webView synchronouslyLoadTestPageNamed:@"SkipAdInPictureInPicture"];
 
-    didEnterPiP = false;
+    _didEnterPiP = false;
     [webView evaluateJavaScript:@"document.getElementById('enter-pip').click()" completionHandler:nil];
     TestWebKitAPI::Util::waitFor([&] {
-        return didEnterPiP;
+        return _didEnterPiP;
     });
-    EXPECT_TRUE(didEnterPiP);
+    EXPECT_TRUE(_didEnterPiP);
 
     __block NSWindow *pipPanel = nil;
     [[NSApplication sharedApplication] enumerateWindowsWithOptions:0 usingBlock:^(NSWindow *window, BOOL *stop) {
@@ -114,12 +114,12 @@ TEST(SkipAdInPictureInPicture, VideoHasNoAd)
 
     [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
 
-    didEnterPiP = false;
+    _didEnterPiP = false;
     [webView evaluateJavaScript:@"document.getElementsByTagName('video')[0].webkitSetPresentationMode('picture-in-picture')" completionHandler:nil];
     TestWebKitAPI::Util::waitFor([&] {
-        return didEnterPiP;
+        return _didEnterPiP;
     });
-    EXPECT_TRUE(didEnterPiP);
+    EXPECT_TRUE(_didEnterPiP);
 
     __block NSWindow *pipPanel = nil;
     [[NSApplication sharedApplication] enumerateWindowsWithOptions:0 usingBlock:^(NSWindow *window, BOOL *stop) {


### PR DESCRIPTION
#### e78e1b72a759be2e387bf71c9652059c3d8d0363
<pre>
[TestWebKitAPI] Fix unified source build with CMake + internal SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=317109">https://bugs.webkit.org/show_bug.cgi?id=317109</a>
<a href="https://rdar.apple.com/179677961">rdar://179677961</a>

Reviewed by Richard Robinson.

For build speed optimization, the CMake build dynamically resizes
unified sources. Fix naming collisions and duplicate declaration errors
that only appear when building from CMake with an internal macOS SDK:

When MediaSession.mm and NowPlaying.mm are bundled together, they
duplicate each other&apos;s MediaRemote soft-link declarations. Pull the
soft-linking out to its own file and deduplicate.

* Tools/TestWebKitAPI/Helpers/cocoa/MediaRemoteSoftLink.h: Added.
* Tools/TestWebKitAPI/Helpers/cocoa/MediaRemoteSoftLink.mm: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaSession.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NowPlaying.mm:
* Tools/TestWebKitAPI/SourcesCocoa.txt:

Deduplicate a declaration granting write access to a property on
STWebpageController by pulling it into its own header.

* Tools/TestWebKitAPI/Helpers/cocoa/ScreenTimeExtras.h: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScreenTime.mm:
(-[STPictureInPictureUIDelegate _webView:hasVideoInPictureInPictureDidChange:]):
(TEST(ScreenTime, URLIsPictureInPicture)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:

Remaining changes are renames of variables and static methods.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm:
(readRTFDDataFromPasteboard):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, CopyRTF)):
(readRTFDataFromPasteboard): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Badging.mm:
((Badging, DedicatedWorker)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaMutedState.mm:
(-[AudioStateObserver observeValueForKeyPath:ofObject:change:context:]):
(TestWebKitAPI::TEST(WKWebView, MediaMuted)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/SkipAdInPictureInPicture.mm:
(-[SkipAdInPiPFullscreenDelegate _webView:hasVideoInPictureInPictureDidChange:]):
(TestWebKitAPI::TEST(SkipAdInPictureInPicture, VideoHasAd)):
(TestWebKitAPI::TEST(SkipAdInPictureInPicture, VideoHasNoAd)):

Canonical link: <a href="https://commits.webkit.org/315252@main">https://commits.webkit.org/315252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fde78edf4cec6ce28f97213f7ac3af112f36929

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126204 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b8287b7-249c-4f24-b2fd-6e5a2aacc556) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9ac009c-3f0e-4370-b299-9f1f6f7ef759) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33621 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111668 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6098948-2478-4e65-b60c-2dbace37d09d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26528 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142593 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180431 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33155 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139598 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37546 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42760 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106421 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34742 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41264 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114520 "Build is in progress. Recent messages:") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40661 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5888 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40912 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->