### PR TITLE
[WebCore] Fix unified source build with CMake + internal SDK

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -34,6 +34,11 @@
 #if USE(AVFOUNDATION)
 
 #import <AVFoundation/AVFoundation.h>
+#if USE(APPLE_INTERNAL_SDK)
+// Load private headers before their declarations are redefined as macros
+// below.
+#import <pal/spi/cocoa/AVFoundationSPI.h>
+#endif
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 

--- a/Source/WebCore/PAL/pal/spi/cf/CoreMediaSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreMediaSPI.h
@@ -35,6 +35,13 @@ DECLARE_SYSTEM_HEADER
 
 #include <CoreMedia/CoreMedia.h>
 
+#if USE(APPLE_INTERNAL_SDK)
+// Include some private headers before CoreMediaSoftLink.h overshadows
+// declarations with its macros to soft-link call sites.
+#include <CoreMedia/CMTimePrivate.h>
+#include <MediaToolbox/FigImageQueueDispatch.h>
+#endif
+
 #if PLATFORM(MAC)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnon-modular-include-in-module"

--- a/Source/WebCore/bridge/objc/WebScriptObject.mm
+++ b/Source/WebCore/bridge/objc/WebScriptObject.mm
@@ -55,7 +55,6 @@
 #import <wtf/Threading.h>
 #import <wtf/text/WTFString.h>
 
-using namespace JSC::Bindings;
 using namespace WebCore;
 
 using JSC::CallData;
@@ -66,6 +65,13 @@ using JSC::MarkedArgumentBuffer;
 using JSC::PutPropertySlot;
 using JSC::jsUndefined;
 using JSC::makeSource;
+
+using JSC::Bindings::ObjCRuntimeObject;
+using JSC::Bindings::ObjcInstance;
+using JSC::Bindings::ObjcObjectType;
+using JSC::Bindings::RootObject;
+using JSC::Bindings::convertObjcValueToValue;
+using JSC::Bindings::convertValueToObjcValue;
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
@@ -34,6 +34,7 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/TZoneMallocInlines.h>
 
+#import <AVFAudio/AVAudioRoutingArbiter.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCMacros.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCMacros.h
@@ -46,4 +46,12 @@
 
 #define WEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS 0
 
+// This private header defines some short-name macros that collide with
+// libwebrtc/abseil identifiers. Include it early and undef the offenders.
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<CoreUtils/CommonServices.h>)
+#include <CoreUtils/CommonServices.h>
+#endif
+#undef IsPowerOf2
+#undef RoundTo
+
 #endif // USE(LIBWEBRTC)

--- a/Source/WebCore/platform/network/cocoa/ResourceHandleCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceHandleCocoa.mm
@@ -192,7 +192,7 @@ void ResourceHandle::createNSURLConnection(id delegate, bool shouldUseCredential
         // requests may get stuck waiting for delegate calls while we are in nested run loop, and the sync
         // request won't start because there are no available connections.
         // Connections are grouped by their socket stream properties, with each group having a separate count.
-        [streamProperties setObject:@TRUE forKey:@"_WebKitSynchronousRequest"];
+        [streamProperties setObject:@YES forKey:@"_WebKitSynchronousRequest"];
     }
 
     RetainPtr<CFDataRef> sourceApplicationAuditData = d->m_context->sourceApplicationAuditData();


### PR DESCRIPTION
#### 35056630b567d9265fbbf23ca35ff8bd69b36163
<pre>
[WebCore] Fix unified source build with CMake + internal SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=317114">https://bugs.webkit.org/show_bug.cgi?id=317114</a>
<a href="https://rdar.apple.com/179682924">rdar://179682924</a>

Reviewed by Geoffrey Garen.

Fix some header include order and duplicate definition issues that
appear due to dynamic bundle sizes.

* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h:
* Source/WebCore/PAL/pal/spi/cf/CoreMediaSPI.h:
* Source/WebCore/bridge/objc/WebScriptObject.mm:
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCMacros.h:
* Source/WebCore/platform/network/cocoa/ResourceHandleCocoa.mm:
(WebCore::ResourceHandle::createNSURLConnection):

Canonical link: <a href="https://commits.webkit.org/315240@main">https://commits.webkit.org/315240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e5c24d518e9c26c124c4739ca25ddd0d3afc0f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126092 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0eafabe-fd4f-415e-be32-191c55b080fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131052 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92145 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64c58c44-aae1-4aaa-9a12-4123c26ff748) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111563 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ba60ee4-7cd8-43dc-864e-3473d8d98b02) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32506 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31207 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26415 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142492 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180319 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33043 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30734 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139487 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139351 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37540 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42648 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106223 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27704 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114408 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40549 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5789 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40694 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->