### PR TITLE
Building WebKit with PGO profile should not be sensitive to compiling directory structure.

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -62,7 +62,8 @@ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) $(WK_GCC_PREPROCESSOR_DEFINITIONS);
 WK_COMMON_OTHER_CFLAGS = $(WK_SANITIZER_OTHER_CFLAGS) $(WK_COMMON_OTHER_CFLAGS_PGO_$(WK_OR_$(WK_ENABLE_PGO_USE)_$(ENABLE_LLVM_PROFILE_GENERATION)));
 // Work around rdar://141760829 until the fix is available on all clang-1700
 // based toolchains.
-WK_COMMON_OTHER_CFLAGS_PGO_YES = -mllvm -system-headers-coverage;
+// Fix from rdar://178983382 to avoid symbol module prefix differences causing performance loss.
+WK_COMMON_OTHER_CFLAGS_PGO_YES = -mllvm -system-headers-coverage -mllvm -static-func-full-module-prefix=false;
 
 OTHER_CFLAGS = $(inherited) $(WK_COMMON_OTHER_CFLAGS);
 


### PR DESCRIPTION
#### 3aeb235fd2f99d10ceaff35c69551205f8a17348
<pre>
Building WebKit with PGO profile should not be sensitive to compiling directory structure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317115">https://bugs.webkit.org/show_bug.cgi?id=317115</a>
<a href="https://rdar.apple.com/178983382">rdar://178983382</a>

Reviewed by Alexey Proskuryakov and Elliott Williams.

Add &apos;-mllvm -static-func-full-module-prefix=false&apos; flag to remove path in the PGO profile symbols.
This will ensure optimization for those symbols being reliably applied even when environment for
building instrumentation binary and final binary differ.

* Configurations/CommonBase.xcconfig:

Canonical link: <a href="https://commits.webkit.org/315355@main">https://commits.webkit.org/315355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b85de3b95d59e1791f50e78b21bad052398c5ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126400 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/030a2039-efcc-415f-92c6-12d44c610ff5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131337 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92389 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d21176d-93f1-4a1e-8c0b-b37b8050d5b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111841 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a779e1c5-2630-4df3-8424-1af449569f65) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31490 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26719 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180625 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139779 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42264 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139628 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/37589 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42953 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27976 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106716 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34909 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41456 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6064 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40853 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41107 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40998 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->