### PR TITLE
Have AudioVideoRenderer take and update a SharedTimebase and reduce noticeable drift

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -474,6 +474,7 @@ platform/graphics/cocoa/IntRectCocoa.mm @nonARC
 platform/graphics/cocoa/ImageAdapterCocoa.mm @nonARC
 platform/graphics/cocoa/MediaPlayerCocoa.mm @nonARC
 platform/graphics/cocoa/MediaPlayerPrivateWebM.mm @nonARC @no-unify-when(bundle<=8) @cost:7
+platform/graphics/cocoa/PeriodicSharedTimer.mm @nonARC
 platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
 platform/graphics/cocoa/PlatformTimeRangesCocoa.mm @nonARC @no-unify-when(bundle<=8)
 platform/graphics/cocoa/ShareableCVPixelBuffer.cpp

--- a/Source/WebCore/platform/SharedTimebase.cpp
+++ b/Source/WebCore/platform/SharedTimebase.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SharedTimebase.h"
 
+#include "Logging.h"
 #include <WebCore/SharedMemory.h>
 #include <wtf/MediaTime.h>
 #include <wtf/MonotonicTime.h>
@@ -97,19 +98,18 @@ public:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedTimebaseReader);
 
-std::unique_ptr<SharedTimebaseReader> SharedTimebaseReader::create(SharedTimebase::Handle&& handle, Seconds maxExtrapolation, Function<MonotonicTime()>&& clock)
+std::unique_ptr<SharedTimebaseReader> SharedTimebaseReader::create(SharedTimebase::Handle&& handle, Function<MonotonicTime()>&& clock)
 {
     RefPtr sharedMemory = SharedMemory::map(WTF::move(handle.memory), SharedMemoryProtection::ReadOnly);
     if (!sharedMemory || sharedMemory->size() < sizeof(SnapshotBuffer))
         return nullptr;
-    return std::unique_ptr<SharedTimebaseReader>(new SharedTimebaseReader(sharedMemory.releaseNonNull(), maxExtrapolation, WTF::move(clock)));
+    return makeUnique<SharedTimebaseReader>(sharedMemory.releaseNonNull(), WTF::move(clock));
 }
 
-SharedTimebaseReader::SharedTimebaseReader(Ref<SharedMemory>&& storage, Seconds maxExtrapolation, Function<MonotonicTime()>&& clock)
+SharedTimebaseReader::SharedTimebaseReader(Ref<SharedMemory>&& storage, Function<MonotonicTime()>&& clock)
     : m_impl { makeUniqueRef<SharedTimebaseReader::Impl>(SharedTimebaseReader::Impl {
         .storage = WTF::move(storage)
     }) }
-    , m_maxExtrapolation(maxExtrapolation)
     , m_clock(clock ? WTF::move(clock) : Function<MonotonicTime()> { [] { return MonotonicTime::now(); } })
 {
 }
@@ -125,14 +125,22 @@ MediaTime SharedTimebaseReader::currentTime() const
     if (!rate)
         calculated = snapshot.currentTime;
     else {
-        auto elapsed = std::min(m_clock() - snapshot.hostTime, m_maxExtrapolation);
-        calculated = snapshot.currentTime + MediaTime::createWithDouble(rate * elapsed.seconds());
+        auto elapsed = m_clock() - snapshot.hostTime;
+        calculated = (snapshot.currentTime + MediaTime::createWithDouble(rate * elapsed.seconds())).toTimeScale(snapshot.currentTime.timeScale());
     }
 
-    if (rate >= 0)
-        calculated = std::max(m_lastReturnedTime.value_or(calculated), calculated);
-    else
-        calculated = std::min(m_lastReturnedTime.value_or(calculated), calculated);
+    // Enforce forward monotonicity: if the writer's published value (or our extrapolation of it)
+    // would step backward, log it and clamp. Backward steps that survive the writer's own
+    // monotonicity guarantees indicate a writer-side anomaly worth surfacing in the log, but the
+    // reader must not propagate the regression to its callers.
+    if (rate >= 0) {
+        if (m_lastReturnedTime && *m_lastReturnedTime > calculated) {
+            RELEASE_LOG_ERROR(Media, "SharedTimebaseReader: backward step suppressed lastReturned=%.7f calculated=%.7f delta=%.7f",
+                m_lastReturnedTime->toDouble(), calculated.toDouble(), (*m_lastReturnedTime - calculated).toDouble());
+            calculated = *m_lastReturnedTime;
+        }
+    } else if (m_lastReturnedTime && *m_lastReturnedTime < calculated)
+        calculated = *m_lastReturnedTime;
 
     m_lastReturnedTime = calculated;
     return calculated;
@@ -145,6 +153,8 @@ double SharedTimebaseReader::currentRate() const
 
 void SharedTimebaseReader::resetForTimeDiscontinuity()
 {
+    // Drop the high-water-mark so the next snapshot establishes a fresh baseline; the post-
+    // discontinuity time is allowed to be lower than what was previously returned.
     m_lastReturnedTime.reset();
 }
 

--- a/Source/WebCore/platform/SharedTimebase.h
+++ b/Source/WebCore/platform/SharedTimebase.h
@@ -67,23 +67,18 @@ private:
 
 // Reader-side companion to SharedTimebase. Owns its own read-only mapping of
 // the shared memory plus the per-reader state needed to turn the writer's raw
-// snapshot stream into a bounded, monotonic playback time: a forward-monotonic
-// high-water-mark clamp, and rate-based extrapolation from the latest snapshot
-// capped at maxExtrapolation.
+// snapshot stream into a forward-monotonic playback time, with rate-based
+// extrapolation from the latest snapshot.
 //
 // Not thread-safe: callers must serialize all method invocations on a given
 // instance.
 class WEBCORE_EXPORT SharedTimebaseReader final {
     WTF_MAKE_TZONE_ALLOCATED(SharedTimebaseReader);
 public:
-    // maxExtrapolation caps rate-based extrapolation from the latest snapshot
-    // to "now" — if the writer has been silent for longer than this, we don't
-    // trust that the published rate held for the entire interval. Pass the
-    // producer's refresh cadence.
-    //
     // clock is the source of "now" for extrapolation; defaults to
     // MonotonicTime::now. Override for tests that need deterministic timing.
-    static std::unique_ptr<SharedTimebaseReader> create(SharedTimebase::Handle&&, Seconds maxExtrapolation, Function<MonotonicTime()>&& clock = { });
+    static std::unique_ptr<SharedTimebaseReader> create(SharedTimebase::Handle&&, Function<MonotonicTime()>&& clock = { });
+    SharedTimebaseReader(Ref<SharedMemory>&&, Function<MonotonicTime()>&&);
     ~SharedTimebaseReader();
 
     MediaTime currentTime() const;
@@ -92,11 +87,8 @@ public:
     void resetForTimeDiscontinuity();
 
 private:
-    SharedTimebaseReader(Ref<SharedMemory>&&, Seconds maxExtrapolation, Function<MonotonicTime()>&&);
-
     struct Impl;
     UniqueRef<Impl> m_impl;
-    const Seconds m_maxExtrapolation;
     const Function<MonotonicTime()> m_clock;
     mutable std::optional<MediaTime> m_lastReturnedTime;
 };

--- a/Source/WebCore/platform/graphics/AudioVideoRenderer.h
+++ b/Source/WebCore/platform/graphics/AudioVideoRenderer.h
@@ -52,6 +52,7 @@ class MediaSample;
 class NativeImage;
 class PlatformDynamicRangeLimit;
 class ProcessIdentity;
+class SharedTimebase;
 class TextTrackRepresentation;
 class VideoFrame;
 
@@ -130,6 +131,9 @@ public:
     virtual Ref<GenericPromise> finishSeek(const MediaTime&) = 0;
     virtual bool seeking() const = 0;
     virtual void setScreenReserved(bool) = 0;
+
+    // The timebase the renderer keeps up to date as time/rate change. Null if unavailable.
+    virtual SharedTimebase* sharedTimebase() = 0;
 };
 
 struct SamplesRendererTrackIdentifierType;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/AudioVideoRenderer.h>
+#include <WebCore/PeriodicSharedTimer.h>
 #include <WebCore/PlatformDynamicRangeLimit.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/TrackInfo.h>
@@ -34,6 +35,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
+#include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RetainPtr.h>
@@ -55,6 +57,7 @@ class EffectiveRateChangedListener;
 class MediaSample;
 class NativeImage;
 class PixelBufferConformerCV;
+class SharedTimebase;
 class VideoLayerManagerObjC;
 class VideoMediaSampleRenderer;
 
@@ -62,10 +65,12 @@ class AudioVideoRendererAVFObjC
     : public AudioVideoRenderer
     , public WebAVSampleBufferListenerClient
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioVideoRendererAVFObjC>
+    , private PeriodicSharedTimer::Client
     , private LoggerHelper {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(AudioVideoRendererAVFObjC, WEBCORE_EXPORT);
 public:
-    static Ref<AudioVideoRendererAVFObjC> create(const Logger& logger, uint64_t logIdentifier) { return adoptRef(*new AudioVideoRendererAVFObjC(logger, logIdentifier)); }
+    WEBCORE_EXPORT static Ref<AudioVideoRendererAVFObjC> create(const Logger&, uint64_t logIdentifier);
+    WEBCORE_EXPORT static Ref<AudioVideoRendererAVFObjC> create(const Logger&, uint64_t logIdentifier, UniqueRef<SharedTimebase>&&);
 
     ~AudioVideoRendererAVFObjC();
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
@@ -109,6 +114,7 @@ public:
     void notifyEffectiveRateChanged(Function<void(double)>&&) final;
     bool seeking() const final;
     void setScreenReserved(bool) final;
+    SharedTimebase* sharedTimebase() final { return m_sharedTimebase.get(); }
 
     // AudioInterface
     void setVolume(float) final;
@@ -153,9 +159,10 @@ public:
     void isInFullscreenOrPictureInPictureChanged(bool) final;
 
 private:
-    WEBCORE_EXPORT AudioVideoRendererAVFObjC(const Logger&, uint64_t);
+    WEBCORE_EXPORT AudioVideoRendererAVFObjC(const Logger&, uint64_t, std::unique_ptr<SharedTimebase>&&);
 
     MediaTime clampTimeToLastSeekTime(const MediaTime&) const;
+    void setTimeFloor(const MediaTime&);
     void maybeCompleteSeek();
     bool shouldBePlaying() const;
     bool allRenderersHaveAvailableSamples() const { return m_allRenderersHaveAvailableSamples; }
@@ -226,6 +233,9 @@ private:
     void handleEffectiveRateChanged(double);
     void releaseStartupGateAndForwardRate();
     void cancelStartupGateObserver();
+    void updateSharedTimebase();
+    void publishSnapshot(MediaTime currentTime, double playbackRate);
+    void periodicSharedTimerFired() final;
     bool updateLastPixelBuffer();
     void maybePurgeLastPixelBuffer();
     void setNeedsPlaceholderImage(bool);
@@ -310,6 +320,7 @@ private:
     String m_audioOutputDeviceId;
 #endif
 
+    mutable Lock m_publishLock;
     // Seek Logic
     MediaTime m_lastSeekTime;
     SeekState m_seekState { SeekCompleted };
@@ -357,6 +368,11 @@ private:
     // Video Frame metadata gathering
     RetainPtr<id> m_videoFrameMetadataGatheringObserver;
     MonotonicTime m_startupTime;
+    const std::unique_ptr<SharedTimebase> m_sharedTimebase;
+    bool m_registeredWithSharedTimer { false };
+    std::optional<MediaTime> m_stallCap WTF_GUARDED_BY_LOCK(m_publishLock);
+    // Floor for SharedTimebase publishes; locked so off-main-thread publishers can read it.
+    MediaTime m_publishedTimeFloor WTF_GUARDED_BY_LOCK(m_publishLock);
 
     RefPtr<EffectiveRateChangedListener> m_effectiveRateChangedListener;
     Function<void(double)> m_effectiveRateChangedCallback;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -40,8 +40,10 @@
 #import "MediaSampleAVFObjC.h"
 #import "MediaSessionManagerCocoa.h"
 #import "NativeImage.h"
+#import "PeriodicSharedTimer.h"
 #import "PixelBufferConformerCV.h"
 #import "PlatformDynamicRangeLimitCocoa.h"
+#import "SharedTimebase.h"
 #import "SpatialAudioExperienceHelper.h"
 #import "TextTrackRepresentation.h"
 #import "Timer.h"
@@ -57,6 +59,7 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/MainThread.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WorkQueue.h>
@@ -89,13 +92,30 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioVideoRendererAVFObjC);
 
-AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogger, uint64_t logSiteIdentifier)
+static PeriodicSharedTimer& sharedTimebaseTimer()
+{
+    static NeverDestroyed<PeriodicSharedTimer> timer { 100_ms };
+    return timer.get();
+}
+
+Ref<AudioVideoRendererAVFObjC> AudioVideoRendererAVFObjC::create(const Logger& logger, uint64_t logIdentifier)
+{
+    return adoptRef(*new AudioVideoRendererAVFObjC(logger, logIdentifier, nullptr));
+}
+
+Ref<AudioVideoRendererAVFObjC> AudioVideoRendererAVFObjC::create(const Logger& logger, uint64_t logIdentifier, UniqueRef<SharedTimebase>&& sharedTimebase)
+{
+    return adoptRef(*new AudioVideoRendererAVFObjC(logger, logIdentifier, sharedTimebase.moveToUniquePtr()));
+}
+
+AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogger, uint64_t logSiteIdentifier, std::unique_ptr<SharedTimebase>&& sharedTimebase)
     : m_logger(originalLogger)
     , m_logIdentifier(logSiteIdentifier)
     , m_videoLayerManager(makeUniqueRef<VideoLayerManagerObjC>(originalLogger, logSiteIdentifier))
     , m_synchronizer(adoptNS([PAL::allocAVSampleBufferRenderSynchronizerInstance() init]))
     , m_listener(WebAVSampleBufferListener::create(*this))
     , m_startupTime(MonotonicTime::now())
+    , m_sharedTimebase(WTF::move(sharedTimebase))
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
     , m_keyStatusesChangedObserver(Observer<void()>::create([weakThis = ThreadSafeWeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get())
@@ -125,6 +145,8 @@ AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC(const Logger& originalLogge
 
 AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC()
 {
+    if (std::exchange(m_registeredWithSharedTimer, false))
+        sharedTimebaseTimer().removeClient(*this);
     if (RefPtr rateChangeListener = std::exchange(m_effectiveRateChangedListener, { }))
         rateChangeListener->stop();
     cancelStartupGateObserver();
@@ -460,7 +482,7 @@ void AudioVideoRendererAVFObjC::pause(std::optional<MonotonicTime> hostTime)
     // False positive see webkit.org/b/298024
     SUPPRESS_UNRETAINED_ARG MediaTime pauseTime = PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase]));
     if (pauseTime.isFinite() && pauseTime > m_lastSeekTime)
-        m_lastSeekTime = pauseTime;
+        setTimeFloor(pauseTime);
     setSynchronizerRate(0, hostTime);
 }
 
@@ -476,14 +498,20 @@ bool AudioVideoRendererAVFObjC::timeIsProgressing() const
 
 MediaTime AudioVideoRendererAVFObjC::currentTime() const
 {
+    ASSERT(isMainThread());
     if (seeking())
         return m_lastSeekTime;
-
     // False positive see webkit.org/b/298024
     SUPPRESS_UNRETAINED_ARG MediaTime synchronizerTime = clampTimeToLastSeekTime(PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase])));
     if (synchronizerTime < MediaTime::zeroTime())
         return MediaTime::zeroTime();
 
+    // Clamp to the stall cap. The synchronizer can overshoot the registered boundary during the
+    // observer's dispatch latency; without the clamp the overshoot leaks into snapshots and the
+    // observer's eventual setRate:0 time:cap visibly walks ct backward.
+    Locker locker { m_publishLock };
+    if (m_stallCap && synchronizerTime > *m_stallCap)
+        return *m_stallCap;
     return synchronizerTime;
 }
 
@@ -509,8 +537,47 @@ double AudioVideoRendererAVFObjC::effectiveRate() const
 {
     if (m_startupGateObserver)
         return 0;
+    // currentTime() floors the reported time to m_lastSeekTime while the timebase is in pre-roll
+    // (negative at startup, below the seek target right after a seek). While floored the published
+    // time isn't advancing, so report 0 to keep the snapshot self-consistent — otherwise the reader
+    // would extrapolate ahead of a frozen currentTime and the next honest snapshot would land below
+    // its high-water-mark.
+    SUPPRESS_UNRETAINED_ARG MediaTime rawTime = PAL::toMediaTime(PAL::CMTimebaseGetTime([m_synchronizer timebase]));
+    if (clampTimeToLastSeekTime(rawTime) != rawTime || rawTime < MediaTime::zeroTime())
+        return 0;
     // False positive see webkit.org/b/298024
     SUPPRESS_UNRETAINED_ARG return PAL::CMTimebaseGetEffectiveRate([m_synchronizer timebase]);
+}
+
+void AudioVideoRendererAVFObjC::updateSharedTimebase()
+{
+    ASSERT(isMainThread());
+    if (!m_sharedTimebase)
+        return;
+    publishSnapshot(currentTime(), effectiveRate());
+}
+
+void AudioVideoRendererAVFObjC::publishSnapshot(MediaTime currentTime, double playbackRate)
+{
+    if (!m_sharedTimebase)
+        return;
+    Locker locker { m_publishLock };
+    // Floor: never publish below the high-water-mark. Catches AVF retroactive anchor changes
+    // that lower CMTimebaseGetTime after rate changes, and is reset downward at seek sites.
+    if (m_publishedTimeFloor.isFinite() && currentTime < m_publishedTimeFloor)
+        currentTime = m_publishedTimeFloor;
+    // Ceiling: stall cap from the boundary observer, masking the synchronizer's overshoot
+    // during dispatch latency until the observer parks the timebase.
+    if (m_stallCap && currentTime > *m_stallCap) {
+        currentTime = *m_stallCap;
+        playbackRate = 0;
+    }
+    m_publishedTimeFloor = currentTime;
+    m_sharedTimebase->storeSnapshot({
+        .currentTime = currentTime,
+        .playbackRate = playbackRate,
+        .hostTime = MonotonicTime::now()
+    });
 }
 
 void AudioVideoRendererAVFObjC::stall()
@@ -533,11 +600,20 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const
     m_stallProducer.emplace();
     Ref promise = m_stallProducer->promise();
 
+    // Register the observer at a 1ms-aligned tick at-or-before the boundary so it fires reliably;
+    // sample-unit values land between ticks and the observer never fires. The synchronizer is
+    // still parked at, and the producer resolves with, the original boundary.
+    auto roundedBoundary = timeBoundary.toTimeScale(1000, MediaTime::RoundingFlags::TowardNegativeInfinity);
+    {
+        Locker locker { m_publishLock };
+        m_stallCap = timeBoundary;
+    }
+    RetainPtr<NSArray> times = @[[NSValue valueWithCMTime:PAL::toCMTime(roundedBoundary)]];
+
     auto logSiteIdentifier = LOGIDENTIFIER;
     DEBUG_LOG(logSiteIdentifier, timeBoundary);
     UNUSED_PARAM(logSiteIdentifier);
 
-    RetainPtr<NSArray> times = @[[NSValue valueWithCMTime:PAL::toCMTime(timeBoundary)]];
     m_currentTimeObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times.get() queue:mainDispatchQueueSingleton() usingBlock:makeBlockPtr([weakThis = ThreadSafeWeakPtr { *this }, timeBoundary, logSiteIdentifier]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -550,6 +626,7 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const
         [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(timeBoundary)];
         protectedThis->m_lastSetSyncRate = 0;
 
+        protectedThis->updateSharedTimebase();
         if (auto producer = std::exchange(protectedThis->m_stallProducer, std::nullopt))
             producer->resolve(timeBoundary);
     }).get()];
@@ -558,6 +635,10 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const
 
 void AudioVideoRendererAVFObjC::cancelTimeReachedAction()
 {
+    {
+        Locker locker { m_publishLock };
+        m_stallCap.reset();
+    }
     if (auto producer = std::exchange(m_stallProducer, std::nullopt))
         producer->reject(PlatformMediaError::Cancelled);
     if (RetainPtr observer = std::exchange(m_currentTimeObserver, nullptr))
@@ -582,6 +663,7 @@ void AudioVideoRendererAVFObjC::performTaskAtTime(const MediaTime& time, Functio
         MediaTime now = protectedThis->currentTime();
         ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now: ", now);
 
+        protectedThis->updateSharedTimebase();
         task(now);
 
         protectedThis->cancelPerformTaskAtTimeObserverIfNeeded();
@@ -600,6 +682,7 @@ void AudioVideoRendererAVFObjC::setTimeObserver(Seconds interval, Function<void(
         if (!protectedThis)
             return;
         auto clampedTime = CMTIME_IS_NUMERIC(time) ? protectedThis->clampTimeToLastSeekTime(PAL::toMediaTime(time)) : MediaTime::zeroTime();
+        protectedThis->updateSharedTimebase();
         callback(clampedTime);
     }).get()];
 }
@@ -631,7 +714,7 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::prepareToSeek(const MediaTime& 
         // In cases where the destination seek time matches too closely the synchronizer's existing time
         // no time jumped notification will be issued. In this case, just notify the MediaPlayer that
         // the seek completed successfully.
-        m_lastSeekTime = synchronizerTime;
+        setTimeFloor(synchronizerTime);
         m_seekState = SeekCompleted;
 
         auto shouldBePlaying = this->shouldBePlaying();
@@ -639,8 +722,10 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::prepareToSeek(const MediaTime& 
 
         if (shouldBePlaying)
             setSynchronizerRate(m_rate, { });
+        else
+            updateSharedTimebase();
 
-        return MediaTimePromise::createAndResolve(m_lastSeekTime);
+        return MediaTimePromise::createAndResolve(synchronizerTime);
     }
 
     setHasAvailableVideoFrame(false);
@@ -650,10 +735,11 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::prepareToSeek(const MediaTime& 
         properties.readyToRequestAudioData = false;
     }
 
-    m_lastSeekTime = seekTime;
+    setTimeFloor(seekTime);
     m_isSynchronizerSeeking = isSynchronizerSeeking;
     [m_synchronizer setRate:0 time:PAL::toCMTime(seekTime)];
     m_lastSetSyncRate = 0;
+    updateSharedTimebase();
     return MediaTimePromise::createAndResolve(MediaTime::indefiniteTime());
 }
 
@@ -675,6 +761,15 @@ void AudioVideoRendererAVFObjC::notifyEffectiveRateChanged(Function<void(double)
     m_effectiveRateChangedCallback = WTF::move(callback);
     // False positive see webkit.org/b/298024
     SUPPRESS_UNRETAINED_ARG m_effectiveRateChangedListener = EffectiveRateChangedListener::create([weakThis = ThreadSafeWeakPtr { *this }](double rate) mutable {
+        // On rate->0, publish synchronously on the listener thread before the main-thread hop.
+        // The main-thread updateSharedTimebase that handleEffectiveRateChanged would do is too
+        // late: the reader keeps extrapolating off the prior (rate=1) snapshot in the interim.
+        // Rate->non-zero is left to the main-thread path, which applies clampTimeToLastSeekTime
+        // and the startup gate.
+        if (RefPtr protectedThis = weakThis.get(); !rate && protectedThis && protectedThis->m_sharedTimebase) {
+            SUPPRESS_UNRETAINED_ARG MediaTime time = std::max(MediaTime::zeroTime(), PAL::toMediaTime(PAL::CMTimebaseGetTime([protectedThis->m_synchronizer timebase])));
+            protectedThis->publishSnapshot(time, 0);
+        }
         callOnMainThread([weakThis, rate] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->handleEffectiveRateChanged(rate);
@@ -691,6 +786,7 @@ void AudioVideoRendererAVFObjC::handleEffectiveRateChanged(double rate)
     if (!rate || m_lastForwardedEffectiveRate) {
         cancelStartupGateObserver();
         m_lastForwardedEffectiveRate = rate;
+        updateSharedTimebase();
         if (m_effectiveRateChangedCallback)
             m_effectiveRateChangedCallback(rate);
         return;
@@ -719,6 +815,8 @@ void AudioVideoRendererAVFObjC::releaseStartupGateAndForwardRate()
     cancelStartupGateObserver();
     SUPPRESS_UNRETAINED_ARG double liveRate = PAL::CMTimebaseGetEffectiveRate([m_synchronizer timebase]);
     m_lastForwardedEffectiveRate = liveRate;
+    // The gate just lifted: effectiveRate() now returns the live rate; publish before notifying.
+    updateSharedTimebase();
     if (m_effectiveRateChangedCallback)
         m_effectiveRateChangedCallback(liveRate);
 }
@@ -1079,10 +1177,19 @@ void AudioVideoRendererAVFObjC::setScreenReserved(bool reserved)
 
 MediaTime AudioVideoRendererAVFObjC::clampTimeToLastSeekTime(const MediaTime& time) const
 {
+    ASSERT(isMainThread());
     if (m_lastSeekTime.isFinite() && time < m_lastSeekTime)
         return m_lastSeekTime;
 
     return time;
+}
+
+void AudioVideoRendererAVFObjC::setTimeFloor(const MediaTime& time)
+{
+    ASSERT(isMainThread());
+    m_lastSeekTime = time;
+    Locker locker { m_publishLock };
+    m_publishedTimeFloor = time;
 }
 
 void AudioVideoRendererAVFObjC::maybeCompleteSeek()
@@ -1104,8 +1211,10 @@ void AudioVideoRendererAVFObjC::maybeCompleteSeek()
     m_seekState = SeekCompleted;
     if (shouldBePlaying())
         setSynchronizerRate(m_rate, { });
-    else
+    else {
         ALWAYS_LOG(LOGIDENTIFIER, "Not resuming playback, shouldBePlaying:false");
+        updateSharedTimebase();
+    }
 
     if (auto promise = std::exchange(m_seekPromise, std::nullopt))
         promise->resolve();
@@ -1870,6 +1979,28 @@ void AudioVideoRendererAVFObjC::setSynchronizerRate(float rate, std::optional<Mo
         updateLastPixelBuffer();
     else
         maybePurgeLastPixelBuffer();
+
+    // Rate (and possibly time) just changed; publish so the reader extrapolates from a fresh anchor.
+    updateSharedTimebase();
+
+    if (!m_sharedTimebase)
+        return;
+    if (rate && !m_registeredWithSharedTimer) {
+        m_registeredWithSharedTimer = true;
+        sharedTimebaseTimer().addClient(*this);
+    } else if (!rate && m_registeredWithSharedTimer) {
+        m_registeredWithSharedTimer = false;
+        sharedTimebaseTimer().removeClient(*this);
+    }
+}
+
+void AudioVideoRendererAVFObjC::periodicSharedTimerFired()
+{
+    ASSERT(m_sharedTimebase);
+    SUPPRESS_UNRETAINED_ARG auto timebase = [m_synchronizer timebase];
+    SUPPRESS_UNRETAINED_ARG MediaTime rawTime = std::max(MediaTime::zeroTime(), PAL::toMediaTime(PAL::CMTimebaseGetTime(timebase)));
+    SUPPRESS_UNRETAINED_ARG double rate = PAL::CMTimebaseGetEffectiveRate(timebase);
+    publishSnapshot(rawTime, rate);
 }
 
 RefPtr<NativeImage> AudioVideoRendererAVFObjC::currentNativeImage() const

--- a/Source/WebCore/platform/graphics/cocoa/PeriodicSharedTimer.h
+++ b/Source/WebCore/platform/graphics/cocoa/PeriodicSharedTimer.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dispatch/dispatch.h>
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
+#include <wtf/Lock.h>
+#include <wtf/OSObjectPtr.h>
+#include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
+
+namespace WebCore {
+
+// Periodic dispatch timer that broadcasts ticks to multiple clients. A single
+// dispatch source serves every registered client; the source is suspended
+// whenever the client set is empty, so an idle instance pays no wakeups.
+class PeriodicSharedTimer final {
+    WTF_MAKE_NONCOPYABLE(PeriodicSharedTimer);
+    WTF_MAKE_TZONE_ALLOCATED(PeriodicSharedTimer);
+public:
+    class Client : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
+    public:
+        virtual ~Client() = default;
+        // Invoked on the PeriodicSharedTimer's serial queue. Implementations
+        // should keep the body short; while running, the client is kept alive
+        // by a strong reference held by the iteration snapshot.
+        virtual void periodicSharedTimerFired() = 0;
+    };
+
+    explicit PeriodicSharedTimer(Seconds interval);
+    ~PeriodicSharedTimer();
+
+    void addClient(Client&);
+    void removeClient(Client&);
+
+private:
+    void timerFired();
+
+    Lock m_activeLock;
+    bool m_active WTF_GUARDED_BY_LOCK(m_activeLock) { false };
+    ThreadSafeWeakHashSet<Client> m_clients WTF_GUARDED_BY_LOCK(m_activeLock);
+    OSObjectPtr<dispatch_queue_t> m_queue;
+    OSObjectPtr<dispatch_source_t> m_timer;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/PeriodicSharedTimer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/PeriodicSharedTimer.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "PeriodicSharedTimer.h"
+
+#import <wtf/BlockPtr.h>
+#import <wtf/TZoneMallocInlines.h>
+#import <wtf/Vector.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PeriodicSharedTimer);
+
+PeriodicSharedTimer::PeriodicSharedTimer(Seconds interval)
+    : m_queue(adoptOSObject(dispatch_queue_create("WebCore PeriodicSharedTimer", DISPATCH_QUEUE_SERIAL)))
+    , m_timer(adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_queue.get())))
+{
+    auto intervalNs = interval.nanosecondsAs<uint64_t>();
+    dispatch_source_set_timer(m_timer.get(), DISPATCH_TIME_NOW, intervalNs, intervalNs / 10);
+    dispatch_source_set_event_handler(m_timer.get(), makeBlockPtr([this] {
+        timerFired();
+    }).get());
+    // Source starts inactive; addClient() resumes it on the 0 -> 1 transition.
+}
+
+PeriodicSharedTimer::~PeriodicSharedTimer()
+{
+    // Per <dispatch/source.h>: "Releasing the last reference count on an inactive
+    // object is undefined." Resume before cancelling so the cancel + release run
+    // against an active source.
+    if (!m_active)
+        dispatch_resume(m_timer.get());
+    dispatch_source_cancel(m_timer.get());
+}
+
+void PeriodicSharedTimer::timerFired()
+{
+    Vector<Ref<Client>> clients;
+    {
+        Locker locker { m_activeLock };
+        clients = m_clients.values();
+    }
+    for (auto& client : clients)
+        client->periodicSharedTimerFired();
+}
+
+void PeriodicSharedTimer::addClient(Client& client)
+{
+    Locker locker { m_activeLock };
+    m_clients.add(client);
+    if (m_active)
+        return;
+    m_active = true;
+    dispatch_resume(m_timer.get());
+}
+
+void PeriodicSharedTimer::removeClient(Client& client)
+{
+    Locker locker { m_activeLock };
+    m_clients.remove(client);
+    if (!m_clients.isEmptyIgnoringNullReferences())
+        return;
+    if (!m_active)
+        return;
+    m_active = false;
+    dispatch_suspend(m_timer.get());
+}
+
+} // namespace WebCore

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -58,6 +58,7 @@
 #endif
 #include <wtf/Markable.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/UniqueRef.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_gpuConnectionToWebProcess.get()->connection())
 #define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, m_gpuConnectionToWebProcess.get()->connection(), completion)
@@ -68,32 +69,21 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioVideoRendererProxyManager);
 
-void RemoteAudioVideoRendererProxyManager::updateContextSharedTimebase(const RendererContext& context)
-{
-    if (!context.sharedTimebase)
-        return;
-    context.sharedTimebase->storeSnapshot({
-        .currentTime = context.renderer->currentTime(),
-        .playbackRate = context.renderer->effectiveRate(),
-        .hostTime = MonotonicTime::now()
-    });
-}
-
 template<typename Message>
 void RemoteAudioVideoRendererProxyManager::publishAndSend(RemoteAudioVideoRendererIdentifier identifier, Message&& message)
 {
     auto iterator = m_renderers.find(identifier);
     if (iterator == m_renderers.end())
         return;
-    updateContextSharedTimebase(iterator->value);
     m_gpuConnectionToWebProcess.get()->connection().send(std::forward<Message>(message), identifier);
 }
 
-RefPtr<AudioVideoRenderer> RemoteAudioVideoRendererProxyManager::createRenderer()
+RefPtr<AudioVideoRenderer> RemoteAudioVideoRendererProxyManager::createRenderer(UniqueRef<SharedTimebase>&& sharedTimebase)
 {
 #if USE(AVFOUNDATION)
-    return AudioVideoRendererAVFObjC::create(Ref { m_gpuConnectionToWebProcess.get()->logger() }, LoggerHelper::uniqueLogIdentifier());
+    return AudioVideoRendererAVFObjC::create(Ref { m_gpuConnectionToWebProcess.get()->logger() }, LoggerHelper::uniqueLogIdentifier(), WTF::move(sharedTimebase));
 #else
+    UNUSED_PARAM(sharedTimebase);
     ASSERT_NOT_REACHED();
     return nullptr;
 #endif
@@ -135,23 +125,28 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
 {
     MESSAGE_CHECK(!m_renderers.contains(identifier));
 
-    RefPtr renderer = createRenderer();
+    auto sharedTimebase = SharedTimebase::create();
+    if (!sharedTimebase) {
+        completionHandler(std::nullopt);
+        return;
+    }
+    auto handle = sharedTimebase->createHandle();
+    if (!handle) {
+        completionHandler(std::nullopt);
+        return;
+    }
+
+    RefPtr renderer = createRenderer(makeUniqueRefFromNonNullUniquePtr(WTF::move(sharedTimebase)));
     ASSERT(renderer);
     if (!renderer) {
         completionHandler(std::nullopt);
         return;
     }
 
-    auto sharedTimebase = SharedTimebase::create();
-    std::optional<SharedTimebaseHandle> handle;
-    if (sharedTimebase)
-        handle = sharedTimebase->createHandle();
-
     RendererContext context {
         .renderer = renderer.releaseNonNull(),
         .mediaElementIdentifier = mediaElementIdentifier,
         .playerIdentifier = playerIdentifier,
-        .sharedTimebase = WTF::move(sharedTimebase)
     };
 
     context.renderer->notifyWhenErrorOccurs([weakThis = ThreadSafeWeakPtr { *this }, identifier](PlatformMediaError error) {
@@ -195,8 +190,6 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
 #endif
 
     m_renderers.set(identifier, WTF::move(context));
-
-    installTimeObserver(identifier, remoteAudioVideoRendererUpdateInterval);
 
     publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(stateFor(identifier)));
     completionHandler(WTF::move(handle));
@@ -395,12 +388,9 @@ void RemoteAudioVideoRendererProxyManager::installTimeObserver(RemoteAudioVideoR
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        auto iterator = protectedThis->m_renderers.find(identifier);
-        if (iterator == protectedThis->m_renderers.end())
+        if (!protectedThis->m_renderers.contains(identifier))
             return;
-        auto& context = iterator->value;
         protectedThis->maybeUpdateCachedVideoMetrics(identifier);
-        protectedThis->updateContextSharedTimebase(context);
     });
 }
 
@@ -414,7 +404,6 @@ void RemoteAudioVideoRendererProxyManager::play(RemoteAudioVideoRendererIdentifi
     auto& context = iterator->value;
 
     context.renderer->play(hostTime);
-    updateContextSharedTimebase(context);
 }
 
 void RemoteAudioVideoRendererProxyManager::pause(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
@@ -426,7 +415,6 @@ void RemoteAudioVideoRendererProxyManager::pause(RemoteAudioVideoRendererIdentif
     auto& context = iterator->value;
 
     context.renderer->pause(hostTime);
-    updateContextSharedTimebase(context);
 }
 
 void RemoteAudioVideoRendererProxyManager::setRate(RemoteAudioVideoRendererIdentifier identifier, double rate)
@@ -438,7 +426,6 @@ void RemoteAudioVideoRendererProxyManager::setRate(RemoteAudioVideoRendererIdent
     auto& context = iterator->value;
 
     context.renderer->setRate(rate);
-    updateContextSharedTimebase(context);
 }
 
 void RemoteAudioVideoRendererProxyManager::stall(RemoteAudioVideoRendererIdentifier identifier)
@@ -448,7 +435,6 @@ void RemoteAudioVideoRendererProxyManager::stall(RemoteAudioVideoRendererIdentif
     auto& context = iterator->value;
 
     context.renderer->stall();
-    updateContextSharedTimebase(context);
 }
 
 void RemoteAudioVideoRendererProxyManager::prepareToSeek(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& seekTime, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&& completionHandler)
@@ -599,6 +585,13 @@ void RemoteAudioVideoRendererProxyManager::setVideoPlaybackMetricsUpdateInterval
     updateCachedVideoMetrics(identifier);
     context.videoPlaybackMetricsUpdateInterval = Seconds(interval);
     context.nextPlaybackQualityMetricsUpdateTime = MonotonicTime::now() + Seconds(interval) - metricsAdvanceUpdate;
+
+    // The metrics push is the only consumer of the periodic time observer; install it on
+    // demand and tear it down when no longer needed.
+    if (interval > 0)
+        installTimeObserver(identifier, metricsAdvanceUpdate);
+    else
+        context.renderer->setTimeObserver(0_s, { });
 }
 
 void RemoteAudioVideoRendererProxyManager::maybeUpdateCachedVideoMetrics(RemoteAudioVideoRendererIdentifier identifier)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -170,7 +170,6 @@ private:
         RefPtr<WebCore::AudioVideoRenderer> renderer;
         Markable<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier;
         Markable<WebCore::MediaPlayerIdentifier> playerIdentifier;
-        std::unique_ptr<WebCore::SharedTimebase> sharedTimebase;
 #if PLATFORM(COCOA)
         LayerHostingContextManager layerHostingContextManager;
 #endif
@@ -180,7 +179,7 @@ private:
         MonotonicTime nextPlaybackQualityMetricsUpdateTime { };
         bool isGatheringVideoFrameMetadata { false };
     };
-    RefPtr<WebCore::AudioVideoRenderer> createRenderer();
+    RefPtr<WebCore::AudioVideoRenderer> createRenderer(UniqueRef<WebCore::SharedTimebase>&&);
     RefPtr<WebCore::AudioVideoRenderer> rendererFor(RemoteAudioVideoRendererIdentifier) const;
     RemoteAudioVideoRendererState stateFor(RemoteAudioVideoRendererIdentifier) const;
     RendererContext& NODELETE contextFor(RemoteAudioVideoRendererIdentifier);
@@ -191,7 +190,6 @@ private:
     using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
     void requestHostingContext(RemoteAudioVideoRendererIdentifier, LayerHostingContextCallback&&);
     WebCore::MediaSampleConverter& converterFor(RendererContext&, TrackIdentifier);
-    static void updateContextSharedTimebase(const RendererContext&);
     template<typename Message> void publishAndSend(RemoteAudioVideoRendererIdentifier, Message&&);
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -118,7 +118,7 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
             });
             return;
         }
-        auto reader = SharedTimebaseReader::create(WTF::move(*handle), remoteAudioVideoRendererUpdateInterval);
+        auto reader = SharedTimebaseReader::create(WTF::move(*handle));
         if (!reader) {
             protectedThis->ensureOnDispatcher([protectedThis] {
                 assertIsCurrent(queueSingleton());

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -153,6 +153,7 @@ private:
     Ref<GenericPromise> finishSeek(const MediaTime&) final;
     bool seeking() const final;
     void setScreenReserved(bool) final;
+    WebCore::SharedTimebase* sharedTimebase() final { return nullptr; }
 
     void setPreferences(WebCore::VideoRendererPreferences) final;
     void setHasProtectedVideoContent(bool) final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
@@ -27,14 +27,8 @@
 
 #include <WebCore/FloatSize.h>
 #include <wtf/MediaTime.h>
-#include <wtf/Seconds.h>
 
 namespace WebKit {
-
-// Cadence at which the GPU-side proxy refreshes the SharedTimebase anchor
-// during steady-state playback. Also caps SharedTimebaseReader's
-// between-anchor extrapolation to this interval.
-constexpr Seconds remoteAudioVideoRendererUpdateInterval = 250_ms;
 
 struct RemoteAudioVideoRendererState {
     bool paused { false };

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedTimebaseTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedTimebaseTests.cpp
@@ -43,9 +43,8 @@ TEST(SharedTimebase, Basic)
     ASSERT_TRUE(timebaseHandle);
 
     auto now = MonotonicTime::now();
-    constexpr Seconds maxExtrapolation = 10_s;
     auto fakeNow = now;
-    auto reader = SharedTimebaseReader::create(WTF::move(*timebaseHandle), maxExtrapolation, [&fakeNow] { return fakeNow; });
+    auto reader = SharedTimebaseReader::create(WTF::move(*timebaseHandle), [&fakeNow] { return fakeNow; });
     ASSERT_TRUE(reader);
 
     writerTimebase->storeSnapshot({
@@ -74,9 +73,8 @@ TEST(SharedTimebase, Basic)
     fakeNow = now - 1_s;
     EXPECT_EQ(reader->currentTime().toDouble(), 1.5);
 
-    // Beyond cap — elapsed clamped to maxExtrapolation taking into account rate.
     fakeNow = now + 20_s;
-    EXPECT_EQ(reader->currentTime().toDouble(), maxExtrapolation.seconds() * 0.5 + 1); // Time was 1s at now+1 with a rate of 0.5.
+    EXPECT_EQ(reader->currentTime().toDouble(), (19_s).seconds() * 0.5 + 1); // Time was 1s at now+1 with a rate of 0.5.
 
     // High-water-mark clamp: a snapshot rewinding to zero must not make
     // currentTime() go backwards.


### PR DESCRIPTION
#### beb0b2162e807bbe1178b79e8ad7c058c5f9a2d9
<pre>
Have AudioVideoRenderer take and update a SharedTimebase and reduce noticeable drift
<a href="https://bugs.webkit.org/show_bug.cgi?id=317117">https://bugs.webkit.org/show_bug.cgi?id=317117</a>
<a href="https://rdar.apple.com/problem/179688028">rdar://problem/179688028</a>

Reviewed by Youenn Fablet.

The WebContent process reads currentTime() during script execution and
requestAnimationFrame callbacks, but the authoritative time lives in
the GPU process on the AVSampleBufferRenderSynchronizer&apos;s CMTimebase.
Previously the SharedTimebase was owned by
RemoteAudioVideoRendererProxyManager, one layer removed from the
renderer. Snapshots were refreshed both from a periodic time observer
on the synchronizer and from state-change callbacks, but every refresh
went through the main thread. While the main thread was blocked the
snapshot went stale, and any state change that happened in an AVF
thread (most notably the synchronizer rate-changed callback transitioning
to 0) had to wait for the main-thread hop before the reader saw it. The
reader meanwhile kept extrapolating off the prior snapshot and its
computed currentTime drifted from the renderer&apos;s actual state.

Move SharedTimebase ownership onto AudioVideoRendererAVFObjC itself and
publish from inside the renderer. AudioVideoRendererRemote hands the
read-only handle to the WebContent process at construction; reads on
that side go through SharedTimebaseReader against shared memory.

Publishing is centralized through a single helper:

AudioVideoRendererAVFObjC::publishSnapshot(currentTime, playbackRate)

which takes m_publishLock (SequenceLocked is multi-reader, single-writer
— writers must be externally synchronized), applies the same floor /
ceiling clamps for every publish path, advances the high-water-mark,
and stores the snapshot. Three writers feed it:

- Main thread on state changes via updateSharedTimebase().
- A 100ms wall-clock dispatch timer on a dedicated serial queue.
    Independent of the synchronizer (which doesn&apos;t tick periodic
    observers when paused) and of the main runloop, so a blocked main
    thread or an AVF rate-lie window can&apos;t keep the snapshot stale for
    longer than one tick.
- The rate-changed listener on rate→0, publishing synchronously from
    the AVF thread before the main-thread hop, so the reader stops
    extrapolating off the prior rate≠0 snapshot in the interim.

What this does not — and cannot — fix:

- AVSampleBufferRenderSynchronizer / CMTimebase can return a smaller
    time at a later host time. Observed during play() resumption when
    FigAudioQueueRenderPipeline re-anchors the timebase via
    CMTimebaseSetRateAndAnchorTime(rate=1, mediaTime=t, sourceTime=ts)
    with sourceTime in the future of &quot;now&quot;: the linear mapping
    f(host) = anchor + rate × (host − sourceTime) is replaced, and
    f(now_pre) &gt; f(now_post) even though host time is monotonic.
- CMTimebaseGetEffectiveRate likewise lies briefly — the synchronizer
    publishes a non-zero rate before its timebase starts advancing
    (handled separately by the startup gate observer), and time can
    advance for a window even after the effective rate reports 0.

We can&apos;t make AVF stop doing this. To keep the writer honest we
maintain m_publishedTimeFloor (under m_publishLock): the high-water-mark
of every published currentTime, reset downward only on seek. Every
publishSnapshot call clamps up to this floor before storing, so a
backward step from the synchronizer is suppressed before it reaches
the shared memory.

On the reader, the analogous m_lastReturnedTime clamp catches anything
that survives — extrapolation jitter, a writer-side occurence we haven&apos;t
found yet — we log those for now.
The reader stays forward-monotonic without ever propagating a regression to callers.

Other simplifications enabled by the new ownership:

- SharedTimebaseReader::create no longer takes a maxExtrapolation
    parameter; the reader extrapolates directly from the last snapshot
    and is bounded by the 100ms publish cadence.
- RemoteAudioVideoRendererProxyManager no longer owns the timebase
    or pumps periodic time updates; its remaining time observer fires
    only at the metricsAdvanceUpdate cadence needed by
    videoPlaybackQualityMetrics.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/SharedTimebase.cpp:
(WebCore::SharedTimebaseReader::create):
(WebCore::SharedTimebaseReader::SharedTimebaseReader):
(WebCore::SharedTimebaseReader::currentTime const):
(WebCore::SharedTimebaseReader::resetForTimeDiscontinuity):
* Source/WebCore/platform/SharedTimebase.h:
* Source/WebCore/platform/graphics/AudioVideoRenderer.h:
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.h:
(WebCore::AudioVideoRendererAVFObjC::create): Deleted.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::create):
(WebCore::AudioVideoRendererAVFObjC::AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::~AudioVideoRendererAVFObjC):
(WebCore::AudioVideoRendererAVFObjC::pause):
(WebCore::AudioVideoRendererAVFObjC::currentTime const):
(WebCore::AudioVideoRendererAVFObjC::effectiveRate const):
(WebCore::AudioVideoRendererAVFObjC::updateSharedTimebase):
(WebCore::AudioVideoRendererAVFObjC::publishSnapshot):
(WebCore::AudioVideoRendererAVFObjC::notifyTimeReachedAndStall):
(WebCore::AudioVideoRendererAVFObjC::cancelTimeReachedAction):
(WebCore::AudioVideoRendererAVFObjC::performTaskAtTime):
(WebCore::AudioVideoRendererAVFObjC::setTimeObserver):
(WebCore::AudioVideoRendererAVFObjC::prepareToSeek):
(WebCore::AudioVideoRendererAVFObjC::notifyEffectiveRateChanged):
(WebCore::AudioVideoRendererAVFObjC::handleEffectiveRateChanged):
(WebCore::AudioVideoRendererAVFObjC::releaseStartupGateAndForwardRate):
(WebCore::AudioVideoRendererAVFObjC::clampTimeToLastSeekTime const):
(WebCore::AudioVideoRendererAVFObjC::maybeCompleteSeek):
(WebCore::AudioVideoRendererAVFObjC::setSynchronizerRate):
(WebCore::AudioVideoRendererAVFObjC::periodicSharedTimerFired):
* Source/WebCore/platform/graphics/cocoa/PeriodicSharedTimer.h: Added.
(WebCore::PeriodicSharedTimer::WTF_GUARDED_BY_LOCK):
* Source/WebCore/platform/graphics/cocoa/PeriodicSharedTimer.mm: Added.
(WebCore::PeriodicSharedTimer::singleton):
(WebCore::PeriodicSharedTimer::PeriodicSharedTimer):
(WebCore::PeriodicSharedTimer::timerFired):
(WebCore::PeriodicSharedTimer::addClient):
(WebCore::PeriodicSharedTimer::removeClient):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::publishAndSend):
(WebKit::RemoteAudioVideoRendererProxyManager::createRenderer):
(WebKit::RemoteAudioVideoRendererProxyManager::create):
(WebKit::RemoteAudioVideoRendererProxyManager::installTimeObserver):
(WebKit::RemoteAudioVideoRendererProxyManager::play):
(WebKit::RemoteAudioVideoRendererProxyManager::pause):
(WebKit::RemoteAudioVideoRendererProxyManager::setRate):
(WebKit::RemoteAudioVideoRendererProxyManager::stall):
(WebKit::RemoteAudioVideoRendererProxyManager::setVideoPlaybackMetricsUpdateInterval):
(WebKit::RemoteAudioVideoRendererProxyManager::updateContextSharedTimebase): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::AudioVideoRendererRemote):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h:
* Tools/TestWebKitAPI/Tests/WebCore/SharedTimebaseTests.cpp:
(TestWebKitAPI::TEST(SharedTimebase, Basic)):

Canonical link: <a href="https://commits.webkit.org/315527@main">https://commits.webkit.org/315527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/266d51ef7c65f9685ad12750444a370d841f0984

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169335 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178691 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127047 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131901 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4215a8a9-8d53-48cd-ad00-d7abbcbbe2e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172294 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112405 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcdd23a5-87a1-4f48-80ff-e0cfcfeb367a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27391 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181291 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34001 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42913 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37720 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43602 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107593 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35460 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115367 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42112 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6653 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41505 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41648 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->