### PR TITLE
Cherry-pick 44721@main (cb638e335cee). https://bugs.webkit.org/show_bug.cgi?id=317078

### DIFF
--- a/LayoutTests/accessibility/gtk/text-attribute-run-offsets-for-inline-elements-expected.txt
+++ b/LayoutTests/accessibility/gtk/text-attribute-run-offsets-for-inline-elements-expected.txt
@@ -1,0 +1,17 @@
+before link after
+
+one two
+
+solo
+An inline element that starts right after preceding text must report in-bounds text-attribute-run offsets without hanging or crashing.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS inlineRuns.includes("Range attributes for 'link'") is true
+PASS secondRuns.includes("Range attributes for 'two'") is true
+PASS soloItemRuns.includes("Range attributes for '<obj>'") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/gtk/text-attribute-run-offsets-for-inline-elements.html
+++ b/LayoutTests/accessibility/gtk/text-attribute-run-offsets-for-inline-elements.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body id="body">
+<p>before <a id="inline" href="#">link</a> after</p>
+<p><a href="#">one</a> <a id="second" href="#">two</a></p>
+<ul><li id="solo-item"><a href="#">solo</a></li></ul>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+ description("An inline element that starts right after preceding text must report in-bounds text-attribute-run offsets without hanging or crashing.");
+
+ if (window.accessibilityController) {
+     var inline = accessibilityController.accessibleElementById("inline");
+     var inlineRuns = inline.attributedStringForRange(0, 4);
+     shouldBeTrue("inlineRuns.includes(\"Range attributes for 'link'\")");
+
+     var second = accessibilityController.accessibleElementById("second");
+     var secondRuns = second.attributedStringForRange(0, 3);
+     shouldBeTrue("secondRuns.includes(\"Range attributes for 'two'\")");
+
+     var soloItem = accessibilityController.accessibleElementById("solo-item");
+     var soloItemRuns = soloItem.attributedStringForRange(0, 1);
+     shouldBeTrue("soloItemRuns.includes(\"Range attributes for '<obj>'\")");
+ }
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -849,7 +849,14 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
     }
 
     VisiblePosition offsetPosition = m_coreObject->visiblePositionForIndex(adjustInputOffset(*utf16Offset, m_hasListMarkerAtStart));
-    RefPtr childNode = offsetPosition.deepEquivalent().deprecatedNode();
+    auto deepPosition = offsetPosition.deepEquivalent();
+    RefPtr childNode = deepPosition.deprecatedNode();
+    // visiblePositionForIndex() may canonicalize to an equivalent position in preceding content; use
+    // the downstream position so childNode stays inside this object.
+    if (childNode && !m_coreObject->node()->contains(*childNode)) {
+        if (RefPtr downstreamNode = deepPosition.downstream().deprecatedNode(); m_coreObject->node()->contains(downstreamNode.get()))
+            childNode = WTF::move(downstreamNode);
+    }
     if (!childNode)
         return { WTF::move(defaultAttributes), -1, -1 };
 


### PR DESCRIPTION
#### bc22e64695c742626a408df1cad5783fe6437d38
<pre>
Cherry-pick 44721@main (cb638e335cee). <a href="https://bugs.webkit.org/show_bug.cgi?id=317078">https://bugs.webkit.org/show_bug.cgi?id=317078</a>

    Reliable crash triggered by WebCore::AccessibilityObjectAtspi::textAttributesWithUTF88888888Offset
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317078">https://bugs.webkit.org/show_bug.cgi?id=317078</a>

    Reviewed by Carlos Garcia Campos.

    textAttributes() maps an offset to a node via visiblePositionForIndex(), whose
    canonical position can resolve outside the object for inline content not at the
    start of its container; the run-boundary walk then returns out-of-range offsets,
    crashing (CrashOnOverflow) when the text is a single object replacement character.
    Keep the resolved node inside the object by falling back to the downstream position.

    * LayoutTests/accessibility/gtk/text-attribute-run-offsets-for-inline-elements-expected.txt: Added.
    * LayoutTests/accessibility/gtk/text-attribute-run-offsets-for-inline-elements.html: Added.
    * Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
    (WebCore::AccessibilityObjectAtspi::textAttributes const):

    Canonical link: <a href="https://commits.webkit.org/315208@main">https://commits.webkit.org/315208@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.763@webkitglib/2.52">https://commits.webkit.org/305877.763@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/153b08f0b3a4ff7e62692da69555e9d8061bba4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168405 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/41962 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35549 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177733 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126106 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170271 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/42337 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41922 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131064 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126106 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171364 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/42337 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/35549 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111575 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/42337 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/41922 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26429 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/42337 "The change is no longer eligible for processing.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180333 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33057 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35549 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139499 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/41974 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/41922 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139363 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/42662 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/35549 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106265 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25647 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/42662 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/35549 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/41166 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114422 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/40563 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/35549 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/40814 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/40708 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->