### PR TITLE
REGRESSION(315027@main): [GTK] skia/src/gpu/ganesh/GrSurfaceProxy.cpp:484: fatal error: "assertf(surface->backendFormat() == fFormat): OpenGL-BGRA8 != OpenGL-RGBA8"

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -145,10 +145,10 @@ sk_sp<SkImage> SkiaGPUAtlas::atlasImageForCurrentThread() const
 {
     if (m_threadSafeGrContext) {
         ref();
-        auto backendFormat = m_threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
+        auto backendFormat = m_threadSafeGrContext->defaultBackendFormat(kBGRA_8888_SkColorType, GrRenderable::kYes);
         ASSERT(backendFormat.isValid());
         return SkImages::PromiseTextureFrom(m_threadSafeGrContext, backendFormat, SkISize::Make(m_atlasTexture->size().width(), m_atlasTexture->size().height()), skgpu::Mipmapped::kNo,
-            kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB(),
+            kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB(),
             +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
                 auto& atlas = *static_cast<SkiaGPUAtlas*>(userData);
                 atlas.waitForUpload();

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -273,7 +273,7 @@ sk_sp<SkImage> createPromiseImageIfNeeded(const sk_sp<SkImage>& image, const sk_
     if (!context)
         return image;
 
-    auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
+    auto backendFormat = threadSafeGrContext->defaultBackendFormat(image->colorType(), GrRenderable::kYes);
     ASSERT(backendFormat.isValid());
     return SkImages::PromiseTextureFrom(threadSafeGrContext, backendFormat, image->dimensions(), skgpu::Mipmapped::kNo,
         kTopLeft_GrSurfaceOrigin, image->colorType(), image->alphaType(), image->refColorSpace(),


### PR DESCRIPTION
#### 05ac376de6ca7049d954017408a5a941c3c896dd
<pre>
REGRESSION(315027@main): [GTK] skia/src/gpu/ganesh/GrSurfaceProxy.cpp:484: fatal error: &quot;assertf(surface-&gt;backendFormat() == fFormat): OpenGL-BGRA8 != OpenGL-RGBA8&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=317120">https://bugs.webkit.org/show_bug.cgi?id=317120</a>

Reviewed by Carlos Garcia Campos.

Pass the color type from the image to the backend format in createPromiseImageIfNeeded()
instead of assuming RGBA8888.

Do the same in SkiaGPUAtlas::atlasImageForCurrentThread(), where the promise image also
assumed RGBA8888 while the atlas texture uses a BGRA8888 layout, just like the non-promise
path that borrows the texture already does.

Covered by existing tests.

* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::atlasImageForCurrentThread const):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:
(WebCore::SkiaUtilities::createPromiseImageIfNeeded):

Canonical link: <a href="https://commits.webkit.org/315218@main">https://commits.webkit.org/315218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa193f6bafce4da9bb7c8d505886d92736c41c54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126128 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131085 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32534 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31237 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142520 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180355 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139520 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139384 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42684 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106308 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25650 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27733 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114444 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40585 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5817 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->