### PR TITLE
Fix sandbox style issue in preferences.sb

### DIFF
--- a/Source/WebKit/Shared/Sandbox/preferences.sb
+++ b/Source/WebKit/Shared/Sandbox/preferences.sb
@@ -38,16 +38,14 @@
         domains))
 
 (define (allow-reading-global-preferences)
-    (allow user-preference-read (preference-domain "kCFPreferencesAnyApplication"))
 #if ENABLE(CFPREFS_DIRECT_MODE)
     (allow file-read*
         (literal "/Library/Preferences/.GlobalPreferences.plist")
         (home-subpath "/Library/Preferences/.GlobalPreferences.plist")
         (home-subpath "/Library/Preferences/.GlobalPreferences_m.plist")
-        (home-regex #"/Library/Preferences/ByHost/\.GlobalPreferences\..*\.plist$")
-    )
+        (home-regex #"/Library/Preferences/ByHost/\.GlobalPreferences\..*\.plist$"))
 #endif
-)
+    (allow user-preference-read (preference-domain "kCFPreferencesAnyApplication")))
 
 
 


### PR DESCRIPTION
#### cf5e1300464ccd8d4b4be3af5e8fee2f6dfb4283
<pre>
Fix sandbox style issue in preferences.sb
<a href="https://bugs.webkit.org/show_bug.cgi?id=317124">https://bugs.webkit.org/show_bug.cgi?id=317124</a>
<a href="https://rdar.apple.com/179706193">rdar://179706193</a>

Reviewed by Basuke Suzuki.

Parenthesis should not be placed on a separate line. There is no behavior change after this fix.

* Source/WebKit/Shared/Sandbox/preferences.sb:

Canonical link: <a href="https://commits.webkit.org/315235@main">https://commits.webkit.org/315235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77c7b794378de2ec0a1b1feb9e3e6643a0c6eb84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126122 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbcd50a3-c8ed-4b24-b864-46a33353fd5e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131078 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92174 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb819fe8-1676-4010-984d-ff6ed2dbf806) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111589 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/871d4c61-038d-4d9c-80e6-bf4cfd5fc765) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32530 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31233 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26445 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142516 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180349 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139513 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139377 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42678 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106292 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34669 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27728 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114438 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40579 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5813 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->