### PR TITLE
Fix cmake builds on Mac without using presets

### DIFF
--- a/Source/cmake/WebKitXcodeSDK.cmake
+++ b/Source/cmake/WebKitXcodeSDK.cmake
@@ -94,7 +94,7 @@ endfunction()
 
 if (CMAKE_OSX_SYSROOT)
     WEBKIT_RESOLVE_SDK(${CMAKE_OSX_SYSROOT})
-elseif (PORT STREQUAL "Mac" OR PORT STREQUAL "JSCOnly")
+elseif (PORT STREQUAL "Mac" OR PORT STREQUAL "JSCOnly" OR NOT PORT)
     # FIXME: Support macosx.internal.
     WEBKIT_RESOLVE_SDK(macosx)
 elseif (PORT STREQUAL "IOS" AND CMAKE_IOS_SIMULATOR)
@@ -103,7 +103,7 @@ elseif (PORT STREQUAL "IOS" AND NOT CMAKE_IOS_SIMULATOR)
     WEBKIT_RESOLVE_SDK(iphoneos.internal iphoneos)
 else ()
     message(FATAL_ERROR "Building for an Apple platform without an SDK "
-        "directory (CMAKE_OSX_SYSROOT) or a hard-coded PORT provided.")
+        "directory (CMAKE_OSX_SYSROOT) or supported PORT variable.")
 endif ()
 
 # Subsequent use of `xcrun` or any of the system Xcode and BSD tools will


### PR DESCRIPTION
#### 734f002a22a020e212940a0583c09ff055dbd33b
<pre>
Fix cmake builds on Mac without using presets
<a href="https://bugs.webkit.org/show_bug.cgi?id=317131">https://bugs.webkit.org/show_bug.cgi?id=317131</a>
<a href="https://rdar.apple.com/179730255">rdar://179730255</a>

Reviewed by Elliott Williams.

Before 314875@main I used to be able to just run cmake -G Ninja
and it worked, defaulting to a Mac build with the non-internal SDK
because of these lines in WebKitCommon.cmake:

if (APPLE AND PORT STREQUAL &quot;NOPORT&quot;)
    set(PORT &quot;Mac&quot; CACHE STRING &quot;choose which WebKit port to build (one of ${ALL_PORTS})&quot; FORCE)

After that change, it failed with this error:

CMake Error at Source/cmake/WebKitXcodeSDK.cmake:105 (message):
 Building for an Apple platform without an SDK directory (CMAKE_OSX_SYSROOT)
 or a hard-coded PORT provided.

This small change makes it so that if PORT is not specified on a
Darwin operating system, we continue to assume you are building
the Mac port.

* Source/cmake/WebKitXcodeSDK.cmake:

Canonical link: <a href="https://commits.webkit.org/315260@main">https://commits.webkit.org/315260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0ccce9233871d2100e6a6976050d863ee42b559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126165 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b3fce3b-e48d-4ad2-aa6f-7bc95e9874c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131119 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92215 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b7545db4-6117-4436-be25-e5e23b93d00d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111630 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98b93e3a-f560-42f4-9b86-7635ce24d32c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32566 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31268 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26488 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161083 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142552 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180392 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29711 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139555 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139418 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42721 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106372 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25667 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27765 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201142 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41225 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54025 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40622 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5848 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->