### PR TITLE
[WebKit] Fix unified source build with CMake + internal SDK

### DIFF
--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -38,7 +38,7 @@
 #import <wtf/URL.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
-using namespace WebKit;
+namespace WebKit {
 
 static RefPtr<NetworkProcess>& NODELETE firstNetworkProcess()
 {
@@ -60,12 +60,14 @@ void LegacyCustomProtocolManager::networkProcessCreated(NetworkProcess& networkP
     firstNetworkProcess() = networkProcess;
 }
 
+} // namespace WebKit
+
 NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface WKCustomProtocol : NSURLProtocol {
 @private
-    Markable<LegacyCustomProtocolID> _customProtocolID;
+    Markable<WebKit::LegacyCustomProtocolID> _customProtocolID;
 }
-@property (nonatomic, readonly) Markable<LegacyCustomProtocolID> customProtocolID;
+@property (nonatomic, readonly) Markable<WebKit::LegacyCustomProtocolID> customProtocolID;
 @property (nonatomic, readonly) CFRunLoopRef initializationRunLoop;
 @end
 
@@ -78,7 +80,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)canInitWithRequest:(NSURLRequest *)request
 {
     // FIXME: This code runs in a dispatch queue so we can't ref NetworkProcess here.
-    if (SUPPRESS_UNCOUNTED_LOCAL auto* customProtocolManager = protect(firstNetworkProcess())->supplement<LegacyCustomProtocolManager>())
+    if (SUPPRESS_UNCOUNTED_LOCAL auto* customProtocolManager = protect(WebKit::firstNetworkProcess())->supplement<WebKit::LegacyCustomProtocolManager>())
         SUPPRESS_UNCOUNTED_ARG return customProtocolManager->supportsScheme([[[request URL] scheme] lowercaseString]);
     return NO;
 }
@@ -99,7 +101,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
     if (!self)
         return nil;
 
-    if (RefPtr customProtocolManager = protect(firstNetworkProcess())->supplement<LegacyCustomProtocolManager>())
+    if (RefPtr customProtocolManager = protect(WebKit::firstNetworkProcess())->supplement<WebKit::LegacyCustomProtocolManager>())
         _customProtocolID = customProtocolManager->addCustomProtocol(self);
     _initializationRunLoop = CFRunLoopGetCurrent();
 
@@ -114,7 +116,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)startLoading
 {
     ensureOnMainRunLoop([customProtocolID = *self.customProtocolID, request = retainPtr([self request])] {
-        if (RefPtr customProtocolManager = protect(firstNetworkProcess())->supplement<LegacyCustomProtocolManager>())
+        if (RefPtr customProtocolManager = protect(WebKit::firstNetworkProcess())->supplement<WebKit::LegacyCustomProtocolManager>())
             customProtocolManager->startLoading(customProtocolID, request.get());
     });
 }
@@ -122,7 +124,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)stopLoading
 {
     ensureOnMainRunLoop([customProtocolID = *self.customProtocolID] {
-        if (RefPtr customProtocolManager = protect(firstNetworkProcess())->supplement<LegacyCustomProtocolManager>()) {
+        if (RefPtr customProtocolManager = protect(WebKit::firstNetworkProcess())->supplement<WebKit::LegacyCustomProtocolManager>()) {
             customProtocolManager->stopLoading(customProtocolID);
             customProtocolManager->removeCustomProtocol(customProtocolID);
         }

--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
@@ -46,10 +46,6 @@ void initializeAuxiliaryProcess<NetworkProcess>(AuxiliaryProcessInitializationPa
     static NeverDestroyed<Ref<NetworkProcess>> networkProcess = NetworkProcess::create(WTF::move(parameters));
 }
 
-} // namespace WebKit
-
-using namespace WebKit;
-
 extern "C" WK_EXPORT void NETWORK_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializerMessage);
 
 void NETWORK_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializerMessage)
@@ -57,3 +53,5 @@ void NETWORK_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initi
     WTF::initializeMainThread();
     XPCServiceInitializer<NetworkProcess, NetworkServiceInitializerDelegate>(connection, initializerMessage);
 }
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -115,7 +115,14 @@ SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_stack_requires_http_protocols, bo
 
 #import "DeviceManagementSoftLink.h"
 
-using namespace WebKit;
+using WebKit::IsolatedSession;
+using WebKit::NegotiatedLegacyTLS;
+using WebKit::NetworkDataTaskCocoa;
+using WebKit::NetworkSession;
+using WebKit::NetworkSessionCocoa;
+using WebKit::PrivateRelayed;
+using WebKit::SessionWrapper;
+using WebKit::WebSocketTask;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IsolatedSession);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NetworkSessionCocoa);

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -41,9 +41,8 @@
 #endif
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
-using namespace WebCore;
-
 namespace WebKit {
+using namespace WebCore;
 
 MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(const MediaPlaybackTarget& target)
     : m_deviceName { target.deviceName() }

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -38,9 +38,8 @@
 #import <wtf/spi/cf/CFBundleSPI.h>
 #import <wtf/text/WTFString.h>
 
-using namespace Inspector;
-
 namespace WebKit {
+using namespace Inspector;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AutomationClient);
 

--- a/Source/WebKit/UIProcess/Cocoa/WKEditCommand.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKEditCommand.mm
@@ -52,13 +52,13 @@
 - (void)undoEditing:(id)sender
 {
     ASSERT([sender isKindOfClass:WKEditCommand.class]);
-    Ref { [sender command] }->unapply();
+    Ref { [(WKEditCommand *)sender command] }->unapply();
 }
 
 - (void)redoEditing:(id)sender
 {
     ASSERT([sender isKindOfClass:WKEditCommand.class]);
-    Ref { [sender command] }->reapply();
+    Ref { [(WKEditCommand *)sender command] }->reapply();
 }
 
 @end

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -182,7 +182,11 @@ void WebPageProxy::speak(const String& string)
 void WebPageProxy::stopSpeaking()
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    // Work around incorrect nullability annotation in the internal SDK, cf. rdar://179681908
     [NSApp stopSpeaking:nil];
+#pragma clang diagnostic pop
 }
 
 void WebPageProxy::searchTheWeb(const String& string)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -234,6 +234,7 @@ class WebPageProxy;
 class WebProcessPool;
 class WebProcessProxy;
 
+struct InteractionInformationAtPosition;
 struct WebHitTestResultData;
 
 enum class ContinueUnsafeLoad : bool;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4590,8 +4590,8 @@ CursorContext UnifiedPDFPlugin::cursorContext(FloatPoint pointInRootView) const
         return context;
 
     auto elementTypes = pdfElementTypesForPagePoint(roundedIntPoint(pointInPage), page.get());
-    if (toWebCoreCursorType(elementTypes) == Cursor::Type::IBeam)
-        context.cursor = Cursor::fromType(Cursor::Type::IBeam);
+    if (toWebCoreCursorType(elementTypes) == WebCore::Cursor::Type::IBeam)
+        context.cursor = WebCore::Cursor::fromType(WebCore::Cursor::Type::IBeam);
 
     RetainPtr lineUnderCursor = selectionAtPoint(pointInPage, page.get(), TextGranularity::LineGranularity);
     auto pageRectForLine = FloatRect { [lineUnderCursor boundsForPage:page.get()] };


### PR DESCRIPTION
#### ebfe48e9d68d15a220ef5db7dc1fe29bd7140bb2
<pre>
[WebKit] Fix unified source build with CMake + internal SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=317135">https://bugs.webkit.org/show_bug.cgi?id=317135</a>
<a href="https://rdar.apple.com/179731765">rdar://179731765</a>

Reviewed by Alex Christensen.

Fix namespace pollution and duplicate definition errors that appear
under the dynamic source bundling logic we use in CMake.

* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(+[WKCustomProtocol canInitWithRequest:]):
(-[WKCustomProtocol initWithRequest:cachedResponse:client:]):
(-[WKCustomProtocol startLoading]):
(-[WKCustomProtocol stopLoading]):
(firstNetworkProcess): Deleted.
(LegacyCustomProtocolManager::networkProcessCreated): Deleted.
* Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm:
(NETWORK_SERVICE_INITIALIZER): Deleted.
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:

* Source/WebKit/UIProcess/Cocoa/WKEditCommand.mm: The first
  non-naming change. There may be two -[(id) command] methods visible to
  the compiler, so annotate which one we want to influence
  type resolution.
(-[WKEditorUndoTarget undoEditing:]):
(-[WKEditorUndoTarget redoEditing:]):

* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::stopSpeaking):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::cursorContext const):

Canonical link: <a href="https://commits.webkit.org/315251@main">https://commits.webkit.org/315251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5694d7da48c24451606e2573be509684a7650678

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126161 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9097eef9-f8c5-48b4-82e7-71084e6f0f69) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131115 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a70148f6-a8d5-46da-89d0-0059453ffcc3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111626 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c6c511d-bfda-4240-9ac8-f23ec3532368) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32563 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31265 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26484 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142549 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180388 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33112 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139551 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42029 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139414 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37551 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42717 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106368 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34701 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27761 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41221 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114477 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40618 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5844 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40763 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->