### PR TITLE
[WebXR Layers] Implement Cube layer

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -346,6 +346,7 @@ PlatformXR::DeviceLayer WebXRWebGLLayer::endFrame()
         .quadLayerData = std::nullopt,
         .equirectLayerData = std::nullopt,
         .cylinderLayerData = std::nullopt,
+        .cubeLayerData = std::nullopt,
 #endif
 #endif
     };

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -355,8 +355,18 @@ WebXRWebGLStaticImageSwapchain::~WebXRWebGLStaticImageSwapchain()
 
 PlatformGLObject WebXRWebGLStaticImageSwapchain::currentTexture()
 {
-    RELEASE_ASSERT(m_textures.size() > m_currentImageIndex);
-    return m_textures[m_currentImageIndex];
+    size_t index = m_imageAttributes.textureType == GL::TEXTURE_CUBE_MAP ? m_currentImageIndex * m_imageAttributes.arrayLength : m_currentImageIndex;
+    RELEASE_ASSERT(m_textures.size() > index);
+    return m_textures[index];
+}
+
+PlatformGLObject WebXRWebGLStaticImageSwapchain::currentTextureAtIndex(uint32_t cubeIndex)
+{
+    if (m_imageAttributes.textureType != GL::TEXTURE_CUBE_MAP)
+        return currentTexture();
+    size_t index = m_currentImageIndex * m_imageAttributes.arrayLength + cubeIndex;
+    RELEASE_ASSERT(m_textures.size() > index);
+    return m_textures[index];
 }
 
 void WebXRWebGLStaticImageSwapchain::releaseDisplayImagesAtIndex(size_t index)
@@ -373,8 +383,23 @@ void WebXRWebGLStaticImageSwapchain::releaseDisplayImagesAtIndex(size_t index)
 
 void WebXRWebGLStaticImageSwapchain::bindCompositorTexturesForDisplay(GraphicsContextGL& gl, PlatformXR::FrameData::LayerData& layerData)
 {
-    bool shouldCreateNewTexture = false;
     m_currentImageIndex = layerData.textureData ? layerData.textureData->reusableTextureIndex : 0;
+
+    if (m_imageAttributes.textureType == GL::TEXTURE_CUBE_MAP) {
+        size_t baseIndex = m_currentImageIndex * m_imageAttributes.arrayLength;
+        if (m_textures.size() > baseIndex && m_textures[baseIndex])
+            return;
+        m_textures.resizeToFit(baseIndex + m_imageAttributes.arrayLength);
+        for (uint32_t i = 0; i < m_imageAttributes.arrayLength; ++i) {
+            PlatformGLObject texture = gl.createTexture();
+            gl.bindTexture(GL::TEXTURE_CUBE_MAP, texture);
+            gl.texStorage2D(GL::TEXTURE_CUBE_MAP, 1, m_imageAttributes.internalFormat, m_texSize.width(), m_texSize.height());
+            m_textures[baseIndex + i] = texture;
+        }
+        return;
+    }
+
+    bool shouldCreateNewTexture = false;
     if (m_textures.size() <= m_currentImageIndex) {
         m_textures.resizeToFit(m_currentImageIndex + 1);
         shouldCreateNewTexture = true;
@@ -401,22 +426,35 @@ void WebXRWebGLStaticImageSwapchain::bindCompositorTexturesForDisplay(GraphicsCo
 
 void WebXRWebGLStaticImageSwapchain::clearTextureRegion(GraphicsContextGL& gl, const IntRect& viewport, std::optional<GCGLint> slice)
 {
-    if (m_imageAttributes.textureType != GL::TEXTURE_2D_ARRAY) {
-        WebXRWebGLSwapchain::clearTextureRegion(gl, viewport, slice);
-        return;
-    }
-
     if (!m_framebufferForClearing)
         return;
 
-    auto texture = currentTexture();
-    if (!texture)
+    switch (m_imageAttributes.textureType) {
+    case GL::TEXTURE_CUBE_MAP: {
+        uint32_t cubeIndex = slice ? static_cast<uint32_t>(*slice) : 0;
+        auto texture = currentTextureAtIndex(cubeIndex);
+        if (!texture)
+            return;
+        for (uint32_t face = 0; face < 6; ++face) {
+            clearAttachmentRegion(gl, viewport, [&](GCGLenum attachment) {
+                gl.framebufferTexture2D(GL::FRAMEBUFFER, attachment, GL::TEXTURE_CUBE_MAP_POSITIVE_X + face, texture, 0);
+            });
+        }
         return;
-
-    ASSERT(slice);
-    clearAttachmentRegion(gl, viewport, [&](GCGLenum attachment) {
-        gl.framebufferTextureLayer(GL::FRAMEBUFFER, attachment, texture, 0, *slice);
-    });
+    }
+    case GL::TEXTURE_2D_ARRAY: {
+        auto texture = currentTexture();
+        if (!texture)
+            return;
+        ASSERT(slice);
+        clearAttachmentRegion(gl, viewport, [&](GCGLenum attachment) {
+            gl.framebufferTextureLayer(GL::FRAMEBUFFER, attachment, texture, 0, *slice);
+        });
+        return;
+    }
+    default:
+        WebXRWebGLSwapchain::clearTextureRegion(gl, viewport, slice);
+    }
 }
 
 void WebXRWebGLStaticImageSwapchain::startFrame(PlatformXR::FrameData::LayerData& data)
@@ -435,27 +473,19 @@ void WebXRWebGLStaticImageSwapchain::endFrame(PlatformXR::DeviceLayer&)
 
 bool WebXRWebGLStaticImageSwapchain::allTexturesAreBound() const
 {
-    return m_textures.size() == m_imageCount && std::all_of(m_textures.begin(), m_textures.end(), [](const auto& texture) {
+    size_t expected = m_imageAttributes.textureType == GL::TEXTURE_CUBE_MAP ? m_imageCount * m_imageAttributes.arrayLength : m_imageCount;
+    return m_textures.size() == expected && std::all_of(m_textures.begin(), m_textures.end(), [](const auto& texture) {
         return texture;
     });
 }
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(WebXRWebGLTextureArraySwapchain);
-
-std::unique_ptr<WebXRWebGLTextureArraySwapchain> WebXRWebGLTextureArraySwapchain::create(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength)
-{
-    ASSERT(arrayLength);
-    return std::unique_ptr<WebXRWebGLTextureArraySwapchain>(new WebXRWebGLTextureArraySwapchain(context, targets, internalFormat, clearOnAccess, imageCount, arrayLength));
-}
-
-WebXRWebGLTextureArraySwapchain::WebXRWebGLTextureArraySwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength)
+WebXRWebGLMultiTextureSwapchain::WebXRWebGLMultiTextureSwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount)
     : WebXRWebGLSwapchain(context, targets, clearOnAccess, imageCount)
-    , m_arrayLength(arrayLength)
     , m_internalFormat(internalFormat)
 {
 }
 
-WebXRWebGLTextureArraySwapchain::~WebXRWebGLTextureArraySwapchain()
+WebXRWebGLMultiTextureSwapchain::~WebXRWebGLMultiTextureSwapchain()
 {
     for (size_t i = 0; i < m_textureSets.size(); ++i)
         releaseTexturesAtIndex(i);
@@ -469,30 +499,37 @@ WebXRWebGLTextureArraySwapchain::~WebXRWebGLTextureArraySwapchain()
     }
 }
 
-void WebXRWebGLTextureArraySwapchain::TextureSet::release(GraphicsContextGL& gl)
+void WebXRWebGLMultiTextureSwapchain::TextureSet::release(GraphicsContextGL& gl)
 {
-    if (arrayTexture) {
-        gl.deleteTexture(arrayTexture);
-        arrayTexture = 0;
+    for (auto& texture : renderTextures) {
+        if (texture)
+            gl.deleteTexture(texture);
     }
+    renderTextures.clear();
     sharedImage.release(gl);
 }
 
-void WebXRWebGLTextureArraySwapchain::TextureSet::leakObject()
+void WebXRWebGLMultiTextureSwapchain::TextureSet::leakObject()
 {
-    arrayTexture = 0;
+    renderTextures.clear();
     sharedImage.leakObject();
 }
 
-PlatformGLObject WebXRWebGLTextureArraySwapchain::currentTexture()
+PlatformGLObject WebXRWebGLMultiTextureSwapchain::currentTexture()
+{
+    return currentTextureAtIndex(0);
+}
+
+PlatformGLObject WebXRWebGLMultiTextureSwapchain::currentTextureAtIndex(uint32_t index)
 {
     if (m_textureSets.isEmpty())
         return 0;
     RELEASE_ASSERT(m_textureSets.size() > m_currentImageIndex);
-    return m_textureSets[m_currentImageIndex].arrayTexture;
+    auto& renderTextures = m_textureSets[m_currentImageIndex].renderTextures;
+    return index < renderTextures.size() ? renderTextures[index] : 0;
 }
 
-void WebXRWebGLTextureArraySwapchain::releaseTexturesAtIndex(size_t index)
+void WebXRWebGLMultiTextureSwapchain::releaseTexturesAtIndex(size_t index)
 {
     if (index >= m_textureSets.size())
         return;
@@ -503,7 +540,7 @@ void WebXRWebGLTextureArraySwapchain::releaseTexturesAtIndex(size_t index)
         m_textureSets[index].leakObject();
 }
 
-const WebXRExternalImages* WebXRWebGLTextureArraySwapchain::reusableTextures(const PlatformXR::FrameData::ExternalTextureData& textureData) const
+const WebXRExternalImages* WebXRWebGLMultiTextureSwapchain::reusableTextures(const PlatformXR::FrameData::ExternalTextureData& textureData) const
 {
     if (textureData.colorTexture)
         return nullptr;
@@ -516,6 +553,49 @@ const WebXRExternalImages* WebXRWebGLTextureArraySwapchain::reusableTextures(con
     }
 
     return &m_textureSets[reusableTextureIndex].sharedImage;
+}
+
+void WebXRWebGLMultiTextureSwapchain::startFrame(PlatformXR::FrameData::LayerData& data)
+{
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+
+    if (data.layerSetup)
+        setupExternalImage(*data.layerSetup);
+
+    bindCompositorTexturesForDisplay(*gl, data);
+}
+
+void WebXRWebGLMultiTextureSwapchain::endFrame(PlatformXR::DeviceLayer& layerData)
+{
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+
+    blitToSharedImage(*gl);
+    signalEndFrame(*gl, layerData);
+}
+
+bool WebXRWebGLMultiTextureSwapchain::allTexturesAreBound() const
+{
+    return m_textureSets.size() == m_imageCount && std::all_of(m_textureSets.begin(), m_textureSets.end(), [](const auto& set) {
+        return static_cast<bool>(set);
+    });
+}
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebXRWebGLTextureArraySwapchain);
+
+std::unique_ptr<WebXRWebGLTextureArraySwapchain> WebXRWebGLTextureArraySwapchain::create(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength)
+{
+    ASSERT(arrayLength);
+    return std::unique_ptr<WebXRWebGLTextureArraySwapchain>(new WebXRWebGLTextureArraySwapchain(context, targets, internalFormat, clearOnAccess, imageCount, arrayLength));
+}
+
+WebXRWebGLTextureArraySwapchain::WebXRWebGLTextureArraySwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength)
+    : WebXRWebGLMultiTextureSwapchain(context, targets, internalFormat, clearOnAccess, imageCount)
+    , m_arrayLength(arrayLength)
+{
 }
 
 void WebXRWebGLTextureArraySwapchain::bindCompositorTexturesForDisplay(GraphicsContextGL& gl, PlatformXR::FrameData::LayerData& layerData)
@@ -556,18 +636,19 @@ void WebXRWebGLTextureArraySwapchain::bindCompositorTexturesForDisplay(GraphicsC
     }
 
     // Create the GL_TEXTURE_2D_ARRAY that the WebXR app will render into. Each array layer has the per-eye width.
-    if (!currentSet.arrayTexture) {
+    if (currentSet.renderTextures.isEmpty()) {
         auto sliceWidth = m_texSize.width() / static_cast<int>(m_arrayLength);
-        currentSet.arrayTexture = gl.createTexture();
-        gl.bindTexture(GL::TEXTURE_2D_ARRAY, currentSet.arrayTexture);
+        PlatformGLObject arrayTexture = gl.createTexture();
+        gl.bindTexture(GL::TEXTURE_2D_ARRAY, arrayTexture);
         gl.texStorage3D(GL::TEXTURE_2D_ARRAY, 1, m_internalFormat, sliceWidth, m_texSize.height(), m_arrayLength);
+        currentSet.renderTextures.append(arrayTexture);
     }
 }
 
-void WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage(GraphicsContextGL& gl)
+void WebXRWebGLTextureArraySwapchain::blitToSharedImage(GraphicsContextGL& gl)
 {
     auto& currentSet = m_textureSets[m_currentImageIndex];
-    if (!currentSet.arrayTexture || !currentSet.sharedImage.colorBuffer.tex)
+    if (currentSet.renderTextures.isEmpty() || !currentSet.sharedImage.colorBuffer.tex)
         return;
 
     if (!m_blitReadFBO)
@@ -575,6 +656,7 @@ void WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage(GraphicsCont
     if (!m_blitDrawFBO)
         m_blitDrawFBO = gl.createFramebuffer();
 
+    auto arrayTexture = currentSet.renderTextures[0];
     auto sliceWidth = m_texSize.width() / static_cast<int>(m_arrayLength);
     auto sliceHeight = m_texSize.height();
 
@@ -583,7 +665,7 @@ void WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage(GraphicsCont
     gl.framebufferTexture2D(GL::DRAW_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_2D, currentSet.sharedImage.colorBuffer.tex, 0);
 
     for (uint32_t layer = 0; layer < m_arrayLength; ++layer) {
-        gl.framebufferTextureLayer(GL::READ_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, currentSet.arrayTexture, 0, static_cast<GCGLint>(layer));
+        gl.framebufferTextureLayer(GL::READ_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, arrayTexture, 0, static_cast<GCGLint>(layer));
         auto dstX = static_cast<GCGLint>(layer) * sliceWidth;
         gl.blitFramebuffer(0, 0, sliceWidth, sliceHeight, dstX, 0, dstX + sliceWidth, sliceHeight, GL::COLOR_BUFFER_BIT, GL::NEAREST);
     }
@@ -606,33 +688,110 @@ void WebXRWebGLTextureArraySwapchain::clearTextureRegion(GraphicsContextGL& gl, 
     });
 }
 
-void WebXRWebGLTextureArraySwapchain::startFrame(PlatformXR::FrameData::LayerData& data)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebXRWebGLCubeSwapchain);
+
+std::unique_ptr<WebXRWebGLCubeSwapchain> WebXRWebGLCubeSwapchain::create(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t cubeCount)
 {
-    RefPtr gl = m_context->graphicsContextGL();
-    if (!gl)
-        return;
-
-    if (data.layerSetup)
-        setupExternalImage(*data.layerSetup);
-
-    bindCompositorTexturesForDisplay(*gl, data);
+    return std::unique_ptr<WebXRWebGLCubeSwapchain>(new WebXRWebGLCubeSwapchain(context, targets, internalFormat, clearOnAccess, imageCount, cubeCount));
 }
 
-void WebXRWebGLTextureArraySwapchain::endFrame(PlatformXR::DeviceLayer& layerData)
+WebXRWebGLCubeSwapchain::WebXRWebGLCubeSwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t cubeCount)
+    : WebXRWebGLMultiTextureSwapchain(context, targets, internalFormat, clearOnAccess, imageCount)
+    , m_cubeCount(cubeCount)
 {
-    RefPtr gl = m_context->graphicsContextGL();
-    if (!gl)
-        return;
-
-    blitTextureArrayToSharedImage(*gl);
-    signalEndFrame(*gl, layerData);
 }
 
-bool WebXRWebGLTextureArraySwapchain::allTexturesAreBound() const
+void WebXRWebGLCubeSwapchain::bindCompositorTexturesForDisplay(GraphicsContextGL& gl, PlatformXR::FrameData::LayerData& layerData)
 {
-    return m_textureSets.size() == m_imageCount && std::all_of(m_textureSets.begin(), m_textureSets.end(), [](const auto& set) {
-        return set.arrayTexture && set.sharedImage;
-    });
+    m_currentImageIndex = layerData.textureData ? layerData.textureData->reusableTextureIndex : 0;
+    if (m_textureSets.size() <= m_currentImageIndex)
+        m_textureSets.resizeToFit(m_currentImageIndex + 1);
+
+    if (!layerData.textureData) {
+        m_currentImageIndex = 0;
+        return;
+    }
+
+    auto& currentSet = m_textureSets[m_currentImageIndex];
+
+    auto* reusable = reusableTextures(*(layerData.textureData));
+    if (!reusable) {
+        releaseTexturesAtIndex(m_currentImageIndex);
+
+        if (!layerData.textureData->colorTexture)
+            return;
+
+        // The shared image is the side-by-side 2D texture (cubeCount*faceCount faces laid out horizontally) that the UIProcess reconstructs into cube swapchain faces.
+        IntSize texSize = layerData.layerSetup ? toIntSize(layerData.layerSetup->physicalSize[0]) : IntSize(32, 32);
+        auto colorTextureSource = makeExternalImageSource(layerData.textureData->colorTexture, texSize);
+#if PLATFORM(COCOA)
+        constexpr auto kColorFormat = GL::BGRA_EXT;
+#else
+        constexpr auto kColorFormat = GL::RGBA8;
+#endif
+        GCGLint layer = 0;
+        createAndBindCompositorTexture(gl, currentSet.sharedImage.colorBuffer, kColorFormat, WTF::move(colorTextureSource), layer);
+        if (!currentSet.sharedImage.colorBuffer.tex)
+            return;
+    }
+
+    // One square cubemap per eye for the app to render into, the shared image is cubeCount*faceCount faces wide.
+    if (currentSet.renderTextures.isEmpty()) {
+        auto faceSize = m_texSize.height();
+        for (uint32_t cube = 0; cube < m_cubeCount; ++cube) {
+            PlatformGLObject cubeTexture = gl.createTexture();
+            gl.bindTexture(GL::TEXTURE_CUBE_MAP, cubeTexture);
+            gl.texStorage2D(GL::TEXTURE_CUBE_MAP, 1, m_internalFormat, faceSize, faceSize);
+            currentSet.renderTextures.append(cubeTexture);
+        }
+    }
+}
+
+void WebXRWebGLCubeSwapchain::blitToSharedImage(GraphicsContextGL& gl)
+{
+    auto& currentSet = m_textureSets[m_currentImageIndex];
+    if (currentSet.renderTextures.isEmpty() || !currentSet.sharedImage.colorBuffer.tex)
+        return;
+
+    if (!m_blitReadFBO)
+        m_blitReadFBO = gl.createFramebuffer();
+    if (!m_blitDrawFBO)
+        m_blitDrawFBO = gl.createFramebuffer();
+
+    auto faceSize = m_texSize.height();
+
+    gl.bindFramebuffer(GL::READ_FRAMEBUFFER, m_blitReadFBO);
+    gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, m_blitDrawFBO);
+    gl.framebufferTexture2D(GL::DRAW_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_2D, currentSet.sharedImage.colorBuffer.tex, 0);
+
+    // Region (cube*faceCount + face) holds GL_TEXTURE_CUBE_MAP_POSITIVE_X + face of that cube. UIProcess reconstruction must use the same ordering.
+    for (uint32_t cube = 0; cube < currentSet.renderTextures.size(); ++cube) {
+        for (uint32_t face = 0; face < faceCount; ++face) {
+            gl.framebufferTexture2D(GL::READ_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_CUBE_MAP_POSITIVE_X + face, currentSet.renderTextures[cube], 0);
+            auto dstX = static_cast<GCGLint>(cube * faceCount + face) * faceSize;
+            gl.blitFramebuffer(0, 0, faceSize, faceSize, dstX, 0, dstX + faceSize, faceSize, GL::COLOR_BUFFER_BIT, GL::NEAREST);
+        }
+    }
+
+    gl.bindFramebuffer(GL::FRAMEBUFFER, 0);
+}
+
+void WebXRWebGLCubeSwapchain::clearTextureRegion(GraphicsContextGL& gl, const IntRect& viewport, std::optional<GCGLint> slice)
+{
+    if (!m_framebufferForClearing || m_textureSets.isEmpty())
+        return;
+
+    // slice selects the cube (eye) othewise clearing all cubes would wipe the other eye's content.
+    auto& renderTextures = m_textureSets[m_currentImageIndex].renderTextures;
+    auto cube = static_cast<size_t>(slice.value_or(0));
+    if (cube >= renderTextures.size())
+        return;
+
+    for (uint32_t face = 0; face < faceCount; ++face) {
+        clearAttachmentRegion(gl, viewport, [&](GCGLenum attachment) {
+            gl.framebufferTexture2D(GL::FRAMEBUFFER, attachment, GL::TEXTURE_CUBE_MAP_POSITIVE_X + face, renderTextures[cube], 0);
+        });
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
@@ -93,6 +93,9 @@ public:
 
     virtual GCGLenum textureTarget() const { return GraphicsContextGL::TEXTURE_2D; }
 
+    // Per-view texture accessor; only cube layers expose more than one (one cubemap per eye).
+    virtual PlatformGLObject currentTextureAtIndex(uint32_t) { return currentTexture(); }
+
     void clearTextureIfNeeded(const IntRect& viewport, std::optional<GCGLint> slice);
 
 protected:
@@ -165,6 +168,7 @@ public:
     ~WebXRWebGLStaticImageSwapchain() override;
 
     PlatformGLObject currentTexture() override;
+    PlatformGLObject currentTextureAtIndex(uint32_t) override;
 
     void startFrame(PlatformXR::FrameData::LayerData&) override;
     void endFrame(PlatformXR::DeviceLayer&) override;
@@ -186,49 +190,84 @@ private:
     Vector<PlatformGLObject> m_textures;
 };
 
-// Swapchain that renders internally into a GL_TEXTURE_2D_ARRAY and blits each array slice into the corresponding
-// horizontal region of a side-by-side shared texture exported to the UIProcess. Used whenever texture arrays
-// cannot be shared directly (like with DMABuf) so this approach keeps the existing sharing mechanism intact.
-class WebXRWebGLTextureArraySwapchain final : public WebXRWebGLSwapchain {
-    WTF_MAKE_TZONE_ALLOCATED(WebXRWebGLTextureArraySwapchain);
-    WTF_MAKE_NONCOPYABLE(WebXRWebGLTextureArraySwapchain);
+// Base for swapchains that render into one or more per-image textures and blit them into the corresponding horizontal regions of
+// a side-by-side shared 2D texture exported to the UIProcess. Used whenever the textures can't be shared directly (like with DMABuf).
+// Requires an extra blit per frame from the per-image textures into the shared texture.
+class WebXRWebGLMultiTextureSwapchain : public WebXRWebGLSwapchain {
 public:
-    static std::unique_ptr<WebXRWebGLTextureArraySwapchain> create(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength);
-    ~WebXRWebGLTextureArraySwapchain() override;
+    ~WebXRWebGLMultiTextureSwapchain() override;
 
     PlatformGLObject currentTexture() override;
+    PlatformGLObject currentTextureAtIndex(uint32_t) override;
 
     void startFrame(PlatformXR::FrameData::LayerData&) override;
     void endFrame(PlatformXR::DeviceLayer&) override;
 
     bool allTexturesAreBound() const override;
 
-    GCGLenum textureTarget() const override { return GraphicsContextGL::TEXTURE_2D_ARRAY; }
-    uint32_t arrayLength() const { return m_arrayLength; }
-
-private:
+protected:
     struct TextureSet {
-        PlatformGLObject arrayTexture { 0 };
+        Vector<PlatformGLObject> renderTextures;
         WebXRExternalImages sharedImage;
 
-        explicit operator bool() const { return arrayTexture && sharedImage; }
+        explicit operator bool() const { return !renderTextures.isEmpty() && renderTextures[0] && sharedImage; }
         void release(GraphicsContextGL&);
         void leakObject();
     };
 
-    WebXRWebGLTextureArraySwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength);
+    WebXRWebGLMultiTextureSwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount);
 
-    void clearTextureRegion(GraphicsContextGL&, const IntRect& viewport, std::optional<GCGLint> slice) override;
-    void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
-    void blitTextureArrayToSharedImage(GraphicsContextGL&);
     void releaseTexturesAtIndex(size_t);
     const WebXRExternalImages* reusableTextures(const PlatformXR::FrameData::ExternalTextureData&) const;
 
-    uint32_t m_arrayLength;
+    virtual void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&) = 0;
+    virtual void blitToSharedImage(GraphicsContextGL&) = 0;
+
     GCGLenum m_internalFormat;
     Vector<TextureSet> m_textureSets;
     PlatformGLObject m_blitReadFBO { 0 };
     PlatformGLObject m_blitDrawFBO { 0 };
+};
+
+// Renders into a GL_TEXTURE_2D_ARRAY and blits each slice into a side-by-side shared texture.
+class WebXRWebGLTextureArraySwapchain final : public WebXRWebGLMultiTextureSwapchain {
+    WTF_MAKE_TZONE_ALLOCATED(WebXRWebGLTextureArraySwapchain);
+    WTF_MAKE_NONCOPYABLE(WebXRWebGLTextureArraySwapchain);
+public:
+    static std::unique_ptr<WebXRWebGLTextureArraySwapchain> create(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength);
+
+    GCGLenum textureTarget() const override { return GraphicsContextGL::TEXTURE_2D_ARRAY; }
+    uint32_t arrayLength() const { return m_arrayLength; }
+
+private:
+    WebXRWebGLTextureArraySwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength);
+
+    void clearTextureRegion(GraphicsContextGL&, const IntRect& viewport, std::optional<GCGLint> slice) override;
+    void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&) override;
+    void blitToSharedImage(GraphicsContextGL&) override;
+
+    uint32_t m_arrayLength;
+};
+
+// Renders into one GL_TEXTURE_CUBE_MAP per eye and blits each face into a side-by-side shared texture.
+class WebXRWebGLCubeSwapchain final : public WebXRWebGLMultiTextureSwapchain {
+    WTF_MAKE_TZONE_ALLOCATED(WebXRWebGLCubeSwapchain);
+    WTF_MAKE_NONCOPYABLE(WebXRWebGLCubeSwapchain);
+public:
+    static constexpr uint32_t faceCount = 6;
+
+    static std::unique_ptr<WebXRWebGLCubeSwapchain> create(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t cubeCount);
+
+    GCGLenum textureTarget() const override { return GraphicsContextGL::TEXTURE_CUBE_MAP; }
+
+private:
+    WebXRWebGLCubeSwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t cubeCount);
+
+    void clearTextureRegion(GraphicsContextGL&, const IntRect& viewport, std::optional<GCGLint> slice) override;
+    void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&) override;
+    void blitToSharedImage(GraphicsContextGL&) override;
+
+    uint32_t m_cubeCount;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRCubeLayer.h
+++ b/Source/WebCore/Modules/webxr/XRCubeLayer.h
@@ -28,29 +28,37 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "DOMPointReadOnly.h"
 #include "XRCompositionLayer.h"
+#include "XRCubeLayerInit.h"
+#include <wtf/Ref.h>
 
 namespace WebCore {
 
-class DOMPointReadOnly;
-class WebXRSpace;
+class WebXRSession;
+class XRLayerBacking;
 
 // https://immersive-web.github.io/layers/#xcubelayertype
 class XRCubeLayer : public XRCompositionLayer {
+    WTF_MAKE_TZONE_ALLOCATED(XRCubeLayer);
 public:
+    static Ref<XRCubeLayer> create(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRCubeLayerInit& init)
+    {
+        return adoptRef(*new XRCubeLayer(scriptExecutionContext, session, WTF::move(backing), init));
+    }
+
     virtual ~XRCubeLayer();
 
-    const WebXRSpace& space() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setSpace(WebXRSpace&) { RELEASE_ASSERT_NOT_REACHED(); }
-    const DOMPointReadOnly& orientation() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setOrientation(DOMPointReadOnly&) { RELEASE_ASSERT_NOT_REACHED(); }
+    const DOMPointReadOnly& orientation() const { return m_orientation.get(); }
+    void setOrientation(DOMPointReadOnly&);
 
 private:
+    XRCubeLayer(ScriptExecutionContext&, WebXRSession&, Ref<XRLayerBacking>&&, const XRCubeLayerInit&);
     bool isXRCubeLayer() const final { return true; }
 
-    // WebXRLayer.
-    [[noreturn]] void startFrame(PlatformXR::FrameData&) final { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] PlatformXR::DeviceLayer endFrame() final { RELEASE_ASSERT_NOT_REACHED(); }
+    void fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer&) const final;
+
+    Ref<DOMPointReadOnly> m_orientation;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -38,6 +38,8 @@
 #include "WebXRSession.h"
 #include "WebXRView.h"
 #include "WebXRViewport.h"
+#include "XRCubeLayer.h"
+#include "XRCubeLayerInit.h"
 #include "XRCylinderLayer.h"
 #include "XRCylinderLayerInit.h"
 #include "XREquirectLayer.h"
@@ -47,6 +49,7 @@
 #include "XRProjectionLayerInit.h"
 #include "XRQuadLayer.h"
 #include "XRQuadLayerInit.h"
+#include "XRWebGLCubeLayerBacking.h"
 #include "XRWebGLCylinderLayerBacking.h"
 #include "XRWebGLEquirectLayerBacking.h"
 #include "XRWebGLProjectionLayerBacking.h"
@@ -260,10 +263,14 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateColorTex
 
             // Layout / textureType differences (size, array length, texture target) are baked into the swapchain at construction time.
             Vector<RefPtr<WebGLOpaqueTexture>> textures;
-            RefPtr currentColorTexture = static_cast<XRWebGLLayerBacking&>(layer.backing()).currentColorTexture();
-            if (!currentColorTexture)
-                return Exception { ExceptionCode::InvalidStateError, "Failed to get the current color texture."_s };
-            textures.append(currentColorTexture);
+            auto& backing = static_cast<XRWebGLLayerBacking&>(layer.backing());
+            uint32_t textureCount = backing.requiresPerViewColorTextures() ? 2 : 1;
+            for (uint32_t index = 0; index < textureCount; ++index) {
+                RefPtr currentColorTexture = backing.currentColorTexture(index);
+                if (!currentColorTexture)
+                    return Exception { ExceptionCode::InvalidStateError, "Failed to get the current color texture."_s };
+                textures.append(currentColorTexture);
+            }
             return textures;
         },
         [](std::monostate) {
@@ -287,10 +294,14 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTex
             ASSERT(depthFormatIsSupportedForNonProjectionLayer(*init.depthFormat));
             ASSERT(layer.layout() != XRLayerLayout::Default);
 
-            RefPtr currentDepthTexture = static_cast<XRWebGLLayerBacking&>(layer.backing()).currentDepthTexture();
-            if (!currentDepthTexture)
-                return Exception { ExceptionCode::InvalidStateError, "Failed to get the current depth texture."_s };
-            textures.append(currentDepthTexture);
+            auto& backing = static_cast<XRWebGLLayerBacking&>(layer.backing());
+            uint32_t textureCount = backing.requiresPerViewColorTextures() ? 2 : 1;
+            for (uint32_t index = 0; index < textureCount; ++index) {
+                RefPtr currentDepthTexture = backing.currentDepthTexture(index);
+                if (!currentDepthTexture)
+                    return Exception { ExceptionCode::InvalidStateError, "Failed to get the current depth texture."_s };
+                textures.append(currentDepthTexture);
+            }
             return textures;
         },
         [](std::monostate) {
@@ -619,6 +630,62 @@ ExceptionOr<Ref<XRCylinderLayer>> XRWebGLBinding::createCylinderLayer(ScriptExec
     );
 }
 
+ExceptionOr<Ref<XRCubeLayer>> XRWebGLBinding::createCubeLayer(ScriptExecutionContext& scriptExecutionContext, const XRCubeLayerInit& init)
+{
+    if (!m_session->supportsFeature(PlatformXR::SessionFeature::Layers))
+        return Exception { ExceptionCode::NotSupportedError, "Layers are not supported by the session."_s };
+
+    if (m_session->ended())
+        return Exception { ExceptionCode::InvalidStateError, "Cannot create a cube layer with an XRSession that has ended."_s };
+
+    return WTF::switchOn(m_context,
+        [&](const Ref<WebGLRenderingContext>&) -> ExceptionOr<Ref<XRCubeLayer>> {
+            return Exception { ExceptionCode::InvalidStateError, "Cube layers are only supported on WebGL2 contexts."_s };
+        },
+        [&](const Ref<WebGL2RenderingContext>& baseContext) -> ExceptionOr<Ref<XRCubeLayer>> {
+            if (baseContext->isContextLost())
+                return Exception { ExceptionCode::InvalidStateError, "Cannot create a cube layer with a lost WebGL context"_s };
+
+            if (!init.space->isReferenceSpace())
+                return Exception { ExceptionCode::TypeError, "The space is not a reference space."_s };
+
+            if (downcast<WebXRReferenceSpace>(init.space)->type() == XRReferenceSpaceType::Viewer)
+                return Exception { ExceptionCode::TypeError, "Viewer space is not allowed for cube layers."_s };
+
+            if (init.layout == XRLayerLayout::Default || init.layout == XRLayerLayout::StereoLeftRight || init.layout == XRLayerLayout::StereoTopBottom)
+                return Exception { ExceptionCode::TypeError, "Cube layers only support mono or stereo layout."_s };
+
+            if (init.viewPixelWidth != init.viewPixelHeight)
+                return Exception { ExceptionCode::TypeError, "Cube layer width and height must be equal."_s };
+
+            auto validateInitResult = validateCompositionLayerInitParameters(init);
+            if (validateInitResult.hasException())
+                return validateInitResult.releaseException();
+
+            auto createBackingResult = XRWebGLCubeLayerBacking::create(m_session, baseContext, init);
+            if (createBackingResult.hasException())
+                return createBackingResult.releaseException();
+            Ref backing = createBackingResult.releaseReturnValue();
+
+            auto checkSpaceResult = checkCanSetSpace(init.space.get(), m_session);
+            if (checkSpaceResult.hasException())
+                return checkSpaceResult.releaseException();
+
+            Ref layer = XRCubeLayer::create(scriptExecutionContext, m_session, WTF::move(backing), init);
+            initializeCompositionLayer(layer.get());
+
+            layer->setLayout(init.layout == XRLayerLayout::Stereo ? XRLayerLayout::Stereo : XRLayerLayout::Mono);
+            layer->setNeedsRedraw(true);
+
+            return layer;
+        },
+        [](std::monostate) {
+            ASSERT_NOT_REACHED();
+            return Exception { ExceptionCode::OperationError, "Could not get a WebGL rendering context."_s };
+        }
+    );
+}
+
 // https://immersive-web.github.io/layers/#initialize-the-viewport
 Ref<WebXRViewport> XRWebGLBinding::initializeViewport(IntSize textureSize, XRLayerLayout layout, XRTextureType textureType, int offset, int num)
 {
@@ -676,7 +743,10 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getSubImage(XRCompositionLayer
             int viewsPerTexture = layout == XRLayerLayout::StereoLeftRight || layout == XRLayerLayout::StereoTopBottom ? 2 : 1;
             Ref viewport = initializeViewport(IntSize(init.viewPixelWidth, init.viewPixelHeight), layout, init.textureType, index, viewsPerTexture);
 
-            auto createSubImageResult = XRWebGLSubImage::create(WTF::move(viewport), layer);
+            // A stereo cube layer exposes one cubemap per eye (two color textures); pick the eye's texture.
+            uint32_t colorTextureIndex = layer.isXRCubeLayer() && layout == XRLayerLayout::Stereo && init.textureType != XRTextureType::TextureArray && eye == XREye::Right ? 1 : 0;
+
+            auto createSubImageResult = XRWebGLSubImage::create(WTF::move(viewport), layer, colorTextureIndex);
             if (createSubImageResult.hasException())
                 return createSubImageResult.releaseException();
             Ref subImage = createSubImageResult.releaseReturnValue();
@@ -689,7 +759,16 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getSubImage(XRCompositionLayer
             }
 
             const auto& vp = subImage->viewport();
-            layer.backing().clearTexturesIfNeeded(IntRect(vp.x(), vp.y(), vp.width(), vp.height()), subImage->imageIndex());
+            IntRect clearRect(vp.x(), vp.y(), vp.width(), vp.height());
+            if (layer.isXRCubeLayer() && init.textureType == XRTextureType::TextureArray) {
+                // Each eye occupies 6 consecutive array layers (one per face). index is the base layer for the current eye (0 for left/mono, 6 for right eye).
+                for (uint32_t face = 0; face < 6; ++face)
+                    layer.backing().clearTexturesIfNeeded(clearRect, static_cast<uint32_t>(index) + face);
+            } else {
+                // For non texture array cubes the clear slice selects the eye's cubemap texture. For other layer types it is the array layer (imageIndex).
+                auto clearSlice = layer.isXRCubeLayer() ? std::optional<uint32_t>(colorTextureIndex) : subImage->imageIndex();
+                layer.backing().clearTexturesIfNeeded(clearRect, clearSlice);
+            }
             return subImage;
         },
         [](const auto&) -> ExceptionOr<Ref<XRWebGLSubImage>> {

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -79,7 +79,7 @@ public:
     ExceptionOr<Ref<XRQuadLayer>> createQuadLayer(ScriptExecutionContext&, const XRQuadLayerInit&);
     ExceptionOr<Ref<XRCylinderLayer>> createCylinderLayer(ScriptExecutionContext&, const XRCylinderLayerInit&);
     ExceptionOr<Ref<XREquirectLayer>> createEquirectLayer(ScriptExecutionContext&, const XREquirectLayerInit&);
-    ExceptionOr<Ref<XRCubeLayer>> createCubeLayer(const XRCubeLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
+    ExceptionOr<Ref<XRCubeLayer>> createCubeLayer(ScriptExecutionContext&, const XRCubeLayerInit&);
 
     Ref<WebXRViewport> initializeViewport(IntSize, XRLayerLayout, XRTextureType, int offset, int num);
 

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.idl
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.idl
@@ -40,7 +40,7 @@ typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingCon
     [CallWith=CurrentScriptExecutionContext] XRQuadLayer createQuadLayer(optional XRQuadLayerInit init = {});
     [CallWith=CurrentScriptExecutionContext] XRCylinderLayer createCylinderLayer(optional XRCylinderLayerInit init = {});
     [CallWith=CurrentScriptExecutionContext] XREquirectLayer createEquirectLayer(optional XREquirectLayerInit init = {});
-    XRCubeLayer createCubeLayer(optional XRCubeLayerInit init = {});
+    [CallWith=CurrentScriptExecutionContext] XRCubeLayer createCubeLayer(optional XRCubeLayerInit init = {});
 
     XRWebGLSubImage getSubImage(XRCompositionLayer layer, WebXRFrame frame, optional XREye eye = "none");
     XRWebGLSubImage getViewSubImage(XRProjectionLayer layer, WebXRView view);

--- a/Source/WebCore/Modules/webxr/XRWebGLCubeLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLCubeLayerBacking.cpp
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (C) 2025 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,45 +24,32 @@
  */
 
 #include "config.h"
-#include "XRCubeLayer.h"
+#include "XRWebGLCubeLayerBacking.h"
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "WebXRSession.h"
+#include "WebXRWebGLSwapchain.h"
+#include "XRCubeLayerInit.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(XRCubeLayer);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLCubeLayerBacking);
 
-XRCubeLayer::XRCubeLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRCubeLayerInit& init)
-    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init, init.space, nullptr)
-    , m_orientation(init.orientation ? Ref<DOMPointReadOnly>(*init.orientation) : DOMPointReadOnly::create(0, 0, 0, 1))
+ExceptionOr<Ref<XRWebGLCubeLayerBacking>> XRWebGLCubeLayerBacking::create(WebXRSession& session, WebGLRenderingContextBase& context, const XRCubeLayerInit& init)
 {
-    setIsStatic(init.isStatic);
+    auto swapchains = XRWebGLLayerBacking::createCompositionLayerSwapchains(session, context, PlatformXR::CompositionLayerType::Cube, init);
+    if (swapchains.hasException())
+        return swapchains.releaseException();
+    auto [handle, colorSwapchain, depthSwapchain, arrayLength] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLCubeLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), arrayLength, init));
 }
 
-XRCubeLayer::~XRCubeLayer() = default;
-
-void XRCubeLayer::setOrientation(DOMPointReadOnly& orientation)
+XRWebGLCubeLayerBacking::XRWebGLCubeLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength, const XRCubeLayerInit& init)
+    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), colorTextureArrayLength)
+    , m_init(init)
 {
-    m_orientation = orientation;
-    setNeedsRedraw(true);
-}
-
-void XRCubeLayer::fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer& layerData) const
-{
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    layerData.cubeLayerData = {
-        .orientation = {
-            static_cast<float>(m_orientation->x()),
-            static_cast<float>(m_orientation->y()),
-            static_cast<float>(m_orientation->z()),
-            static_cast<float>(m_orientation->w()),
-        },
-    };
-#else
-    UNUSED_PARAM(layerData);
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRWebGLCubeLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLCubeLayerBacking.h
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (C) 2025 Apple, Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,47 +23,32 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "XRCubeLayer.h"
+#pragma once
 
 #if ENABLE(WEBXR_LAYERS)
 
-#include <wtf/TZoneMallocInlines.h>
+#include "XRCubeLayerInit.h"
+#include "XRWebGLLayerBacking.h"
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(XRCubeLayer);
+class WebGLRenderingContextBase;
+class WebXRWebGLSwapchain;
+class WebXRSession;
 
-XRCubeLayer::XRCubeLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRCubeLayerInit& init)
-    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init, init.space, nullptr)
-    , m_orientation(init.orientation ? Ref<DOMPointReadOnly>(*init.orientation) : DOMPointReadOnly::create(0, 0, 0, 1))
-{
-    setIsStatic(init.isStatic);
-}
+class XRWebGLCubeLayerBacking : public XRWebGLLayerBacking {
+    WTF_MAKE_TZONE_ALLOCATED(XRWebGLCubeLayerBacking);
+public:
+    static ExceptionOr<Ref<XRWebGLCubeLayerBacking>> create(WebXRSession&, WebGLRenderingContextBase&, const XRCubeLayerInit&);
 
-XRCubeLayer::~XRCubeLayer() = default;
+private:
+    XRWebGLCubeLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength, const XRCubeLayerInit&);
 
-void XRCubeLayer::setOrientation(DOMPointReadOnly& orientation)
-{
-    m_orientation = orientation;
-    setNeedsRedraw(true);
-}
-
-void XRCubeLayer::fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer& layerData) const
-{
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    layerData.cubeLayerData = {
-        .orientation = {
-            static_cast<float>(m_orientation->x()),
-            static_cast<float>(m_orientation->y()),
-            static_cast<float>(m_orientation->z()),
-            static_cast<float>(m_orientation->w()),
-        },
-    };
-#else
-    UNUSED_PARAM(layerData);
-#endif
-}
+    XRCubeLayerInit m_init;
+};
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
@@ -120,16 +120,26 @@ void XRWebGLLayerBacking::endFrame(PlatformXR::DeviceLayer& layerData)
 }
 #endif
 
-RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentColorTexture() const
+RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentColorTexture(uint32_t index) const
 {
-    if (auto texture = m_colorSwapchain->currentTexture())
+    if (auto texture = m_colorSwapchain->currentTextureAtIndex(index))
         return WebGLOpaqueTexture::create(*m_colorSwapchain->context(), texture, m_colorSwapchain->textureTarget());
     return nullptr;
 }
 
-RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentDepthTexture() const
+bool XRWebGLLayerBacking::requiresPerViewColorTextures() const
 {
-    if (auto texture = m_depthSwapchain->currentTexture())
+    // Non-array stereo cube layers use two separate GL_TEXTURE_CUBE_MAP objects (one per eye);
+    // all other layer types (including TextureArray cube, which uses one TEXTURE_2D_ARRAY) use one texture.
+    // That's because you cannot concat multiple cube map textures into a single side-by-side cube map texture.
+    return m_colorSwapchain->textureTarget() == GraphicsContextGL::TEXTURE_CUBE_MAP && m_colorTextureArrayLength > 1;
+}
+
+RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentDepthTexture(uint32_t index) const
+{
+    if (!m_depthSwapchain)
+        return nullptr;
+    if (auto texture = m_depthSwapchain->currentTextureAtIndex(index))
         return WebGLOpaqueTexture::create(*m_depthSwapchain->context(), texture, m_depthSwapchain->textureTarget());
     return nullptr;
 }
@@ -162,18 +172,33 @@ ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createC
     if (!device)
         return Exception { ExceptionCode::OperationError, "Cannot create a composition layer without a valid device."_s };
 
-    auto [layerSize, layerLayout] = computeNonProjectionLayerSize(init.viewPixelWidth, init.viewPixelHeight, init.layout);
+    bool useTextureArray = init.textureType == XRTextureType::TextureArray;
+
+    IntSize layerSize;
+    PlatformXR::LayerLayout layerLayout;
+    GCGLenum colorTextureType;
+    uint32_t arrayLength;
+
+    if (layerType == PlatformXR::CompositionLayerType::Cube) {
+        bool isStereo = init.layout == XRLayerLayout::Stereo;
+        layerSize = IntSize { static_cast<int>(init.viewPixelWidth), static_cast<int>(init.viewPixelHeight) };
+        layerLayout = init.layout == XRLayerLayout::Stereo ? PlatformXR::LayerLayout::Stereo : PlatformXR::LayerLayout::Mono;
+        // TextureArray: one TEXTURE_2D_ARRAY with 6 faces per eye (spec: +X,-X,+Y,-Y,+Z,-Z; right eye starts at layer 6 for stereo)
+        // Non-array: one GL_TEXTURE_CUBE_MAP per eye
+        colorTextureType = useTextureArray ? GL::TEXTURE_2D_ARRAY : GL::TEXTURE_CUBE_MAP;
+        arrayLength = useTextureArray ? (isStereo ? 12 : 6) : (isStereo ? 2 : 1);
+    } else {
+        std::tie(layerSize, layerLayout) = computeNonProjectionLayerSize(init.viewPixelWidth, init.viewPixelHeight, init.layout);
+        colorTextureType = useTextureArray ? GL::TEXTURE_2D_ARRAY : GL::TEXTURE_2D;
+        uint32_t slicesPerLayer = layerLayout == PlatformXR::LayerLayout::Mono ? 1 : 2;
+        arrayLength = computeArrayLength(useTextureArray, slicesPerLayer);
+    }
 
     auto layerInfo = device->createCompositionLayer(layerType, layerSize, layerLayout);
     if (!layerInfo)
         return Exception { ExceptionCode::OperationError, "Unable to create a composition layer."_s };
 
-    bool useTextureArray = init.textureType == XRTextureType::TextureArray;
-    GCGLenum colorTextureType = useTextureArray ? GL::TEXTURE_2D_ARRAY : GL::TEXTURE_2D;
-    uint32_t slicesPerLayer = layerLayout == PlatformXR::LayerLayout::Mono ? 1 : 2;
-    uint32_t arrayLength = computeArrayLength(useTextureArray, slicesPerLayer);
-
-    return XRWebGLLayerBacking::createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, layerSize, init.clearOnAccess, layerInfo->numImages, arrayLength, colorTextureType);
+    return createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, layerSize, init.clearOnAccess, layerInfo->numImages, arrayLength, colorTextureType);
 }
 
 ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createProjectionLayerSwapchains(WebXRSession& session, WebGLRenderingContextBase& context, const XRProjectionLayerInit& init)
@@ -204,7 +229,11 @@ ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createC
     std::unique_ptr<WebXRWebGLSwapchain> depthSwapchain;
 
     bool useTextureArray = colorTextureType == GL::TEXTURE_2D_ARRAY;
-    if (useTextureArray) {
+    bool isCube = colorTextureType == GL::TEXTURE_CUBE_MAP;
+    if (isCube) {
+        auto colorFormats = swapchainFormatsForLayerFormat(colorFormat);
+        colorSwapchain = WebXRWebGLCubeSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, colorFormats.internalFormat, clearOnAccess, numImages, arrayLength);
+    } else if (useTextureArray) {
         auto colorFormats = swapchainFormatsForLayerFormat(colorFormat);
         colorSwapchain = WebXRWebGLTextureArraySwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, colorFormats.internalFormat, clearOnAccess, numImages, arrayLength);
     } else
@@ -214,7 +243,7 @@ ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createC
         return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
 
     if (depthFormat && *depthFormat) {
-        IntSize depthSize = useTextureArray ? IntSize(size.width() / static_cast<int>(arrayLength), size.height()) : size;
+        IntSize depthSize = (!isCube && useTextureArray) ? IntSize(size.width() / static_cast<int>(arrayLength), size.height()) : size;
         depthSwapchain = createDepthSwapchain(context, *depthFormat, depthSize, clearOnAccess, numImages, arrayLength, colorTextureType);
     }
 

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -76,8 +76,12 @@ public:
     void endFrame(PlatformXR::DeviceLayer&) final;
 #endif
 
-    RefPtr<WebGLOpaqueTexture> currentColorTexture() const;
-    RefPtr<WebGLOpaqueTexture> currentDepthTexture() const;
+    RefPtr<WebGLOpaqueTexture> currentColorTexture(uint32_t index = 0) const;
+    RefPtr<WebGLOpaqueTexture> currentDepthTexture(uint32_t index = 0) const;
+
+    // Returns true for non-array stereo cube layers, which require two separate GL_TEXTURE_CUBE_MAP
+    // objects (one per view). All other layer types use a single texture regardless of layout.
+    bool requiresPerViewColorTextures() const;
 
     bool allColorTexturesAreBound() const final;
 

--- a/Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp
@@ -51,9 +51,9 @@ XRWebGLSubImage::XRWebGLSubImage(Ref<WebXRViewport>&& viewport, WebGLTexture& co
 {
 }
 
-ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLSubImage::create(Ref<WebXRViewport>&& viewport, XRCompositionLayer& layer)
+ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLSubImage::create(Ref<WebXRViewport>&& viewport, XRCompositionLayer& layer, uint32_t colorTextureIndex)
 {
-    auto colorTexture = layer.colorTextures()[0].get();
+    auto colorTexture = layer.colorTextures()[colorTextureIndex].get();
     if (!colorTexture || !colorTexture->isUsable())
         return Exception { ExceptionCode::InvalidStateError, "Cannot get a usable texture for the subimage."_s };
 
@@ -62,7 +62,8 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLSubImage::create(Ref<WebXRViewport>&& v
     std::optional<IntSize> depthTextureSize;
     WebGLOpaqueTexture* depthTexture = nullptr;
     if (!layer.depthStencilTextures().isEmpty()) {
-        depthTexture = layer.depthStencilTextures()[0].get();
+        auto depthIndex = colorTextureIndex < layer.depthStencilTextures().size() ? colorTextureIndex : 0U;
+        depthTexture = layer.depthStencilTextures()[depthIndex].get();
         if (!depthTexture || !depthTexture->isUsable())
             depthTexture = nullptr;
         else

--- a/Source/WebCore/Modules/webxr/XRWebGLSubImage.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLSubImage.h
@@ -43,7 +43,7 @@ class XRCompositionLayer;
 class XRWebGLSubImage : public XRSubImage {
     WTF_MAKE_TZONE_ALLOCATED(XRWebGLSubImage);
 public:
-    static ExceptionOr<Ref<XRWebGLSubImage>> create(Ref<WebXRViewport>&&, XRCompositionLayer&);
+    static ExceptionOr<Ref<XRWebGLSubImage>> create(Ref<WebXRViewport>&&, XRCompositionLayer&, uint32_t colorTextureIndex = 0);
     virtual ~XRWebGLSubImage();
 
     const WebXRViewport& viewport() const final { return m_viewport.get(); }

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -582,6 +582,7 @@ Modules/webxr/WebXRRay.cpp
 Modules/webxr/XRReferenceSpaceEvent.cpp
 Modules/webxr/XRSessionEvent.cpp
 Modules/webxr/XRSubImage.cpp
+Modules/webxr/XRWebGLCubeLayerBacking.cpp
 Modules/webxr/XRWebGLCylinderLayerBacking.cpp
 Modules/webxr/XRWebGLEquirectLayerBacking.cpp
 Modules/webxr/XRWebGLLayerBacking.cpp

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -491,10 +491,12 @@ enum class CompositionLayerType : uint8_t {
     Quad,
     Equirect,
     Cylinder,
+    Cube,
 };
 
 enum class LayerLayout : uint8_t {
     Mono,
+    Stereo,
     StereoLeftRight,
     StereoTopBottom,
 };
@@ -534,6 +536,11 @@ struct DeviceLayer {
         FrameData::Pose poseInLocalSpace;
     };
     std::optional<CylinderLayerData> cylinderLayerData;
+    struct CubeLayerData {
+        // Cube layers are mono and positioned solely by their orientation relative to the layer's space.
+        FrameData::FloatQuaternion orientation;
+    };
+    std::optional<CubeLayerData> cubeLayerData;
 #endif
 };
 

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -324,6 +324,11 @@ header: <WebCore/PlatformXR.h>
 };
 
 header: <WebCore/PlatformXR.h>
+[Nested] struct PlatformXR::DeviceLayer::CubeLayerData {
+    PlatformXR::FrameData::FloatQuaternion orientation;
+};
+
+header: <WebCore/PlatformXR.h>
 [CustomHeader] struct PlatformXR::DeviceLayer {
     PlatformXR::LayerHandle handle;
     bool visible;
@@ -335,6 +340,7 @@ header: <WebCore/PlatformXR.h>
     std::optional<PlatformXR::DeviceLayer::QuadLayerData> quadLayerData;
     std::optional<PlatformXR::DeviceLayer::EquirectLayerData> equirectLayerData;
     std::optional<PlatformXR::DeviceLayer::CylinderLayerData> cylinderLayerData;
+    std::optional<PlatformXR::DeviceLayer::CubeLayerData> cubeLayerData;
 #endif
 };
 #endif
@@ -349,10 +355,12 @@ enum class PlatformXR::CompositionLayerType : uint8_t {
     Quad,
     Equirect,
     Cylinder,
+    Cube,
 };
 
 enum class PlatformXR::LayerLayout : uint8_t {
     Mono,
+    Stereo,
     StereoLeftRight,
     StereoTopBottom,
 };

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -58,6 +58,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRQuadLayer);
 #if defined(XR_KHR_composition_layer_equirect2)
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXREquirectLayer);
 #endif
+#if defined(XR_KHR_composition_layer_cube)
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRCubeLayer);
+#endif
 
 OpenXRLayer::OpenXRLayer(UniqueRef<OpenXRSwapchain>&& swapchain)
     : m_swapchain(WTF::move(swapchain))
@@ -76,18 +79,18 @@ OpenXRLayer::~OpenXRLayer()
 }
 
 #if OS(ANDROID)
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureAndroid(WebCore::GLDisplay& display, PlatformGLObject openxrTexture)
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureAndroid(WebCore::GLDisplay& display, PlatformGLObject openxrTexture, uint32_t width, uint32_t height)
 {
     static constexpr auto kHardwareBufferUsage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER | AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
 
     RefPtr<AHardwareBuffer> hardwareBuffer;
     {
-        RELEASE_ASSERT(m_swapchain->width() > 0);
-        RELEASE_ASSERT(m_swapchain->height() > 0);
+        RELEASE_ASSERT(width > 0);
+        RELEASE_ASSERT(height > 0);
 
         AHardwareBuffer_Desc bufferDesc = { };
-        bufferDesc.width = static_cast<uint32_t>(m_swapchain->width());
-        bufferDesc.height = static_cast<uint32_t>(m_swapchain->height());
+        bufferDesc.width = width;
+        bufferDesc.height = height;
         bufferDesc.usage = kHardwareBufferUsage;
         bufferDesc.layers = 1;
 
@@ -227,7 +230,7 @@ void OpenXRLayer::setGBMDevice(RefPtr<WebCore::GBMDevice> gbmDevice)
     m_gbmDevice = gbmDevice;
 }
 
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureGBM(WebCore::GLDisplay& display, PlatformGLObject openxrTexture)
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureGBM(WebCore::GLDisplay& display, PlatformGLObject openxrTexture, uint32_t width, uint32_t height)
 {
     static constexpr std::array<WebCore::FourCC, 3> preferredAlphaDRMFormats = { DRM_FORMAT_ARGB8888, DRM_FORMAT_RGBA8888, DRM_FORMAT_ABGR8888 };
     static constexpr std::array<WebCore::FourCC, 3> preferredNoAlphaDRMFormats = { DRM_FORMAT_XRGB8888, DRM_FORMAT_RGBX8888, DRM_FORMAT_BGRX8888 };
@@ -249,9 +252,9 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
         return std::nullopt;
     }
 
-    auto* buffer = gbm_bo_create_with_modifiers2(m_gbmDevice->device(), m_swapchain->width(), m_swapchain->height(), format.fourcc.value, format.modifiers.span().data(), format.modifiers.size(), GBM_BO_USE_RENDERING);
+    auto* buffer = gbm_bo_create_with_modifiers2(m_gbmDevice->device(), width, height, format.fourcc.value, format.modifiers.span().data(), format.modifiers.size(), GBM_BO_USE_RENDERING);
     if (!buffer)
-        buffer = gbm_bo_create(m_gbmDevice->device(), m_swapchain->width(), m_swapchain->height(), format.fourcc.value, GBM_BO_USE_RENDERING);
+        buffer = gbm_bo_create(m_gbmDevice->device(), width, height, format.fourcc.value, GBM_BO_USE_RENDERING);
     if (!buffer) {
         RELEASE_LOG(XR, "Failed to allocate GBM buffer for OpenXR texture");
         return std::nullopt;
@@ -319,7 +322,7 @@ void OpenXRLayer::blitTexture() const
 }
 #endif // USE(GBM) || OS(ANDROID)
 
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTexture(PlatformGLObject openxrTexture)
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTexture(PlatformGLObject openxrTexture, uint32_t width, uint32_t height)
 {
     auto* glContext = WebCore::GLContext::current();
     ASSERT(glContext);
@@ -328,7 +331,7 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
     ASSERT(display);
 
 #if OS(ANDROID)
-    return exportOpenXRTextureAndroid(*display, openxrTexture);
+    return exportOpenXRTextureAndroid(*display, openxrTexture, width, height);
 #else
     if (display->extensions().MESA_image_dma_buf_export)
         return exportOpenXRTextureDMABuf(*display, *glContext, openxrTexture);
@@ -336,7 +339,7 @@ std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRT
 
 #if USE(GBM)
     if (m_gbmDevice)
-        return exportOpenXRTextureGBM(*display, openxrTexture);
+        return exportOpenXRTextureGBM(*display, openxrTexture, width, height);
 #endif
 
     RELEASE_LOG(XR, "Failed to export OpenXR texture");
@@ -377,7 +380,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFram
         return layerData;
     m_nextReusableTextureIndex++;
 
-    auto externalTexture = exportOpenXRTexture(*texture);
+    auto externalTexture = exportOpenXRTexture(*texture, m_swapchain->width(), m_swapchain->height());
     if (!externalTexture)
         return std::nullopt;
 
@@ -484,7 +487,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRQuadLayer::startFrame()
         return layerData;
     m_nextReusableTextureIndex++;
 
-    auto externalTexture = exportOpenXRTexture(*texture);
+    auto externalTexture = exportOpenXRTexture(*texture, m_swapchain->width(), m_swapchain->height());
     if (!externalTexture)
         return std::nullopt;
 
@@ -615,7 +618,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXREquirectLayer::startFrame(
         return layerData;
     m_nextReusableTextureIndex++;
 
-    auto externalTexture = exportOpenXRTexture(*texture);
+    auto externalTexture = exportOpenXRTexture(*texture, m_swapchain->width(), m_swapchain->height());
     if (!externalTexture)
         return std::nullopt;
 
@@ -748,7 +751,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRCylinderLayer::startFrame(
         return layerData;
     m_nextReusableTextureIndex++;
 
-    auto externalTexture = exportOpenXRTexture(*texture);
+    auto externalTexture = exportOpenXRTexture(*texture, m_swapchain->width(), m_swapchain->height());
     if (!externalTexture)
         return std::nullopt;
 
@@ -825,6 +828,168 @@ Vector<XrCompositionLayerBaseHeader*> OpenXRCylinderLayer::endFrame(const Platfo
     }
 
     m_swapchain->releaseImage();
+
+    return layerHeaders;
+}
+
+#endif
+
+#if defined(XR_KHR_composition_layer_cube)
+
+std::unique_ptr<OpenXRCubeLayer> OpenXRCubeLayer::create(std::unique_ptr<OpenXRSwapchain>&& swapchain, std::unique_ptr<OpenXRSwapchain>&& rightSwapchain, PlatformXR::LayerLayout layout)
+{
+    return std::unique_ptr<OpenXRCubeLayer>(new OpenXRCubeLayer(makeUniqueRefFromNonNullUniquePtr(WTF::move(swapchain)), WTF::move(rightSwapchain), layout));
+}
+
+OpenXRCubeLayer::OpenXRCubeLayer(UniqueRef<OpenXRSwapchain>&& swapchain, std::unique_ptr<OpenXRSwapchain>&& rightSwapchain, PlatformXR::LayerLayout layout)
+    : OpenXRCompositionLayer(WTF::move(swapchain), layout)
+    , m_rightSwapchain(WTF::move(rightSwapchain))
+{
+    m_layers.resize(cubeCount());
+    m_layers.fill(createOpenXRStruct<XrCompositionLayerCubeKHR, XR_TYPE_COMPOSITION_LAYER_CUBE_KHR>());
+    for (uint32_t cube = 0; cube < cubeCount(); ++cube) {
+        m_layers[cube].swapchain = swapchainForCube(cube).swapchain();
+        m_layers[cube].imageArrayIndex = 0;
+        m_layers[cube].eyeVisibility = cubeCount() == 1 ? XR_EYE_VISIBILITY_BOTH : (!cube ? XR_EYE_VISIBILITY_LEFT : XR_EYE_VISIBILITY_RIGHT);
+    }
+}
+
+OpenXRCubeLayer::~OpenXRCubeLayer()
+{
+    ASSERT(WebCore::GLContext::current());
+    for (auto texture : m_sideBySideTextures.values())
+        glDeleteTextures(1, &texture);
+    if (m_reconstructionFBOs[0])
+        glDeleteFramebuffers(m_reconstructionFBOs.size(), m_reconstructionFBOs.data());
+}
+
+std::optional<PlatformXR::FrameData::LayerData> OpenXRCubeLayer::startFrame()
+{
+    auto texture = m_swapchain->acquireImage();
+    if (!texture)
+        return std::nullopt;
+
+    auto releaseSwapchainImagesOnError = makeScopeExit([&] {
+        m_swapchain->releaseImage();
+        if (m_rightSwapchain)
+            m_rightSwapchain->releaseImage();
+    });
+
+    if (m_rightSwapchain && !m_rightSwapchain->acquireImage())
+        return std::nullopt;
+
+    auto addResult = m_exportedTextures.add(*texture, m_nextReusableTextureIndex);
+    bool needsExport = addResult.isNewEntry;
+
+    PlatformXR::FrameData::LayerData layerData;
+    layerData.renderingFrameIndex = m_renderingFrameIndex++;
+    layerData.textureData = {
+        .reusableTextureIndex = addResult.iterator->value,
+        .colorTexture = { },
+        .depthStencilBuffer = { },
+    };
+
+    if (!needsExport) {
+        releaseSwapchainImagesOnError.release();
+        return layerData;
+    }
+    m_nextReusableTextureIndex++;
+
+    // The WebProcess renders the cube faces into a side-by-side 2D buffer (cubeCount*faceCount faces laid
+    // out horizontally, each face square). This layer reconstructs those into the cubemap swapchain(s).
+    int faceSize = m_swapchain->width();
+    int sideBySideWidth = static_cast<int>(faceCount * cubeCount()) * faceSize;
+    uint32_t width = static_cast<uint32_t>(sideBySideWidth);
+    uint32_t height = static_cast<uint32_t>(faceSize);
+
+    std::optional<PlatformXR::FrameData::ExternalTexture> externalTexture;
+    PlatformGLObject sideBySideTexture = 0;
+#if OS(ANDROID)
+    externalTexture = exportOpenXRTexture(*texture, width, height);
+    if (externalTexture)
+        sideBySideTexture = m_exportedTexturesMap.take(*texture);
+#else
+    GLint boundTexture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
+    glGenTextures(1, &sideBySideTexture);
+    glBindTexture(GL_TEXTURE_2D, sideBySideTexture);
+    glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, sideBySideWidth, faceSize);
+    glBindTexture(GL_TEXTURE_2D, boundTexture);
+    externalTexture = exportOpenXRTexture(sideBySideTexture, width, height);
+#endif
+    if (!externalTexture || !sideBySideTexture)
+        return std::nullopt;
+
+    m_sideBySideTextures.set(*texture, sideBySideTexture);
+    layerData.textureData->colorTexture = WTF::move(externalTexture.value());
+    layerData.layerSetup = {
+        .physicalSize = { { { static_cast<uint16_t>(sideBySideWidth), static_cast<uint16_t>(faceSize) } } },
+        .viewports = { },
+        .foveationRateMapDesc = { }
+    };
+
+    releaseSwapchainImagesOnError.release();
+    return layerData;
+}
+
+void OpenXRCubeLayer::reconstructCubeFaces()
+{
+    auto sideBySideTexture = m_sideBySideTextures.get(m_swapchain->acquiredTexture());
+    if (!sideBySideTexture)
+        return;
+
+    if (!m_reconstructionFBOs[0])
+        glGenFramebuffers(m_reconstructionFBOs.size(), m_reconstructionFBOs.data());
+
+    int faceSize = m_swapchain->width();
+
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_reconstructionFBOs[0]);
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, sideBySideTexture, 0);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_reconstructionFBOs[1]);
+
+    // Region (cube*faceCount + face) maps to GL_TEXTURE_CUBE_MAP_POSITIVE_X + face of that cube's swapchain;
+    // same ordering as the WebProcess blit.
+    // FIXME: face winding/orientation may need adjustment once validated against a runtime.
+    for (uint32_t cube = 0; cube < cubeCount(); ++cube) {
+        auto cubeTexture = swapchainForCube(cube).acquiredTexture();
+        if (!cubeTexture)
+            continue;
+        for (uint32_t face = 0; face < faceCount; ++face) {
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, cubeTexture, 0);
+            int srcX = static_cast<int>(cube * faceCount + face) * faceSize;
+            glBlitFramebuffer(srcX, 0, srcX + faceSize, faceSize, 0, 0, faceSize, faceSize, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        }
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+Vector<XrCompositionLayerBaseHeader*> OpenXRCubeLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>&)
+{
+    ASSERT(m_swapchain->acquiredTexture());
+
+    reconstructCubeFaces();
+
+    auto flags = layer.blendTextureSourceAlpha ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
+    XrQuaternionf orientation { 0, 0, 0, 1 };
+    ASSERT(layer.cubeLayerData);
+    if (layer.cubeLayerData) {
+        auto& cubeOrientation = layer.cubeLayerData->orientation;
+        orientation = { cubeOrientation.x, cubeOrientation.y, cubeOrientation.z, cubeOrientation.w };
+    }
+
+    Vector<XrCompositionLayerBaseHeader*> layerHeaders;
+    layerHeaders.reserveCapacity(m_layers.size());
+    for (auto& xrLayer : m_layers) {
+        xrLayer.layerFlags = flags;
+        xrLayer.space = space;
+        xrLayer.orientation = orientation;
+        layerHeaders.append(reinterpret_cast<XrCompositionLayerBaseHeader*>(&xrLayer));
+    }
+
+    m_swapchain->releaseImage();
+    if (m_rightSwapchain)
+        m_rightSwapchain->releaseImage();
 
     return layerHeaders;
 }

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -54,18 +54,18 @@ public:
 protected:
     OpenXRLayer(UniqueRef<OpenXRSwapchain>&&);
 #if OS(ANDROID)
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureAndroid(WebCore::GLDisplay&, PlatformGLObject);
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureAndroid(WebCore::GLDisplay&, PlatformGLObject, uint32_t width, uint32_t height);
     void blitTexture() const;
     inline bool needsBlitTexture() const { return true; }
 #else
     std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureDMABuf(WebCore::GLDisplay&, WebCore::GLContext&, PlatformGLObject);
 #endif
 #if USE(GBM)
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureGBM(WebCore::GLDisplay&, PlatformGLObject);
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureGBM(WebCore::GLDisplay&, PlatformGLObject, uint32_t width, uint32_t height);
     void blitTexture() const;
     inline bool needsBlitTexture() const { return m_gbmDevice; }
 #endif
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTexture(PlatformGLObject);
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTexture(PlatformGLObject, uint32_t width, uint32_t height);
 
     UniqueRef<OpenXRSwapchain> m_swapchain;
 
@@ -159,6 +159,38 @@ private:
     explicit OpenXRCylinderLayer(UniqueRef<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
 
     Vector<XrCompositionLayerCylinderKHR> m_layers;
+};
+#endif
+
+#if defined(XR_KHR_composition_layer_cube)
+// The OpenXR cube swapchain is a cubemap (faceCount=6) that cannot be shared cross-process as a 2D DMABuf,
+// so the WebProcess renders into a side-by-side 2D buffer (cubeCount*6 faces laid out horizontally) which
+// this layer reconstructs into the cubemap swapchain(s) each frame. Stereo uses one cube swapchain per eye.
+class OpenXRCubeLayer final : public OpenXRCompositionLayer {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRCubeLayer);
+    WTF_MAKE_NONCOPYABLE(OpenXRCubeLayer);
+public:
+    static std::unique_ptr<OpenXRCubeLayer> create(std::unique_ptr<OpenXRSwapchain>&&, std::unique_ptr<OpenXRSwapchain>&& rightSwapchain, PlatformXR::LayerLayout);
+    ~OpenXRCubeLayer();
+
+    std::optional<PlatformXR::FrameData::LayerData> startFrame() override;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
+
+private:
+    OpenXRCubeLayer(UniqueRef<OpenXRSwapchain>&&, std::unique_ptr<OpenXRSwapchain>&& rightSwapchain, PlatformXR::LayerLayout);
+
+    void reconstructCubeFaces();
+    uint32_t cubeCount() const { return m_layout == PlatformXR::LayerLayout::Mono ? 1 : 2; }
+    OpenXRSwapchain& swapchainForCube(uint32_t cube) { return cube && m_rightSwapchain ? *m_rightSwapchain : m_swapchain.get(); }
+
+    static constexpr uint32_t faceCount = 6;
+
+    Vector<XrCompositionLayerCubeKHR> m_layers;
+    std::unique_ptr<OpenXRSwapchain> m_rightSwapchain;
+    // One side-by-side buffer per swapchain image (keyed by the image), so the WebProcess and the
+    // reconstruction don't read/write the same buffer concurrently. Mirrors the per-image reuse of other layers.
+    HashMap<PlatformGLObject, PlatformGLObject> m_sideBySideTextures;
+    std::array<PlatformGLObject, 2> m_reconstructionFBOs { 0, 0 };
 };
 #endif
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp
@@ -31,7 +31,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRSwapchain);
 std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrSession session, const XrSwapchainCreateInfo& info, HasAlpha hasAlpha)
 {
     ASSERT(session != XR_NULL_HANDLE);
-    ASSERT(info.faceCount == 1);
+    // faceCount is 1 for regular swapchains and 6 for cube (cubemap) swapchains.
+    ASSERT(info.faceCount == 1 || info.faceCount == 6);
 
     XrSwapchain swapchain { XR_NULL_HANDLE };
     CHECK_XRCMD(xrCreateSwapchain(session, &info, &swapchain));

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -188,7 +188,7 @@ bool OpenXRCoordinator::collectSwapchainFormatsIfNeeded()
     return true;
 }
 
-std::unique_ptr<OpenXRSwapchain> OpenXRCoordinator::createSwapchain(uint32_t width, uint32_t height, bool alpha) const
+std::unique_ptr<OpenXRSwapchain> OpenXRCoordinator::createSwapchain(uint32_t width, uint32_t height, bool alpha, uint32_t faceCount) const
 {
     // Even if alpha is false we always ask for the RGBA8 format, as the DRM_FORMAT_RGB8 is not supported by ANGLE.
     // In this case we ignore the alpha channel by using DRM_FORMAT_XRGB8888 when exporting the texture.
@@ -202,7 +202,7 @@ std::unique_ptr<OpenXRSwapchain> OpenXRCoordinator::createSwapchain(uint32_t wid
     info.width = width;
     info.height = height;
     info.mipCount = 1;
-    info.faceCount = 1;
+    info.faceCount = faceCount;
     info.sampleCount = sampleCount;
     info.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
 
@@ -267,6 +267,20 @@ void OpenXRCoordinator::createCompositionLayer(PlatformXR::CompositionLayerType 
 #endif
     }
 
+    if (type == PlatformXR::CompositionLayerType::Cube) {
+#if !defined(XR_KHR_composition_layer_cube)
+        RELEASE_LOG(XR, "OpenXRCoordinator: cube layer not supported (XR_KHR_composition_layer_cube not defined)");
+        reply(std::nullopt);
+        return;
+#else
+        if (!OpenXRExtensions::singleton().isExtensionSupported(XR_KHR_COMPOSITION_LAYER_CUBE_EXTENSION_NAME ""_span)) {
+            RELEASE_LOG(XR, "OpenXRCoordinator: cube layer extension not supported");
+            reply(std::nullopt);
+            return;
+        }
+#endif
+    }
+
     WTF::switchOn(m_state,
         [&](Idle&) { reply(std::nullopt); },
         [&](Active& active) {
@@ -280,7 +294,8 @@ void OpenXRCoordinator::createCompositionLayer(PlatformXR::CompositionLayerType 
                 }
 
                 bool alpha = false;
-                auto swapchain = createSwapchain(size.width(), size.height(), alpha);
+                uint32_t faceCount = type == PlatformXR::CompositionLayerType::Cube ? 6 : 1;
+                auto swapchain = createSwapchain(size.width(), size.height(), alpha, faceCount);
                 if (!swapchain) {
                     RELEASE_LOG(XR, "OpenXRCoordinator: failed to create swapchain");
                     callOnMainRunLoop([completion = WTF::move(completionHandler)] mutable {
@@ -304,6 +319,15 @@ void OpenXRCoordinator::createCompositionLayer(PlatformXR::CompositionLayerType 
                 case PlatformXR::CompositionLayerType::Cylinder:
 #if defined(XR_KHR_composition_layer_cylinder)
                     layer = OpenXRCylinderLayer::create(WTF::move(swapchain), layout);
+#endif
+                    break;
+                case PlatformXR::CompositionLayerType::Cube:
+#if defined(XR_KHR_composition_layer_cube)
+                    ASSERT(layout == PlatformXR::LayerLayout::Mono || layout == PlatformXR::LayerLayout::Stereo);
+                    if (layout == PlatformXR::LayerLayout::Mono)
+                        layer = OpenXRCubeLayer::create(WTF::move(swapchain), nullptr, layout);
+                    else if (auto rightSwapchain = createSwapchain(size.width(), size.height(), alpha, faceCount))
+                        layer = OpenXRCubeLayer::create(WTF::move(swapchain), WTF::move(rightSwapchain), layout);
 #endif
                     break;
                 }
@@ -680,6 +704,10 @@ void OpenXRCoordinator::createInstance()
 #if defined(XR_KHR_composition_layer_cylinder)
     if (OpenXRExtensions::singleton().isExtensionSupported(XR_KHR_COMPOSITION_LAYER_CYLINDER_EXTENSION_NAME ""_span))
         extensions.append(const_cast<char*>(XR_KHR_COMPOSITION_LAYER_CYLINDER_EXTENSION_NAME));
+#endif
+#if defined(XR_KHR_composition_layer_cube)
+    if (OpenXRExtensions::singleton().isExtensionSupported(XR_KHR_COMPOSITION_LAYER_CUBE_EXTENSION_NAME ""_span))
+        extensions.append(const_cast<char*>(XR_KHR_COMPOSITION_LAYER_CUBE_EXTENSION_NAME));
 #endif
 
     XrInstanceCreateInfo createInfo = createOpenXRStruct<XrInstanceCreateInfo, XR_TYPE_INSTANCE_CREATE_INFO >();

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -102,7 +102,7 @@ private:
     bool collectSwapchainFormatsIfNeeded();
     enum class PollResult : bool;
     PollResult pollEvents();
-    std::unique_ptr<OpenXRSwapchain> createSwapchain(uint32_t width, uint32_t height, bool alpha) const;
+    std::unique_ptr<OpenXRSwapchain> createSwapchain(uint32_t width, uint32_t height, bool alpha, uint32_t faceCount = 1) const;
     void createReferenceSpacesIfNeeded(Box<RenderState>);
 #if ENABLE(WEBXR_HIT_TEST)
     XrSpace spaceForHitTest(const PlatformXR::NativeOriginInformation&) const;


### PR DESCRIPTION
#### bccc4656ae3a49244121bd612f08e5dacff7ac64
<pre>
[WebXR Layers] Implement Cube layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=317134">https://bugs.webkit.org/show_bug.cgi?id=317134</a>

Reviewed by Dan Glastonbury.

This implements the required changes to create cube layers on UIProcess
side and share them with the WebProcess so that web authors could use
them in their WebXR experiences.

Both mono and stereo cube layers are supported. This commit also
provides support for cube layers implemented with texture arrays.

This adds the platform implementation using OpenXR via the
XR_KHR_composition_layer_cube extension.

The cube layer is a bit special because it does not use regular textures
but texture cube maps. Those cannot be shared via DMABuf so we have to
&quot;serialize&quot; the faces of the cube in large side by side regular
textures. What&apos;s more, two texture cube maps cannot be concatenated as
we do with quad layers for example for the stereo case. We need to
create two different cube maps, and that requires slight changes to the
current code. In that sense this layer is a bit different to other
composition layers.

Cube layers can be backed by texture arrays too. In that case we need to
create a texture array with 6 slices or with 12 for the stereo case as
described by specs.

There are several similarities between the texture arrays and the
texture cube maps, both are composed by multiple slices/faces. That&apos;s
why we decided to generalize that common behaviour in a new abstract
MultiTextureSwapchain which is the new parent of the texture array
swapchain and also the cube swapchain.

* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::WebXRWebGLLayer::endFrame):
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp:
(WebCore::WebXRWebGLStaticImageSwapchain::currentTexture):
(WebCore::WebXRWebGLStaticImageSwapchain::currentTextureAtIndex):
(WebCore::WebXRWebGLStaticImageSwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLStaticImageSwapchain::clearTextureRegion):
(WebCore::WebXRWebGLStaticImageSwapchain::allTexturesAreBound const):
(WebCore::WebXRWebGLMultiTextureSwapchain::WebXRWebGLMultiTextureSwapchain):
(WebCore::WebXRWebGLMultiTextureSwapchain::~WebXRWebGLMultiTextureSwapchain):
(WebCore::WebXRWebGLMultiTextureSwapchain::TextureSet::release):
(WebCore::WebXRWebGLMultiTextureSwapchain::TextureSet::leakObject):
(WebCore::WebXRWebGLMultiTextureSwapchain::currentTexture):
(WebCore::WebXRWebGLMultiTextureSwapchain::currentTextureAtIndex):
(WebCore::WebXRWebGLMultiTextureSwapchain::releaseTexturesAtIndex):
(WebCore::WebXRWebGLMultiTextureSwapchain::reusableTextures const):
(WebCore::WebXRWebGLMultiTextureSwapchain::startFrame):
(WebCore::WebXRWebGLMultiTextureSwapchain::endFrame):
(WebCore::WebXRWebGLMultiTextureSwapchain::allTexturesAreBound const):
(WebCore::WebXRWebGLTextureArraySwapchain::create):
(WebCore::WebXRWebGLTextureArraySwapchain::WebXRWebGLTextureArraySwapchain):
(WebCore::WebXRWebGLTextureArraySwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLTextureArraySwapchain::blitToSharedImage):
(WebCore::WebXRWebGLCubeSwapchain::create):
(WebCore::WebXRWebGLCubeSwapchain::WebXRWebGLCubeSwapchain):
(WebCore::WebXRWebGLCubeSwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLCubeSwapchain::blitToSharedImage):
(WebCore::WebXRWebGLCubeSwapchain::clearTextureRegion):
(WebCore::WebXRWebGLTextureArraySwapchain::~WebXRWebGLTextureArraySwapchain): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::TextureSet::release): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::TextureSet::leakObject): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::currentTexture): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::releaseTexturesAtIndex): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::reusableTextures const): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::startFrame): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::endFrame): Deleted.
(WebCore::WebXRWebGLTextureArraySwapchain::allTexturesAreBound const): Deleted.
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h:
(WebCore::WebXRWebGLSwapchain::currentTextureAtIndex):
(WebCore::WebXRWebGLMultiTextureSwapchain::TextureSet::operator bool const):
* Source/WebCore/Modules/webxr/XRCubeLayer.cpp:
(WebCore::XRCubeLayer::XRCubeLayer):
(WebCore::XRCubeLayer::setOrientation):
(WebCore::XRCubeLayer::fillInTypeSpecificDeviceLayerData const):
* Source/WebCore/Modules/webxr/XRCubeLayer.h:
(WebCore::XRCubeLayer::create):
(WebCore::XRCubeLayer::orientation const):
(WebCore::XRCubeLayer::space const): Deleted.
(WebCore::XRCubeLayer::setSpace): Deleted.
(WebCore::XRCubeLayer::setOrientation): Deleted.
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::allocateColorTexturesForLayer):
(WebCore::XRWebGLBinding::allocateDepthTexturesForLayer):
(WebCore::XRWebGLBinding::createCubeLayer):
(WebCore::XRWebGLBinding::getSubImage):
* Source/WebCore/Modules/webxr/XRWebGLBinding.h:
(WebCore::XRWebGLBinding::createCubeLayer): Deleted.
* Source/WebCore/Modules/webxr/XRWebGLBinding.idl:
* Source/WebCore/Modules/webxr/XRWebGLCubeLayerBacking.cpp: Copied from Source/WebCore/Modules/webxr/XRCubeLayer.h.
(WebCore::XRWebGLCubeLayerBacking::create):
(WebCore::XRWebGLCubeLayerBacking::XRWebGLCubeLayerBacking):
* Source/WebCore/Modules/webxr/XRWebGLCubeLayerBacking.h: Copied from Source/WebCore/Modules/webxr/XRCubeLayer.cpp.
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp:
(WebCore::XRWebGLLayerBacking::currentColorTexture const):
(WebCore::XRWebGLLayerBacking::requiresPerViewColorTextures const):
(WebCore::XRWebGLLayerBacking::currentDepthTexture const):
(WebCore::XRWebGLLayerBacking::createCompositionLayerSwapchains):
(WebCore::XRWebGLLayerBacking::createColorAndDepthSwapchains):
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h:
* Source/WebCore/Modules/webxr/XRWebGLSubImage.cpp:
(WebCore::XRWebGLSubImage::create):
* Source/WebCore/Modules/webxr/XRWebGLSubImage.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensionsImpl):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::enableRequiredWebXRExtensions):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
(WebKit::OpenXRLayer::exportOpenXRTextureAndroid):
(WebKit::OpenXRLayer::exportOpenXRTexture):
(WebKit::OpenXRCubeLayer::create):
(WebKit::OpenXRCubeLayer::OpenXRCubeLayer):
(WebKit::OpenXRCubeLayer::~OpenXRCubeLayer):
(WebKit::OpenXRCubeLayer::startFrame):
(WebKit::OpenXRCubeLayer::reconstructCubeFaces):
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h:
* Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp:
(WebKit::OpenXRSwapchain::create):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::createSwapchain const):
(WebKit::OpenXRCoordinator::createCompositionLayer):
(WebKit::OpenXRCoordinator::createInstance):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/315665@main">https://commits.webkit.org/315665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e838bdb5d9dc049ffcb07b5c7bd357d519e221b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127423 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171577 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43262 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172670 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112761 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27767 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181669 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34377 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43289 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140539 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37827 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43978 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108240 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/35808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115743 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42489 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7114 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->