### PR TITLE
AX: Relations are never built for elements that gain a relation attribute via innerHTML or before having an AX object

### DIFF
--- a/LayoutTests/accessibility/aria-labelledby-added-via-innerHTML-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-added-via-innerHTML-expected.txt
@@ -1,0 +1,8 @@
+This test checks that a relation resolves once its aria-labelledby target is inserted via innerHTML after the initial relations build.
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+fallback name
+the resolved label

--- a/LayoutTests/accessibility/aria-labelledby-added-via-innerHTML.html
+++ b/LayoutTests/accessibility/aria-labelledby-added-via-innerHTML.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- #label does not exist initially, which is key to reproducing the bug. -->
+<div id="host"></div>
+
+<script>
+let output = "This test checks that a relation resolves once its aria-labelledby target is inserted via innerHTML after the initial relations build.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // 1. Force the initial relations build by calling titleUIElement().
+    accessibilityController.rootElement.titleUIElement();
+
+    var source, label;
+    setTimeout(async function() {
+        // 2. Now insert #label via innerHTML (this is important for triggering the bug).
+        document.getElementById("host").innerHTML = "<button id='source' aria-labelledby='label'>fallback name</button><p id='label'>the resolved label</p>";
+
+        // 3. The source's titleUIElement should now resolve to the inserted #label target.
+        await waitFor(() => {
+            source = accessibilityController.accessibleElementById("source");
+            label = accessibilityController.accessibleElementById("label");
+            return source && label && label.isEqual(source.titleUIElement());
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3513,10 +3513,8 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     // The remaining code in this method relies on shouldProcessAttributeChange null-checking element.
     AX_ASSERT(element);
 
-    if (relationAttributes().contains(attrName)) {
-        m_elementsWithRelationAttributes.add(*element);
+    if (isRelationAttribute(attrName))
         updateRelations(*element, attrName);
-    }
 
     if (attrName == hrefAttr) {
         // An anchor's role depends on whether it is a link (Element::isLink(), i.e. whether it has an
@@ -6206,6 +6204,7 @@ AXTreeData AXObjectCache::treeData(std::optional<OptionSet<AXStreamOptions>> add
 
 Vector<QualifiedName>& AXObjectCache::relationAttributes()
 {
+    // Keep this list in sync with the switch in isRelationAttribute().
     static NeverDestroyed<Vector<QualifiedName>> relationAttributes = Vector<QualifiedName> {
         aria_actionsAttr,
         aria_activedescendantAttr,
@@ -6222,6 +6221,30 @@ Vector<QualifiedName>& AXObjectCache::relationAttributes()
         popovertargetAttr,
     };
     return relationAttributes;
+}
+
+bool AXObjectCache::isRelationAttribute(const QualifiedName& attribute)
+{
+    // A faster equivalent of relationAttributes().contains(attribute) for the DOM-mutation hot
+    // path (Element::attributeChanged). Keep this in sync with the list in relationAttributes().
+    switch (attribute.nodeName()) {
+    case AttributeNames::aria_actionsAttr:
+    case AttributeNames::aria_activedescendantAttr:
+    case AttributeNames::aria_controlsAttr:
+    case AttributeNames::aria_describedbyAttr:
+    case AttributeNames::aria_detailsAttr:
+    case AttributeNames::aria_errormessageAttr:
+    case AttributeNames::aria_flowtoAttr:
+    case AttributeNames::aria_labelledbyAttr:
+    case AttributeNames::aria_labeledbyAttr:
+    case AttributeNames::aria_ownsAttr:
+    case AttributeNames::commandforAttr:
+    case AttributeNames::headersAttr:
+    case AttributeNames::popovertargetAttr:
+        return true;
+    default:
+        return false;
+    }
 }
 
 AXRelation AXObjectCache::symmetricRelation(AXRelation relation)
@@ -6571,6 +6594,18 @@ void AXObjectCache::updateRelationsForTree(ContainerNode& rootNode)
         if (hasRelationAttribute || is<HTMLLabelElement>(element.get()))
             m_elementsWithRelationAttributes.add(element);
     }
+}
+
+void AXObjectCache::trackRelationAttributeElement(Element& element)
+{
+    // This runs synchronously during DOM mutation and parsing, so it must not
+    // resolve relations or touch layout.
+    if (!canHaveRelations(element))
+        return;
+    m_elementsWithRelationAttributes.add(element);
+
+    if (!m_relationsNeedUpdate)
+        relationsNeedUpdate(true);
 }
 
 bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -529,6 +529,12 @@ public:
     Node* modalNode();
 
     void deferAttributeChangeIfNeeded(Element&, const QualifiedName&, const AtomString&, const AtomString&);
+
+    // True for the attributes in relationAttributes() (aria-labelledby, aria-owns, etc.).
+    static bool isRelationAttribute(const QualifiedName&);
+    // Records that an element carries a relation attribute so the next relations rebuild includes it.
+    void trackRelationAttributeElement(Element&);
+
     void recomputeIsIgnored(RenderObject&);
     void recomputeIsIgnored(Node*);
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2440,6 +2440,8 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
             if (auto* map = explicitlySetAttrElementsMapIfExists())
                 map->remove(name);
         }
+        if (CheckedPtr cache = document->existingAXObjectCache(); cache && AXObjectCache::isRelationAttribute(name))
+            cache->trackRelationAttributeElement(*this);
         break;
     }
     }


### PR DESCRIPTION
#### 7c45c234f6ac9cdb41cf2f1716fe7c4100e4cacf
<pre>
AX: Relations are never built for elements that gain a relation attribute via innerHTML or before having an AX object
<a href="https://bugs.webkit.org/show_bug.cgi?id=317136">https://bugs.webkit.org/show_bug.cgi?id=317136</a>
<a href="https://rdar.apple.com/179732590">rdar://179732590</a>

Reviewed by Chris Fleizach and Dominic Mazzoni.

312262@main changed updateRelationsIfNeeded() from walking the entire DOM on
every rebuild to doing a one-time full-DOM build and thereafter re-walking
only m_elementsWithRelationAttributes. That set was populated only
from handleAttributeChange(), which is gated by shouldProcessAttributeChange()
and so requires an AX object to already exist, and from &lt;label&gt; insertions.

As a result, an element that acquires a relation attribute (aria-labelledby,
aria-owns, etc.) without going through handleAttributeChange() with an AX
object was never added to the set, and after the initial build its relations
were never rebuilt. This happens for:
- parser-/innerHTML-created elements
- cloneNode()
- setAttribute() on an element that has no AX object yet (the common case for
  lazily/virtualized-rendered content).

Fix by tracking relation-attribute elements at Element::attributeChanged(), the
single chokepoint reached on every mutation path (parser/innerHTML, cloneNode,
and script setAttribute) regardless of whether an AX object exists yet.

* LayoutTests/accessibility/aria-labelledby-added-via-innerHTML-expected.txt: Added.
* LayoutTests/accessibility/aria-labelledby-added-via-innerHTML.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::isRelationAttribute):
(WebCore::AXObjectCache::trackRelationAttributeElement):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/315281@main">https://commits.webkit.org/315281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cc7004799c81def82463c42f1c6d513af30befc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126283 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69c7eba9-eadf-442b-bf83-62b3053ba166) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131228 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86644f93-f5e3-4e90-b9c4-e33b24ff8166) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111739 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b2a228f-7cea-496f-a3bb-f11f00eb6767) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31377 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26603 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180507 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139676 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139530 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37573 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106506 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34809 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114595 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41339 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5963 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->