### PR TITLE
1D textureSampleLevel was not supported

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1823,6 +1823,7 @@ static void emitTextureSampleGrad(FunctionDefinitionWriter* writer, AST::CallExp
 static void emitTextureSampleLevel(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
     bool isArray = false;
+    bool is1d = false;
     auto& texture = call.arguments()[0];
     if (auto* textureType = std::get_if<Types::Texture>(texture.inferredType())) {
         switch (textureType->kind) {
@@ -1831,6 +1832,8 @@ static void emitTextureSampleLevel(FunctionDefinitionWriter* writer, AST::CallEx
             isArray = true;
             break;
         case Types::Texture::Kind::Texture1d:
+            is1d = true;
+            break;
         case Types::Texture::Kind::Texture2d:
         case Types::Texture::Kind::Texture3d:
         case Types::Texture::Kind::TextureCube:
@@ -1843,6 +1846,8 @@ static void emitTextureSampleLevel(FunctionDefinitionWriter* writer, AST::CallEx
             isArray = true;
             break;
         case Types::TextureStorage::Kind::TextureStorage1d:
+            is1d = true;
+            break;
         case Types::TextureStorage::Kind::TextureStorage2d:
         case Types::TextureStorage::Kind::TextureStorage3d:
             break;
@@ -1869,9 +1874,11 @@ static void emitTextureSampleLevel(FunctionDefinitionWriter* writer, AST::CallEx
             writer->stringBuilder().append(',');
         writer->visit(call.arguments()[i]);
     }
-    writer->stringBuilder().append(", level("_s);
-    writer->visit(call.arguments()[levelIndex]);
-    writer->stringBuilder().append(')');
+    if (!is1d) {
+        writer->stringBuilder().append(", level("_s);
+        writer->visit(call.arguments()[levelIndex]);
+        writer->stringBuilder().append(')');
+    }
     for (unsigned i = levelIndex + 1; i < call.arguments().size(); ++i) {
         writer->stringBuilder().append(',');
         writer->visit(call.arguments()[i]);

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -1314,6 +1314,8 @@ function :textureSampleGrad, {
 function :textureSampleLevel, {
     must_use: true,
 
+    [].(texture_1d[f32], sampler, f32, f32) => vec4[f32],
+
     [].(texture_2d[f32], sampler, vec2[f32], f32) => vec4[f32],
 
     [].(texture_2d[f32], sampler, vec2[f32], f32, vec2[i32]) => vec4[f32],

--- a/Tools/TestWebKitAPI/Tests/WGSL/shaders/overload.wgsl
+++ b/Tools/TestWebKitAPI/Tests/WGSL/shaders/overload.wgsl
@@ -4577,6 +4577,9 @@ fn testTextureSampleGrad()
 @compute @workgroup_size(1)
 fn testTextureSampleLevel()
 {
+    // [].(Texture[F32, Texture1d], Sampler, F32, F32) => Vector[F32, 4],
+    _ = textureSampleLevel(t1d, s, 0, 0);
+
     // [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32) => Vector[F32, 4],
     _ = textureSampleLevel(t2d, s, vec2f(0), 0);
 


### PR DESCRIPTION
#### 5b1956e908ba88b7cfc5b6bb61588a3e977ed636
<pre>
1D textureSampleLevel was not supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=316293">https://bugs.webkit.org/show_bug.cgi?id=316293</a>
<a href="https://rdar.apple.com/179334632">rdar://179334632</a>

Reviewed by Tadeu Zagallo and Dan Glastonbury.

Add support for 1D textureSampleLevel calls, which is required
by the specification.

Test: Tools/TestWebKitAPI/Tests/WGSL/shaders/overload.wgsl

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitTextureSampleLevel):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Tools/TestWebKitAPI/Tests/WGSL/shaders/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/315278@main">https://commits.webkit.org/315278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5752161af18a9191e44d9cca8485c277b0729617

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126176 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5479341f-f518-4f7f-a8da-638146fb2c36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131132 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92224 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fd1265c-f964-4438-a591-cc8b280b20d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111643 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e9eeb2f-1b95-46c5-80b2-73e3fd5a30e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32578 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31278 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26499 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142564 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180403 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33127 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139569 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37571 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42732 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106384 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34719 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27779 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41236 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114492 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40633 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5862 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->