### PR TITLE
Use protect() instead of Ref { } in SVG animation and graphics code

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3662,6 +3662,7 @@ svg/graphics/SVGImage.cpp @header:RenderStyleGetters
 svg/graphics/SVGImageCache.cpp
 svg/graphics/SVGImageForContainer.cpp
 svg/graphics/SVGResourceImage.cpp
+svg/graphics/filters/SVGFilterPrimitiveGraph.cpp
 svg/graphics/filters/SVGFilterRenderer.cpp
 svg/properties/SVGAnimatedPropertyBase.cpp
 svg/properties/SVGAnimatedString.cpp

--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -254,7 +254,7 @@ void SMILTimeContainer::processScheduledAnimations(NOESCAPE const Function<void(
 {
     for (auto& animations : copyToVector(m_scheduledAnimations.values())) {
         for (auto& weakAnimation : animations)
-            callback(Ref { weakAnimation.get() });
+            callback(protect(weakAnimation));
     }
 }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -636,7 +636,7 @@ void SVGSMILElement::disconnectConditions()
             // our condition event listener, in case it later fires.
             RefPtr eventBase = eventBaseFor(condition);
             if (eventBase)
-                eventBase->removeEventListener(condition.m_name, Ref { *condition.m_eventListener }, { .capture = false });
+                eventBase->removeEventListener(condition.m_name, protect(*condition.m_eventListener), { .capture = false });
             protect(condition.m_eventListener)->disconnectAnimation();
             condition.m_eventListener = nullptr;
         } else if (condition.m_type == Condition::Syncbase) {

--- a/Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h
@@ -39,8 +39,8 @@ public:
         m_sourceNodes.add(SourceGraphic::effectName(), WTF::move(sourceGraphic));
         m_sourceNodes.add(SourceAlpha::effectName(), WTF::move(sourceAlpha));
 
-        setNodeInputs(Ref { *this->sourceGraphic() }, NodeVector { });
-        setNodeInputs(Ref { *this->sourceAlpha() }, NodeVector { *this->sourceGraphic() });
+        setNodeInputs(protect(*this->sourceGraphic()), NodeVector { });
+        setNodeInputs(protect(*this->sourceAlpha()), NodeVector { *this->sourceGraphic() });
     }
 
     void addNamedNode(const AtomString& name, Ref<FilterEffect>&& node) override
@@ -54,7 +54,7 @@ public:
             return;
 
         m_lastNode = WTF::move(node);
-        m_namedNodes.set(name, Ref { *m_lastNode });
+        m_namedNodes.set(name, protect(*m_lastNode));
     }
 
 private:

--- a/Source/WebCore/svg/graphics/filters/SVGFilterPrimitiveGraph.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterPrimitiveGraph.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SVGFilterPrimitiveGraph.h"
+
+#include "SVGFilterPrimitiveStandardAttributes.h"
+
+namespace WebCore {
+
+void SVGFilterPrimitiveGraph::addNamedNode(const AtomString& name, Ref<SVGFilterPrimitiveStandardAttributes>&& node)
+{
+    if (name.isEmpty()) {
+        m_lastNode = WTF::move(node);
+        return;
+    }
+
+    m_lastNode = WTF::move(node);
+    m_namedNodes.set(name, protect(*m_lastNode));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/svg/graphics/filters/SVGFilterPrimitiveGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterPrimitiveGraph.h
@@ -36,16 +36,7 @@ class SVGFilterPrimitiveGraph final : public SVGFilterGraph<SVGFilterPrimitiveSt
 public:
     SVGFilterPrimitiveGraph() = default;
 
-    void addNamedNode(const AtomString& name, Ref<SVGFilterPrimitiveStandardAttributes>&& node) override
-    {
-        if (name.isEmpty()) {
-            m_lastNode = WTF::move(node);
-            return;
-        }
-
-        m_lastNode = WTF::move(node);
-        m_namedNodes.set(name, Ref { *m_lastNode });
-    }
+    void addNamedNode(const AtomString& name, Ref<SVGFilterPrimitiveStandardAttributes>&& node) override;
 
 private:
     RefPtr<SVGFilterPrimitiveStandardAttributes> getNamedNode(const AtomString& name) const override

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -354,7 +354,7 @@ RefPtr<FilterImage> SVGFilterRenderer::apply(FilterImage* sourceImage, FilterRes
                 return nullptr;
 
             // Add sourceImage as an input to the SourceGraphic.
-            stack.append(Ref { *sourceImage });
+            stack.append(protect(*sourceImage));
         }
 
         // Need to remove the inputs here in case the effect already has a result.


### PR DESCRIPTION
#### 144a04f29f5bbd9dd230d9cd89ccfc39c467bcbd
<pre>
Use protect() instead of Ref { } in SVG animation and graphics code
<a href="https://bugs.webkit.org/show_bug.cgi?id=317146">https://bugs.webkit.org/show_bug.cgi?id=317146</a>
<a href="https://rdar.apple.com/179744332">rdar://179744332</a>

Reviewed by Anne van Kesteren.

Mechanical migration from brace-initialized Ref temporaries to the protect()
free function in Source/WebCore/svg/animation/ and Source/WebCore/svg/graphics/,
aligning with the codebase-wide transition.

All 7 instances are function arguments. In SVGFilterPrimitiveGraph.h, the
forward declaration of SVGFilterPrimitiveStandardAttributes is replaced with
a full include so that protect() can resolve the type.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::processScheduledAnimations):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::disconnectConditions):
* Source/WebCore/svg/graphics/filters/SVGFilterEffectGraph.h:
(WebCore::SVGFilterEffectGraph::SVGFilterEffectGraph):
(WebCore::SVGFilterEffectGraph::addNamedNode):
* Source/WebCore/svg/graphics/filters/SVGFilterPrimitiveGraph.h:
(WebCore::SVGFilterPrimitiveGraph::addNamedNode):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::SVGFilterRenderer::apply):

Canonical link: <a href="https://commits.webkit.org/316370@main">https://commits.webkit.org/316370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/009731c88c695f60fefe6a1f5338484187b942ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128540 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b6a8900-4217-45df-ae04-45342e79c36e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133238 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94029 "1 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91b40052-d5e7-4cf2-a363-7c5ae047150e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113726 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a1dbaaa-11ed-420d-a4ca-827f114b3aa2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35081 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33397 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28883 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182789 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141701 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44406 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38472 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45880 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109800 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37277 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116986 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43606 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8164 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43252 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43141 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->