### PR TITLE
[Site Isolation] Fix crash in OOP iframe processes after enabling MultiProcessBackForwardCache

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7530,12 +7530,20 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
 
         if (RefPtr idbConnectionProxy = m_idbConnectionProxy)
             idbConnectionProxy->setContextSuspended(*scriptExecutionContext(), true);
+#if ENABLE(CONTENT_EXTENSIONS)
+        if (RefPtr resourceMonitor = m_resourceMonitor)
+            resourceMonitor->cancelPendingChecks();
+#endif
         break;
     case NotInBackForwardCache:
         if (childNeedsStyleRecalc())
             scheduleStyleRecalc();
         if (RefPtr idbConnectionProxy = m_idbConnectionProxy)
             idbConnectionProxy->setContextSuspended(*scriptExecutionContext(), false);
+#if ENABLE(CONTENT_EXTENSIONS)
+        if (RefPtr resourceMonitor = m_resourceMonitor)
+            resourceMonitor->resumePendingChecks();
+#endif
         break;
     case AboutToEnterBackForwardCache:
         break;

--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -131,8 +131,21 @@ static ASCIILiteral eligibilityToString(ResourceMonitorEligibility eligibility)
 }
 #endif
 
+void ResourceMonitor::cancelPendingChecks()
+{
+    m_pendingChecksCancelled = true;
+}
+
+void ResourceMonitor::resumePendingChecks()
+{
+    m_pendingChecksCancelled = false;
+}
+
 void ResourceMonitor::continueAfterDidReceiveEligibility(Eligibility eligibility, const URL& url, OptionSet<ContentExtensions::ResourceType> resourceType)
 {
+    if (m_pendingChecksCancelled)
+        return;
+
     RefPtr frame = m_frame.get();
     RefPtr page = frame ? frame->mainFrame().page() : nullptr;
     if (!page)

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -60,6 +60,9 @@ public:
 
     void updateNetworkUsageThreshold(size_t);
 
+    void cancelPendingChecks();
+    void resumePendingChecks();
+
 private:
     explicit ResourceMonitor(LocalFrame&);
 
@@ -74,6 +77,7 @@ private:
     CheckedSize m_networkUsage;
     Eligibility m_eligibility { Eligibility::Unsure };
     bool m_networkUsageExceed { false };
+    bool m_pendingChecksCancelled { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### da07892bc68996c91f08994962a85eb840f842fc
<pre>
[Site Isolation] Fix crash in OOP iframe processes after enabling MultiProcessBackForwardCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=317155">https://bugs.webkit.org/show_bug.cgi?id=317155</a>
<a href="https://rdar.apple.com/179750953">rdar://179750953</a>

Reviewed by NOBODY (OOPS!).

After enabling MultiProcessBackForwardCache, we are seeing crashes in ResourceMonitor in OOP iframe
processes. After a top-level navigation, in the OOP iframe process, the iframe&apos;s document ends up
in the B/F cache and still processes deferred ResourceMonitor eligibility checks. Then, when
ResourceMonitor::continueAfterDidReceiveEligibility tries to handle the eligibility check, it can
follow the pointer to the document&apos;s LocalFrame, but not back to the main RemoteFrame (which has
already gone away due to the navigation).

Fix this by disabling ResourceMonitor eligibility checks once a document enters the B/F cache.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setBackForwardCacheState):
* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::cancelPendingChecks):
(WebCore::ResourceMonitor::resumePendingChecks):
(WebCore::ResourceMonitor::continueAfterDidReceiveEligibility):
* Source/WebCore/loader/ResourceMonitor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da07892bc68996c91f08994962a85eb840f842fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126207 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30801904-d748-4d4b-8226-ab8ee1a4849d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131160 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d54bd150-488e-4b42-bda0-b6b3f9f0f8f5) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171465 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33620 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a16f50e7-a0b5-4705-b33f-38270129fac2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31309 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26531 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142592 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180435 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33158 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139600 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42075 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35472 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139459 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42763 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106424 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34746 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114523 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40664 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5898 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40915 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40809 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->