### PR TITLE
Possible fix to possible null dereference crash in ResourceMonitor::continueAfterDidReceiveEligibility

### DIFF
--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -107,7 +107,7 @@ void ResourceMonitor::didReceiveResponse(const URL& url, OptionSet<ContentExtens
         return;
 
     RefPtr frame = m_frame.get();
-    RefPtr page = frame ? frame->mainFrame().page() : nullptr;
+    RefPtr page = frame ? frame->page() : nullptr;
     if (!page)
         return;
 
@@ -134,7 +134,7 @@ static ASCIILiteral eligibilityToString(ResourceMonitorEligibility eligibility)
 void ResourceMonitor::continueAfterDidReceiveEligibility(Eligibility eligibility, const URL& url, OptionSet<ContentExtensions::ResourceType> resourceType)
 {
     RefPtr frame = m_frame.get();
-    RefPtr page = frame ? frame->mainFrame().page() : nullptr;
+    RefPtr page = frame ? frame->page() : nullptr;
     if (!page)
         return;
 


### PR DESCRIPTION
#### ba40f4667ee05729c7cdf0f1a99b1469bf84f42b
<pre>
Possible fix to possible null dereference crash in ResourceMonitor::continueAfterDidReceiveEligibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=317157">https://bugs.webkit.org/show_bug.cgi?id=317157</a>
<a href="https://rdar.apple.com/179753540">rdar://179753540</a>

Reviewed by Charlie Wolfe and Ben Nham.

A Frame&apos;s page should always be the same as its main frame&apos;s page.
There&apos;s a chance we&apos;ve seen some crashes from a frame whose main frame has been
destroyed, in which case calling Frame::mainFrame would dereference null.
Since there&apos;s no reason to go to the main frame, omit the call to see if
this fixes the crash.

* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::didReceiveResponse):
(WebCore::ResourceMonitor::continueAfterDidReceiveEligibility):

Canonical link: <a href="https://commits.webkit.org/315259@main">https://commits.webkit.org/315259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75db774fa82a38a1c318ea9e8b77209c68dd5f10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177859 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13cd5fd7-1de5-4059-948f-2546bf76793f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42048 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe43bd0b-9e8a-49e3-b981-1e451a65c8ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171488 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111694 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcc91079-7617-4d5f-abd6-43cffc4e5ca4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26554 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180458 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30858 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42098 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139481 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42786 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106447 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25666 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34762 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41290 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40687 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5914 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40938 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->