### PR TITLE
Find in page cmd-g continues to highlight matches after ending a find session

### DIFF
--- a/LayoutTests/editing/text-iterator/find-in-page-sets-active-text-match-expected.txt
+++ b/LayoutTests/editing/text-iterator/find-in-page-sets-active-text-match-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Find "fox" in "the quick brown fox jumped over the lazy dog" with ShowOverlay
+PASS Find "fox" in "the quick brown fox jumped over the lazy dog" without ShowOverlay
+PASS Find "dog" in "the quick brown fox jumped over the lazy dog" with ShowOverlay
+PASS Find "dog" in "the quick brown fox jumped over the lazy dog" without ShowOverlay
+PASS Find "cat" in "the quick brown fox jumped over the lazy dog" with ShowOverlay
+PASS Find "cat" in "the quick brown fox jumped over the lazy dog" without ShowOverlay
+

--- a/LayoutTests/editing/text-iterator/find-in-page-sets-active-text-match.html
+++ b/LayoutTests/editing/text-iterator/find-in-page-sets-active-text-match.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Find in Page sets active text match document marker</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<div id="container"></div>
+
+
+<script>
+    async function findInPage(textToSearch, searchTerm, shouldShowOverlay)
+    {
+        const container = document.getElementById("container");
+        container.appendChild(document.createTextNode(textToSearch));
+
+        const matchFound = await testRunner.findString(searchTerm, shouldShowOverlay ? ["ShowOverlay"] : []);
+
+        if (!textToSearch.includes(searchTerm)) {
+            assert_false(matchFound);
+            container.replaceChildren();
+            return;
+        }
+
+        assert_true(matchFound);
+
+        const start = textToSearch.indexOf(searchTerm);
+        const hasMarker = window.internals.hasMarkerFor("ActiveTextMatch", start, searchTerm.length);
+
+        assert_equals(shouldShowOverlay, hasMarker);
+        container.replaceChildren();
+    }
+
+
+    const text = "the quick brown fox jumped over the lazy dog";
+    for (const word of ["fox", "dog", "cat"]) {
+        for (const showOverlay of [true, false])
+            promise_test(async() => await findInPage(text, word, showOverlay), `Find "${word}" in "${text}" ${showOverlay ? "with" : "without"} ShowOverlay`);
+    }
+</script>
+</html>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -546,6 +546,8 @@ static bool markerTypeFrom(const String& markerType, DocumentMarkerType& result)
         result = DocumentMarkerType::Grammar;
     else if (equalLettersIgnoringASCIICase(markerType, "textmatch"_s))
         result = DocumentMarkerType::TextMatch;
+    else if (equalLettersIgnoringASCIICase(markerType, "activetextmatch"_s))
+        result = DocumentMarkerType::ActiveTextMatch;
     else if (equalLettersIgnoringASCIICase(markerType, "replacement"_s))
         result = DocumentMarkerType::Replacement;
     else if (equalLettersIgnoringASCIICase(markerType, "correctionindicator"_s))
@@ -3074,7 +3076,16 @@ void Internals::updateEditorUINowIfScheduled()
     }
 }
 
-bool Internals::hasMarkerFor(DocumentMarkerType type, int from, int length)
+ExceptionOr<bool> Internals::hasMarkerFor(const String& type, int from, int length)
+{
+    DocumentMarkerType markerType;
+    if (!markerTypeFrom(type, markerType))
+        return Exception { ExceptionCode::SyntaxError };
+
+    return hasMarkerForInternal(markerType, from, length);
+}
+
+bool Internals::hasMarkerForInternal(DocumentMarkerType type, int from, int length)
 {
     Document* document = contextDocument();
     if (!document || !document->frame())
@@ -3103,12 +3114,12 @@ ExceptionOr<void> Internals::setMarkerFor(const String& markerTypeString, int fr
 
 bool Internals::hasSpellingMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarkerType::Spelling, from, length);
+    return hasMarkerForInternal(DocumentMarkerType::Spelling, from, length);
 }
 
 bool Internals::hasGrammarMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarkerType::Grammar, from, length);
+    return hasMarkerForInternal(DocumentMarkerType::Grammar, from, length);
 }
 
 unsigned Internals::appliedGrammarTextEffectCount() const
@@ -3129,34 +3140,34 @@ bool Internals::isAlternativeTextUIActive() const
 
 bool Internals::hasAutocorrectedMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarkerType::Autocorrected, from, length);
+    return hasMarkerForInternal(DocumentMarkerType::Autocorrected, from, length);
 }
 
 bool Internals::hasDictationAlternativesMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarkerType::DictationAlternatives, from, length);
+    return hasMarkerForInternal(DocumentMarkerType::DictationAlternatives, from, length);
 }
 
 bool Internals::hasCorrectionIndicatorMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarkerType::CorrectionIndicator, from, length);
+    return hasMarkerForInternal(DocumentMarkerType::CorrectionIndicator, from, length);
 }
 
 #if ENABLE(WRITING_TOOLS)
 bool Internals::hasWritingToolsTextSuggestionMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarkerType::WritingToolsTextSuggestion, from, length);
+    return hasMarkerForInternal(DocumentMarkerType::WritingToolsTextSuggestion, from, length);
 }
 #endif
 
 bool Internals::hasTransparentContentMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarkerType::TransparentContent, from, length);
+    return hasMarkerForInternal(DocumentMarkerType::TransparentContent, from, length);
 }
 
 bool Internals::hasDictationStreamingOpacityMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarkerType::DictationStreamingOpacity, from, length);
+    return hasMarkerForInternal(DocumentMarkerType::DictationStreamingOpacity, from, length);
 }
 
 void Internals::setContinuousSpellCheckingEnabled(bool enabled)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1700,6 +1700,8 @@ public:
     MockMediaDeviceRouteController& NODELETE mockMediaDeviceRouteController();
 #endif
 
+    ExceptionOr<bool> hasMarkerFor(const String&, int from, int length);
+
 private:
     explicit Internals(Document&);
 
@@ -1734,7 +1736,7 @@ private:
 
     CachedResource* resourceFromMemoryCache(const String& url);
 
-    bool hasMarkerFor(DocumentMarkerType, int from, int length);
+    bool hasMarkerForInternal(DocumentMarkerType, int from, int length);
 
     RefPtr<MediaSessionManagerInterface> sessionManager() const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -746,6 +746,7 @@ enum ContentsFormat {
     undefined setAutomaticSpellingCorrectionEnabled(boolean enabled);
 
     undefined setMarkerFor(DOMString markerTypeString, long from, long length, DOMString data);
+    boolean hasMarkerFor(DOMString markerTypeString, long from, long length);
 
     undefined handleAcceptedCandidate(DOMString candidate, unsigned long location, unsigned long length);
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -199,7 +199,6 @@ void FindController::updateFindUIAfterIncrementalFind(bool found, const String& 
     if (auto range = protect(webPage->corePage())->selection().firstRange())
         matchRects = RenderObject::absoluteTextRects(*range);
 
-    updateFindPageOverlay(shouldShowOverlay);
     updateFindIndicatorIfNeeded(found, options, shouldShowOverlay);
     completionHandler(idOfFrameContainingString, WTF::move(matchRects), matchCount, m_foundStringMatchIndex.value_or(0), didWrap == WebCore::DidWrap::Yes);
 }
@@ -289,6 +288,7 @@ void FindController::updateFindUIAfterFindingAllMatches(bool found, const String
 
 void FindController::updateFindPageOverlay(bool shouldShowOverlay)
 {
+    m_pageOverlayIsShowing = shouldShowOverlay;
     if (!shouldShowOverlay) {
         if (RefPtr findPageOverlay = m_findPageOverlay.get())
             m_webPage->corePage()->pageOverlayController().uninstallPageOverlay(*findPageOverlay, PageOverlay::FadeMode::Fade);
@@ -347,6 +347,7 @@ void FindController::selectLastFoundRange(const String& string, OptionSet<FindOp
 
 void FindController::findString(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, ShouldReuseLastFoundRange shouldReuseLastFoundRange, CompletionHandler<void(std::optional<FrameIdentifier>, Vector<IntRect>&&, uint32_t, int32_t, bool)>&& completionHandler)
 {
+    updateFindPageOverlay(options.contains(FindOptions::ShowOverlay));
 #if ENABLE(PDF_PLUGIN)
     RefPtr pluginView = mainFramePlugIn();
 #endif
@@ -415,7 +416,7 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
         RefPtr selectedFrame = frameWithSelection(protect(m_webPage->corePage()).get());
         m_findIndicator->didFindString(selectedFrame);
 
-        if (selectedFrame) {
+        if (selectedFrame && m_pageOverlayIsShowing) {
             if (std::optional<SimpleRange> range = selectedFrame->selection().selection().range())
                 addMarker(*range, DocumentMarkerType::ActiveTextMatch);
         }
@@ -493,8 +494,10 @@ void FindController::indicateFindMatch(uint32_t matchIndex)
 
     m_findIndicator->didFindString(selectedFrame);
 
-    if (std::optional<SimpleRange> range = selectedFrame->selection().selection().range())
-        addMarker(*range, DocumentMarkerType::ActiveTextMatch);
+    if (m_pageOverlayIsShowing) {
+        if (std::optional<SimpleRange> range = selectedFrame->selection().selection().range())
+            addMarker(*range, DocumentMarkerType::ActiveTextMatch);
+    }
 
     m_findIndicator->update(selectedFrame, !!m_findPageOverlay);
 }
@@ -503,6 +506,7 @@ void FindController::hideFindUI()
 {
     m_findMatches.clear();
     m_lastFoundRange = std::nullopt;
+    m_pageOverlayIsShowing = false;
     if (RefPtr findPageOverlay = m_findPageOverlay.get())
         m_webPage->corePage()->pageOverlayController().uninstallPageOverlay(*findPageOverlay, PageOverlay::FadeMode::Fade);
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -121,6 +121,7 @@ private:
     std::optional<WebCore::SimpleRange> m_lastFoundRange;
     bool m_lastFoundRangeDidWrap { false };
     std::unique_ptr<FindIndicator> m_findIndicator;
+    bool m_pageOverlayIsShowing { false };
 };
 
 } // namespace WebKit

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2141,6 +2141,8 @@ static WKFindOptions findOptionsFromArray(WKArrayRef array)
             options |= kWKFindOptionsAtWordStarts;
         else if (WKStringIsEqualToUTF8CString(optionName, "TreatMedialCapitalAsWordStart"))
             options |= kWKFindOptionsTreatMedialCapitalAsWordStart;
+        else if (WKStringIsEqualToUTF8CString(optionName, "ShowOverlay"))
+            options |= kWKFindOptionsShowOverlay;
         else if (WKStringIsEqualToUTF8CString(optionName, "Backwards"))
             options |= kWKFindOptionsBackwards;
         else if (WKStringIsEqualToUTF8CString(optionName, "WrapAround"))


### PR DESCRIPTION
#### 971b29f2b644e795120dbbedb8534102416b1f0f
<pre>
Find in page cmd-g continues to highlight matches after ending a find session
<a href="https://bugs.webkit.org/show_bug.cgi?id=317159">https://bugs.webkit.org/show_bug.cgi?id=317159</a>
<a href="https://rdar.apple.com/177107898">rdar://177107898</a>

Reviewed by NOBODY (OOPS!).

If you press cmd-g after exiting a find session, matches are still found.
This behavior matches chromes. When a match is found it is decorated with a
DocumentMarkerType::ActiveTextMatch. This match is usually cleared when
FindController::hideFindUI() is called. Since the find session is already
over, we have to wait until the find UI is shown and closed again before
the highlight is removed.

To fix this, we do not set DocumentMarkerType::ActiveTextMatch unless the
find UI overlay is showing.

* LayoutTests/editing/text-iterator/find-in-page-sets-active-text-match-expected.txt: Added.
* LayoutTests/editing/text-iterator/find-in-page-sets-active-text-match.html: Added.
* Source/WebCore/testing/Internals.cpp:
Expose window.internals.hasMarkerFor

(WebCore::markerTypeFrom):
(WebCore::Internals::hasMarkerFor):
(WebCore::Internals::hasMarkerForInternal):
(WebCore::Internals::hasSpellingMarker):
(WebCore::Internals::hasGrammarMarker):
(WebCore::Internals::hasAutocorrectedMarker):
(WebCore::Internals::hasDictationAlternativesMarker):
(WebCore::Internals::hasCorrectionIndicatorMarker):
(WebCore::Internals::hasWritingToolsTextSuggestionMarker):
(WebCore::Internals::hasTransparentContentMarker):
(WebCore::Internals::hasDictationStreamingOpacityMarker):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::updateFindUIAfterIncrementalFind):
(WebKit::FindController::updateFindPageOverlay):
(WebKit::FindController::findString):
(WebKit::FindController::indicateFindMatch):
(WebKit::FindController::hideFindUI):
* Source/WebKit/WebProcess/WebPage/FindController.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::findOptionsFromArray):
Expose the showOverlay find option to testRunner.findString
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/971b29f2b644e795120dbbedb8534102416b1f0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126900 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f6b21f3-25d5-41e6-b71a-8a74aedbc934) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131772 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92729 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3be4566a-668c-42bb-870c-ffb2172f485a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112275 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1843cc9-ea68-4a12-89ac-eb38b580a81c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33218 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31919 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27244 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181144 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140224 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43455 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107375 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35339 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115220 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41964 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6529 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41358 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41613 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41501 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->