### PR TITLE
Snapshot for relayout during live resize sometimes stays visible for too long on visionOS

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -324,6 +324,7 @@ struct PerWebProcessState {
 struct LiveResizeSnapshotState {
     RetainPtr<UIView> snapshotView;
     CGFloat initialWidth { 0 };
+    BOOL didForceEndLiveResize { NO };
 };
 #endif
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -187,7 +187,7 @@ enum class TapHandlingResult : uint8_t;
 
 #if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
 - (void)_beginLiveResize;
-- (void)_endLiveResize;
+- (void)_endLiveResize:(BOOL)didForceEndLiveResize;
 #endif
 
 #if ENABLE(LOCKDOWN_MODE_API)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1200,11 +1200,13 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
         if (transactionIDForEndLiveResize && transactionID.greaterThanOrEqualSameProcess(*transactionIDForEndLiveResize)) {
             _perProcessState.waitingForEndLiveResizePresentationUpdate = YES;
             _perProcessState.transactionIDForEndLiveResize = std::nullopt;
-            [self _doAfterNextPresentationUpdate:makeBlockPtr([weakSelf = WeakObjCPtr<WKWebView>(self)] {
+            [self _doAfterNextPresentationUpdate:makeBlockPtr([transactionIDForEndLiveResize, weakSelf = WeakObjCPtr<WKWebView>(self)] {
                 RetainPtr strongSelf = weakSelf.get();
                 if (!strongSelf)
                     return;
                 strongSelf->_perProcessState.waitingForEndLiveResizePresentationUpdate = NO;
+                if (strongSelf->_liveResizeSnapshotState && strongSelf->_liveResizeSnapshotState->first == *transactionIDForEndLiveResize && !strongSelf->_liveResizeSnapshotState->second.didForceEndLiveResize)
+                    [strongSelf _removeLiveSnapshotState];
             }).get()];
         }
 #endif
@@ -1934,7 +1936,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     [self _invalidateResizeAssertions];
 #endif
 #if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
-    [self _endLiveResize];
+    [self _endLiveResize:NO];
 #endif
     [self _updateLastKnownWindowSizeAndOrientation];
 }
@@ -2693,7 +2695,7 @@ static CGFloat liveResizeMinimumWidthDifference()
     [_endLiveResizeTimer invalidate];
 
     auto endLiveResizeHysteresis = 500_ms;
-    bool didEndLiveResizeImmediately = false;
+    BOOL didForceEndLiveResize = NO;
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
     if ([self _shouldForceEndLiveResize]
 #if ENABLE(FULLSCREEN_API)
@@ -2701,21 +2703,24 @@ static CGFloat liveResizeMinimumWidthDifference()
 #endif
     ) {
         endLiveResizeHysteresis = 0_ms;
-        didEndLiveResizeImmediately = true;
+        didForceEndLiveResize = YES;
     }
 #endif
 
     _endLiveResizeTimer = [NSTimer
         scheduledTimerWithTimeInterval:endLiveResizeHysteresis.seconds()
         repeats:NO
-        block:makeBlockPtr([didEndLiveResizeImmediately, weakSelf = WeakObjCPtr<WKWebView>(self)](NSTimer *) {
-            auto strongSelf = weakSelf.get();
-            [strongSelf _endLiveResize];
+        block:makeBlockPtr([didForceEndLiveResize, weakSelf = WeakObjCPtr<WKWebView>(self)](NSTimer *) {
+            RetainPtr strongSelf = weakSelf.get();
+            if (!strongSelf)
+                return;
+
+            [strongSelf _endLiveResize:didForceEndLiveResize];
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-            if (!didEndLiveResizeImmediately)
+            if (!didForceEndLiveResize)
                 [strongSelf _resetResponsiveResizeState];
 #else
-            UNUSED_PARAM(didEndLiveResizeImmediately);
+            UNUSED_PARAM(didForceEndLiveResize);
 #endif
         }).get()];
 }
@@ -3806,7 +3811,7 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 }
 
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-- (void)_endLiveResizeWithResponsiveRelayout
+- (void)_endLiveResizeWithResponsiveRelayout:(BOOL)didForceEndLiveResize
 {
     if (_liveResizeSnapshotState)
         [self _removeLiveSnapshotState];
@@ -3833,7 +3838,7 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     [liveResizeSnapshotView layer].position = CGPointZero;
     [self addSubview:liveResizeSnapshotView.get()];
     auto transactionIDForEndLiveResize = *_perProcessState.transactionIDForEndLiveResize;
-    _liveResizeSnapshotState = { { transactionIDForEndLiveResize, { liveResizeSnapshotView, self.bounds.size.width } } };
+    _liveResizeSnapshotState = { { transactionIDForEndLiveResize, { liveResizeSnapshotView, self.bounds.size.width, didForceEndLiveResize } } };
 
     _perProcessState.lastResizeTimestamp = [NSDate now];
     _perProcessState.lastResizedViewWidth = self.bounds.size.width;
@@ -3881,7 +3886,7 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     });
 }
 
-- (void)_endLiveResize
+- (void)_endLiveResize:(BOOL)didForceEndLiveResize
 {
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _endLiveResize]", self, _page->identifier().toUInt64());
 
@@ -3892,8 +3897,9 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     _endLiveResizeTimer = nil;
 
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    [self _endLiveResizeWithResponsiveRelayout];
+    [self _endLiveResizeWithResponsiveRelayout:didForceEndLiveResize];
 #else
+    UNUSED_PARAM(didForceEndLiveResize);
     [self _endLiveResizeDefault];
 #endif
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AnimatedResize.mm
@@ -45,7 +45,7 @@
 #if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
 @interface WKWebView ()
 - (void)_beginLiveResize;
-- (void)_endLiveResize;
+- (void)_endLiveResize:(BOOL)didForceEndLiveResize;
 @end
 #endif
 
@@ -565,7 +565,7 @@ TEST(AnimatedResize, MinimumEffectiveDeviceWidthChangeIsDeferredDuringLiveResize
     [webView waitForNextPresentationUpdate];
     EXPECT_EQ([webView scrollView].zoomScale, 1);
 
-    [webView _endLiveResize];
+    [webView _endLiveResize:NO];
 
     [webView waitForNextPresentationUpdate];
     EXPECT_EQ([webView scrollView].zoomScale, 0.5);
@@ -588,7 +588,7 @@ TEST(AnimatedResize, PinScrollPositionRelativeToTopEdgeOnPageScaleChange)
 
     [webView _beginLiveResize];
     [webView setFrame:CGRectMake(0, 0, frame.size.width - 200, frame.size.height)];
-    [webView _endLiveResize];
+    [webView _endLiveResize:NO];
 
     [webView waitForNextPresentationUpdate];
 
@@ -608,7 +608,7 @@ TEST(AnimatedResize, PinScrollPositionRelativeToTopEdgeOnPageScaleChangeAfterInc
 
     [webView _beginLiveResize];
     [webView setFrame:CGRectMake(0, 0, layoutWidth, 600)];
-    [webView _endLiveResize];
+    [webView _endLiveResize:NO];
 
     [webView waitForNextPresentationUpdate];
 
@@ -630,7 +630,7 @@ TEST(AnimatedResize, ChangingWebViewGeometryDuringLiveResizeDoesNotHang)
     auto layoutSize = CGSizeMake(100, 200);
     [webView _overrideLayoutParametersWithMinimumLayoutSize:layoutSize minimumUnobscuredSizeOverride:layoutSize maximumUnobscuredSizeOverride:layoutSize];
 
-    [webView _endLiveResize];
+    [webView _endLiveResize:NO];
 
     __block bool didReadLayoutSize = false;
 


### PR DESCRIPTION
#### e7e4231516b7817b4dc6200703d207933f828059
<pre>
Snapshot for relayout during live resize sometimes stays visible for too long on visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=317160">https://bugs.webkit.org/show_bug.cgi?id=317160</a>
<a href="https://rdar.apple.com/179733894">rdar://179733894</a>

Reviewed by Abrar Rahman Protyasha.

This PR addresses an issue where at the end of the responsive live resize on visionOS,
the snapshot view sometimes does not get removed for ~1-2s. This happens because in this flow,
we rely on the 500ms endResizeTimer to fire, which triggers an updated commit to the web process.
However, in this state, we rely on the user triggering a bounds update to then trigger another
liveResize cycle, such that the snapshot gets removed when we next trigger
`ensureLiveResizeAnimationView`.

In the case where the window has settled to a set size,
because there is no new resizeAnimationView being created, we never remove the snapshot, so
WebKit falls back to its 1s timer. In total, this means that the user
is waiting for 1.5s-2s after the window has been resized before the snapshot gets removed,
accounting for the time spent committing to the layer tree via the web process.

The fix here is that we assume that when endLiveResize is called with the 500ms timer
it is safe to remove the snapshot immediately without needing to wait on the next resizeAnimationView
container to get created.

We make this change by storing didForceEndLiveResize (renamed to better reflect intent of variable)
as a property of the LiveResizeSnapshotState associated with the specific transactionID during
which it was created. To that end, we introduce an argument to `_endLiveResize` and
`_endLiveResizeWithResponsiveRelayout` that passes that value over. Together
we use that to track whether to remove the snapshot immediately.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
Introduce didForceEndLiveResize in the LiveResizeSnapshotState

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):
Updates the responsive relayout presentation update to check for the transactionID and
whether the liveSnapshot was created from a forceEndLiveResize or not. If not, we remove
the snapshot.

(-[WKWebView didMoveToWindow]):
Update call to endLiveResize to now pass a boolean for didForceEndLiveResize.

(-[WKWebView _rescheduleEndLiveResizeTimer]):
Update captures for the timer to plumb the value of didForceEndLiveResize for endLiveResize.

(-[WKWebView _endLiveResizeWithResponsiveRelayout:]):
Updates call to now receive the didForceEndLiveResize to then pass into the next liveResizeSnapshotState

(-[WKWebView _endLiveResize:]):
Update the call to pass in the didForceEndLiveResize boolean to avoid transient states via the
perProcessState

(-[WKWebView _endLiveResizeWithResponsiveRelayout]):
Update calls to pass didEndLiveResizeImmediately to the snapshot state. Read by didCommitLayerTree
to skip waiting until the next resizeAnimationView gets created.
(-[WKWebView _endLiveResize]): Deleted.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AnimatedResize.mm:
(TEST(AnimatedResize, MinimumEffectiveDeviceWidthChangeIsDeferredDuringLiveResize)):
(TEST(AnimatedResize, PinScrollPositionRelativeToTopEdgeOnPageScaleChange)):
(TEST(AnimatedResize, PinScrollPositionRelativeToTopEdgeOnPageScaleChangeAfterIncreasedSize)):
(TEST(AnimatedResize, ChangingWebViewGeometryDuringLiveResizeDoesNotHang)):
Updated unit tests to account for the new call for _endLiveResize

Canonical link: <a href="https://commits.webkit.org/316439@main">https://commits.webkit.org/316439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10dba2441ca53dbd73da8aac58fae0d7e4d0b65b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133985 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37422 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114456 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36056 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184252 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36935 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142749 "Found 1 new test failure: fast/parser/fonts.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45857 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142631 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38526 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46535 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111252 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37700 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45052 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8981 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44452 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->