### PR TITLE
fromBacking() maps WGPUTextureFormat_RGBA16Unorm to Rgba16snorm

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.cpp
@@ -237,7 +237,7 @@ static TextureFormat NODELETE fromBacking(WGPUTextureFormat textureFormat)
     case WGPUTextureFormat_RG16Snorm:
         return TextureFormat::Rg16snorm;
     case WGPUTextureFormat_RGBA16Unorm:
-        return TextureFormat::Rgba16snorm;
+        return TextureFormat::Rgba16unorm;
     case WGPUTextureFormat_RGBA16Snorm:
         return TextureFormat::Rgba16snorm;
     case WGPUTextureFormat_Undefined:


### PR DESCRIPTION
#### 8896cf9f1cbcc66d53ac350eca0aeaa81e90a739
<pre>
fromBacking() maps WGPUTextureFormat_RGBA16Unorm to Rgba16snorm
<a href="https://bugs.webkit.org/show_bug.cgi?id=317166">https://bugs.webkit.org/show_bug.cgi?id=317166</a>
<a href="https://rdar.apple.com/179757943">rdar://179757943</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.cpp:
(WebCore::WebGPU::fromBacking):

Canonical link: <a href="https://commits.webkit.org/315286@main">https://commits.webkit.org/315286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ccb3a5344d56f1fe7d2e48eb013153bc702e37e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126231 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c66ccfdd-dd67-41e3-9c0d-239573401821) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131184 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92263 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c551121d-6c89-434d-b3a2-d56063dbaea0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/263c8656-3c9a-40fb-8ddd-25e098190136) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31332 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26555 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142612 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180459 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139625 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139483 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42787 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106448 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25677 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27832 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114547 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40688 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5915 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40833 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->