### PR TITLE
Refactor _endLiveResize to separate Responsive and Unresponsive Live-resize Updates

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3793,7 +3793,73 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     [self _ensureResizeAnimationView];
 }
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=317000
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+- (void)_endLiveResizeWithResponsiveRelayout
+{
+    if (_liveResizeSnapshotState)
+        [self _removeLiveSnapshotState];
+
+    if (RefPtr drawingArea = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->drawingArea()))
+        _perProcessState.transactionIDForEndLiveResize = drawingArea->nextMainFrameLayerTreeTransactionID();
+
+    if (!_perProcessState.transactionIDForEndLiveResize)
+        return;
+
+    auto liveResizeSnapshotView = retainPtr([self snapshotViewAfterScreenUpdates:NO]);
+    [liveResizeSnapshotView setFrame:self.bounds];
+    [liveResizeSnapshotView layer].anchorPoint = CGPointZero;
+    [liveResizeSnapshotView layer].position = CGPointZero;
+    [self addSubview:liveResizeSnapshotView.get()];
+
+    auto transactionIDForEndLiveResize = *_perProcessState.transactionIDForEndLiveResize;
+    _liveResizeSnapshotState = { { transactionIDForEndLiveResize, { liveResizeSnapshotView, self.bounds.size.width } } };
+
+    _perProcessState.lastResizeTimestamp = [NSDate now];
+    _perProcessState.lastResizedViewWidth = self.bounds.size.width;
+
+    _perProcessState.liveResizeParameters = std::nullopt;
+
+    ASSERT(_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing);
+    [self _destroyResizeAnimationView];
+    [self _didStopDeferringGeometryUpdates];
+
+    // Ensure that the live resize snapshot is eventually removed, even if the webpage is unresponsive.
+    RunLoop::mainSingleton().dispatchAfter(1_s, [weakSelf = WeakObjCPtr<WKWebView>(self), transactionIDForEndLiveResize] {
+        RetainPtr strongSelf = weakSelf.get();
+        if (!strongSelf || !strongSelf->_liveResizeSnapshotState || strongSelf->_liveResizeSnapshotState->first != transactionIDForEndLiveResize)
+            return;
+        [strongSelf _removeLiveSnapshotState];
+        strongSelf->_perProcessState.transactionIDForEndLiveResize = std::nullopt;
+        strongSelf->_perProcessState.waitingForEndLiveResizePresentationUpdate = NO;
+    });
+}
+#endif
+
+- (void)_endLiveResizeDefault
+{
+    auto liveResizeSnapshotView = retainPtr([self snapshotViewAfterScreenUpdates:NO]);
+    [liveResizeSnapshotView setFrame:self.bounds];
+    [self addSubview:liveResizeSnapshotView.get()];
+
+    _perProcessState.liveResizeParameters = std::nullopt;
+
+    ASSERT(_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing);
+    [self _destroyResizeAnimationView];
+    [self _didStopDeferringGeometryUpdates];
+
+    [self _doAfterNextVisibleContentRectUpdate:makeBlockPtr([liveResizeSnapshotView, weakSelf = WeakObjCPtr<WKWebView>(self)] mutable {
+        RetainPtr strongSelf = weakSelf.get();
+        [strongSelf _doAfterNextPresentationUpdate:makeBlockPtr([liveResizeSnapshotView] {
+            [liveResizeSnapshotView removeFromSuperview];
+        }).get()];
+    }).get()];
+
+    // Ensure that the live resize snapshot is eventually removed, even if the webpage is unresponsive.
+    RunLoop::mainSingleton().dispatchAfter(1_s, [liveResizeSnapshotView] {
+        [liveResizeSnapshotView removeFromSuperview];
+    });
+}
+
 - (void)_endLiveResize
 {
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _endLiveResize]", self, _page->identifier().toUInt64());
@@ -3805,65 +3871,10 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     _endLiveResizeTimer = nil;
 
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    if (_liveResizeSnapshotState)
-        [self _removeLiveSnapshotState];
-
-    if (RefPtr drawingArea = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->drawingArea()))
-        _perProcessState.transactionIDForEndLiveResize = drawingArea->nextMainFrameLayerTreeTransactionID();
-
-    if (!_perProcessState.transactionIDForEndLiveResize)
-        return;
-#endif
-
-    RetainPtr liveResizeSnapshotView = [self snapshotViewAfterScreenUpdates:NO];
-    [liveResizeSnapshotView setFrame:self.bounds];
-
-#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    [liveResizeSnapshotView layer].anchorPoint = CGPointZero;
-    [liveResizeSnapshotView layer].position = CGPointZero;
-    [self addSubview:liveResizeSnapshotView.get()];
-    auto transactionIDForEndLiveResize = *_perProcessState.transactionIDForEndLiveResize;
-    _liveResizeSnapshotState = { { transactionIDForEndLiveResize, { liveResizeSnapshotView, self.bounds.size.width } } };
-
-    _perProcessState.lastResizeTimestamp = [NSDate now];
-    _perProcessState.lastResizedViewWidth = self.bounds.size.width;
+    [self _endLiveResizeWithResponsiveRelayout];
 #else
-    [self addSubview:liveResizeSnapshotView.get()];
+    [self _endLiveResizeDefault];
 #endif
-
-    _perProcessState.liveResizeParameters = std::nullopt;
-
-    ASSERT(_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing);
-    [self _destroyResizeAnimationView];
-    [self _didStopDeferringGeometryUpdates];
-
-#if !ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    [self _doAfterNextVisibleContentRectUpdate:makeBlockPtr([liveResizeSnapshotView, weakSelf = WeakObjCPtr<WKWebView>(self)] mutable {
-        RetainPtr strongSelf = weakSelf.get();
-        [strongSelf _doAfterNextPresentationUpdate:makeBlockPtr([liveResizeSnapshotView] {
-            [liveResizeSnapshotView removeFromSuperview];
-        }).get()];
-    }).get()];
-#endif
-
-    RunLoop::mainSingleton().dispatchAfter(1_s, [
-#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-        weakSelf = WeakObjCPtr<WKWebView>(self), transactionIDForEndLiveResize
-#else
-        liveResizeSnapshotView
-#endif
-    ] {
-#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-        RetainPtr strongSelf = weakSelf.get();
-        if (!strongSelf || !strongSelf->_liveResizeSnapshotState || strongSelf->_liveResizeSnapshotState->first != transactionIDForEndLiveResize)
-            return;
-        [strongSelf _removeLiveSnapshotState];
-        strongSelf->_perProcessState.transactionIDForEndLiveResize = std::nullopt;
-        strongSelf->_perProcessState.waitingForEndLiveResizePresentationUpdate = NO;
-#else
-        [liveResizeSnapshotView removeFromSuperview];
-#endif
-    });
 }
 
 #endif // HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)


### PR DESCRIPTION
#### 378b9645698fd67b24167ea0efc87ddc2453d80a
<pre>
Refactor _endLiveResize to separate Responsive and Unresponsive Live-resize Updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=317000">https://bugs.webkit.org/show_bug.cgi?id=317000</a>
<a href="https://rdar.apple.com/179498356">rdar://179498356</a>

Reviewed by NOBODY (OOPS!).

This PR separates the logic for the responsive live resize for _endLiveResize
to make the code more readable and maintainable. The underlying logic should be
the same with no changes.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _endLiveResizeWithResponsiveRelayout]):
(-[WKWebView _endLiveResizeDefault]):
(-[WKWebView _endLiveResize]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/378b9645698fd67b24167ea0efc87ddc2453d80a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126240 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131192 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92269 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32633 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31340 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26564 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142619 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180468 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139633 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42108 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35504 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139491 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42796 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106457 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34769 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27841 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114556 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40697 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5924 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->