### PR TITLE
UserScript::debugDescription mishandles the substring length for the sourceURL prefix

### DIFF
--- a/Source/WebCore/page/UserScript.cpp
+++ b/Source/WebCore/page/UserScript.cpp
@@ -115,7 +115,7 @@ String UserScript::debugDescription() const
     auto truncated = view.left(64);
     if (size_t pos = truncated.find('\n'); pos != notFound) {
         if (truncated.startsWith("//# sourceURL="_s))
-            truncated = truncated.substring(14, pos);
+            truncated = truncated.substring(14, pos - 14);
         else
             truncated = truncated.substring(0, pos);
     }


### PR DESCRIPTION
#### 3b126365d9119fdd039d50acf2c0bcf76a348484
<pre>
UserScript::debugDescription mishandles the substring length for the sourceURL prefix
<a href="https://bugs.webkit.org/show_bug.cgi?id=317176">https://bugs.webkit.org/show_bug.cgi?id=317176</a>
<a href="https://rdar.apple.com/179766868">rdar://179766868</a>

Reviewed by Pascoe.

StringView::substring(start, length) takes a length as its second argument. After detecting a
&quot;//# sourceURL=&quot; prefix (14 characters), the code started the substring at offset 14 but passed pos
(the newline index) as the length, reading indices [14, 14 + pos) and overshooting the newline by 14
characters. As a result debugDescription() returned the sourceURL value plus the newline and the
following script body instead of just the sourceURL. The length must be pos - 14, mirroring the
else-branch&apos;s substring(0, pos).

* Source/WebCore/page/UserScript.cpp:
(WebCore::UserScript::debugDescription const):

Canonical link: <a href="https://commits.webkit.org/315705@main">https://commits.webkit.org/315705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01c20146ee4bc12b8a888343d4b0094b0ccfbca3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177879 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126250 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cb523f7-3e65-468b-9550-6b5db9c21253) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131202 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92276 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3de7a40c-b9fc-479b-9a7d-3c365f50a311) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111713 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c53c4add-e306-4b03-ad9b-0138a4617465) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32641 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31350 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26574 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180478 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33201 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35514 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139643 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42118 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139501 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42806 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106467 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34781 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114566 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41310 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5925 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40707 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40958 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40852 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->