### PR TITLE
[Scrollbar gutter] scrollbar-gutter: both-edges should not reserve a gutter on the block-start edge

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-gutter-both-edges-block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-gutter-both-edges-block-size-expected.txt
@@ -1,0 +1,4 @@
+
+PASS horizontal-tb: both-edges does not change the block-axis (height)
+PASS vertical-rl: both-edges does not change the block-axis (width)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-gutter-both-edges-block-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-gutter-both-edges-block-size.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>scrollbar-gutter: stable both-edges must not reserve a block-axis gutter</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
+<meta name="assert" content="scrollbar-gutter: stable both-edges reserves gutters on the inline edges only; it must not affect the block-axis size of the content box.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.scroller {
+    box-sizing: content-box;
+    width: 200px;
+    height: 200px;
+    border: 0;
+    padding: 0;
+    /* overflow: scroll keeps both scrollbars present so both gutter axes exist. */
+    overflow: scroll;
+}
+
+/* Horizontal writing mode: block axis is the height; both-edges must not change it. */
+#stable     { scrollbar-gutter: stable; }
+#bothEdges  { scrollbar-gutter: stable both-edges; }
+
+/* Vertical writing mode: block axis is the width; both-edges must not change it. */
+.vertical   { writing-mode: vertical-rl; }
+#vStable    { scrollbar-gutter: stable; }
+#vBothEdges { scrollbar-gutter: stable both-edges; }
+</style>
+</head>
+<body>
+<div class="scroller" id="stable"></div>
+<div class="scroller" id="bothEdges"></div>
+<div class="scroller vertical" id="vStable"></div>
+<div class="scroller vertical" id="vBothEdges"></div>
+
+<script>
+const px = (el, prop) => parseFloat(getComputedStyle(el).getPropertyValue(prop));
+
+const stable = document.getElementById('stable');
+const bothEdges = document.getElementById('bothEdges');
+const vStable = document.getElementById('vStable');
+const vBothEdges = document.getElementById('vBothEdges');
+
+setup(() => {
+    assert_implements_optional(stable.offsetWidth - stable.clientWidth > 0,
+        "test requires classic (non-overlay) scrollbars that take up space");
+    assert_implements_optional(stable.offsetHeight - stable.clientHeight > 0,
+        "test requires classic (non-overlay) scrollbars that take up space");
+});
+
+test(() => {
+    // Spec: both-edges affects the inline edges only, so the height is unchanged.
+    assert_equals(px(bothEdges, 'height'), px(stable, 'height'),
+        "both-edges must not subtract a horizontal-scrollbar gutter from the height");
+}, "horizontal-tb: both-edges does not change the block-axis (height)");
+
+test(() => {
+    // Mirror in vertical-rl: the block axis is the width. Per spec it stays equal to stable.
+    assert_equals(px(vBothEdges, 'width'), px(vStable, 'width'),
+        "both-edges must not subtract a scrollbar gutter from the block-axis width");
+}, "vertical-rl: both-edges does not change the block-axis (width)");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6947,6 +6947,7 @@ imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-00
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-005.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-006.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-007.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-gutter-both-edges-block-size.html [ Skip ]
 
 # Trailing space/text alignment iOS-specific WPT failures
 webkit.org/b/257182 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -942,8 +942,11 @@ LayoutRect RenderBox::paddingBoxRect() const
 
 LayoutPoint RenderBox::contentBoxLocation() const
 {
-    LayoutUnit verticalScrollbarSpace = (shouldPlaceVerticalScrollbarOnLeft() || style().scrollbarGutter().isStableBothEdges()) ? verticalScrollbarWidth() : 0;
-    LayoutUnit horizontalScrollbarSpace = style().scrollbarGutter().isStableBothEdges() ? horizontalScrollbarHeight() : 0;
+    bool bothEdgeScrollbarGutters = style().scrollbarGutter().isStableBothEdges();
+    // scrollbar-gutter reserves a gutter on the inline-start edge for both-edges; which physical
+    // edge that maps to depends on the writing mode. It never reserves on the block-start edge.
+    LayoutUnit verticalScrollbarSpace = (shouldPlaceVerticalScrollbarOnLeft() || (bothEdgeScrollbarGutters && isHorizontalWritingMode())) ? verticalScrollbarWidth() : 0;
+    LayoutUnit horizontalScrollbarSpace = (bothEdgeScrollbarGutters && !isHorizontalWritingMode()) ? horizontalScrollbarHeight() : 0;
     return { borderLeft() + paddingLeft() + verticalScrollbarSpace, borderTop() + paddingTop() + horizontalScrollbarSpace };
 }
 

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -36,13 +36,12 @@ inline LayoutUnit RenderBox::clientLogicalBottom() const { return borderBefore()
 inline LayoutUnit RenderBox::clientLogicalHeight() const { return writingMode().isHorizontal() ? clientHeight() : clientWidth(); }
 inline LayoutUnit RenderBox::clientLogicalWidth() const { return writingMode().isHorizontal() ? clientWidth() : clientHeight(); }
 inline LayoutUnit RenderBox::clientTop() const { return borderTop(); }
-inline LayoutRect RenderBox::computedCSSContentBoxRect() const { return LayoutRect(borderLeft() + computedCSSPaddingLeft(), borderTop() + computedCSSPaddingTop(), paddingBoxWidth() - computedCSSPaddingLeft() - computedCSSPaddingRight()  - (style().scrollbarGutter().isStableBothEdges() ? verticalScrollbarWidth() : 0), paddingBoxHeight() - computedCSSPaddingTop() - computedCSSPaddingBottom() - (style().scrollbarGutter().isStableBothEdges() ? horizontalScrollbarHeight() : 0)); }
-inline LayoutUnit RenderBox::contentBoxHeight() const { return std::max(0_lu, paddingBoxHeight() - paddingTop() - paddingBottom() - (style().scrollbarGutter().isStableBothEdges() ? horizontalScrollbarHeight() : 0)); }
+inline LayoutRect RenderBox::computedCSSContentBoxRect() const { return LayoutRect(borderLeft() + computedCSSPaddingLeft(), borderTop() + computedCSSPaddingTop(), paddingBoxWidth() - computedCSSPaddingLeft() - computedCSSPaddingRight()  - ((style().scrollbarGutter().isStableBothEdges() && isHorizontalWritingMode()) ? verticalScrollbarWidth() : 0), paddingBoxHeight() - computedCSSPaddingTop() - computedCSSPaddingBottom() - ((style().scrollbarGutter().isStableBothEdges() && !isHorizontalWritingMode()) ? horizontalScrollbarHeight() : 0)); }
+inline LayoutUnit RenderBox::contentBoxHeight() const { return std::max(0_lu, paddingBoxHeight() - paddingTop() - paddingBottom() - ((style().scrollbarGutter().isStableBothEdges() && !isHorizontalWritingMode()) ? horizontalScrollbarHeight() : 0)); }
 inline LayoutUnit RenderBox::contentBoxLogicalHeight() const { return writingMode().isHorizontal() ? contentBoxHeight() : contentBoxWidth(); }
 inline LayoutUnit RenderBox::contentBoxLogicalHeight(LayoutUnit overridingBorderBoxHeight) const
 {
-    auto scrollbarLogicalHeight = this->scrollbarLogicalHeight();
-    return std::max(0_lu, overridingBorderBoxHeight - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight - (style().scrollbarGutter().isStableBothEdges() ? scrollbarLogicalHeight : 0));
+    return std::max(0_lu, overridingBorderBoxHeight - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight());
 }
 inline LayoutSize RenderBox::contentBoxLogicalSize() const { return writingMode().isHorizontal() ? contentBoxSize() : contentBoxSize().transposedSize(); }
 inline LayoutUnit RenderBox::contentBoxLogicalWidth() const { return writingMode().isHorizontal() ? contentBoxWidth() : contentBoxHeight(); }
@@ -52,7 +51,7 @@ inline LayoutUnit RenderBox::contentBoxLogicalWidth(LayoutUnit overridingBorderB
     return std::max(LayoutUnit(), overridingBorderBoxWidth - borderAndPaddingLogicalWidth() - scrollbarLogicalWidth - (style().scrollbarGutter().isStableBothEdges() ? scrollbarLogicalWidth : 0));
 }
 inline LayoutSize RenderBox::contentBoxSize() const { return { contentBoxWidth(), contentBoxHeight() }; }
-inline LayoutUnit RenderBox::contentBoxWidth() const { return std::max(0_lu, paddingBoxWidth() - paddingLeft() - paddingRight() - (style().scrollbarGutter().isStableBothEdges() ? verticalScrollbarWidth() : 0)); }
+inline LayoutUnit RenderBox::contentBoxWidth() const { return std::max(0_lu, paddingBoxWidth() - paddingLeft() - paddingRight() - ((style().scrollbarGutter().isStableBothEdges() && isHorizontalWritingMode()) ? verticalScrollbarWidth() : 0)); }
 inline std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerLogicalHeight() const { return writingMode().isHorizontal() ? explicitIntrinsicInnerHeight() : explicitIntrinsicInnerWidth(); }
 inline std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerLogicalWidth() const { return writingMode().isHorizontal() ? explicitIntrinsicInnerWidth() : explicitIntrinsicInnerHeight(); }
 inline bool RenderBox::hasHorizontalOverflow() const { return scrollWidth() != roundToInt(paddingBoxWidth()); }
@@ -142,10 +141,13 @@ inline LayoutRect RenderBox::contentBoxRect() const
 
         bool bothEdgeScrollbarGutters = style().scrollbarGutter().isStableBothEdges();
 
-        if ((shouldPlaceVerticalScrollbarOnLeft() || bothEdgeScrollbarGutters))
+        // scrollbar-gutter only reserves gutters on the inline edges. The scrollbar itself is
+        // reserved on the inline-end edge by paddingBox{Width,Height} below; both-edges mirrors
+        // an equal gutter onto the inline-start edge. Which physical edge that is depends on the
+        // writing mode, so it must never affect the block-start (e.g. top in horizontal) edge.
+        if (shouldPlaceVerticalScrollbarOnLeft() || (bothEdgeScrollbarGutters && isHorizontalWritingMode()))
             leftScrollbarSpace = verticalScrollbarWidth;
-        // FIXME: It's wrong that scrollbar-gutter: both-edges affects height: webkit.org/b/266938
-        if (bothEdgeScrollbarGutters)
+        if (bothEdgeScrollbarGutters && !isHorizontalWritingMode())
             topScrollbarSpace = horizontalScrollbarHeight;
     }
 


### PR DESCRIPTION
#### 9f5da6f47eb950669c6f3bd0a24bfd5625f5b36a
<pre>
[Scrollbar gutter] scrollbar-gutter: both-edges should not reserve a gutter on the block-start edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=266938">https://bugs.webkit.org/show_bug.cgi?id=266938</a>
<a href="https://rdar.apple.com/120570031">rdar://120570031</a>

Reviewed by NOBODY (OOPS!).

scrollbar-gutter reserves gutters on the inline edges only. For
`stable both-edges` the gutter on the inline-end edge (where the
scrollbar lives) is mirrored onto the inline-start edge. WebKit instead
treated both-edges as also reserving a horizontal-scrollbar gutter on the
block-start (top, in horizontal writing mode) edge, and in
contentBoxRect() that height was subtracted twice -- once for the actual
scrollbar and again for the phantom block-start gutter -- shrinking the
content box and pushing content down.

Make the both-edges gutter writing-mode aware: it maps to the inline
axis (width in horizontal writing mode, height in vertical writing mode)
and never to the block axis. The vertical-writing-mode case, where the
inline-start edge legitimately is the top edge, is preserved.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::contentBoxLocation): Only offset the content origin
by the both-edges gutter on the inline-start edge for the current writing
mode.
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::computedCSSContentBoxRect): Apply the both-edges
gutter to the inline axis only.
(WebCore::RenderBox::contentBoxHeight): Ditto.
(WebCore::RenderBox::contentBoxLogicalHeight): Drop the spurious
block-axis both-edges term from the overriding-border-box overload.
(WebCore::RenderBox::contentBoxWidth): Ditto.
(WebCore::RenderBox::contentBoxRect): Remove the double subtraction of
the horizontal scrollbar height; reserve the mirrored gutter on the
inline-start edge only.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-gutter-both-edges-block-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-gutter-both-edges-block-size-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f5da6f47eb950669c6f3bd0a24bfd5625f5b36a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126255 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c784abd2-a162-4187-a3ca-31e7722ed509) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131206 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92279 "4 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53637126-e9b6-45ed-b13c-797e5128f47a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111717 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0da23644-b277-470e-8b30-f705f8c6f28c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32650 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31353 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26579 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142636 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180483 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33206 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139647 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42123 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35517 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139505 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150953 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106472 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27854 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114571 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40712 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5937 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40857 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->