### PR TITLE
[ iOS ] media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html is a constant TEXT failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3077,6 +3077,7 @@ imported/w3c/web-platform-tests/selection/user-select-on-input-and-contenteditab
 # accessibilityController.role cannot be tested on iOS
 media/modern-media-controls/time-label/time-label.html [ Skip ]
 media/modern-media-controls/tracks-button [ Pass ]
+media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html [ Pass ]
 
 # AirPlay cannot be tested on iOS
 webkit.org/b/166062 media/modern-media-controls/airplay-support [ Skip ]

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -425,8 +425,10 @@ class MediaController
         else
             window.removeEventListener("dragstart", this, true);
 
+        this._stopPropagationOnTouchEvents();
+
         if (this.host && this.host.inWindowFullscreen) {
-            this._stopPropagationOnInteractionEvents();
+            this._stopPropagationOnClickEvents();
             if (!this.host.supportsRewind && this.controls.rewindButton)
                 this.controls.rewindButton.dropped = true;
         }
@@ -437,11 +439,21 @@ class MediaController
             this.controls.element.setAttribute('useragentpart', '-webkit-media-controls');
     }
 
-    _stopPropagationOnInteractionEvents()
+    _stopPropagationOnClickEvents()
     {
-        let clickEvents = ["click", "mousedown", "mouseup", "pointerdown", "pointerup", "touchstart", "touchmove", "touchend"];
+        let clickEvents = ["click", "mousedown", "mouseup", "pointerdown", "pointerup"];
         for (let clickEvent of clickEvents) {
             this.controls.element.addEventListener(clickEvent, (event) => {
+                event.stopPropagation();
+            });
+        }
+    }
+
+    _stopPropagationOnTouchEvents()
+    {
+        let touchEvents = ["touchstart", "touchmove", "touchend"];
+        for (let touchEvent of touchEvents) {
+            this.controls.element.addEventListener(touchEvent, (event) => {
                 event.stopPropagation();
             });
         }


### PR DESCRIPTION
#### 39da8f95880344dd0768ffa6a0b614bb3403b7a5
<pre>
[ iOS ] media/modern-media-controls/ios-inline-media-controls/touch/ios-inline-media-controls-timeline-scrub-stops-propagation.html is a constant TEXT failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=317180">https://bugs.webkit.org/show_bug.cgi?id=317180</a>
<a href="https://rdar.apple.com/174860301">rdar://174860301</a>

Reviewed by Jer Noble.

Follow-up to <a href="https://commits.webkit.org/303986@main.">https://commits.webkit.org/303986@main.</a> That commit added touchstart/touchmove/touchend
to _stopPropagationOnInteractionEvents() and renamed it from _stopPropagationOnClickEvents(), but
the method was still only called inside the `host.inWindowFullscreen` branch — so the
inline-controls case the test targets never actually attached the new listeners. Move the call out
of the fullscreen guard so it runs for every controls update, matching the original commit&apos;s stated
intent (&quot;ensure the method is called for all controls (not just fullscreen)&quot;). Also un-skip the
existing test on iOS

* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._updateControlsIfNeeded):

Canonical link: <a href="https://commits.webkit.org/315298@main">https://commits.webkit.org/315298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d59793b4c96b364b8654ce5b3ce81a118f87f6d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126280 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131225 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111736 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32668 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31374 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26600 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180504 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139667 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42144 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139525 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37582 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42832 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27875 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106501 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34806 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114592 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41336 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5958 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40733 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40878 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->