### PR TITLE
[JSC] Avoid fix-point iteration in B3 ReduceStrength

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -49,6 +49,7 @@
 #include "B3WasmRefTypeCheckValue.h"
 #include "B3WasmStructGetValue.h"
 #include "B3WasmStructSetValue.h"
+#include "Options.h"
 #include "SIMDShuffle.h"
 #include <wtf/HashMap.h>
 #include <wtf/MathExtras.h>
@@ -572,85 +573,146 @@ public:
 
     bool run()
     {
+        if (Options::useB3ReduceStrengthFixpoint())
+            return runFixpoint();
+        return runSinglePass();
+    }
+
+    bool runFixpoint()
+    {
         bool result = false;
-        bool first = true;
-        unsigned index = 0;
         do {
-            m_changed = false;
-            m_changedCFG = false;
-            ++index;
-
-            if (first)
-                first = false;
-            else if (B3ReduceStrengthInternal::verbose) {
-                dataLog("B3 after iteration #", index - 1, " of reduceStrength:\n");
-                dataLog(m_proc);
-            }
-            
-            simplifyCFG();
-
-            if (m_changedCFG) {
-                m_proc.resetReachability();
-                m_proc.invalidateCFG();
-                m_changed = true;
-            }
-
-            // We definitely want to do DCE before we do CSE so that we don't hoist things. For
-            // example:
-            //
-            // @dead = Mul(@a, @b)
-            // ... lots of control flow and stuff
-            // @thing = Mul(@a, @b)
-            //
-            // If we do CSE before DCE, we will remove @thing and keep @dead. Effectively, we will
-            // "hoist" @thing. On the other hand, if we run DCE before CSE, we will kill @dead and
-            // keep @thing. That's better, since we usually want things to stay wherever the client
-            // put them. We're not actually smart enough to move things around at random.
-            m_changed |= eliminateDeadCodeImpl(m_proc);
-            m_valueForConstant.clear();
-            
-            simplifySSA();
-            
-            if (m_proc.optLevel() >= 2) {
-                m_proc.resetValueOwners();
-                m_dominators = &m_proc.dominators(); // Recompute if necessary.
-                m_pureCSE.clear();
-            }
-
-            for (BasicBlock* block : m_proc.blocksInPreOrder()) {
-                m_block = block;
-                
-                for (m_index = 0; m_index < block->size(); ++m_index) {
-                    if (B3ReduceStrengthInternal::verbose) {
-                        dataLog(
-                            "Looking at ", *block, " #", m_index, ": ",
-                            deepDump(m_proc, block->at(m_index)), "\n");
-                    }
-                    m_value = m_block->at(m_index);
-                    m_value->performSubstitution();
-                    reduceValueStrength();
-                    if (m_proc.optLevel() >= 2)
-                        replaceIfRedundant();
-                }
-                m_insertionSet.execute(m_block);
-            }
-
-            m_changedCFG |= m_blockInsertionSet.execute();
-            handleChangedCFGIfNecessary();
-            
-            result |= m_changed;
+            result |= runOnePass();
         } while (m_changed && m_proc.optLevel() >= 2);
-        
+
         if (m_proc.optLevel() < 2) {
             m_changedCFG = false;
             simplifyCFG();
             handleChangedCFGIfNecessary();
         }
-        
+
         return result;
     }
-    
+
+    bool runSinglePass()
+    {
+        bool result = runOnePass();
+
+        if (m_proc.optLevel() >= 2) {
+            if (result) {
+                m_changed = false;
+                simplifyCFGToFixpoint();
+                simplifySSA();
+
+                // A second value walk is only worthwhile when pass 1 specialized a Select (which
+                // appends cloned values that never saw the reducer) or the CFG/SSA cleanup above
+                // exposed new opportunities (merged blocks enabling Check CSE, or a folded Phi
+                // turning Branch(Phi) into Branch(Identity)).
+                if (m_didSpecializeSelect || m_changed) {
+                    m_valueForConstant.clear();
+                    reduceAllBlocksStrength();
+                    simplifyCFGToFixpoint();
+                }
+
+                eliminateDeadCodeImpl(m_proc);
+            }
+        } else {
+            m_changedCFG = false;
+            simplifyCFG();
+            handleChangedCFGIfNecessary();
+            result |= m_changed;
+        }
+
+        return result;
+    }
+
+    bool runOnePass()
+    {
+        m_changed = false;
+        m_changedCFG = false;
+        m_didSpecializeSelect = false;
+
+        simplifyCFG();
+
+        if (m_changedCFG) {
+            m_proc.resetReachability();
+            m_proc.invalidateCFG();
+            m_changed = true;
+        }
+
+        // We definitely want to do DCE before we do CSE so that we don't hoist things. For
+        // example:
+        //
+        // @dead = Mul(@a, @b)
+        // ... lots of control flow and stuff
+        // @thing = Mul(@a, @b)
+        //
+        // If we do CSE before DCE, we will remove @thing and keep @dead. Effectively, we will
+        // "hoist" @thing. On the other hand, if we run DCE before CSE, we will kill @dead and
+        // keep @thing. That's better, since we usually want things to stay wherever the client
+        // put them. We're not actually smart enough to move things around at random.
+        m_changed |= eliminateDeadCodeImpl(m_proc);
+        m_valueForConstant.clear();
+
+        simplifySSA();
+
+        reduceAllBlocksStrength();
+
+        return m_changed;
+    }
+
+    // Recompute the per-walk caches (value owners, dominators, pure CSE) then run
+    // reduceBlockStrength over every block and flush the pending CFG/value insertions.
+    void reduceAllBlocksStrength()
+    {
+        if (m_proc.optLevel() >= 2) {
+            m_proc.resetValueOwners();
+            m_dominators = &m_proc.dominators(); // Recompute if necessary.
+            m_pureCSE.clear();
+        }
+
+        for (BasicBlock* block : m_proc.blocksInPreOrder())
+            reduceBlockStrength(block);
+
+        m_changedCFG |= m_blockInsertionSet.execute();
+        handleChangedCFGIfNecessary();
+    }
+
 private:
+    void reduceBlockStrength(BasicBlock* block)
+    {
+        m_block = block;
+        for (m_index = 0; m_index < block->size(); ++m_index) {
+            if (B3ReduceStrengthInternal::verbose) {
+                dataLog(
+                    "Looking at ", *block, " #", m_index, ": ",
+                    deepDump(m_proc, block->at(m_index)), "\n");
+            }
+            m_value = m_block->at(m_index);
+            m_value->performSubstitution();
+
+            // Many rules mutate the current value's children in place (e.g. Add(Add(x, c1), c2)
+            // becomes Add(x, c1 + c2)), and the result may match another rule. Without fixpoint
+            // iteration we re-run reductions on the same value until it stops changing or gets
+            // replaced (Identity) / erased (Nop).
+            constexpr unsigned maxReductionAttempts = 8;
+            for (unsigned attempt = 0; attempt < maxReductionAttempts; ++attempt) {
+                bool savedChanged = std::exchange(m_changed, false);
+                reduceValueStrength();
+                bool changedThisAttempt = m_changed;
+                m_changed |= savedChanged;
+                if (!changedThisAttempt)
+                    break;
+                Opcode opcode = m_value->opcode();
+                if (opcode == Identity || opcode == Nop)
+                    break;
+            }
+            if (m_proc.optLevel() >= 2)
+                replaceIfRedundant();
+        }
+        m_insertionSet.execute(m_block);
+    }
+
     void reduceValueStrength()
     {
         switch (m_value->opcode()) {
@@ -814,6 +876,13 @@ private:
                     else
                         minusOne = m_insertionSet.insert<Const64Value>(m_index, m_value->origin(), -1);
                     replaceWithNew<Value>(BitXor, m_value->origin(), m_value->child(0)->child(0), minusOne);
+                    break;
+                }
+
+                // Turn this: Sub(value, 0)
+                // Into this: value
+                if (m_value->child(1)->isInt(0)) {
+                    replaceWithIdentity(m_value->child(0));
                     break;
                 }
 
@@ -2871,62 +2940,15 @@ private:
             }
 
             if (comparison.opcode != m_value->opcode()) {
-                replaceWithNew<Value>(comparison.opcode, m_value->origin(), comparison.operands[0], comparison.operands[1]);
+                // Canonicalization flipped the comparison (e.g. AboveEqual(0, x) -> BelowEqual(x, 0)).
+                // Apply any immediate equality fold so we don't depend on a second pass.
+                if (!tryFoldComparisonToEquality(comparison.opcode, comparison.operands[0], comparison.operands[1]))
+                    replaceWithNew<Value>(comparison.opcode, m_value->origin(), comparison.operands[0], comparison.operands[1]);
                 break;
             }
 
-            {
-                bool converted = false;
-                switch (m_value->opcode()) {
-                case BelowEqual: {
-                    // Turn this: value <= 0
-                    // Into this: value == 0
-                    if (m_value->child(1)->isInt(0)) {
-                        replaceWithNew<Value>(Equal, m_value->origin(), m_value->child(0), m_value->child(1));
-                        converted = true;
-                        break;
-                    }
-                    break;
-                }
-                case Below: {
-                    // Turn this: value < 1
-                    // Into this: value == 0
-                    if (m_value->child(1)->isInt(1)) {
-                        auto* constant = m_insertionSet.insertValue(m_index, m_proc.addIntConstant(m_value->child(1), 0));
-                        replaceWithNew<Value>(Equal, m_value->origin(), m_value->child(0), constant);
-                        converted = true;
-                        break;
-                    }
-                    break;
-                }
-                case AboveEqual: {
-                    // Turn this: value >= 1
-                    // Into this: value != 0
-                    if (m_value->child(1)->isInt(1)) {
-                        auto* constant = m_insertionSet.insertValue(m_index, m_proc.addIntConstant(m_value->child(1), 0));
-                        replaceWithNew<Value>(NotEqual, m_value->origin(), m_value->child(0), constant);
-                        converted = true;
-                        break;
-                    }
-                    break;
-                }
-                case Above: {
-                    // Turn this: value > 0
-                    // Into this: value != 0
-                    if (m_value->child(1)->isInt(0)) {
-                        replaceWithNew<Value>(NotEqual, m_value->origin(), m_value->child(0), m_value->child(1));
-                        converted = true;
-                        break;
-                    }
-                    break;
-                }
-                default:
-                    break;
-                }
-
-                if (converted)
-                    break;
-            }
+            if (tryFoldComparisonToEquality(m_value->opcode(), m_value->child(0), m_value->child(1)))
+                break;
 
             if (m_value->child(0)->isInteger() && m_value->child(0) == m_value->child(1)) {
                 switch (m_value->opcode()) {
@@ -3220,7 +3242,7 @@ private:
             // blocks. This is pretty much guaranteed since one of those blocks will replace all
             // uses of the Select with a constant, and that constant will be transitively used
             // from the check.
-            static constexpr unsigned selectSpecializationBound = 3;
+            constexpr unsigned selectSpecializationBound = 5;
             Value* select = findRecentNodeMatching(
                 m_value->child(0), selectSpecializationBound,
                 [&] (Value* value) -> bool {
@@ -3230,6 +3252,7 @@ private:
             
             if (select) {
                 specializeSelect(select);
+                m_didSpecializeSelect = true;
                 break;
             }
             break;
@@ -4176,7 +4199,19 @@ private:
     template<typename Functor>
     Value* findRecentNodeMatching(Value* start, unsigned bound, const Functor& functor)
     {
-        unsigned startIndex = bound < m_index ? m_index - bound : 0;
+        // The bound counts back over non-free nodes, skipping the Nops etc. that this phase
+        // generates, so it reflects "this many useful operations back".
+        unsigned startIndex = 0;
+        unsigned remaining = bound;
+        for (unsigned i = m_index; i--;) {
+            if (!m_block->at(i)->isFree()) {
+                if (!remaining) {
+                    startIndex = i + 1;
+                    break;
+                }
+                --remaining;
+            }
+        }
         Value* result = nullptr;
         start->walk(
             [&] (Value* value) -> Value::WalkStatus {
@@ -4620,6 +4655,51 @@ private:
         replaceWithNewValue(m_proc.add<ValueType>(arguments...));
     }
 
+    // Fold an unsigned comparison against a small constant into an (in)equality against zero.
+    // Returns true if it replaced m_value.
+    bool tryFoldComparisonToEquality(Opcode opcode, Value* left, Value* right)
+    {
+        switch (opcode) {
+        case BelowEqual:
+            // Turn this: value <= 0
+            // Into this: value == 0
+            if (right->isInt(0)) {
+                replaceWithNew<Value>(Equal, m_value->origin(), left, right);
+                return true;
+            }
+            break;
+        case Below:
+            // Turn this: value < 1
+            // Into this: value == 0
+            if (right->isInt(1)) {
+                auto* zero = m_insertionSet.insertValue(m_index, m_proc.addIntConstant(right, 0));
+                replaceWithNew<Value>(Equal, m_value->origin(), left, zero);
+                return true;
+            }
+            break;
+        case AboveEqual:
+            // Turn this: value >= 1
+            // Into this: value != 0
+            if (right->isInt(1)) {
+                auto* zero = m_insertionSet.insertValue(m_index, m_proc.addIntConstant(right, 0));
+                replaceWithNew<Value>(NotEqual, m_value->origin(), left, zero);
+                return true;
+            }
+            break;
+        case Above:
+            // Turn this: value > 0
+            // Into this: value != 0
+            if (right->isInt(0)) {
+                replaceWithNew<Value>(NotEqual, m_value->origin(), left, right);
+                return true;
+            }
+            break;
+        default:
+            break;
+        }
+        return false;
+    }
+
     bool replaceWithNewValue(Value* newValue)
     {
         if (!newValue)
@@ -4660,6 +4740,17 @@ private:
     void replaceIfRedundant()
     {
         m_changed |= m_pureCSE.process(m_value, *m_dominators);
+    }
+
+    // simplifyCFG's rules chain: redirecting past a jump can expose a single-predecessor merge,
+    // and merging a block can redirect more successors. Iterate until the CFG stops changing.
+    void simplifyCFGToFixpoint()
+    {
+        do {
+            m_changedCFG = false;
+            simplifyCFG();
+            handleChangedCFGIfNecessary();
+        } while (m_changedCFG);
     }
 
     void simplifyCFG()
@@ -4886,6 +4977,7 @@ private:
     PureCSE m_pureCSE;
     bool m_changed { false };
     bool m_changedCFG { false };
+    bool m_didSpecializeSelect { false };
 };
 
 } // anonymous namespace

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -524,6 +524,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxB3TailDupBlockSuccessors, 3, Normal, nullptr) \
     v(Bool, useB3HoistLoopInvariantValues, true, Normal, nullptr) \
     v(Bool, useB3CanonicalizePrePostIncrements, false, Normal, nullptr) \
+    v(Bool, useB3ReduceStrengthFixpoint, false, Normal, "iterate B3 reduceStrength to a fixpoint instead of a single pass (for debugging)"_s) \
     v(Bool, useAirOptimizePairedLoadStore, true, Normal, nullptr) \
     \
     v(Bool, useDollarVM, false, Restricted, "installs the $vm debugging tool in global objects"_s) \


### PR DESCRIPTION
#### 0ba6297de022a3c74ee5c06cec673bb4f3b9d970
<pre>
[JSC] Avoid fix-point iteration in B3 ReduceStrength
<a href="https://bugs.webkit.org/show_bug.cgi?id=317181">https://bugs.webkit.org/show_bug.cgi?id=317181</a>
<a href="https://rdar.apple.com/179773016">rdar://179773016</a>

Reviewed by Justin Michaud.

We are finding that B3 ReduceStrength is taking too long time for large
graph. And because of characteristics of fix-point analysis, the last
iteration is wasteful no-op. Based on preliminary analysis, actually 98%
of B3 values are converged in the first run and remaining runs are only
handling the remaining 2%.

Based on this characteristics, we reorganize B3 ReduceStrength phase to
run only up to twice. But when I did this, we observed several JetStream3
benchmark regressions, thus we look into each case and ensure that the
required conversion happens in the single path and making them neutral.

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/315315@main">https://commits.webkit.org/315315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f77ac87b808b4428ff3f3e9fc558ccb2dde1599

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126307 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0d07e0d-9401-40a0-8c6e-6c7e221cdce5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3ed1a90-73bd-44d1-baf0-9623d7e23067) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111760 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/787c0cd7-f8ab-4173-9b9c-d3a836df1209) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31400 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26627 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161221 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180531 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29849 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139691 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42171 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139548 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42859 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106544 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25694 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34832 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114619 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201280 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41363 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5983 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54053 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40760 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40905 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->