### PR TITLE
[AppKit Gestures] REGRESSION(313984@main): Long press over non-editable text does not produce word selection

### DIFF
--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
@@ -67,6 +67,7 @@ struct InteractionInformationAtPosition {
         std::optional<bool> hitNodeOrWindowHasDoubleClickListener,
         Selectability&&,
         bool isSelected,
+        bool isOverSelectableText,
         bool prefersDraggingOverTextSelection,
         bool isDHTMLDraggable,
         bool isColorInput,
@@ -136,6 +137,7 @@ struct InteractionInformationAtPosition {
     Selectability selectability { Selectability::Selectable };
 
     bool isSelected { false };
+    bool isOverSelectableText { false };
     bool prefersDraggingOverTextSelection { false };
     bool isDHTMLDraggable { false };
     bool isColorInput { false };

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
@@ -40,6 +40,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     std::optional<bool> hitNodeOrWindowHasDoubleClickListener,
     Selectability&& selectability,
     bool isSelected,
+    bool isOverSelectableText,
     bool prefersDraggingOverTextSelection,
     bool isDHTMLDraggable,
     bool isColorInput,
@@ -105,6 +106,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     , hitNodeOrWindowHasDoubleClickListener(hitNodeOrWindowHasDoubleClickListener)
     , selectability(selectability)
     , isSelected(isSelected)
+    , isOverSelectableText(isOverSelectableText)
     , prefersDraggingOverTextSelection(prefersDraggingOverTextSelection)
     , isDHTMLDraggable(isDHTMLDraggable)
     , isColorInput(isColorInput)

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
@@ -38,6 +38,7 @@ struct WebKit::InteractionInformationAtPosition {
     WebKit::InteractionInformationAtPosition::Selectability selectability;
 
     bool isSelected;
+    bool isOverSelectableText;
     bool prefersDraggingOverTextSelection;
     bool isDHTMLDraggable;
     bool isColorInput;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -863,7 +863,12 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     bool requestIsValid = _hasValidPositionInformation && _positionInformation.request.isValidForRequest(request);
     bool isSelectable = _positionInformation.isSelectable();
-    bool shouldBegin = requestIsValid && isSelectable;
+    bool isOverSelectableText = _positionInformation.isOverSelectableText;
+
+    // The secondary click owns selectable points that are not over actual text (e.g. the page
+    // background). Over a run of selectable text, the text selection manager should win so that a
+    // long press selects a word instead of synthesizing a context menu.
+    bool shouldBegin = requestIsValid && isSelectable && !isOverSelectableText;
 
     if (!requestIsValid)
         [self _invalidateCurrentPositionInformation];

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -384,6 +384,8 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
     })();
     info.isSelected = result.isSelected();
 
+    info.isOverSelectableText = info.isSelectable() && renderer->isRenderText() && hitNode->canStartSelection();
+
     if (info.isLink || info.isImage)
         return;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -223,6 +223,40 @@ struct AppKitGesturesTests {
         }
     }
 
+    @Test(
+        .bug(
+            "rdar://179184036",
+            "REGRESSION(313984@main): Long-press over non-editable text shows a context menu instead of selecting a word"
+        )
+    )
+    func longPressOverTextSelectsWordAndDoesNotOpenContextMenu() async throws {
+        try await loadHTML(contentEditable: false)
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+
+        let crazyBoundsInScreenCoordinates = try await screenBoundsOfText("crazy")
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(1))
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        #expect(newSelection == crazySelection)
+    }
+
     @Test
     func scrollingDoesNotRemoveTextSelection() async throws {
         try await loadHTML()


### PR DESCRIPTION
#### 9e74eac7aaebc36b060438a12ba9f63ac4fafd30
<pre>
[AppKit Gestures] REGRESSION(313984@main): Long press over non-editable text does not produce word selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=317182">https://bugs.webkit.org/show_bug.cgi?id=317182</a>
<a href="https://rdar.apple.com/179184036">rdar://179184036</a>

Reviewed by Abrar Rahman Protyasha.

313984@main added `_secondaryClickGestureRecognizer` which synthesizes a right mouse-down/up to show
a context menu. Its begin gate, `-_secondaryClickShouldBeginAtLocation:`, started the gesture whenever
the position was `isSelectable()`. But `Selectable` only means selection is permitted there (it&apos;s true
both over a real run of text and over empty-but-selectable page background.) So the secondary click
fired over actual words, suppressing the text-selection manager&apos;s word selection.

`isSelectable()` cannot distinguish &quot;a word is here&quot; from &quot;empty selectable area&quot;, so this adds an
explicit signal. The secondary click now owns selectable points that are not over text (e.g. the page
background); over a run of selectable text the text-selection manager wins, so a long press selects the
word as before.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift

* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm:
(WebKit::InteractionInformationAtPosition::InteractionInformationAtPosition):
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController _secondaryClickShouldBeginAtLocation:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::selectionPositionInformation):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.longPressOverTextSelectsWordAndDoesNotOpenContextMenu):

Canonical link: <a href="https://commits.webkit.org/315270@main">https://commits.webkit.org/315270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87b4c77786686fdf6adc95ed29aa3ad3d3b427f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177913 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec32736e-8334-444a-9c18-2e7fa1248f06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42102 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65fdc4bd-41a0-4334-97ee-61cd84236a6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33691 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111746 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e39d1dd-c7e5-4594-97b3-b114d5086c83) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26608 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180512 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33235 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/30912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42152 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139535 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37563 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42840 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106512 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34817 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41344 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114600 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40741 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5968 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40886 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->