### PR TITLE
[JSC] for-of with closure-captured const binding never reaches DFG/FTL

### DIFF
--- a/JSTests/stress/for-of-const-closure-captured-tier-up.js
+++ b/JSTests/stress/for-of-const-closure-captured-tier-up.js
@@ -1,0 +1,29 @@
+//@ skip if not $jitTests
+//@ runDefault("--useConcurrentJIT=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual);
+}
+
+function hot(arr) {
+    let sum = 0;
+    for (const x of arr)
+        (() => sum += x)();
+    return sum;
+}
+noInline(hot);
+
+const a = new Int32Array(1000).map((_, i) => i);
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(hot(a), 499500);
+
+// The per-iteration lexical scope for `const x` is populated by reading the
+// previous iteration's value and writing it to the freshly-created scope. On
+// the first iteration that value is the TDZ empty sentinel, which never makes
+// it into the value profile, so FixupPhase used to insert an Int32 hint check
+// at the PutClosureVar that BadType-exits once per call and never converges.
+// We allow one recompile (the first attempt may still take the exit before the
+// exit site is recorded), but not a recompile loop.
+if (numberOfDFGCompiles(hot) > 2)
+    throw new Error("hot() was recompiled " + numberOfDFGCompiles(hot) + " times; speculateForBarrier should back off after BadType exit");

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -5134,7 +5134,10 @@ private:
         // Currently, the DFG won't take advantage of this speculation. But, we want to do it in
         // the DFG anyway because if such a speculation would be wrong, we want to know before
         // we do an expensive compile.
-        
+
+        if (m_graph.hasExitSite(m_currentNode->origin.semantic, BadType))
+            return;
+
         if (value->shouldSpeculateInt32()) {
             insertCheck<Int32Use>(value.node());
             return;


### PR DESCRIPTION
#### 85309cfe91e8b4b000e2fb44c13e71ce2558674d
<pre>
[JSC] for-of with closure-captured const binding never reaches DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=317169">https://bugs.webkit.org/show_bug.cgi?id=317169</a>

Reviewed by Yusuke Suzuki.

`for (const x of arr)` whose body captures `x` in a closure emits a per-iteration
copy: it reads `x` from the previous iteration&apos;s scope and writes it into a freshly
created lexical environment. On the first iteration of every call, the value being
copied is the TDZ empty sentinel, but the value profile for the source GetClosureVar
is dominated by the steady-state Int32 samples and never reflects SpecEmpty.

DFGFixupPhase::speculateForBarrier therefore inserts an Int32Use hint Check at the
PutClosureVar. That check BadType-exits once per call on the empty sentinel, the
DFG code is jettisoned, and on recompile the same hint is inserted again because
speculateForBarrier never consults the exit profile. The function loops between
Baseline and DFG and never reaches FTL (the repro case is recompiled 7 times under
--useConcurrentJIT=0).

speculateForBarrier is purely advisory (&quot;we want to know before we do an expensive
compile&quot;), so this patch makes it back off when a BadType exit has already been
recorded at the current site, mirroring the existing check in
attemptToMakeDoubleRepForPut. With this change the second DFG compile drops the
hint, the function tiers up to FTL, and the included microbenchmark is ~2.5x faster.

    function hot(arr) {
      let sum = 0;
      for (const x of arr)
        (() =&gt; sum += x)();
      return sum;
    }

Test: JSTests/stress/for-of-const-closure-captured-tier-up.js

* JSTests/stress/for-of-const-closure-captured-tier-up.js: Added.
(shouldBe):
(hot):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::speculateForBarrier):

Canonical link: <a href="https://commits.webkit.org/315274@main">https://commits.webkit.org/315274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/152681078a3e0e210e424464536e98a253baada8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177903 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126278 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131224 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111735 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31373 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26598 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161192 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180502 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29820 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139665 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42142 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139523 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37568 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42830 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106498 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34805 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114590 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201251 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41334 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5956 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54045 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->