### PR TITLE
[GFC] Flex tracks are sized imprecisely

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 202px 198px 200px;
+    grid-template-rows: 100px;
+    width: 600px;
+}
+</style>
+<div class="grid">
+    <div style="grid-column: 1 / 2; background: red"></div>
+    <div style="grid-column: 2 / 3; background: green"></div>
+    <div style="grid-column: 3 / 4; background: blue"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 202px 198px 200px;
+    grid-template-rows: 100px;
+    width: 600px;
+}
+</style>
+<div class="grid">
+    <div style="grid-column: 1 / 2; background: red"></div>
+    <div style="grid-column: 2 / 3; background: green"></div>
+    <div style="grid-column: 3 / 4; background: blue"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Verify no rounding loss for flex track sizing</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-find-fr-size">
+<link rel="match" href="grid-flexible-track-fractional-flex-factor-ref.html">
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 1.01fr 0.99fr 1fr;
+    grid-template-rows: 100px;
+    width: 600px;
+}
+</style>
+<div class="grid">
+    <div style="grid-row: 1 / 2; grid-column: 1 / 2; background: red"></div>
+    <div style="grid-row: 1 / 2; grid-column: 2 / 3; background: green"></div>
+    <div style="grid-row: 1 / 2; grid-column: 3 / 4; background: blue"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Verify no rounding loss for flex track sizing</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-find-fr-size">
+<link rel="match" href="grid-flexible-track-free-space-distribution-ref.html">
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+    grid-template-rows: 100px;
+    width: 100px;
+    background: red;
+}
+.item { background: green; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="grid">
+    <div class="item" style="grid-row: 1 / 2; grid-column: 1 / 2"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 2 / 3"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 3 / 4"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 4 / 5"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 5 / 6"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 6 / 7"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 7 / 8"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 8 / 9"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 9 / 10"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 10 / 11"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 11 / 12"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 12 / 13"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 13 / 14"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 14 / 15"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 15 / 16"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 16 / 17"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 17 / 18"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 18 / 19"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 19 / 20"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 20 / 21"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 21 / 22"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 22 / 23"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 23 / 24"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 24 / 25"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 25 / 26"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 26 / 27"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 27 / 28"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 28 / 29"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 29 / 30"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 30 / 31"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 31 / 32"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 32 / 33"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 33 / 34"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 34 / 35"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 35 / 36"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 36 / 37"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 37 / 38"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 38 / 39"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 39 / 40"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 40 / 41"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 41 / 42"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 42 / 43"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 43 / 44"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 44 / 45"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 45 / 46"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 46 / 47"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 47 / 48"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 48 / 49"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 49 / 50"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 50 / 51"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 51 / 52"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 52 / 53"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 53 / 54"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 54 / 55"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 55 / 56"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 56 / 57"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 57 / 58"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 58 / 59"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 59 / 60"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 60 / 61"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 61 / 62"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 62 / 63"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 63 / 64"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 64 / 65"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 65 / 66"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 66 / 67"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 67 / 68"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 68 / 69"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 69 / 70"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 70 / 71"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 71 / 72"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 72 / 73"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 73 / 74"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 74 / 75"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 75 / 76"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 76 / 77"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 77 / 78"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 78 / 79"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 79 / 80"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 80 / 81"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 81 / 82"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 82 / 83"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 83 / 84"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 84 / 85"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 85 / 86"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 86 / 87"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 87 / 88"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 88 / 89"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 89 / 90"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 90 / 91"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 91 / 92"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 92 / 93"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 93 / 94"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 94 / 95"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 95 / 96"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 96 / 97"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 97 / 98"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 98 / 99"></div>
+    <div class="item" style="grid-row: 1 / 2; grid-column: 99 / 100"></div>
+</div>

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -138,7 +138,7 @@ static FrSizeComponents computeFRSizeComponents(const UnsizedTracks& tracks, con
 // https://drafts.csswg.org/css-grid-1/#algo-find-fr-size
 // Step 4: If the product of the hypothetical fr size and a flexible track’s flex factor is less than
 // the track’s base size, restart this algorithm treating all such tracks as inflexible.
-static bool isValidFlexFactorUnit(const UnsizedTracks& tracks, LayoutUnit hypotheticalFrSize, InflexibleTrackState& state)
+static bool isValidFlexFactorUnit(const UnsizedTracks& tracks, double hypotheticalFrSize, InflexibleTrackState& state)
 {
     bool hasInvalidTracks = false;
     for (auto [index, track] : indexedRange(tracks)) {
@@ -146,11 +146,11 @@ static bool isValidFlexFactorUnit(const UnsizedTracks& tracks, LayoutUnit hypoth
             continue;
 
         auto flexFactor = track.trackSizingFunction.max.flex();
-        LayoutUnit computedSize = hypotheticalFrSize * LayoutUnit(flexFactor.value);
+        double computedSize = hypotheticalFrSize * flexFactor.value;
 
         // If the product of the hypothetical fr size and a flexible track's flex factor is less
         // than the track's base size, we should treat this track as inflexible.
-        if (computedSize < track.baseSize) {
+        if (computedSize < track.baseSize.toDouble()) {
             hasInvalidTracks = true;
             state.markAsInflexible(index);
         }
@@ -539,7 +539,7 @@ static double flexFactorSum(const FlexTracks& flexTracks)
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-find-fr-size
-static LayoutUnit findSizeOfFr(const UnsizedTracks& tracks, const LayoutUnit availableSpace, const LayoutUnit gapSize)
+static double findSizeOfFr(const UnsizedTracks& tracks, const LayoutUnit availableSpace, const LayoutUnit gapSize)
 {
     ASSERT(availableSpace >= 0_lu);
 
@@ -550,8 +550,8 @@ static LayoutUnit findSizeOfFr(const UnsizedTracks& tracks, const LayoutUnit ava
     InflexibleTrackState state;
     FrSizeComponents components;
     LayoutUnit freeSpace;
-    double flexFactorSum;
-    LayoutUnit hypotheticalFrSize;
+    double flexFactorSum = 0;
+    double hypotheticalFrSize = 0;
 
     while (true) {
         components = computeFRSizeComponents(tracks, state);
@@ -562,7 +562,7 @@ static LayoutUnit findSizeOfFr(const UnsizedTracks& tracks, const LayoutUnit ava
         // If leftover space is negative, the non-flexible tracks have already exceeded the space to fill; flex tracks should be sized to zero.
         // https://www.w3.org/TR/css-grid-1/#grid-track-concept
         if (freeSpace <= 0_lu)
-            return 0_lu;
+            return 0;
 
         // https://drafts.csswg.org/css-grid-1/#typedef-flex
         // Values between 0fr and 1fr have a somewhat special behavior: when the sum of the
@@ -573,7 +573,7 @@ static LayoutUnit findSizeOfFr(const UnsizedTracks& tracks, const LayoutUnit ava
         flexFactorSum = std::max(1.0, components.flexFactorSum);
 
         // Let the hypothetical fr size be the leftover space divided by the flex factor sum.
-        hypotheticalFrSize = freeSpace / LayoutUnit(flexFactorSum);
+        hypotheticalFrSize = freeSpace / flexFactorSum;
 
         // If the hypothetical fr size is valid for all flexible tracks, return that size.
         // Otherwise, restart the algorithm treating the invalid tracks as inflexible.
@@ -586,11 +586,11 @@ static LayoutUnit findSizeOfFr(const UnsizedTracks& tracks, const LayoutUnit ava
 
 // "... if the flexible track's flex factor is greater than one,
 // the result of dividing the track's base size by its flex factor; otherwise, the track's base size."
-static LayoutUnit NODELETE flexFractionFromTrackBaseSize(const FlexTrack& flexTrack)
+static double NODELETE flexFractionFromTrackBaseSize(const FlexTrack& flexTrack)
 {
     if (flexTrack.flexFactor.value > 1.0)
-        return flexTrack.baseSize / LayoutUnit(flexTrack.flexFactor.value);
-    return flexTrack.baseSize;
+        return flexTrack.baseSize / flexTrack.flexFactor.value;
+    return flexTrack.baseSize.toDouble();
 }
 
 static bool NODELETE itemCrossesFlexibleTrack(const UnsizedTracks& tracks, const WTF::Range<size_t>& span)
@@ -605,12 +605,26 @@ static bool NODELETE itemCrossesFlexibleTrack(const UnsizedTracks& tracks, const
 // Implements the final step of spec section 11.7:
 // "For each flexible track, if the product of the used flex fraction and the track's
 // flex factor is greater than the track's base size, set its base size to that product."
-static void NODELETE applyFlexFractionToTracks(UnsizedTracks& unsizedTracks, const FlexTracks& flexTracks, LayoutUnit flexFraction)
+static void applyFlexFractionToTracks(UnsizedTracks& unsizedTracks, const FlexTracks& flexTracks, double flexFraction)
 {
+    // Track the difference between the ideal size (float, product of the used flex fraction and the track's flex factor)
+    // and the snapped size (LayoutUnit, rounding down from ideal size).
+    double lastTrackRoundingError = 0;
     for (const auto& flexTrack : flexTracks) {
-        LayoutUnit flexSize = flexFraction * LayoutUnit(flexTrack.flexFactor.value);
-        if (flexSize > unsizedTracks[flexTrack.trackIndex].baseSize)
-            unsizedTracks[flexTrack.trackIndex].baseSize = flexSize;
+        // The target size of the flex track is the product of the used flex fraction and the track's flex factor.
+        // Carry the fraction lost when snapping the previous track so flooring errors don't accumulate.
+        double targetSize = flexFraction * flexTrack.flexFactor.value + lastTrackRoundingError;
+
+        // https://drafts.csswg.org/css-grid-2/#algo-flex-tracks
+        // For each flexible track, if the product of the used flex fraction and the track’s flex factor
+        // is greater than the track’s base size, set its base size to that product.
+        LayoutUnit snappedSize { targetSize };
+        LayoutUnit& baseSize = unsizedTracks[flexTrack.trackIndex].baseSize;
+        if (snappedSize > baseSize)
+            baseSize = snappedSize;
+
+        lastTrackRoundingError = targetSize - snappedSize.toDouble();
+        ASSERT(lastTrackRoundingError >= 0);
     }
 }
 
@@ -633,7 +647,7 @@ static void expandFlexibleTracksForMaxContent(UnsizedTracks& unsizedTracks, cons
     const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     // The used flex fraction is the maximum of:
-    LayoutUnit usedFlexFraction = 0_lu;
+    double usedFlexFraction = 0;
 
     // For each flexible track, if the flexible track's flex factor is greater than one,
     // the result of dividing the track's base size by its flex factor; otherwise, the track's base size.
@@ -648,7 +662,7 @@ static void expandFlexibleTracksForMaxContent(UnsizedTracks& unsizedTracks, cons
 
         auto maxContentContribution = gridItemSizingFunctions.maxContentContribution(trackSizingItems[gridItemIndex].gridItem, oppositeAxisConstraints[gridItemIndex]);
         auto itemTracks = unsizedTracks.subspan(gridItemSpan.begin(), gridItemSpan.distance());
-        auto candidateFlexFraction = findSizeOfFr(itemTracks, maxContentContribution, gapSize);
+        double candidateFlexFraction = findSizeOfFr(itemTracks, maxContentContribution, gapSize);
 
         usedFlexFraction = std::max(usedFlexFraction, candidateFlexFraction);
     }
@@ -676,7 +690,7 @@ static void expandFlexibleTracksForDefiniteLength(UnsizedTracks& unsizedTracks, 
     // Otherwise, if the free space is a definite length:
     // The used flex fraction is the result of finding the size of an fr using all of the
     // grid tracks and a space to fill of the available grid space (minus gutters).
-    auto frSize = findSizeOfFr(unsizedTracks, availableGridSpace.value(), gapSize);
+    double frSize = findSizeOfFr(unsizedTracks, availableGridSpace.value(), gapSize);
 
     // For each flexible track, if the product of the used flex fraction and the track's flex factor is greater than the track's base size, set its base size to that product.
     applyFlexFractionToTracks(unsizedTracks, flexTracks, frSize);


### PR DESCRIPTION
#### 91844883b4cca8301c9b9a5605f8098443ef80bd
<pre>
[GFC] Flex tracks are sized imprecisely
<a href="https://bugs.webkit.org/show_bug.cgi?id=317051">https://bugs.webkit.org/show_bug.cgi?id=317051</a>
<a href="https://rdar.apple.com/179531801">rdar://179531801</a>

Reviewed by Sammy Gill.

GFC was was casting unitless flex factor into a LayoutUnit before multiplying it by the fr size.
LayoutUnit has 1/64px resolution causing fractional flex factors such as 1.01fr to be quantized to 1.0fr.

This would cause &quot;grid-template-columns: 1.01fr 0.99fr 1fr&quot; in a 600px grid produced three equal
200px columns instead of 202/198/200.

In addition, each track&apos;s size was floored to a LayoutUnit independently, causing 1/64px rouding errors
to accumulate and the resulting tracks would not sum to the right size.

This would cause three 1fr tracks in a 100px grid totalled 99.98px rather than 100px.

Fix both by using floats for fr size and flex factor and carrying the fraction lost to
flooring form one track to the next to fix the track size sum.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-fractional-flex-factor.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-flexible-track-free-space-distribution.html: Added.
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::isValidFlexFactorUnit):
(WebCore::Layout::findSizeOfFr):
(WebCore::Layout::flexFractionFromTrackBaseSize):
(WebCore::Layout::applyFlexFractionToTracks):
(WebCore::Layout::expandFlexibleTracksForMaxContent):
(WebCore::Layout::expandFlexibleTracksForDefiniteLength):

Canonical link: <a href="https://commits.webkit.org/315479@main">https://commits.webkit.org/315479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0821dde75c7c408f5b0594bee68a011abcc49b89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126716 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad5320cc-2879-4ee8-8287-8a3c7a37ae9e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131609 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a419251-9d53-4887-a56d-5863d2e020c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34064 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112112 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34b12596-10ec-46f5-abb3-8097abfa01a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33050 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31758 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27061 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180960 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140059 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139901 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43272 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107098 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25778 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35181 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115037 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41781 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6481 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41175 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41318 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->