### PR TITLE
[JSC] Add int32 fast path to `parseInt` for short decimal strings

### DIFF
--- a/JSTests/microbenchmarks/parse-int-string-no-radix.js
+++ b/JSTests/microbenchmarks/parse-int-string-no-radix.js
@@ -1,0 +1,16 @@
+function test(strings)
+{
+    let result = 0;
+    for (let i = 0; i < strings.length; ++i)
+        result += parseInt(strings[i]);
+    return result;
+}
+noInline(test);
+
+let strings = ["12345", "6789", "42", "100000", "7", "314159265", "0", "8888"];
+let expected = test(strings);
+
+for (let i = 0; i < 1e6; ++i) {
+    if (test(strings) !== expected)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/parse-int-string-radix-10-slow-shapes.js
+++ b/JSTests/microbenchmarks/parse-int-string-radix-10-slow-shapes.js
@@ -1,0 +1,17 @@
+function test(strings)
+{
+    let result = 0;
+    for (let i = 0; i < strings.length; ++i)
+        result += parseInt(strings[i], 10);
+    return result;
+}
+noInline(test);
+
+// Shapes that miss the leading-'1'..'9' fast path: leading zero, sign, whitespace, 10+ digits.
+let strings = ["0", "007", "-12345", "+6789", "  42", "1234567890", "0000000001", "-999999999"];
+let expected = test(strings);
+
+for (let i = 0; i < 1e6; ++i) {
+    if (test(strings) !== expected)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/parse-int-string-radix-10.js
+++ b/JSTests/microbenchmarks/parse-int-string-radix-10.js
@@ -1,0 +1,16 @@
+function test(strings)
+{
+    let result = 0;
+    for (let i = 0; i < strings.length; ++i)
+        result += parseInt(strings[i], 10);
+    return result;
+}
+noInline(test);
+
+let strings = ["12345", "6789", "42", "100000", "7", "314159265", "0", "8888"];
+let expected = test(strings);
+
+for (let i = 0; i < 1e6; ++i) {
+    if (test(strings) !== expected)
+        throw new Error("bad");
+}

--- a/JSTests/stress/parse-int-radix-10-int32-fast-path.js
+++ b/JSTests/stress/parse-int-radix-10-int32-fast-path.js
@@ -1,0 +1,52 @@
+function shouldBe(actual, expected, msg) {
+    if (!Object.is(actual, expected))
+        throw new Error("FAIL " + msg + ": expected " + expected + " but got " + actual);
+}
+
+function test() {
+    shouldBe(parseInt("0", 10), 0, "0");
+    shouldBe(parseInt("-0", 10), -0, "-0");
+    shouldBe(parseInt("+0", 10), 0, "+0");
+    shouldBe(parseInt("7", 10), 7, "7");
+    shouldBe(parseInt("42", 10), 42, "42");
+    shouldBe(parseInt("007", 10), 7, "007");
+    shouldBe(parseInt("12345", 10), 12345, "12345");
+    shouldBe(parseInt("-12345", 10), -12345, "-12345");
+    shouldBe(parseInt("+12345", 10), 12345, "+12345");
+    shouldBe(parseInt("   42", 10), 42, "leading ws");
+    shouldBe(parseInt("42   ", 10), 42, "trailing ws");
+    shouldBe(parseInt("   42   ", 10), 42, "both ws");
+    shouldBe(parseInt("123abc", 10), 123, "123abc");
+    shouldBe(parseInt("123.456", 10), 123, "123.456");
+    shouldBe(parseInt("999999999", 10), 999999999, "9 digits");
+    shouldBe(parseInt("1000000000", 10), 1000000000, "10 digits small");
+    shouldBe(parseInt("9999999999", 10), 9999999999, "10 digits");
+    shouldBe(parseInt("2147483647", 10), 2147483647, "INT32_MAX");
+    shouldBe(parseInt("2147483648", 10), 2147483648, "INT32_MAX+1");
+    shouldBe(parseInt("-2147483648", 10), -2147483648, "INT32_MIN");
+    shouldBe(parseInt("-2147483649", 10), -2147483649, "INT32_MIN-1");
+    shouldBe(parseInt("9007199254740992", 10), 9007199254740992, "2^53");
+    shouldBe(parseInt("9007199254740993", 10), 9007199254740992, "2^53+1 rounds");
+    shouldBe(parseInt("100000000000000000000000", 10), 1e23, "1e23");
+    shouldBe(Number.isNaN(parseInt("", 10)), true, "empty");
+    shouldBe(Number.isNaN(parseInt("   ", 10)), true, "ws only");
+    shouldBe(Number.isNaN(parseInt("abc", 10)), true, "abc");
+    shouldBe(Number.isNaN(parseInt("-", 10)), true, "minus only");
+    shouldBe(Number.isNaN(parseInt("- 1", 10)), true, "minus space");
+    shouldBe(parseInt("0x10", 10), 0, "0x10 radix10");
+    shouldBe(parseInt("0x10"), 16, "0x10 no radix");
+    shouldBe(parseInt("0"), 0, "0 no radix");
+    shouldBe(parseInt("0", 0), 0, "0 radix 0");
+    shouldBe(parseInt("12345"), 12345, "no radix");
+    shouldBe(parseInt("12345", 0), 12345, "radix 0");
+    shouldBe(parseInt("12345", undefined), 12345, "radix undefined");
+    shouldBe(parseInt("  42 ", 10), 42, "unicode ws");
+    shouldBe(Number.isNaN(parseInt("１２", 10)), true, "fullwidth digits");
+    shouldBe(parseInt("999999999abc", 10), 999999999, "9 digits + junk");
+    shouldBe(parseInt("9999999999abc", 10), 9999999999, "10 digits + junk");
+    shouldBe(parseInt("000000000000000000000001", 10), 1, "many leading zeros");
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i)
+    test();

--- a/Source/JavaScriptCore/runtime/ParseInt.h
+++ b/Source/JavaScriptCore/runtime/ParseInt.h
@@ -132,11 +132,30 @@ template <typename CharType>
 ALWAYS_INLINE
 static double parseInt(std::span<const CharType> data, int radix)
 {
+    static constexpr size_t numberOfDigitsForSafeInt32 = 9;
+
+    size_t length = data.size();
+
+    if ((radix == 10 || !radix) && length && length <= numberOfDigitsForSafeInt32) {
+        auto first = data[0];
+        if (first >= '1' && first <= '9') {
+            int32_t intNumber = first - '0';
+            for (size_t i = 1; i < length; ++i) {
+                auto c = data[i];
+                if (!isASCIIDigit(c))
+                    return intNumber;
+                intNumber = intNumber * 10 + (c - '0');
+            }
+            return intNumber;
+        }
+        if (first == '0' && length == 1)
+            return 0;
+    }
+
     // 1. Let inputString be ToString(string).
     // 2. Let S be a newly created substring of inputString consisting of the first character that is not a
     //    StrWhiteSpaceChar and all characters following that character. (In other words, remove leading white
     //    space.) If inputString does not contain any such characters, let S be the empty string.
-    size_t length = data.size();
     size_t p = 0;
     while (p < length && isStrWhiteSpace(data[p]))
         ++p;
@@ -175,6 +194,30 @@ static double parseInt(std::span<const CharType> data, int radix)
     if (radix < 2 || radix > 36)
         return PNaN;
 
+    if (radix == 10) {
+        size_t firstDigitPosition = p;
+        int32_t intNumber = 0;
+        size_t intEnd = std::min(length, p + numberOfDigitsForSafeInt32);
+        while (p < intEnd && isASCIIDigit(data[p])) {
+            intNumber = intNumber * 10 + (data[p] - '0');
+            ++p;
+        }
+        if (p == firstDigitPosition)
+            return PNaN;
+        if (p == length || !isASCIIDigit(data[p]))
+            return sign * intNumber;
+        double number = intNumber;
+        do {
+            number = number * 10 + (data[p] - '0');
+            ++p;
+        } while (p < length && isASCIIDigit(data[p]));
+        if (number >= mantissaOverflowLowerBound) [[unlikely]] {
+            size_t parsedLength;
+            number = parseDouble(data.subspan(firstDigitPosition, p - firstDigitPosition), parsedLength);
+        }
+        return sign * number;
+    }
+
     // 13. Let mathInt be the mathematical integer value that is represented by Z in radix-R notation, using the letters
     //     A-Z and a-z for digits with values 10 through 35. (However, if R is 10 and Z contains more than 20 significant
     //     digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation;
@@ -199,13 +242,8 @@ static double parseInt(std::span<const CharType> data, int radix)
         return PNaN;
 
     // Alternate code path for certain large numbers.
-    if (number >= mantissaOverflowLowerBound) {
-        if (radix == 10) {
-            size_t parsedLength;
-            number = parseDouble(data.subspan(firstDigitPosition, p - firstDigitPosition), parsedLength);
-        } else if (radix == 2 || radix == 4 || radix == 8 || radix == 16 || radix == 32)
-            number = parseIntOverflow(data.subspan(firstDigitPosition, p - firstDigitPosition), radix);
-    }
+    if (number >= mantissaOverflowLowerBound && (radix == 2 || radix == 4 || radix == 8 || radix == 16 || radix == 32))
+        number = parseIntOverflow(data.subspan(firstDigitPosition, p - firstDigitPosition), radix);
 
     // 15. Return sign x number.
     return sign * number;


### PR DESCRIPTION
#### 8c5c8fb7bbb1259ee1d37c9d39b9cbab10bbfebf
<pre>
[JSC] Add int32 fast path to `parseInt` for short decimal strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=317187">https://bugs.webkit.org/show_bug.cgi?id=317187</a>

Reviewed by Yusuke Suzuki.

parseInt always accumulates digits in double and runs the generic
parseDigit dispatch (digit/upper/lower three-way branch) even for
radix 10. Add two layers of fast paths:

1. At the top of parseInt(): when radix is 10 or 0, length is 1..9,
   and the first character is &apos;1&apos;..&apos;9&apos;, skip whitespace, sign,
   0x-prefix and radix-range handling entirely and accumulate the
   result in int32.
2. After the generic setup, when radix resolved to 10: accumulate up
   to 9 digits in int32, seeding into double only when a 10th digit
   appears, and use isASCIIDigit instead of parseDigit. This also
   covers leading-zero/sign/whitespace inputs that miss path 1 so
   they do not regress.

The generic loop&apos;s now-unreachable radix==10 mantissa-overflow branch
is removed.

                                            TipOfTree                Patched
parse-int-string-no-radix                43.1823+-0.4470    ^    28.2848+-0.1850       ^ definitely 1.5267x faster
parse-int-string-radix-10                42.3626+-0.4482    ^    29.3662+-0.1627       ^ definitely 1.4426x faster
parse-int-string-radix-10-slow-shapes    49.1872+-0.4298    ^    44.4247+-0.5849       ^ definitely 1.1072x faster

Tests: JSTests/microbenchmarks/parse-int-string-no-radix.js
       JSTests/microbenchmarks/parse-int-string-radix-10-slow-shapes.js
       JSTests/microbenchmarks/parse-int-string-radix-10.js
       JSTests/stress/parse-int-radix-10-int32-fast-path.js

* JSTests/microbenchmarks/parse-int-string-no-radix.js: Added.
(test):
* JSTests/microbenchmarks/parse-int-string-radix-10-slow-shapes.js: Added.
(test):
* JSTests/microbenchmarks/parse-int-string-radix-10.js: Added.
(test):
* JSTests/stress/parse-int-radix-10-int32-fast-path.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/runtime/ParseInt.h:
(JSC::parseInt):

Canonical link: <a href="https://commits.webkit.org/315451@main">https://commits.webkit.org/315451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f46f300c5b779812972881221967b6c596cfc58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131269 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92336 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32714 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31418 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26647 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161241 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180553 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29869 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139713 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42191 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139568 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37666 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42879 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27919 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106565 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34849 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114639 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201300 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41383 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6002 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54056 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40780 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->