### PR TITLE
Add WPT tests to show the effects of maskUnits and defaults on a path.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default-expected.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <title>Reference: 100x12 green rectangle at (50,44)</title>
+  <rect x="50" y="44" width="100" height="12" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default-ref.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <title>Reference: 100x12 green rectangle at (50,44)</title>
+  <rect x="50" y="44" width="100" height="12" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
+     width="200" height="100" viewBox="0 0 200 100">
+  <g id="testmeta">
+    <title>CSS Masking: default &lt;mask&gt; (objectBoundingBox) clips stroke on thin-bbox path</title>
+    <html:link rel="help" href="https://drafts.csswg.org/css-masking-1/#MaskElement"/>
+    <html:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/coords.html#TermObjectBoundingBox"/>
+    <html:link rel="match" href="mask-on-thin-stroked-path-default-ref.svg"/>
+    <html:meta name="assert" content="With a default &lt;mask&gt; reference (maskUnits=objectBoundingBox, x=-10% y=-10% width=120% height=120%) on a stroked path whose geometric bounding box is (50,45,100,10), the mask painting region resolves to (40,44,120,12) and clips the rendered stroke to that rectangle. The visible stroke is a 100x12 green rectangle at (50,44)."/>
+  </g>
+
+  <mask id="default-mask">
+    <rect x="0" y="0" width="200" height="100" fill="white"/>
+  </mask>
+
+  <!-- Path bbox: x=50, y=45, width=100, height=10
+       Default mask region (objectBoundingBox + 10% pad):
+         x = 50 - 0.1*100 = 40
+         y = 45 - 0.1*10  = 44
+         w = 1.2*100       = 120
+         h = 1.2*10        = 12
+       Stroke shape (two horizontal bands, stroke-width=20, butt caps):
+         band 1: x=50..150, y=35..55
+         band 2: x=50..150, y=45..65
+         union:  x=50..150, y=35..65
+       Intersected with mask region:
+         x: [50,150] n [40,160] = [50,150]  -> width 100
+         y: [35,65]  n [44,56]  = [44,56]   -> height 12
+       Result: green rect at (50, 44, 100, 12). Pixel-aligned. -->
+  <path d="M 50 45 L 150 45 M 50 55 L 150 55"
+        stroke="green" stroke-width="20" stroke-linecap="butt"
+        fill="none" mask="url(#default-mask)"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <title>Reference: stroked path with no mask (full stroke shape)</title>
+  <!-- Same path geometry as the test, no mask. -->
+  <path d="M 50 45 L 150 45 M 50 55 L 150 55"
+        stroke="green" stroke-width="20" stroke-linecap="butt"
+        fill="none"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse-ref.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100">
+  <title>Reference: stroked path with no mask (full stroke shape)</title>
+  <!-- Same path geometry as the test, no mask. -->
+  <path d="M 50 45 L 150 45 M 50 55 L 150 55"
+        stroke="green" stroke-width="20" stroke-linecap="butt"
+        fill="none"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
+     width="200" height="100" viewBox="0 0 200 100">
+  <g id="testmeta">
+    <title>CSS Masking: maskUnits=userSpaceOnUse preserves stroke on thin-bbox path</title>
+    <html:link rel="help" href="https://drafts.csswg.org/css-masking-1/#element-attrdef-mask-maskunits"/>
+    <html:link rel="match" href="mask-on-thin-stroked-path-userspaceonuse-ref.svg"/>
+    <html:meta name="assert" content="When a &lt;mask&gt; uses maskUnits=userSpaceOnUse with explicit x/y/width/height covering the full SVG viewport, the mask painting region is independent of the masked element's bounding box. A path with a thin geometric bounding box (height=10) and a thick stroke (stroke-width=20) renders with its full stroke shape preserved, identical to the same path without any mask."/>
+  </g>
+
+  <!-- Mask region in user space, covering the whole viewport.
+       Independent of the masked element's bbox. -->
+  <mask id="usu-mask" maskUnits="userSpaceOnUse"
+        x="0" y="0" width="200" height="100">
+    <rect x="0" y="0" width="200" height="100" fill="white"/>
+  </mask>
+
+  <!-- Same geometry as mask-on-thin-stroked-path-default.svg:
+       Path bbox (50,45,100,10), stroke-width=20, butt caps.
+       Stroke shape: union of two horizontal bands -> solid rect (50,35,100,30). -->
+  <path d="M 50 45 L 150 45 M 50 55 L 150 55"
+        stroke="green" stroke-width="20" stroke-linecap="butt"
+        fill="none" mask="url(#usu-mask)"/>
+</svg>


### PR DESCRIPTION
#### d4ec0a394fdb91ba60ee19a0b44066b654cc2442
<pre>
Add WPT tests to show the effects of maskUnits and defaults on a path.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317184">https://bugs.webkit.org/show_bug.cgi?id=317184</a>
<a href="https://rdar.apple.com/179778617">rdar://179778617</a>

Reviewed by Nikolas Zimmermann.

This adds two WPT tests which were not covered by the current WPT test
suite about the mask element in SVG.

It makes sure to check the effect of maskUnits value on the size of the
stroke of a graphics.

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default-ref.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-default.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse-ref.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-on-thin-stroked-path-userspaceonuse.svg: Added.

Canonical link: <a href="https://commits.webkit.org/315843@main">https://commits.webkit.org/315843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bcaebecc5a851257984b6aa063a91dbaab743d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126289 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/956c0589-a562-4a16-8adc-6e74c2652bf1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131236 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92305 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2400251e-3cab-4cd1-bd7d-357aef9e3e60) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111747 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/420438ad-d3cc-4ecf-85fb-1221873a2073) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32678 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31383 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26609 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180513 "Built successfully") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35547 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139677 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139534 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37962 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42841 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106513 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34816 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41345 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5967 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40993 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->