### PR TITLE
[Smart Lists] Convert to Numbered/Bulleted List doesn't change list formatting

### DIFF
--- a/LayoutTests/editing/execCommand/change-list-type-strips-source-list-attributes-expected.txt
+++ b/LayoutTests/editing/execCommand/change-list-type-strips-source-list-attributes-expected.txt
@@ -1,0 +1,109 @@
+Verifies that converting list type strips list-type-specific attributes.
+
+Before OL to UL:
+| "\n        "
+| <ol>
+|   class="Apple-decimal-list"
+|   start="2"
+|   style="list-style-type: decimal"
+|   "\n            "
+|   <li>
+|     id="ol1"
+|     "two"
+|   "\n            "
+|   <li>
+|     "three"
+|   "\n            "
+|   <li>
+|     "four"
+|   "\n        "
+| "\n    "
+
+After OL to UL:
+| "\n        "
+| <ul>
+|   class="Apple-disc-list"
+|   style="list-style-type: disc;"
+|   "\n            "
+|   <li>
+|     id="ol1"
+|     "two"
+|   "\n            "
+|   <li>
+|     "three"
+|   "\n            "
+|   <li>
+|     "four<#selection-caret>"
+|   "\n        "
+| "\n    "
+
+After UL back to OL:
+| "\n        "
+| <ol>
+|   class="Apple-decimal-list"
+|   style="list-style-type: decimal;"
+|   "\n            "
+|   <li>
+|     id="ol1"
+|     "two"
+|   "\n            "
+|   <li>
+|     "three"
+|   "\n            "
+|   <li>
+|     "four<#selection-caret>"
+|   "\n        "
+| "\n    "
+
+Before reversed OL to UL:
+| "\n        "
+| <ol>
+|   class="Apple-decimal-list"
+|   reversed=""
+|   style="list-style-type: decimal"
+|   "\n            "
+|   <li>
+|     id="olReversed1"
+|     "alpha"
+|   "\n            "
+|   <li>
+|     "beta"
+|   "\n        "
+| "\n    "
+
+After reversed OL to UL:
+| "\n        "
+| <ul>
+|   class="Apple-disc-list"
+|   style="list-style-type: disc;"
+|   "\n            "
+|   <li>
+|     id="olReversed1"
+|     "alpha"
+|   "\n            "
+|   <li>
+|     "beta<#selection-caret>"
+|   "\n        "
+| "\n    "
+
+Before UL to OL:
+| "\n        "
+| <ul>
+|   class="Apple-disc-list"
+|   "\n            "
+|   <li>
+|     id="ul1"
+|     "alpha"
+|   "\n        "
+| "\n    "
+
+After UL to OL:
+| "\n        "
+| <ol>
+|   class="Apple-decimal-list"
+|   "\n            "
+|   <li>
+|     id="ul1"
+|     "alpha<#selection-caret>"
+|   "\n        "
+| "\n    "

--- a/LayoutTests/editing/execCommand/change-list-type-strips-source-list-attributes.html
+++ b/LayoutTests/editing/execCommand/change-list-type-strips-source-list-attributes.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+    <div contenteditable id="ol-list">
+        <ol start="2" style="list-style-type: decimal" class="Apple-decimal-list">
+            <li id="ol1">two</li>
+            <li>three</li>
+            <li>four</li>
+        </ol>
+    </div>
+
+    <div contenteditable id="ol-reversed-list">
+        <ol reversed style="list-style-type: decimal" class="Apple-decimal-list">
+            <li id="olReversed1">alpha</li>
+            <li>beta</li>
+        </ol>
+    </div>
+
+    <div contenteditable id="ul-list">
+        <ul class="Apple-disc-list">
+            <li id="ul1">alpha</li>
+        </ul>
+    </div>
+
+    <script>
+    Markup.description("Verifies that converting list type strips list-type-specific attributes.");
+    if (!window.internals)
+        Markup.notifyDone();
+
+    Markup.waitUntilDone();
+
+    Markup.dump("ol-list", "Before OL to UL");
+    document.getElementById("ol-list").focus();
+    getSelection().setPosition(ol1, 0);
+    internals.changeSelectionListType();
+    Markup.dump("ol-list", "After OL to UL");
+
+    // Changing from an unordered list to an ordered list should reset the start to 1.
+    getSelection().setPosition(ol1, 0);
+    internals.changeSelectionListType();
+    Markup.dump("ol-list", "After UL back to OL");
+
+    Markup.dump("ol-reversed-list", "Before reversed OL to UL");
+    document.getElementById("ol-list").focus();
+    getSelection().setPosition(olReversed1, 0);
+    internals.changeSelectionListType();
+    Markup.dump("ol-reversed-list", "After reversed OL to UL");
+
+    Markup.dump("ul-list", "Before UL to OL");
+    document.getElementById("ul-list").focus();
+    getSelection().setPosition(ul1, 0);
+    internals.changeSelectionListType();
+    Markup.dump("ul-list", "After UL to OL");
+
+    Markup.notifyDone();
+    </script>
+</body>
+</html>

--- a/LayoutTests/editing/execCommand/change-list-type-undo-redo-expected.txt
+++ b/LayoutTests/editing/execCommand/change-list-type-undo-redo-expected.txt
@@ -1,0 +1,76 @@
+Verifies that converting list, then undo and redo will restore the list accordingly.
+
+Before OL to UL:
+| "\n        "
+| <ol>
+|   class="Apple-decimal-list"
+|   start="2"
+|   style="list-style-type: decimal"
+|   "\n            "
+|   <li>
+|     id="ol1"
+|     "two"
+|   "\n            "
+|   <li>
+|     "three"
+|   "\n            "
+|   <li>
+|     "four"
+|   "\n        "
+| "\n    "
+
+After OL to UL:
+| "\n        "
+| <ul>
+|   class="Apple-disc-list"
+|   style="list-style-type: disc;"
+|   "\n            "
+|   <li>
+|     id="ol1"
+|     "two"
+|   "\n            "
+|   <li>
+|     "three"
+|   "\n            "
+|   <li>
+|     "four<#selection-caret>"
+|   "\n        "
+| "\n    "
+
+After undo:
+| "\n        "
+| <ol>
+|   class="Apple-decimal-list"
+|   start="2"
+|   style="list-style-type: decimal"
+|   "\n            "
+|   <li>
+|     id="ol1"
+|     <#selection-caret>
+|     "two"
+|   "\n            "
+|   <li>
+|     "three"
+|   "\n            "
+|   <li>
+|     "four"
+|   "\n        "
+| "\n    "
+
+After redo:
+| "\n        "
+| <ul>
+|   class="Apple-disc-list"
+|   style="list-style-type: disc;"
+|   "\n            "
+|   <li>
+|     id="ol1"
+|     "two"
+|   "\n            "
+|   <li>
+|     "three"
+|   "\n            "
+|   <li>
+|     "four<#selection-caret>"
+|   "\n        "
+| "\n    "

--- a/LayoutTests/editing/execCommand/change-list-type-undo-redo.html
+++ b/LayoutTests/editing/execCommand/change-list-type-undo-redo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+    <div contenteditable id="ol-list">
+        <ol start="2" style="list-style-type: decimal" class="Apple-decimal-list">
+            <li id="ol1">two</li>
+            <li>three</li>
+            <li>four</li>
+        </ol>
+    </div>
+
+    <script>
+    Markup.description("Verifies that converting list, then undo and redo will restore the list accordingly.");
+    if (!window.internals)
+        Markup.notifyDone();
+
+    Markup.waitUntilDone();
+
+    Markup.dump("ol-list", "Before OL to UL");
+    document.getElementById("ol-list").focus();
+    getSelection().setPosition(ol1, 0);
+    internals.changeSelectionListType();
+    Markup.dump("ol-list", "After OL to UL");
+
+    undoCommand();
+    Markup.dump("ol-list", "After undo");
+
+    redoCommand();
+    Markup.dump("ol-list", "After redo");
+
+    Markup.notifyDone();
+    </script>
+</body>
+</html>

--- a/Source/WebCore/editing/ChangeListTypeCommand.cpp
+++ b/Source/WebCore/editing/ChangeListTypeCommand.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ChangeListTypeCommand.h"
 
+#include "DOMTokenList.h"
 #include "Editing.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "FrameDestructionObserverInlines.h"
@@ -34,6 +35,7 @@
 #include "HTMLOListElement.h"
 #include "HTMLUListElement.h"
 #include "LocalFrameInlines.h"
+#include "StylePropertiesInlines.h"
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
@@ -70,6 +72,30 @@ std::optional<ChangeListTypeCommand::Type> ChangeListTypeCommand::listConversion
     return std::nullopt;
 }
 
+static void removeSourceListAttributes(const HTMLElement& listToReplace, HTMLElement& list, ChangeListTypeCommand::Type type)
+{
+    bool convertToUnorderedList = type == ChangeListTypeCommand::Type::ConvertToUnorderedList;
+    if (convertToUnorderedList) {
+        list.removeAttribute(HTMLNames::startAttr);
+        list.removeAttribute(HTMLNames::typeAttr);
+        list.removeAttribute(HTMLNames::reversedAttr);
+    }
+    list.removeInlineStyleProperty(CSSPropertyListStyleType);
+
+    Ref classList = list.classList();
+    bool sourceHasClassNameForSmartList = classList->contains("Apple-decimal-list"_s) || classList->contains("Apple-disc-list"_s) || classList->contains("Apple-dash-list"_s);
+
+    if (sourceHasClassNameForSmartList) {
+        FixedVector<AtomString> classNamesToRemove { "Apple-dash-list"_s, (convertToUnorderedList ? "Apple-decimal-list"_s : "Apple-disc-list"_s) };
+        classList->remove(classNamesToRemove);
+        classList->add(convertToUnorderedList ? "Apple-disc-list"_s : "Apple-decimal-list"_s);
+    }
+
+    RefPtr existingInlineStyle = listToReplace.inlineStyle();
+    if (existingInlineStyle && !existingInlineStyle->getPropertyValue(CSSPropertyListStyleType).isEmpty())
+        list.setInlineStyleProperty(CSSPropertyListStyleType, (convertToUnorderedList ? CSSValueDisc : CSSValueDecimal));
+}
+
 Ref<HTMLElement> ChangeListTypeCommand::createNewList(const HTMLElement& listToReplace)
 {
     RefPtr<HTMLElement> list;
@@ -78,6 +104,9 @@ Ref<HTMLElement> ChangeListTypeCommand::createNewList(const HTMLElement& listToR
     else
         list = HTMLUListElement::create(document());
     list->cloneDataFromElement(listToReplace);
+
+    removeSourceListAttributes(listToReplace, *list, m_type);
+
     return list.releaseNonNull();
 }
 


### PR DESCRIPTION
#### 0dafd3d138c2d4427019b7c21b8ca007e3f0a065
<pre>
[Smart Lists] Convert to Numbered/Bulleted List doesn&apos;t change list formatting
<a href="https://bugs.webkit.org/show_bug.cgi?id=317188">https://bugs.webkit.org/show_bug.cgi?id=317188</a>
<a href="https://rdar.apple.com/178656218">rdar://178656218</a>

Reviewed by Aditya Keerthi.

Currently, converting list formatting will successfully change the list
type (that is, the tags from &lt;ol&gt; to &lt;ul&gt; and vice versa) but the changed
list still renders as the original/source list type.

This is because when changing the list type, all the attributes are cloned.
So, an ordered list with `start=&quot;1&quot; style=&quot;list-style-type: decimal;&quot;
class=&quot;Apple-decimal-list&quot;` will then become an unordered list with the
same attributes.

To fix this, strip the source list of its type specific attributes in a helper
function. Technically, only removing `list-style-type` is enough to fix this issue
but only removing this will cause an unordered list to potentially have a
start attribute and others specific to ordered lists. Thus, for
correctness, remove those attributes. Additionally, if the source list had
an Apple-specific marker class name or `list-style-type`, add the equivalent
for the changed list.

Add layout tests for this change. Add layout tests for the case where the user
converts the list, then undos the action, and redos.

* LayoutTests/editing/execCommand/change-list-type-strips-source-list-attributes-expected.txt: Added.
* LayoutTests/editing/execCommand/change-list-type-strips-source-list-attributes.html: Added.
* LayoutTests/editing/execCommand/change-list-type-undo-redo-expected.txt: Added.
* LayoutTests/editing/execCommand/change-list-type-undo-redo.html: Added.
* Source/WebCore/editing/ChangeListTypeCommand.cpp:
(WebCore::removeSourceListAttributes):
(WebCore::ChangeListTypeCommand::createNewList):

Canonical link: <a href="https://commits.webkit.org/315416@main">https://commits.webkit.org/315416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b18cbcce6ec26f5a895aa38a712f3b9c23d6ba08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126601 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/696cd822-008d-4b34-aa5b-70cf73aa6875) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131505 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/398f80eb-83f9-4e4c-a2cc-a67646baa3d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112009 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/403b5b4c-17ad-4afd-9726-d07f825cbe9c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32950 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26946 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180845 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139954 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139798 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43157 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28164 "Found 4 new test failures: accessibility/mac/text-operation/text-operation-capitalize.html accessibility/mac/value-change/value-change-user-info-textarea.html accessibility/text-marker/character-offset-visible-position-conversion-hang.html animations/font-variations/font-stretch.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106968 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25744 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35085 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114922 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41666 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6252 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41060 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41315 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41203 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->