### PR TITLE
Text that has been autocorrected and also has a grammar suggestion shows the autocorrected UI and not the grammar suggestion.

### DIFF
--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -457,7 +457,8 @@ void AlternativeTextController::respondToChangedSelection(const VisibleSelection
         return;
 
     bool handled = false;
-    for (auto& marker : markers->markersFor(*node)) {
+    for (auto& marker : markers->markersFor(*node, DocumentMarkerType::Grammar)) {
+        // Grammar markers take precedence.
         ASSERT(marker);
         if (respondToMarkerAtEndOfWord(*marker, position)) {
             handled = true;
@@ -475,9 +476,21 @@ void AlternativeTextController::respondToChangedSelection(const VisibleSelection
             for (auto& marker : markers->markersFor(*node, DocumentMarkerType::Grammar)) {
                 if (static_cast<int>(marker->startOffset()) < selectionDeepPosition.offsetInContainerNode()
                     && selectionDeepPosition.offsetInContainerNode() < static_cast<int>(marker->endOffset())) {
-                    respondToMarkerAtEndOfWord(*marker, makeContainerOffsetPosition(node.copyRef(), marker->endOffset()));
+                    if (respondToMarkerAtEndOfWord(*marker, makeContainerOffsetPosition(node.copyRef(), marker->endOffset())))
+                        handled = true;
                     break;
                 }
+            }
+        }
+    }
+
+    if (!handled) {
+        for (auto& marker : markers->markersFor(*node, DocumentMarker::allMarkers() - DocumentMarkerType::Grammar)) {
+            // Now handle all other markers.
+            ASSERT(marker);
+            if (respondToMarkerAtEndOfWord(*marker, position)) {
+                handled = true;
+                break;
             }
         }
     }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -985,6 +985,7 @@
 				WebKit/WKWebView/mac/FullscreenPointerLeave.mm,
 				WebKit/WKWebView/mac/FullscreenZoomInitialFrame.mm,
 				WebKit/WKWebView/mac/GetMatchedCSSRules.mm,
+				WebKit/WKWebView/mac/GrammarMarkerPrecedence.mm,
 				WebKit/WKWebView/mac/HIDGamepads.mm,
 				WebKit/WKWebView/mac/HTMLCollectionNamedItem.mm,
 				WebKit/WKWebView/mac/HTMLFormCollectionNamedItem.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/GrammarMarkerPrecedence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/GrammarMarkerPrecedence.mm
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import "InstanceMethodSwizzler.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <pal/spi/mac/NSSpellCheckerSPI.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+static NSString * const testText = @"Let's go in then store\n";
+static NSString * const grammarCorrection = @"in the";
+
+static bool didShowCorrectionIndicator = false;
+static bool didReturnGrammarMarker = false;
+static RetainPtr<NSString> capturedPrimaryString;
+
+static NSArray<NSTextCheckingResult *> *swizzledCheckString(id, SEL, NSString *stringToCheck, NSRange, NSTextCheckingTypes types, NSDictionary *, NSInteger, NSOrthography **, NSInteger *)
+{
+    NSRange phraseRange = [stringToCheck rangeOfString:@"go in then"];
+    if (phraseRange.location == NSNotFound)
+        return @[ ];
+
+    RetainPtr results = adoptNS([[NSMutableArray alloc] init]);
+
+    if (types & NSTextCheckingTypeSpelling) {
+        // Same end offset as grammar but smaller start, so it sorts first in the marker list.
+        [results addObject:[NSTextCheckingResult spellCheckingResultWithRange:phraseRange]];
+    }
+
+    if (types & NSTextCheckingTypeGrammar) {
+        NSRange grammarRange = NSMakeRange(phraseRange.location + 3, phraseRange.length - 3);
+        NSDictionary *detail = @{
+            NSGrammarRange: [NSValue valueWithRange:NSMakeRange(0, grammarRange.length)],
+            NSGrammarCorrections: @[ grammarCorrection ],
+        };
+        [results addObject:[NSTextCheckingResult grammarCheckingResultWithRange:grammarRange details:@[ detail ]]];
+        didReturnGrammarMarker = true;
+    }
+
+    return results.autorelease();
+}
+
+using CorrectionIndicatorCompletionHandler = void (^)(NSString *);
+
+static void swizzledShowCorrectionIndicator(id, SEL, NSCorrectionIndicatorType, NSString *primaryString, NSArray<NSString *> *, NSRect, NSView *, CorrectionIndicatorCompletionHandler completionHandler)
+{
+    capturedPrimaryString = primaryString;
+    didShowCorrectionIndicator = true;
+    if (completionHandler)
+        completionHandler(nil);
+}
+
+TEST(GrammarMarkerPrecedence, GrammarTakesPrecedenceOverOverlappingSpellingMarker)
+{
+    didShowCorrectionIndicator = false;
+    didReturnGrammarMarker = false;
+    capturedPrimaryString = nil;
+
+    InstanceMethodSwizzler checkStringSwizzler {
+        NSSpellChecker.sharedSpellChecker.class,
+        @selector(checkString:range:types:options:inSpellDocumentWithTag:orthography:wordCount:),
+        reinterpret_cast<IMP>(swizzledCheckString)
+    };
+
+    InstanceMethodSwizzler showIndicatorSwizzler {
+        NSSpellChecker.sharedSpellChecker.class,
+        @selector(showCorrectionIndicatorOfType:primaryString:alternativeStrings:forStringInRect:view:completionHandler:),
+        reinterpret_cast<IMP>(swizzledShowCorrectionIndicator)
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient> alloc] initWithFrame:NSMakeRect(0, 0, 800, 200)]);
+    [webView synchronouslyLoadHTMLString:@"<body contenteditable style='font-family: monospace; font-size: 24px;'>"];
+    [webView _setContinuousSpellCheckingEnabledForTesting:YES];
+    [webView _setGrammarCheckingEnabledForTesting:YES];
+    [webView objectByEvaluatingJavaScript:@"getSelection().setPosition(document.body)"];
+    [webView insertText:testText replacementRange:NSMakeRange(0, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_TRUE(Util::runFor(&didReturnGrammarMarker, 2_s));
+
+    // Establish an old selection in a different word so respondToChangedSelection fires below.
+    [webView objectByEvaluatingJavaScript:@"(() => { const r = document.createRange(); r.setStart(document.body.firstChild, 19); r.collapse(true); const s = getSelection(); s.removeAllRanges(); s.addRange(r); })()"];
+    [webView waitForNextPresentationUpdate];
+
+    // End-of-word for the caret in "then" is offset 16, matching both markers' endOffsets.
+    [webView objectByEvaluatingJavaScript:@"(() => { const r = document.createRange(); r.setStart(document.body.firstChild, 14); r.collapse(true); const s = getSelection(); s.removeAllRanges(); s.addRange(r); })()"];
+
+    Util::runFor(&didShowCorrectionIndicator, 3_s);
+
+    EXPECT_TRUE(didShowCorrectionIndicator);
+    EXPECT_WK_STREQ(grammarCorrection, capturedPrimaryString.get());
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 3f38324c4333005e30ae69af38d8640fb013251b
<pre>
Text that has been autocorrected and also has a grammar suggestion shows the autocorrected UI and not the grammar suggestion.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317189">https://bugs.webkit.org/show_bug.cgi?id=317189</a>
<a href="https://rdar.apple.com/179382273">rdar://179382273</a>

Reviewed by Abrar Rahman Protyasha.

When the caret lands at the end of a word that has both a grammar marker
and another marker (e.g., a Replacement marker from a recent autocorrection)
ending at the same offset, AlternativeTextController::respondToChangedSelection
iterated all markers in start-offset order and used the first match. The
resulting UI depended on insertion order, and the autocorrect reversion UI
typically won — hiding the grammar suggestion.

Check Grammar markers first. If no grammar marker handles the end-of-word
position, fall back to the existing multi-word grammar covering-the-selection
check, then to the previous &quot;any marker&quot; loop. The multi-word fallback now
also propagates `handled` so the new &quot;any marker&quot; loop doesn&apos;t double-fire.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/GrammarMarkerPrecedenceOverSpelling.mm

* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::respondToChangedSelection):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/GrammarMarkerPrecedence.mm: Added.
(TestWebKitAPI::swizzledShowCorrectionIndicator):
(TestWebKitAPI::TEST(GrammarMarkerPrecedence, GrammarTakesPrecedenceOverOverlappingSpellingMarker)):

Canonical link: <a href="https://commits.webkit.org/315507@main">https://commits.webkit.org/315507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dced3ec32e9e19378b6fc54dd3911214211223c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43188 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36448 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178622 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c03d4c0-0c05-492b-ac09-5243a8ded244) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42814 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f82d127b-fffe-4e82-a50a-b6f2d73bb38c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172225 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112339 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23637294-58bc-4a1a-bbb9-0726d2b97d7d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27322 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181222 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42844 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140129 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37697 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43533 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107464 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/35403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42043 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41436 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41691 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->