### PR TITLE
[visionOS] Add callbacks to spatial image fullscreen requests indicating image overlay feature is the cause of the fullscreen request

### DIFF
--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "SpatialImageControls.h"
 
+#include "Chrome.h"
+#include "ChromeClient.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentEventLoop.h"
 #include "DocumentPage.h"
@@ -238,6 +240,9 @@ bool handleEvent(HTMLElement& element, Event& event)
 
     if (SpatialImageControls::isSpatialImageControlsButtonElement(*target)) {
         RefPtr img = dynamicDowncast<HTMLImageElement>(target->shadowHost());
+        if (!img)
+            return false;
+        page->chrome().client().noteFullscreenRequestFromSpatialImageControls(*img);
         img->webkitRequestFullscreen();
 
         event.setDefaultHandled();

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -548,6 +548,9 @@ public:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual void updateImageSource(Element&) { }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    virtual void noteFullscreenRequestFromSpatialImageControls(Element&) { }
+#endif
     virtual void exitFullScreenForElement(Element*, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
     virtual void setRootFullScreenLayer(GraphicsLayer*) { }
 #endif

--- a/Source/WebKit/Shared/FullScreenMediaDetails.h
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.h
@@ -37,6 +37,13 @@ namespace WebKit {
 struct FullScreenMediaDetails {
     enum class Type : uint8_t { None, Video, ElementWithVideo, Image };
 
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    enum class SpatialImageRequestSource : uint8_t {
+        JavaScript,
+        ControlsOverlay,
+    };
+#endif
+
     Type type { Type::None };
     WebCore::FloatSize mediaDimensions { };
 
@@ -44,6 +51,10 @@ struct FullScreenMediaDetails {
     using ImageData = Variant<std::monostate, WebCore::ShareableBitmap::Handle, WebCore::ShareableSpatialImage>;
     ImageData imageData;
     bool launchInImmersive { false };
+#endif
+
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    SpatialImageRequestSource requestSource { SpatialImageRequestSource::JavaScript };
 #endif
 };
 

--- a/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
@@ -28,11 +28,21 @@
     Image
 };
 
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+[Nested] enum class WebKit::FullScreenMediaDetails::SpatialImageRequestSource : uint8_t {
+    JavaScript,
+    ControlsOverlay
+};
+#endif
+
 [RValue] struct WebKit::FullScreenMediaDetails {
     WebKit::FullScreenMediaDetails::Type type;
     WebCore::FloatSize mediaDimensions;
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     WebKit::FullScreenMediaDetails::ImageData imageData;
     bool launchInImmersive;
+#endif
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    WebKit::FullScreenMediaDetails::SpatialImageRequestSource requestSource;
 #endif
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h
@@ -42,6 +42,7 @@ WK_API_AVAILABLE(macos(10.13), ios(11.3))
 - (void)_webViewDidExitElementFullscreen:(WKWebView *)webView;
 
 - (void)_webView:(WKWebView *)webView didFullscreenImageWithQuickLook:(CGSize)imageDimensions;
+- (void)_webView:(WKWebView *)webView didFullscreenImageWithQuickLookFromControlsOverlay:(CGSize)imageDimensions;
 - (void)_webView:(WKWebView *)webView requestPresentingViewControllerWithCompletionHandler:(void (^)(UIViewController * _Nullable, NSError * _Nullable))completionHandler;
 - (BOOL)_webViewPreventDockingFromElementFullscreen:(WKWebView *)webView;
 #else

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
@@ -80,6 +80,9 @@ private:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
         bool webViewDidFullscreenImageWithQuickLook : 1 { false };
 #endif
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+        bool webViewDidFullscreenImageWithQuickLookFromControlsOverlay : 1 { false };
+#endif
 #if PLATFORM(IOS_FAMILY)
         bool webViewRequestPresentingViewController : 1 { false };
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
@@ -27,6 +27,8 @@
 #import "FullscreenClient.h"
 
 #import "WKWebViewInternal.h"
+#import "WebFullScreenManagerProxy.h"
+#import "WebPageProxy.h"
 #import "_WKFullscreenDelegate.h"
 #import <wtf/TZoneMallocInlines.h>
 
@@ -63,6 +65,9 @@ void FullscreenClient::setDelegate(id <_WKFullscreenDelegate> delegate)
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     m_delegateMethods.webViewDidFullscreenImageWithQuickLook = [delegate respondsToSelector:@selector(_webView:didFullscreenImageWithQuickLook:)];
 #endif
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    m_delegateMethods.webViewDidFullscreenImageWithQuickLookFromControlsOverlay = [delegate respondsToSelector:@selector(_webView:didFullscreenImageWithQuickLookFromControlsOverlay:)];
+#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     m_delegateMethods.webViewPreventDockingFromElementFullscreen = [delegate respondsToSelector:@selector(_webViewPreventDockingFromElementFullscreen:)];
 #endif
@@ -86,7 +91,7 @@ void FullscreenClient::willEnterFullscreen(WebPageProxy*)
 #endif
 }
 
-void FullscreenClient::didEnterFullscreen(WebPageProxy*)
+void FullscreenClient::didEnterFullscreen(WebPageProxy* page)
 {
     RetainPtr webView = m_webView.get();
     [webView willChangeValueForKey:@"fullscreenState"];
@@ -102,8 +107,17 @@ void FullscreenClient::didEnterFullscreen(WebPageProxy*)
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     if (auto fullScreenController = [webView fullScreenWindowController]) {
         CGSize imageDimensions = fullScreenController.imageDimensions;
-        if (fullScreenController.isUsingQuickLook && m_delegateMethods.webViewDidFullscreenImageWithQuickLook)
-            [m_delegate.get() _webView:webView.get() didFullscreenImageWithQuickLook:imageDimensions];
+        if (fullScreenController.isUsingQuickLook) {
+            if (m_delegateMethods.webViewDidFullscreenImageWithQuickLook)
+                [m_delegate.get() _webView:webView.get() didFullscreenImageWithQuickLook:imageDimensions];
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+            if (m_delegateMethods.webViewDidFullscreenImageWithQuickLookFromControlsOverlay) {
+                RefPtr fullScreenManager = page ? page->fullScreenManager() : nullptr;
+                if (fullScreenManager && fullScreenManager->requestedFromSpatialImageControls())
+                    [m_delegate.get() _webView:webView.get() didFullscreenImageWithQuickLookFromControlsOverlay:imageDimensions];
+            }
+#endif
+        }
     }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 }

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -100,6 +100,9 @@ public:
     void prepareQuickLookImageURL(CompletionHandler<void(URL&&)>&&) const;
     bool launchInImmersive() const { return m_launchInImmersive; }
 #endif // QUICKLOOK_FULLSCREEN
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    bool requestedFromSpatialImageControls() const { return m_mediaDetails && m_mediaDetails->requestSource == FullScreenMediaDetails::SpatialImageRequestSource::ControlsOverlay; }
+#endif
     void close();
     void detachFromClient();
     void NODELETE attachToNewClient(WebFullScreenManagerProxyClient&);

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -149,6 +149,10 @@ void WebFullScreenManager::invalidate()
     m_waitingForLargerImageLoad = LargerImageLoadState::NotWaiting;
     m_pendingImageMediaDetails = std::nullopt;
 #endif
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    m_pendingFullscreenRequestElementFromControlsOverlay = nullptr;
+    m_currentEntryFromControlsOverlay = false;
+#endif
 }
 
 WebCore::Element* WebFullScreenManager::element()
@@ -306,6 +310,14 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
 {
     ALWAYS_LOG(LOGIDENTIFIER, "<", element.tagName(), " id=\"", element.getIdAttribute(), "\">");
 
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    // Compare the pending overlay request's element against the entering element. A mismatch means the overlay request was rejected/cancelled upstream and a different entry reached us
+    auto pendingElement = std::exchange(m_pendingFullscreenRequestElementFromControlsOverlay, nullptr);
+    m_currentEntryFromControlsOverlay = pendingElement && pendingElement.get() == &element;
+    if (pendingElement)
+        ALWAYS_LOG(LOGIDENTIFIER, "spatial image controls overlay request: ", m_currentEntryFromControlsOverlay ? "matched entering element" : "mismatch — defaulting to JavaScript attribution");
+#endif
+
     setElement(element);
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
@@ -335,6 +347,10 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
             m_page->freezeLayerTree(WebPage::LayerTreeFreezeReason::OutOfProcessFullscreen);
             m_pendingImageMediaDetails = getImageMediaDetails(renderImage, IsUpdating::No);
             m_pendingImageMediaDetails->launchInImmersive = false;
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+            if (m_currentEntryFromControlsOverlay)
+                m_pendingImageMediaDetails->requestSource = FullScreenMediaDetails::SpatialImageRequestSource::ControlsOverlay;
+#endif
             m_willUseQuickLookForFullscreen = true;
             performEnterFullScreen();
             return;
@@ -378,6 +394,10 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
             if (isPanorama) {
                 m_pendingImageMediaDetails = getImageMediaDetails(renderImage, IsUpdating::No);
                 m_pendingImageMediaDetails->launchInImmersive = true;
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+                if (m_currentEntryFromControlsOverlay)
+                    m_pendingImageMediaDetails->requestSource = FullScreenMediaDetails::SpatialImageRequestSource::ControlsOverlay;
+#endif
                 m_willUseQuickLookForFullscreen = true;
             } else {
                 m_page->setViewportConfigurationViewLayoutSize(m_oldSize, m_scaleFactor, m_minEffectiveWidth);
@@ -431,6 +451,10 @@ void WebFullScreenManager::performEnterFullScreen()
                 // Either timed out OR loaded a panoramic image in time
                 m_pendingImageMediaDetails = getImageMediaDetails(renderImage, IsUpdating::No);
                 m_pendingImageMediaDetails->launchInImmersive = isPanorama;
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+                if (m_currentEntryFromControlsOverlay)
+                    m_pendingImageMediaDetails->requestSource = FullScreenMediaDetails::SpatialImageRequestSource::ControlsOverlay;
+#endif
                 m_willUseQuickLookForFullscreen = true;
             }
         }
@@ -530,6 +554,13 @@ void WebFullScreenManager::waitForLargerImageLoadTimerFired()
     performEnterFullScreen();
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
+
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+void WebFullScreenManager::noteFullscreenRequestFromSpatialImageControls(WebCore::Element& element)
+{
+    m_pendingFullscreenRequestElementFromControlsOverlay = element;
+}
+#endif
 
 void WebFullScreenManager::exitFullScreenForElement(WebCore::Element* element, CompletionHandler<void()>&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -78,6 +78,9 @@ public:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(WebCore::Element&);
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    void noteFullscreenRequestFromSpatialImageControls(WebCore::Element&);
+#endif
     void exitFullScreenForElement(WebCore::Element*, CompletionHandler<void()>&&);
 
     void didEnterFullScreen(CompletionHandler<bool(bool)>&&);
@@ -173,6 +176,12 @@ private:
     void waitForLargerImageLoadTimerFired();
 
     std::optional<FullScreenMediaDetails> m_pendingImageMediaDetails;
+#endif
+
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    // Element for fullscreen request, prevents leaking controls overlay intent in the case of cancelled/rejected fullscreen requests
+    WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> m_pendingFullscreenRequestElementFromControlsOverlay;
+    bool m_currentEntryFromControlsOverlay { false };
 #endif
 
     bool m_closing { false };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1607,6 +1607,14 @@ void WebChromeClient::updateImageSource(Element& element)
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+void WebChromeClient::noteFullscreenRequestFromSpatialImageControls(WebCore::Element& element)
+{
+    if (RefPtr page = m_page.get())
+        page->fullScreenManager().noteFullscreenRequestFromSpatialImageControls(element);
+}
+#endif
+
 void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandler<void()>&& completionHandler)
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -346,6 +346,9 @@ private:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(WebCore::Element&) final;
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
+#if ENABLE(SPATIAL_IMAGE_CONTROLS)
+    void noteFullscreenRequestFromSpatialImageControls(WebCore::Element&) final;
+#endif
     void exitFullScreenForElement(WebCore::Element*, CompletionHandler<void()>&&) final;
 #endif // ENABLE(FULLSCREEN_API)
 


### PR DESCRIPTION
#### f4fbc6c11069567d08a083f9b3657b698ffe9c53
<pre>
[visionOS] Add callbacks to spatial image fullscreen requests indicating image overlay feature is the cause of the fullscreen request
<a href="https://rdar.apple.com/179755322">rdar://179755322</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317162">https://bugs.webkit.org/show_bug.cgi?id=317162</a>

Reviewed by NOBODY (OOPS!).

Distinguish fullscreen entries triggered by the spatial image controls overlay from JavaScript-driven entries.
Add a new informal _WKFullscreenDelegate sibling that fires in addition to didFullscreenImageWithQuickLook: when the entry was initiated by the overlay button.
Add additional piping from the initial SpatialImageControls::handleEvent callsite through to FullscreenClient::didEnterFullscreen to contain the request source information.

* Source/WebCore/html/shadow/SpatialImageControls.cpp:
(WebCore::SpatialImageControls::handleEvent):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::noteFullscreenRequestFromSpatialImageControls):
* Source/WebKit/Shared/FullScreenMediaDetails.h:
* Source/WebKit/Shared/FullScreenMediaDetails.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm:
(WebKit::FullscreenClient::setDelegate):
(WebKit::FullscreenClient::didEnterFullscreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxy::requestedFromSpatialImageControls const):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::invalidate):
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::performEnterFullScreen):
(WebKit::WebFullScreenManager::noteFullscreenRequestFromSpatialImageControls):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::noteFullscreenRequestFromSpatialImageControls):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4fbc6c11069567d08a083f9b3657b698ffe9c53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131247 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92313 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32690 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31396 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180526 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33249 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35560 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139689 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42166 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139546 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42854 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27896 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106537 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34828 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114614 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41358 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5979 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40755 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->