### PR TITLE
Serializations of various CSS at-rules do not escape identifiers tokens

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom-expected.txt
@@ -1,6 +1,6 @@
 
 PASS CSSPositionTryRule attribute values
-FAIL CSSPositionTryRule escaped ident name assert_equals: expected "--\\{" but got "--{"
+PASS CSSPositionTryRule escaped ident name
 PASS CSSPositionTryRule.style.setProperty setting allowed and disallowed properties
 PASS CSSPositionTryDescriptors.item
 PASS CSSPositionTryDescriptors.cssText

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt
@@ -14,4 +14,6 @@ PASS Extra parens and Not
 PASS Subexpressions and extra parens
 PASS Multiple subexpressions and extra parens
 PASS Multiple subexpressions and unknowns
+PASS Escape custom property identifier
+FAIL Escape custom property identifier - range syntax assert_equals: expected "style(100px > --\\{foo > 10px)" but got "style(100px > --\\{foo >10px)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization.html
@@ -23,11 +23,13 @@
   @container style(((--FOO: BAR)) and (--bar: foo)) { }
   @container style((((--foo) or ((--bar)))) and ((--baz)) and ((not ((--xyzzy))))) { }
   @container style((((--a: b) or ((b: a)))) and ((--baz)) and ((not ((x: y))))) { }
+  @container style(--\{foo  : bar) { }
+  @container style(100px  > --\{foo >10px) {}
 </style>
 <script>
   setup(() => {
     assert_implements_style_container_queries();
-    assert_equals(testSheet.sheet.cssRules.length, 15);
+    assert_equals(testSheet.sheet.cssRules.length, 17);
   });
 
   const tests = [
@@ -47,6 +49,8 @@
       ["style(((--FOO: BAR)) and (--bar: foo))", "Subexpressions and extra parens"],
       ["style((((--foo) or ((--bar)))) and ((--baz)) and ((not ((--xyzzy)))))", "Multiple subexpressions and extra parens"],
       ["style((((--a: b) or ((b: a)))) and ((--baz)) and ((not ((x: y)))))", "Multiple subexpressions and unknowns"],
+      ["style(--\\{foo: bar)", "Escape custom property identifier"],
+      ["style(100px > --\\{foo > 10px)", "Escape custom property identifier - range syntax"],
   ].map((e, i) => [testSheet.sheet.cssRules[i], ...e]);
 
   tests.forEach((t) => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/fallback-expected.txt
@@ -1,5 +1,6 @@
 
 PASS @counter-style 'fallback: bar' is valid
+PASS @counter-style 'fallback: foo\{\}bar' is valid
 PASS @counter-style 'fallback: "bar"' is invalid
 PASS @counter-style 'fallback: none' is invalid
 PASS @counter-style 'fallback: initial' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/fallback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/fallback.html
@@ -16,6 +16,7 @@ function test_invalid_fallback(value) {
 // <counter-style-name>
 
 test_valid_fallback('bar');
+test_valid_fallback('foo\\{\\}bar');
 
 // Counter style names are custom identifiers, not strings
 test_invalid_fallback('"bar"');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-syntax-expected.txt
@@ -8,6 +8,7 @@ PASS @counter-style 'system: alphabetic' is valid
 PASS @counter-style 'system: numeric' is valid
 PASS @counter-style 'system: additive' is valid
 PASS @counter-style 'system: extends bar' is valid
+PASS @counter-style 'system: extends foo\{\}bar' is valid
 PASS @counter-style 'system: float' is invalid
 PASS @counter-style 'system: cyclic cyclic' is invalid
 PASS @counter-style 'system: extends none' is invalid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-syntax.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-syntax.html
@@ -25,6 +25,7 @@ test_valid_system('alphabetic');
 test_valid_system('numeric');
 test_valid_system('additive');
 test_valid_system('extends bar');
+test_valid_system('extends foo\\{\\}bar');
 
 test_invalid_system('float');
 test_invalid_system('cyclic cyclic');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt
@@ -34,4 +34,5 @@ PASS CSS Fonts Module Level 4: parsing @font-palette-values 31
 PASS CSS Fonts Module Level 4: parsing @font-palette-values 32
 FAIL CSS Fonts Module Level 4: parsing @font-palette-values 33 assert_equals: expected "0 color-mix(in lch, red, blue)" but got ""
 FAIL CSS Fonts Module Level 4: parsing @font-palette-values 34 assert_equals: expected "0 color-mix(in lch, color-mix(in lch, red, blue), color-mix(in lch, green, white))" but got ""
+PASS CSS Fonts Module Level 4: parsing @font-palette-values 35
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html
@@ -113,6 +113,10 @@
 @font-palette-values --R {
     override-colors: 0 color-mix(in lch, color-mix(in lch, red, blue), color-mix(in lch, green, white));
 }
+
+/* 19 */
+@font-palette-values --\{ {
+}
 </style>
 </head>
 <body>
@@ -411,6 +415,15 @@ test(function() {
     assert_equals(rule.basePalette, "");
     assert_equals(rule.overrideColors, "0 color-mix(in lch, color-mix(in lch, red, blue), color-mix(in lch, green, white))");
 });
+
+test(function() {
+    let rule = rules[19];
+    assert_equals(rule.name, "--{");
+    let text = rule.cssText;
+    assert_equals(text.indexOf("--{"), -1);
+    assert_not_equals(text.indexOf("--\\{"), -1);
+});
+
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/page-rules-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/page-rules-001-expected.txt
@@ -5,6 +5,7 @@ PASS @page { } should be a valid rule
 PASS @page a { } should be a valid rule
 PASS @page page1 { } should be a valid rule
 FAIL @page name1, name2 { } should be a valid rule The string did not match the expected pattern.
+PASS @page name1\{\}name2 { } should be a valid rule
 PASS @page a, { } should be an invalid rule
 PASS @page ,a { } should be an invalid rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/page-rules-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/page-rules-001.html
@@ -13,6 +13,7 @@ test(t => {
     test_valid_rule("@page a { }");
     test_valid_rule("@page page1 { }");
     test_valid_rule("@page name1, name2 { }");
+    test_valid_rule("@page name1\\{\\}name2 { }");
     test_invalid_rule("@page a, { }");
     test_invalid_rule("@page ,a { }");
 }, "page-rules-001");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-escape-identifiers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-escape-identifiers-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Rules must be the same after serialization round-trip, even with escaped characters assert_equals: expected "@import url(\"abc\") layer(\\{\\});\n@font-feature-values \"abc{}oops\" { }\n@font-palette-values --abc{}oops { }\n@keyframes abc{}oops { \n}\n@layer abc\\;oops\\!;" but got "@import url(\"abc\") layer(\\{\\});\n@font-feature-values \"abc{}oops\" { }\n@font-palette-values --abc { }\noops { }\n@keyframes abc { \n}\noops { }\n@layer abc\\;oops\\!;"
+PASS Rules must be the same after serialization round-trip, even with escaped characters
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-escape-identifiers.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-escape-identifiers.html
@@ -12,6 +12,11 @@
       @font-palette-values --abc\{\}oops {}
       @keyframes abc\{\}oops {}
       @layer abc\;oops\!;
+      @media \( {}
+      @position-try abc\{\}oops {}
+      @counter-style abc\{\}oops {}
+      @namespace abc\{\}oops "test";
+      @page abc\{\}def {}
     </style>
   </head>
   <body>

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -418,8 +418,16 @@ String CSSCounterStyleDescriptors::systemCSSText() const
 {
     if (!m_explicitlySetDescriptors.contains(ExplicitlySetDescriptors::System))
         return emptyString();
+
+    auto serializeExtendsName = [](const auto& extendsName) {
+        StringBuilder builder;
+        builder.append("extends "_s);
+        serializeIdentifier(builder, extendsName);
+        return builder.toString();
+    };
+
     if (m_isExtendedResolved)
-        return makeString("extends "_s, m_extendsName);
+        return serializeExtendsName(m_extendsName);
 
     switch (m_system) {
     case System::Cyclic:
@@ -435,7 +443,7 @@ String CSSCounterStyleDescriptors::systemCSSText() const
     case System::Fixed:
         return makeString("fixed "_s, m_fixedSystemFirstSymbolValue);
     case System::Extends:
-        return makeString("extends "_s, m_extendsName);
+        return serializeExtendsName(m_extendsName);
     // Internal values should not be exposed.
     case System::SimplifiedChineseInformal:
     case System::SimplifiedChineseFormal:
@@ -511,7 +519,10 @@ String CSSCounterStyleDescriptors::fallbackCSSText() const
 {
     if (!m_explicitlySetDescriptors.contains(ExplicitlySetDescriptors::Fallback))
         return emptyString();
-    return makeString(m_fallbackName);
+
+    StringBuilder builder;
+    serializeIdentifier(builder, m_fallbackName);
+    return builder.toString();
 }
 
 String CSSCounterStyleDescriptors::symbolsCSSText() const

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCounterStyleDescriptors.h"
 #include "CSSKeywordValue.h"
+#include "CSSMarkup.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+CounterStyles.h"
 #include "CSSStyleSheet.h"
@@ -160,7 +161,12 @@ String CSSCounterStyleRule::cssText() const
     const auto speakAsPrefix = speakAsText.isEmpty() ? ""_s : " speak-as: "_s;
     const auto speakAsSuffix = speakAsText.isEmpty() ? ""_s : ";"_s;
 
-    return makeString("@counter-style "_s, name(), " {"_s,
+    StringBuilder builder;
+
+    builder.append("@counter-style "_s);
+    serializeIdentifier(builder, name());
+
+    builder.append(" {"_s,
         systemPrefix, systemText, systemSuffix,
         symbolsPrefix, symbolsText, symbolsSuffix,
         additiveSymbolsPrefix, additiveSymbolsText, additiveSymbolsSuffix,
@@ -172,6 +178,8 @@ String CSSCounterStyleRule::cssText() const
         fallbackPrefix, fallbackText, fallbackSuffix,
         speakAsPrefix, speakAsText, speakAsSuffix,
     " }"_s);
+
+    return builder.toString();
 }
 
 void CSSCounterStyleRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
@@ -89,7 +89,11 @@ String CSSFontPaletteValuesRule::overrideColors() const
 String CSSFontPaletteValuesRule::cssText() const
 {
     StringBuilder builder;
-    builder.append("@font-palette-values "_s, name(), " { "_s);
+
+    builder.append("@font-palette-values "_s);
+    serializeIdentifier(builder, name());
+    builder.append(" { "_s);
+
     if (!m_fontPaletteValuesRule->fontFamilies().isEmpty())
         builder.append("font-family: "_s, fontFamily(), "; "_s);
 

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -27,6 +27,7 @@
 #include "CSSKeyframesRule.h"
 
 #include "CSSKeyframeRule.h"
+#include "CSSMarkup.h"
 #include "CSSParser.h"
 #include "CSSPropertyParserConsumer+Animations.h"
 #include "CSSRuleList.h"
@@ -165,7 +166,11 @@ CSSKeyframeRule* CSSKeyframesRule::findRule(const String& s)
 String CSSKeyframesRule::cssText() const
 {
     StringBuilder result;
-    result.append("@keyframes "_s, name(), " { \n"_s);
+
+    result.append("@keyframes "_s);
+    serializeIdentifier(result, name());
+    result.append(" { \n"_s);
+
     for (unsigned i = 0, size = length(); i < size; ++i)
         result.append("  "_s, protect(m_keyframesRule)->keyframes()[i]->cssText(), '\n');
     result.append('}');

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSPositionTryRule.h"
 
+#include "CSSMarkup.h"
 #include "CSSPositionTryDescriptors.h"
 #include "CSSSerializationContext.h"
 
@@ -98,9 +99,11 @@ void CSSPositionTryRule::reattach(StyleRuleBase& rule)
         propertiesCSSOMWrapper->reattach(protect(positionTryRule())->mutableProperties());
 }
 
-AtomString CSSPositionTryRule::name() const
+String CSSPositionTryRule::name() const
 {
-    return m_positionTryRule->name();
+    StringBuilder builder;
+    serializeIdentifier(builder, m_positionTryRule->name());
+    return builder.toString();
 }
 
 CSSPositionTryDescriptors& CSSPositionTryRule::style()

--- a/Source/WebCore/css/CSSPositionTryRule.h
+++ b/Source/WebCore/css/CSSPositionTryRule.h
@@ -66,7 +66,7 @@ public:
 
     StyleRulePositionTry& positionTryRule() const { return m_positionTryRule; }
 
-    WEBCORE_EXPORT AtomString NODELETE name() const;
+    WEBCORE_EXPORT String name() const;
     WEBCORE_EXPORT CSSPositionTryDescriptors& style();
 
 private:

--- a/Source/WebCore/css/CSSPositionTryRule.idl
+++ b/Source/WebCore/css/CSSPositionTryRule.idl
@@ -31,6 +31,6 @@ typedef USVString CSSOMString;
     EnabledBySetting=CSSAnchorPositioningEnabled,
     Exposed=Window
 ] interface CSSPositionTryRule : CSSRule {
-    readonly attribute [AtomString] CSSOMString name;
+    readonly attribute CSSOMString name;
     [SameObject, PutForwards=cssText] readonly attribute CSSPositionTryDescriptors style;
 };


### PR DESCRIPTION
#### cde6b7653a3727f86ebd093f379c565e28af4fd2
<pre>
Serializations of various CSS at-rules do not escape identifiers tokens
<a href="https://rdar.apple.com/178750383">rdar://178750383</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317193">https://bugs.webkit.org/show_bug.cgi?id=317193</a>

Reviewed by Tim Nguyen.

CSS identifiers can contain special characters by escaping them using &apos;\&apos;.
For example, &quot;foo{bar}&quot; can be escaped to &quot;foo\{bar\}&quot; for use as a CSS
identifier. The tokenizer then unescapes &quot;foo\{bar\}&quot; in the CSS source code
into &quot;foo{bar}&quot;. If this identifier is then serialized back into CSS
using .cssText, then the identifier should again be escaped.

From code audit, the cssText implementation of some CSS at-rules don&apos;t
properly escape CSS identifiers. This patch fixes this by escaping
identifiers where needed. Additionally, this patch adds cssText tests
for every at-rule that accepts CSS identifiers.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom.html
       imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization.html
       imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/fallback.html
       imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-syntax.html
       imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html
       imported/w3c/web-platform-tests/css/css-page/parsing/page-rules-001.html
       imported/w3c/web-platform-tests/css/css-syntax/serialize-escape-identifiers.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-style-serialization.html:
    - Import test cases from WPT

* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/fallback.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-syntax.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-palette-values-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/page-rules-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/page-rules-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-escape-identifiers-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/serialize-escape-identifiers.html:
    - Import a test case (@media) from WPT
    - Add test cases for @position-try, @counter-style and @page.

* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::CSSCounterStyleDescriptors::systemCSSText const):
(WebCore::CSSCounterStyleDescriptors::fallbackCSSText const):
* Source/WebCore/css/CSSCounterStyleRule.cpp:
(WebCore::CSSCounterStyleRule::cssText const):
* Source/WebCore/css/CSSFontPaletteValuesRule.cpp:
(WebCore::CSSFontPaletteValuesRule::cssText const):
* Source/WebCore/css/CSSKeyframesRule.cpp:
(WebCore::CSSKeyframesRule::cssText const):
* Source/WebCore/css/CSSPositionTryRule.cpp:
(WebCore::CSSPositionTryRule::name const):
* Source/WebCore/css/CSSPositionTryRule.h:
* Source/WebCore/css/CSSPositionTryRule.idl:

Canonical link: <a href="https://commits.webkit.org/315795@main">https://commits.webkit.org/315795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7c149c22f09b792c9ff5dc310004941a4c8ec52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127669 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5372b71a-4f5c-43a0-b220-5df4d9639e3c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132470 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6fdb468-6a2f-457d-9fb3-cf97c4d0d4a9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172916 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112972 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7443b29-8cda-45d7-b608-de62d83469b7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28015 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181915 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140921 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152368 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140752 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37928 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Reviewed by Tim Nguyen; Running compile-webkit; Skipped layout-tests; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44224 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29279 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108551 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36019 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115989 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42735 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7379 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42127 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42382 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42270 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->