### PR TITLE
Reject INT32_MIN in Swift BackForwardList

### DIFF
--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -31,6 +31,7 @@
 #include "MessageNames.h"
 #include "StreamServerConnection.h"
 #include <functional>
+#include <wtf/Compiler.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/CoroutineUtilities.h>
 #include <wtf/ProcessID.h>
@@ -491,7 +492,7 @@ void handleMessageSynchronous(Connection& connection, Decoder& decoder, UniqueRe
     }));
 
     if constexpr (ValidationType::expectsConnectionArgument) {
-        callMemberFunction(object, function, connection, WTF::move(*arguments),
+        SUPPRESS_UNCOUNTED_ARG callMemberFunction(object, function, ValidationType::makeConnectionArgument(connection), WTF::move(*arguments),
             ValidationType::unwrapCompletionHandler(std::forward<decltype(completionHandler)>(completionHandler)));
     } else {
         callMemberFunction(object, function, WTF::move(*arguments),

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -415,7 +415,8 @@ final class WebBackForwardList {
             return nil
         }
 
-        if currentIndex + delta < 0 {
+        let (targetIndex, overflow) = currentIndex.addingReportingOverflow(delta)
+        if overflow || targetIndex < 0 {
             return nil
         }
 
@@ -1203,10 +1204,20 @@ final class WebBackForwardList {
 
     @used
     func backForwardItemAtIndexForWebContent(
+        connection: IPC.Connection,
         delta: Int32,
         frameID: WebCore.FrameIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardItemAtIndexForWebContentCompletionHandler
     ) {
+        let process = WebKit.WebProcessProxy.fromConnection(connection)
+        if messageCheckCompletion(
+            process: process,
+            completionHandler: { completionHandler.pointee(consuming: WebKit.RefPtrFrameState()) },
+            delta != Int32.min
+        ) {
+            return
+        }
+
         // FIXME: This should verify that the web process requesting the item hosts the specified frame.
         let delta = Int(delta)
         guard let item = itemAtDeltaFromCurrentIndex(delta: delta, allowSkipping: false) else {


### PR DESCRIPTION
#### 37310f2c576b2d2bde74ea5831e3c754c076d083
<pre>
Reject INT32_MIN in Swift BackForwardList
<a href="https://bugs.webkit.org/show_bug.cgi?id=317198">https://bugs.webkit.org/show_bug.cgi?id=317198</a>
<a href="https://rdar.apple.com/179805504">rdar://179805504</a>

Reviewed by Geoffrey Garen.

Swift counterpart of 314581@main (a6cd3ca) for WebBackForwardList.swift.

That change rejected INT32_MIN in the BackForwardItemAtIndexForWebContent IPC
handler and reworked itemAtDeltaFromCurrentIndex to range-check without negating
the delta in signed arithmetic.

This ports those changes to the Swift implementation.

This is the first time a Swift IPC handler has taken both a connection and a
completion handler argument, so it requires fixing an omission in the IPC
dispatch code for this combination.

* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageSynchronous):
* Source/WebKit/UIProcess/WebBackForwardList.swift:
(Direction.itemAtDeltaFromCurrentIndex(_:allowSkipping:)):

Canonical link: <a href="https://commits.webkit.org/315459@main">https://commits.webkit.org/315459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8381396caedd2dab413d93930978c808be4f0dc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169066 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126778 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d328dac7-5914-45bb-90fc-83d7722963df) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131667 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9fa47dc-9683-4b1a-b70e-a4cf956cf2d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112170 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f79f15c2-ad9d-4477-a637-58016aa43715) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33111 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27122 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181021 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140116 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42644 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139958 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37671 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43333 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107205 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35237 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115098 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41842 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6409 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41236 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41379 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->