### PR TITLE
[JSC] Map/Set `set` + `delete` churn always expands then immediately shrinks

### DIFF
--- a/JSTests/microbenchmarks/map-set-delete-churn-large.js
+++ b/JSTests/microbenchmarks/map-set-delete-churn-large.js
@@ -1,0 +1,12 @@
+var m = new Map();
+for (var i = 0; i < 8192; ++i)
+    m.set("k" + i, i);
+
+var acc = 0;
+for (var i = 0; i < 100000; ++i) {
+    m.set("t", i);
+    m.delete("t");
+    acc += m.size;
+}
+if (acc !== 819200000)
+    throw new Error("bad result: " + acc);

--- a/JSTests/microbenchmarks/map-set-delete-churn.js
+++ b/JSTests/microbenchmarks/map-set-delete-churn.js
@@ -1,0 +1,12 @@
+var m = new Map();
+for (var i = 0; i < 32; ++i)
+    m.set("k" + i, i);
+
+var acc = 0;
+for (var i = 0; i < 1000000; ++i) {
+    m.set("t", i);
+    m.delete("t");
+    acc += m.size;
+}
+if (acc !== 32000000)
+    throw new Error("bad result: " + acc);

--- a/JSTests/microbenchmarks/set-add-delete-churn.js
+++ b/JSTests/microbenchmarks/set-add-delete-churn.js
@@ -1,0 +1,12 @@
+var s = new Set();
+for (var i = 0; i < 32; ++i)
+    s.add("k" + i);
+
+var acc = 0;
+for (var i = 0; i < 1000000; ++i) {
+    s.add("t");
+    s.delete("t");
+    acc += s.size;
+}
+if (acc !== 32000000)
+    throw new Error("bad result: " + acc);

--- a/Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h
@@ -413,16 +413,17 @@ public:
     {
         ASSERT(!isObsolete(base));
         TableSize capacity = Helper::capacity(base);
+        TableSize dataCapacity = Helper::dataCapacity(capacity);
         TableSize deletedEntryCount = Helper::deletedEntryCount(base);
         TableSize usedCapacity = Helper::aliveEntryCount(base) + deletedEntryCount;
 
-        if (usedCapacity < dataCapacity(capacity))
+        if (usedCapacity < dataCapacity)
             return nullptr;
 
         bool isSmallCapacity = capacity < LargeCapacity;
         TableSize expansionFactor = isSmallCapacity ? 4 : 2;
         TableSize newCapacity = Checked<TableSize>(capacity) * expansionFactor;
-        if (deletedEntryCount >= (capacity / 2)) {
+        if (deletedEntryCount >= (dataCapacity / 2)) {
             // No need to expand. Just clear the deleted entries.
             // FIXME: Can we do this in place?
             newCapacity = capacity;


### PR DESCRIPTION
#### c74b5b63f801e54fe07c3f95be71f3e57d7d8127
<pre>
[JSC] Map/Set `set` + `delete` churn always expands then immediately shrinks
<a href="https://bugs.webkit.org/show_bug.cgi?id=317199">https://bugs.webkit.org/show_bug.cgi?id=317199</a>

Reviewed by Yusuke Suzuki.

expandIfNeeded intends to rehash at the same capacity when tombstones
dominate, but compares deletedEntryCount against capacity / 2 while the
rehash fires at usedCapacity == dataCapacity == capacity / 2 for small
tables, so the branch is unreachable whenever any entry is alive. A Map
kept at constant size by repeated set+delete therefore always expands
x4 only to immediately shrink back, repeating this on every fill while
find() walks an ever-growing tombstone chain.

Compare against dataCapacity / 2 instead (matching V8&apos;s policy). After
the same-capacity rehash alive &lt;= capacity / 4 stays above the
capacity / 8 shrink threshold, so this introduces no new grow/shrink
cycle.

                                  baseline                  patched
map-set-delete-churn-large  2381.5707+-218.4677   ^  522.1759+-9.4359   ^ definitely 4.5609x faster
map-set-delete-churn          86.2613+-3.8686     ^   37.2290+-1.5133   ^ definitely 2.3170x faster
set-add-delete-churn          80.6294+-4.6888     ^   35.3066+-2.2222   ^ definitely 2.2837x faster
set-delete-add                20.3424+-0.2986     ^   15.7992+-0.2317   ^ definitely 1.2876x faster
map-rehash                    18.9758+-0.8362     ?   18.9775+-0.5948   ?

Tests: JSTests/microbenchmarks/map-set-delete-churn-large.js
       JSTests/microbenchmarks/map-set-delete-churn.js
       JSTests/microbenchmarks/set-add-delete-churn.js

* JSTests/microbenchmarks/map-set-delete-churn-large.js: Added.
* JSTests/microbenchmarks/map-set-delete-churn.js: Added.
* JSTests/microbenchmarks/set-add-delete-churn.js: Added.
* Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h:
(JSC::JSOrderedHashTableHelper::expandIfNeeded):

Canonical link: <a href="https://commits.webkit.org/315431@main">https://commits.webkit.org/315431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16c643a32996fd4951338d5ab3e7b7f62e35f81b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126328 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131270 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92337 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111781 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32712 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31419 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26648 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161242 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180554 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29870 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139714 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42192 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139569 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37657 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42880 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27913 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106566 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34851 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114640 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201301 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41384 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5996 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54057 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->