### PR TITLE
Style checker to warn of unpaired WebBackForwardList changes

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -62,6 +62,7 @@ from webkitpy.style.checkers.python import PythonChecker, Python3Checker
 from webkitpy.style.checkers.spi_allowlist import SPIAllowlistChecker
 from webkitpy.style.checkers.api_test_allowlist import APITestAllowlistChecker
 from webkitpy.style.checkers.swift import SwiftChecker
+from webkitpy.style.checkers.swift_association import SwiftAssociationChecker
 from webkitpy.style.checkers.test_expectations import TestExpectationsChecker
 from webkitpy.style.checkers.text import TextChecker
 from webkitpy.style.checkers.watchlist import WatchListChecker
@@ -674,6 +675,7 @@ def _all_categories():
     categories = categories.union(FeatureDefinesChecker.categories)
     categories = categories.union(BaseXcconfigChecker.categories)
     categories = categories.union(XcodeSchemeChecker.categories)
+    categories = categories.union(SwiftAssociationChecker.categories)
 
     # FIXME: Consider adding all of the pep8 categories.  Since they
     #        are not too meaningful for documentation purposes, for
@@ -1325,6 +1327,8 @@ class StyleProcessor(ProcessorBase):
     def do_association_check(self, files, cwd, host=Host()):
         _log.debug("Running TestExpectations linter")
         TestExpectationsChecker.lint_test_expectations(files, self._configuration, cwd, self._increment_error_count, host=host)
+
+        SwiftAssociationChecker.check_associations(files, self._configuration, cwd, self._increment_error_count, host=host)
 
         wpt_dir = os.path.join('LayoutTests', *IMPORTED_WPT_DIR.split('/'))
         wpt_paths = []

--- a/Tools/Scripts/webkitpy/style/checkers/swift_association.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift_association.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Checks that C++ files and their Swift reimplementations are kept in sync."""
+
+import logging
+import os
+
+from webkitpy.common.host import Host
+from webkitpy.style.error_handlers import DefaultStyleErrorHandler
+
+
+_log = logging.getLogger(__name__)
+
+# Pairs of files which reimplement each other and must be kept in sync. When one
+# member of a pair is changed in a patch, the other member is expected to change
+# too. Paths are relative to the root of the repository.
+PAIRED_FILES = [
+    ('Source/WebKit/UIProcess/WebBackForwardList.cpp',
+     'Source/WebKit/UIProcess/WebBackForwardList.swift'),
+]
+
+
+class SwiftAssociationChecker(object):
+    """Flags patches that modify one file of a C++/Swift pair but not the other."""
+
+    categories = set(['swift/association'])
+
+    @staticmethod
+    def check_associations(files, configuration, cwd, increment_error_count=lambda: 0, host=Host()):
+        """Report an error for each paired file changed without its counterpart.
+
+        Args:
+            files: A dictionary mapping absolute file paths to the lists of lines
+                modified in each file. Removed files map to None.
+            configuration: A StyleProcessorConfiguration instance.
+            cwd: The root of the SCM checkout, used to relativize the file paths.
+            increment_error_count: Callable invoked once per reported error.
+            host: The current host (for testing).
+        """
+        # A file is considered changed if it appears in the dictionary at all,
+        # whether it was modified (maps to a list of lines) or removed (maps to None).
+        changed_paths = set(os.path.relpath(abs_path, cwd) for abs_path in files)
+
+        for first, second in PAIRED_FILES:
+            for changed_path, counterpart in ((first, second), (second, first)):
+                if changed_path not in changed_paths or counterpart in changed_paths:
+                    continue
+
+                absolute_path = os.path.join(cwd, changed_path)
+                # Report at line 0 so the error is emitted regardless of which
+                # lines of the file the patch happened to touch.
+                style_error_handler = DefaultStyleErrorHandler(
+                    absolute_path, configuration, increment_error_count, files.get(absolute_path))
+                style_error_handler(
+                    0,
+                    'swift/association',
+                    5,
+                    '{} was modified but its counterpart {} was not. These files '
+                    'reimplement each other and must be kept in sync.'.format(changed_path, counterpart))

--- a/Tools/Scripts/webkitpy/style/checkers/swift_association_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift_association_unittest.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+from unittest.mock import MagicMock
+
+from webkitpy.style.checkers.swift_association import SwiftAssociationChecker
+
+
+CWD = '/mock-checkout'
+CPP = 'Source/WebKit/UIProcess/WebBackForwardList.cpp'
+SWIFT = 'Source/WebKit/UIProcess/WebBackForwardList.swift'
+
+
+def _abs(rel_path):
+    return os.path.join(CWD, rel_path)
+
+
+class SwiftAssociationCheckerTest(unittest.TestCase):
+    def _check(self, files):
+        configuration = MagicMock()
+        configuration.is_reportable.return_value = True
+        increment = MagicMock()
+        SwiftAssociationChecker.check_associations(files, configuration, CWD, increment)
+        return configuration, increment
+
+    def test_cpp_modified_without_swift_is_flagged(self):
+        configuration, increment = self._check({_abs(CPP): [1, 2, 3]})
+
+        self.assertEqual(configuration.write_style_error.call_count, 1)
+        self.assertEqual(increment.call_count, 1)
+        call = configuration.write_style_error.call_args
+        self.assertEqual(call.kwargs['category'], 'swift/association')
+        self.assertEqual(call.kwargs['line_number'], 0)
+        self.assertEqual(call.kwargs['file_path'], _abs(CPP))
+        self.assertIn(CPP, call.kwargs['message'])
+        self.assertIn(SWIFT, call.kwargs['message'])
+
+    def test_swift_modified_without_cpp_is_flagged(self):
+        configuration, increment = self._check({_abs(SWIFT): [4, 5]})
+
+        self.assertEqual(configuration.write_style_error.call_count, 1)
+        call = configuration.write_style_error.call_args
+        self.assertEqual(call.kwargs['file_path'], _abs(SWIFT))
+        self.assertIn(SWIFT, call.kwargs['message'])
+        self.assertIn(CPP, call.kwargs['message'])
+
+    def test_both_modified_is_not_flagged(self):
+        configuration, increment = self._check({_abs(CPP): [1], _abs(SWIFT): [2]})
+
+        configuration.write_style_error.assert_not_called()
+        increment.assert_not_called()
+
+    def test_removed_cpp_without_swift_is_flagged(self):
+        # Removed files map to None; the counterpart is still required to change.
+        configuration, increment = self._check({_abs(CPP): None})
+
+        self.assertEqual(configuration.write_style_error.call_count, 1)
+
+    def test_unrelated_file_is_not_flagged(self):
+        configuration, increment = self._check({_abs('Source/WebKit/UIProcess/WebPageProxy.cpp'): [1]})
+
+        configuration.write_style_error.assert_not_called()
+        increment.assert_not_called()
+
+    def test_filtered_out_errors_are_not_counted(self):
+        configuration = MagicMock()
+        configuration.is_reportable.return_value = False
+        increment = MagicMock()
+
+        SwiftAssociationChecker.check_associations({_abs(CPP): [1]}, configuration, CWD, increment)
+
+        configuration.write_style_error.assert_not_called()
+        increment.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### d96202d52d689b18c2912c0797c6e7b17265c774
<pre>
Style checker to warn of unpaired WebBackForwardList changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=317201">https://bugs.webkit.org/show_bug.cgi?id=317201</a>
<a href="https://rdar.apple.com/179811261">rdar://179811261</a>

Reviewed by Geoffrey Garen.

We temporarily have two copies of WebBackForwardList in Swift and C++.
Until the C++ version is removed, we need to ensure that changes to the C++
version are reflected in the Swift version, or vice-versa. Add a style checker
runs as an association check (operating on the whole set of changed files
rather than one file at a time) and reports an error when one member of
such a pair is changed without the other.

Canonical link: <a href="https://commits.webkit.org/315366@main">https://commits.webkit.org/315366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12b46101c02253baadeefc68467c9090d43c6c1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126332 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daaa9df8-6806-4d04-8593-04d199950e70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131274 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92341 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26760908-9329-4fb7-9b25-4e0746891933) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111785 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3421538-ee59-4649-a927-42729c46e7a0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/167948 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32718 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31423 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26652 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180558 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42196 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139573 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37620 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42884 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27924 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106579 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34855 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41388 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6007 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40785 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40930 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->