### PR TITLE
SVG filter on element below viewport renders spurious black square at viewport origin

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects reference: empty viewport, target stays below</title>
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white; }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects reference: empty viewport, target stays below</title>
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white; }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects test: SVG filter applied to element below initial viewport must not paint at viewport origin</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://drafts.csswg.org/filter-effects-1/#FilterProperty">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=314999">
+<link rel="match" href="filter-target-offscreen-below-viewport-001-ref.html">
+<meta name="assert" content="An element placed entirely below the initial viewport with a CSS filter: url(#…) reference to an SVG filter must not produce any painted pixels inside the initial viewport.">
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white;
+            filter: url(#blur); }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>
+<svg width="0" height="0" color-interpolation-filters="sRGB" aria-hidden="true"
+     style="position: absolute">
+  <defs>
+    <filter id="blur">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="4"></feGaussianBlur>
+    </filter>
+  </defs>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects reference: empty viewport, target stays below</title>
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white; }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects reference: empty viewport, target stays below</title>
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white; }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects test: SVG feMorphology dilate filter applied to element below initial viewport must not paint at viewport origin</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://drafts.csswg.org/filter-effects-1/#FilterProperty">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=314999">
+<link rel="match" href="filter-target-offscreen-below-viewport-002-ref.html">
+<meta name="assert" content="An element placed entirely below the initial viewport with a CSS filter: url(#…) reference to an SVG feMorphology dilate filter must not produce any painted pixels inside the initial viewport.">
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white;
+            filter: url(#dilate); }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>
+<svg width="0" height="0" color-interpolation-filters="sRGB" aria-hidden="true"
+     style="position: absolute">
+  <defs>
+    <filter id="dilate">
+      <feMorphology in="SourceAlpha" operator="dilate" radius="4"></feMorphology>
+    </filter>
+  </defs>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects reference: empty viewport, target stays below</title>
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white; }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects reference: empty viewport, target stays below</title>
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white; }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Filter Effects test: SVG feOffset filter applied to element below initial viewport must not paint at viewport origin</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://drafts.csswg.org/filter-effects-1/#FilterProperty">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=314999">
+<link rel="match" href="filter-target-offscreen-below-viewport-003-ref.html">
+<meta name="assert" content="An element placed entirely below the initial viewport with a CSS filter: url(#…) reference to an SVG feOffset filter must not produce any painted pixels inside the initial viewport.">
+<style>
+  html, body { margin: 0; background: white; }
+  .spacer { height: calc(100vh + 50px); }
+  .target { padding: 10px; background: black; color: white;
+            filter: url(#offset); }
+</style>
+<div class="spacer"></div>
+<div class="target">Filter target — should not contribute to viewport pixels.</div>
+<svg width="0" height="0" color-interpolation-filters="sRGB" aria-hidden="true"
+     style="position: absolute">
+  <defs>
+    <filter id="offset">
+      <feOffset in="SourceAlpha" dx="8" dy="8"></feOffset>
+    </filter>
+  </defs>
+</svg>

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -177,6 +177,9 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
         }
 
         dirtyFilterRegion = intersection(filterBoxRect, dirtyFilterRegion);
+        // Nothing to filter when the target doesn't overlap the dirty rect.
+        if (dirtyFilterRegion.isEmpty())
+            return nullptr;
         filterRegion = dirtyFilterRegion;
 
         if (!outsets.isZero())


### PR DESCRIPTION
#### f3551fa3f5668042e4692c959f2e5a4c7bbbfa6a
<pre>
SVG filter on element below viewport renders spurious black square at viewport origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=314999">https://bugs.webkit.org/show_bug.cgi?id=314999</a>
<a href="https://rdar.apple.com/problem/177482001">rdar://problem/177482001</a>

Reviewed by Simon Fraser.

A CSS `filter: url(#…)` on an element below the initial viewport paints
a black square at the viewport origin.

When the filter target&apos;s box doesn&apos;t overlap the dirty rect, the
intersection collapses to an empty rect at (0, 0). The next expand()
turns that into a non-empty rect at the origin and the filter runs
there.

Bail when the intersection is empty.

Test: imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001.html
      imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002.html
      imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-target-offscreen-below-viewport-003-expected.html: Added.
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):

Canonical link: <a href="https://commits.webkit.org/315329@main">https://commits.webkit.org/315329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/149d3975dda3b7ca060d23af92af07bca4bf388c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126341 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f81ac123-4b2c-43ef-8197-070ef0994031) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131280 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3ef19b5-cd7d-463d-923f-87c1445b3a64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111791 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1cb050a8-ace2-497f-bc08-28028a51523a) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/167957 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32733 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31429 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26661 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180568 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139725 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/168036 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139580 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37604 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42893 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27928 "Too many flaky failures: http/tests/media/video-auth.html, http/tests/misc/slow-preload-cancel.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/report-blocked-uri-after-blocked-redirect.html, http/tests/site-isolation/notify-done.html, http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture-ephemeral.https.html, http/tests/websocket/tests/hybi/invalid-subprotocols.html, http/tests/workers/service/controller-change.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106596 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34859 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114653 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41397 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6011 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40794 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41045 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40939 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->