### PR TITLE
[WKCI][build.webkit.org][WPE] Add a ARM64 Release build&test bot for the stable branch webkitglib/2.52

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -244,6 +244,7 @@
 
                   { "name": "wpe-linux-bot-1", "platform": "wpe" },
                   { "name": "wpe-linux-bot-2", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-3", "platform": "wpe" },
                   { "name": "wpe-linux-bot-4", "platform": "wpe" },
                   { "name": "wpe-linux-bot-5", "platform": "wpe" },
                   { "name": "wpe-linux-bot-7", "platform": "wpe" },
@@ -757,6 +758,11 @@
                     "name": "WPE-Linux-ARM64-bit-Release-JS-Tests", "factory": "TestJSFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["arm64"],
                     "workernames": ["wpe-linux-bot-40"]
+                  },
+                  {
+                    "name": "WPE-Linux-ARM64-bit-Release-v252-BuildAndTest", "factory": "BuildAndTestAllPlusTest262WebDriverMVTFactory",
+                    "platform": "wpe", "configuration": "release", "architectures": ["arm64"],
+                    "workernames": ["wpe-linux-bot-3"]
                   }
                 ],
 
@@ -785,6 +791,9 @@
                                      "WPE-Linux-ARM32-bit-Release-Debian-Stable-Build",
                                      "WPE-Linux-64-bit-Release-Non-Unified-Build",
                                      "WPE-Linux-ARM64-bit-Release-Build"]
+                  },
+                  { "type": "AnyBranchScheduler", "name": "webkitglib-v252", "change_filter": "webkitglib_v252_filter", "treeStableTimer": 45.0,
+                    "builderNames": ["WPE-Linux-ARM64-bit-Release-v252-BuildAndTest"]
                   },
                   { "type": "PlatformSpecificScheduler", "platform": "mac-tahoe", "branch": "main", "treeStableTimer": 45.0,
                   "builderNames": ["Apple-Tahoe-Release-Build", "Apple-Tahoe-Debug-Build", "Apple-Tahoe-LLINT-CLoop-BuildAndTest", "Apple-Tahoe-Safer-CPP-Checks"]

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -177,6 +177,14 @@ class BuildAndTestAllButJSCFactory(BuildAndTestFactory):
     JSCTestClass = None
 
 
+class BuildAndTestAllPlusTest262WebDriverMVTFactory(BuildAndTestFactory):
+    def __init__(self, platform, configuration, architectures, additionalArguments=None, device_model=None, **kwargs):
+        TestFactory.__init__(self, platform, configuration, architectures, additionalArguments, device_model, **kwargs)
+        self.addStep(RunTest262Tests())
+        self.addStep(RunWebDriverTests())
+        self.addStep(RunMVTTests())
+
+
 class BuildAndGenerateJSCBundleFactory(BuildFactory):
     shouldRunJSCBundleStep = True
 

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1474,6 +1474,33 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'jscore-test',
             'test262-test'
+        ],
+        'WPE-Linux-ARM64-bit-Release-v252-BuildAndTest': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'jhbuild',
+            'compile-webkit',
+            'jscore-test',
+            'layout-test',
+            'dashboard-tests',
+            'archive-test-results',
+            'upload',
+            'extract-test-results',
+            'set-permissions',
+            'run-api-tests',
+            'webkitpy-test',
+            'webkitperl-test',
+            'bindings-generation-tests',
+            'builtins-generator-tests',
+            'test262-test',
+            'webdriver-test',
+            'MVT-tests'
         ]
     }
 

--- a/Tools/CISupport/build-webkit-org/loadConfig.py
+++ b/Tools/CISupport/build-webkit-org/loadConfig.py
@@ -37,6 +37,7 @@ from .factories import *
 from . import wkbuild
 
 main_filter = ChangeFilter(branch=["main", None])
+webkitglib_v252_filter = ChangeFilter(branch=["webkitglib/2.52"])
 
 BUILDER_NAME_LENGTH_LIMIT = 70
 STEP_NAME_LENGTH_LIMIT = 50


### PR DESCRIPTION
#### 13ede6febf8ab60048a46337ac6f49e5b2708767
<pre>
[WKCI][build.webkit.org][WPE] Add a ARM64 Release build&amp;test bot for the stable branch webkitglib/2.52
<a href="https://bugs.webkit.org/show_bug.cgi?id=317206">https://bugs.webkit.org/show_bug.cgi?id=317206</a>

Reviewed by Nikolas Zimmermann.

Add a WPE post-commit bot to build and run all the battery of tests with WPE ARM64
on the last stable branch (2.52).

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories.py:
(BuildAndTestAllPlusTest262WebDriverMVTFactory):
(BuildAndTestAllPlusTest262WebDriverMVTFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/loadConfig.py:

Canonical link: <a href="https://commits.webkit.org/315605@main">https://commits.webkit.org/315605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/463859e973ff5e7905d5bb697713072af86e2977

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43476 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171420 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43105 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172513 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112606 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27610 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181512 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36409 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/168954 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43132 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140388 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43821 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108026 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35659 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42331 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41724 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->