### PR TITLE
[Tools][CISupport] start-local-buildbot-server updates for launching with python >= 3.13 and after 315213@main

### DIFF
--- a/Tools/CISupport/start-local-buildbot-server
+++ b/Tools/CISupport/start-local-buildbot-server
@@ -275,6 +275,7 @@ class BuildbotTestRunner(object):
             # dependencies than the ones used for running https://build.webkit.org/about
             buildbot_version = '4.3.0'
             pip_cmd = [virtualenv_pip, 'install',
+                       'boto3==1.43.30',
                        f'buildbot=={buildbot_version}',
                        f'buildbot-console-view=={buildbot_version}',
                        f'buildbot-grid-view=={buildbot_version}',
@@ -287,6 +288,8 @@ class BuildbotTestRunner(object):
                        f'requests==2.26.0',
                        f'twisted==23.10.0',
                        'zope.interface==7.0.1']
+            if sys.version_info >= (3, 13):
+                pip_cmd.append('legacy-cgi==2.6.3')
             pip_process = subprocess.Popen(pip_cmd, cwd=self._base_workdir_temp,
                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             stdout, stderr = pip_process.communicate()


### PR DESCRIPTION
#### 2d7cd0bce564a4b8e85b5ceabc196ec4c9a656f4
<pre>
[Tools][CISupport] start-local-buildbot-server updates for launching with python &gt;= 3.13 and after 315213@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=317208">https://bugs.webkit.org/show_bug.cgi?id=317208</a>

Reviewed by Nikolas Zimmermann.

Since 315213@main in steps.py there is &quot;from Shared import generate_s3_url&quot; which ends importing boto3.
Also since python &gt;= 3.13 legacy-cgi is needed because that provides the cgi module in
newer python versions which is needed by the twisted version used with buildbot.

* Tools/CISupport/start-local-buildbot-server:
(BuildbotTestRunner._setup_virtualenv):

Canonical link: <a href="https://commits.webkit.org/316371@main">https://commits.webkit.org/316371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a74101d423c9ba56ecae4e73aad4fae63dd3271

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131290 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92357 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32741 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31440 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26672 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180579 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139735 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42216 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139590 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42904 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106612 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26118 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34873 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41408 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6025 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->