### PR TITLE
adjustRegionAfterViewportSizeChange shifts rects along X for a viewport height change

### DIFF
--- a/LayoutTests/fast/element-targeting/adjust-region-after-viewport-height-change-expected.html
+++ b/LayoutTests/fast/element-targeting/adjust-region-after-viewport-height-change-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+    overflow: hidden;
+}
+
+.content {
+    width: 320px;
+    height: 200px;
+}
+</style>
+</head>
+<body>
+<p class="content">This test requires WebKitTestRunner.</p>
+<script>
+testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    await UIHelper.resizeWindowTo(800, 700);
+    await UIHelper.waitForCondition(() => document.documentElement.clientHeight === 700);
+    await UIHelper.renderingUpdate();
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/element-targeting/adjust-region-after-viewport-height-change.html
+++ b/LayoutTests/fast/element-targeting/adjust-region-after-viewport-height-change.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+    overflow: hidden;
+}
+
+.box {
+    position: fixed;
+    left: 350px;
+    bottom: 0;
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+
+.content {
+    width: 320px;
+    height: 200px;
+}
+</style>
+</head>
+<body>
+<div class="box"></div>
+<p class="content">This test requires WebKitTestRunner.</p>
+<script>
+testRunner.waitUntilDone();
+
+function addBottomBox() {
+    const box = document.createElement("div");
+    box.classList.add("box");
+    document.body.appendChild(box);
+    return box;
+}
+
+addEventListener("load", async () => {
+    await UIHelper.waitForCondition(() => document.documentElement.clientHeight === 600);
+
+    await UIHelper.adjustVisibilityForFrontmostTarget(document.querySelector(".box"));
+    await UIHelper.renderingUpdate();
+
+    await UIHelper.adjustVisibilityForFrontmostTarget(addBottomBox());
+    await UIHelper.renderingUpdate();
+
+    await UIHelper.resizeWindowTo(800, 700);
+    await UIHelper.waitForCondition(() => document.documentElement.clientHeight === 700);
+    await UIHelper.renderingUpdate();
+
+    for (let i = 0; i < 3; ++i)
+        addBottomBox();
+    await UIHelper.renderingUpdate();
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -258,6 +258,8 @@ fast/events/touch/ios/touch-event-regions-layer-tree/scrolling [ Skip ]
 accessibility
 perf/accessibility-title-ui-element.html
 
+fast/element-targeting/adjust-region-after-viewport-height-change.html [ Skip ]
+
 # webkit.org/b/240843
 fast/images/heic-as-background-image.html [ Pass ]
 fast/images/animated-heics-verify.html [ Pass ]

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -1564,7 +1564,7 @@ static void adjustRegionAfterViewportSizeChange(Region& region, FloatSize oldSiz
             if (std::abs(distanceToTopEdge - distanceToBottomEdge) < minimumDistanceToConsiderEdgesEquidistant)
                 adjustedRect.inflateY(heightDelta / 2);
             else if (distanceToBottomEdge < distanceToTopEdge)
-                adjustedRect.move(heightDelta, 0);
+                adjustedRect.move(0, heightDelta);
         }
 
         auto enclosingAdjustedRect = enclosingIntRect(adjustedRect);


### PR DESCRIPTION
#### d5c98ab9b8e7757990fcb1770e88dec88b6e412c
<pre>
adjustRegionAfterViewportSizeChange shifts rects along X for a viewport height change
<a href="https://bugs.webkit.org/show_bug.cgi?id=317211">https://bugs.webkit.org/show_bug.cgi?id=317211</a>
<a href="https://rdar.apple.com/179832395">rdar://179832395</a>

Reviewed by Wenson Hsieh.

FloatRect::move(float dx, float dy) takes the X delta first and the Y delta second. The height-delta
called adjustedRect.move(heightDelta, 0) and so shifted the rect horizontally by the vertical delta
(and not vertically at all). As a result, after a vertical viewport size change the tracked
adjustment regions shift sideways instead of up/down and no longer contain the elements they track,
so previously-hidden out-of-flow elements are not re-adjusted.

Move along the Y axis with move(0, heightDelta).

Test: fast/element-targeting/adjust-region-after-viewport-height-change.html
* LayoutTests/fast/element-targeting/adjust-region-after-viewport-height-change-expected.html: Added.
* LayoutTests/fast/element-targeting/adjust-region-after-viewport-height-change.html: Added.
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::adjustRegionAfterViewportSizeChange):

Canonical link: <a href="https://commits.webkit.org/315398@main">https://commits.webkit.org/315398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0f244d9a38b3996d3da81f04ab920802cacbf33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42476 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178258 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42450 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171864 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/33978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/112026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31674 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26961 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180860 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42483 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/139814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43172 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106991 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25733 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/35097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41681 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41075 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41218 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->