### PR TITLE
[CMake][Mac] Add straggler files to the unified build in WebKitLegacy/WebKit/WebCore

### DIFF
--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
@@ -55,7 +55,7 @@ static inline CAAudioStreamDescription streamDescription(size_t sampleRate, size
     return streamFormat;
 }
 
-static inline void copyChannelData(AudioChannel& channel, AudioBuffer& buffer, size_t numberOfFrames, bool isMuted)
+static inline void copyChannelData(AudioChannel& channel, ::AudioBuffer& buffer, size_t numberOfFrames, bool isMuted)
 {
     RELEASE_ASSERT(buffer.mDataByteSize <= numberOfFrames * sizeof(float), "copyChannelData() given an AudioBuffer with insufficient size");
     buffer.mNumberChannels = 1;

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -95,6 +95,12 @@ endif ()
 list(APPEND WebCore_UNIFIED_SOURCE_LIST_FILES
     "SourcesCocoa.txt"
 )
+# FIXME: Test building on iOS and then enable on iOS.
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    list(APPEND WebCore_UNIFIED_SOURCE_LIST_FILES
+        "SourcesCMakeCocoa.txt"
+    )
+endif ()
 
 list(APPEND WebCore_LIBRARIES
     ${ACCELERATE_LIBRARY}

--- a/Source/WebCore/SourcesCMakeCocoa.txt
+++ b/Source/WebCore/SourcesCMakeCocoa.txt
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// CMake-only unified source list for the Cocoa ports. The Xcode build compiles
+// these files individually via WebCore.xcodeproj; folding them into the shared
+// SourcesCocoa.txt would require coordinated bundle-count and pbxproj updates.
+//
+// Registered Mac-only for now (see PlatformCocoa.cmake); every entry already
+// comes from CMakeLists.txt or PlatformCocoa.cmake, so iOS adoption should
+// only need a build-verification pass.
+
+Modules/encryptedmedia/CDM.cpp
+Modules/encryptedmedia/InitDataRegistry.cpp
+Modules/encryptedmedia/MediaKeyMessageEvent.cpp
+Modules/encryptedmedia/MediaKeySession.cpp
+Modules/encryptedmedia/MediaKeyStatusMap.cpp
+Modules/encryptedmedia/MediaKeySystemAccess.cpp
+Modules/encryptedmedia/MediaKeySystemController.cpp
+Modules/encryptedmedia/MediaKeySystemRequest.cpp
+Modules/encryptedmedia/MediaKeys.cpp
+Modules/encryptedmedia/NavigatorEME.cpp
+
+Modules/encryptedmedia/legacy/LegacyCDM.cpp
+Modules/encryptedmedia/legacy/LegacyCDMPrivateClearKey.cpp
+Modules/encryptedmedia/legacy/LegacyCDMPrivateMediaPlayer.cpp
+Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
+Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp
+Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp
+Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
+
+Modules/gamepad/Gamepad.cpp
+Modules/gamepad/GamepadButton.cpp
+Modules/gamepad/GamepadEvent.cpp
+Modules/gamepad/GamepadHapticActuator.cpp
+Modules/gamepad/GamepadManager.cpp
+Modules/gamepad/NavigatorGamepad.cpp
+
+Modules/geolocation/cocoa/GeolocationPositionDataCocoa.mm @nonARC
+
+Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+
+Modules/webauthn/AuthenticationExtensionsClientInputs.cpp
+Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
+
+editing/TextListParser.cpp
+
+editing/mac/UniversalAccessZoom.mm @nonARC
+
+html/MediaEncryptedEvent.cpp
+
+html/shadow/SpatialImageControls.cpp
+
+page/UserMessageHandler.cpp
+page/UserMessageHandlerDescriptor.cpp
+page/UserMessageHandlersNamespace.cpp
+page/ViewportConfiguration.cpp
+page/WebKitNamespace.cpp
+
+platform/CPUMonitor.cpp
+platform/DictationCaretAnimator.cpp
+platform/OpacityCaretAnimator.cpp
+
+platform/audio/cocoa/AudioSessionCocoa.mm @nonARC
+
+platform/cocoa/SharedVideoFrameInfo.mm @nonARC
+platform/cocoa/SystemBattery.mm @nonARC
+platform/cocoa/VideoFullscreenCaptions.mm @nonARC
+platform/cocoa/WebAVPlayerLayer.mm @nonARC
+
+platform/gamepad/cocoa/CoreHapticsSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
+platform/gamepad/cocoa/GameControllerHapticEffect.mm @nonARC
+platform/gamepad/cocoa/GameControllerHapticEngines.mm @nonARC
+platform/gamepad/cocoa/GameControllerSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
+
+platform/graphics/FormatConverter.cpp
+
+platform/graphics/angle/ANGLEUtilities.cpp
+
+platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+
+platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm @nonARC
+platform/graphics/avfoundation/objc/QueuedVideoOutput.mm @nonARC
+
+platform/graphics/cocoa/ANGLEUtilitiesCocoa.mm @nonARC
+platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm @nonARC
+platform/graphics/cocoa/TextTransformCocoa.cpp
+platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm @nonARC
+
+platform/graphics/cv/ImageRotationSessionVT.mm @nonARC
+platform/graphics/cv/PixelBufferConformerCV.mm @nonARC
+
+platform/mac/WebCoreView.mm @nonARC
+
+platform/mediarecorder/MediaRecorderPrivateWriter.cpp
+
+platform/mediastream/cocoa/CoreAudioCaptureUnit.mm @nonARC
+
+platform/network/cocoa/WebCoreResourceHandleAsOperationQueueDelegate.mm @nonARC
+
+testing/MockContentFilter.cpp
+testing/MockContentFilterManager.cpp
+testing/MockContentFilterSettings.cpp
+testing/MockParentalControlsURLFilter.mm @nonARC
+
+workers/service/ServiceWorkerRoute.mm @nonARC
+
+// DerivedSources. The four gperf outputs (CSSPropertyNames, HTTPHeaderNames,
+// SelectorPseudoClassAndCompatibilityElementMap, SelectorPseudoElementMap) are
+// not listed: gperf emits TOTAL_KEYWORDS / wordlist / lookup at file scope with
+// fixed names, so any two gperf outputs in one translation unit collide.
+HTMLNames.cpp
+JSMediaConfiguration.cpp
+JSRTCRtpCodingParameters.cpp
+JSTouch.cpp
+JSTouchEvent.cpp
+JSTouchList.cpp
+JSWebXRHitTestResult.cpp
+JSWebXRHitTestSource.cpp
+JSWebXRRay.cpp
+JSWebXRTransientInputHitTestResult.cpp
+JSWebXRTransientInputHitTestSource.cpp
+JSXRHitTestOptionsInit.cpp
+JSXRHitTestTrackableType.cpp
+JSXRLayerInit.cpp
+JSXRRayDirectionInit.cpp
+JSXRTransientInputHitTestOptionsInit.cpp
+MathMLNames.cpp
+Namespace.cpp
+NodeName.cpp
+Settings.cpp
+SVGNames.cpp
+TagName.cpp
+UserAgentParts.cpp
+UserAgentScriptsData.cpp
+WebKitFontFamilyNames.cpp
+XLinkNames.cpp
+XMLNames.cpp
+XMLNSNames.cpp

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -44,9 +44,10 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
-using namespace WebCore;
-
+#if !defined(WebCore_AVKitLibrary_SoftLinked)
+#define WebCore_AVKitLibrary_SoftLinked
 SOFTLINK_AVKIT_FRAMEWORK()
+#endif
 SOFT_LINK_CLASS_OPTIONAL(AVKit, __AVPlayerLayerView)
 
 #if !RELEASE_LOG_DISABLED
@@ -84,15 +85,15 @@ private:
 }
 
 @implementation WebAVPlayerLayer {
-    ThreadSafeWeakPtr<VideoPresentationModel> _presentationModel;
+    ThreadSafeWeakPtr<WebCore::VideoPresentationModel> _presentationModel;
     RetainPtr<WebAVPlayerController> _playerController;
     RetainPtr<CALayer> _videoSublayer;
     RetainPtr<CALayer> _captionsLayer;
-    FloatRect _targetVideoFrame;
+    WebCore::FloatRect _targetVideoFrame;
     CGSize _videoDimensions;
     RetainPtr<NSString> _videoGravity;
     RetainPtr<NSString> _previousVideoGravity;
-    std::unique_ptr<WebAVPlayerLayerPresentationModelClient> _presentationModelClient;
+    std::unique_ptr<WebCore::WebAVPlayerLayerPresentationModelClient> _presentationModelClient;
     NSEdgeInsets _legibleContentInsets;
     BOOL _showingCaptionPreview;
 #if !RELEASE_LOG_DISABLED
@@ -109,7 +110,7 @@ private:
         _videoGravity = AVLayerVideoGravityResizeAspect;
         _previousVideoGravity = AVLayerVideoGravityResizeAspect;
         self.name = @"WebAVPlayerLayer";
-        _presentationModelClient = WTF::makeUnique<WebAVPlayerLayerPresentationModelClient>(self);
+        _presentationModelClient = WTF::makeUnique<WebCore::WebAVPlayerLayerPresentationModelClient>(self);
         _showingCaptionPreview = NO;
     }
     return self;
@@ -124,12 +125,12 @@ private:
     [super dealloc];
 }
 
-- (RefPtr<VideoPresentationModel>)presentationModel
+- (RefPtr<WebCore::VideoPresentationModel>)presentationModel
 {
     return _presentationModel.get();
 }
 
-- (void)setPresentationModel:(RefPtr<VideoPresentationModel>)presentationModel
+- (void)setPresentationModel:(RefPtr<WebCore::VideoPresentationModel>)presentationModel
 {
     auto model = _presentationModel.get();
     if (model == presentationModel)
@@ -156,7 +157,7 @@ private:
 
 - (void)setPlayerController:(AVPlayerController *)playerController
 {
-    ASSERT(!playerController || [playerController isKindOfClass:webAVPlayerControllerClassSingleton()]);
+    ASSERT(!playerController || [playerController isKindOfClass:WebCore::webAVPlayerControllerClassSingleton()]);
     _playerController = (WebAVPlayerController *)playerController;
 }
 
@@ -198,26 +199,26 @@ private:
     if (CGSizeEqualToSize(_videoDimensions, videoDimensions))
         return;
 
-    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, FloatSize { videoDimensions });
+    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, WebCore::FloatSize { videoDimensions });
     _videoDimensions = videoDimensions;
     [self setNeedsLayout];
 }
 
-- (FloatRect)calculateTargetVideoFrame
+- (WebCore::FloatRect)calculateTargetVideoFrame
 {
-    FloatRect targetVideoFrame;
+    WebCore::FloatRect targetVideoFrame;
     float videoAspectRatio = self.videoDimensions.width / self.videoDimensions.height;
 
     if ([AVLayerVideoGravityResize isEqualToString:self.videoGravity])
         targetVideoFrame = self.bounds;
     else if ([AVLayerVideoGravityResizeAspect isEqualToString:self.videoGravity])
-        targetVideoFrame = largestRectWithAspectRatioInsideRect(videoAspectRatio, self.bounds);
+        targetVideoFrame = WebCore::largestRectWithAspectRatioInsideRect(videoAspectRatio, self.bounds);
     else if ([AVLayerVideoGravityResizeAspectFill isEqualToString:self.videoGravity])
-        targetVideoFrame = smallestRectWithAspectRatioAroundRect(videoAspectRatio, self.bounds);
+        targetVideoFrame = WebCore::smallestRectWithAspectRatioAroundRect(videoAspectRatio, self.bounds);
     else
         ASSERT_NOT_REACHED();
 
-    return snappedIntRect(LayoutRect(targetVideoFrame));
+    return snappedIntRect(WebCore::LayoutRect(targetVideoFrame));
 }
 
 // Sometimes the `frame` returned by CA will differ from the value assigned
@@ -228,10 +229,10 @@ private:
 // constant value to use for a custom `areEssentiallyEqual` where we will
 // bail out of -resolveBounds if the _targetVideoFrame is essentially equal
 // to the current video frame.
-static bool NODELETE areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const FloatRect& b)
+static bool NODELETE areFramesEssentiallyEqualWithTolerance(const WebCore::FloatRect& a, const WebCore::FloatRect& b)
 {
     static constexpr double frameValueDeltaTolerance { 0.01 };
-    FloatRect delta { FloatPoint { a.location() - b.location() }, a.size() - b.size() };
+    WebCore::FloatRect delta { WebCore::FloatPoint { a.location() - b.location() }, a.size() - b.size() };
     return abs(delta.x()) < frameValueDeltaTolerance
         && abs(delta.y()) < frameValueDeltaTolerance
         && abs(delta.width()) < frameValueDeltaTolerance
@@ -250,13 +251,13 @@ static bool NODELETE areFramesEssentiallyEqualWithTolerance(const FloatRect& a, 
         return;
     }
 
-    FloatRect sourceVideoFrame = self.videoSublayer.bounds;
+    WebCore::FloatRect sourceVideoFrame = self.videoSublayer.bounds;
     _targetVideoFrame = [self calculateTargetVideoFrame];
 
     if (_captionsLayer) {
         // Captions should be placed atop video content, but if the video content overflows
         // the WebAVPlayerLayer bounds, restrict the caption area to only what is visible.
-        FloatRect captionsFrame = _targetVideoFrame;
+        WebCore::FloatRect captionsFrame = _targetVideoFrame;
         captionsFrame.intersect(self.bounds);
         [_captionsLayer setFrame:captionsFrame];
         if (auto model = _presentationModel.get())
@@ -301,7 +302,7 @@ static bool NODELETE areFramesEssentiallyEqualWithTolerance(const FloatRect& a, 
     [_videoSublayer setPosition:CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds))];
     [CATransaction commit];
 
-    OBJC_DEBUG_LOG(OBJC_LOGIDENTIFIER, "self.bounds: ", FloatRect(self.bounds), ", targetVideoFrame: ", _targetVideoFrame, ", transform: [", transform.a, ", ", transform.d, "]");
+    OBJC_DEBUG_LOG(OBJC_LOGIDENTIFIER, "self.bounds: ", WebCore::FloatRect(self.bounds), ", targetVideoFrame: ", _targetVideoFrame, ", transform: [", transform.a, ", ", transform.d, "]");
 
     NSTimeInterval animationDuration = [CATransaction animationDuration];
     RunLoop::mainSingleton().dispatch([self, strongSelf = retainPtr(self), animationDuration] {
@@ -331,7 +332,7 @@ static bool NODELETE areFramesEssentiallyEqualWithTolerance(const FloatRect& a, 
     OBJC_DEBUG_LOG(OBJC_LOGIDENTIFIER, _targetVideoFrame);
 
     if (auto model = _presentationModel.get()) {
-        FloatRect targetVideoBounds { { }, _targetVideoFrame.size() };
+        WebCore::FloatRect targetVideoBounds { { }, _targetVideoFrame.size() };
         model->setVideoLayerFrame(targetVideoBounds);
     }
 
@@ -358,13 +359,13 @@ static bool NODELETE areFramesEssentiallyEqualWithTolerance(const FloatRect& a, 
     _previousVideoGravity = _videoGravity;
     _videoGravity = videoGravity;
 
-    MediaPlayerEnums::VideoGravity gravity = MediaPlayerEnums::VideoGravity::ResizeAspect;
+    WebCore::MediaPlayerEnums::VideoGravity gravity = WebCore::MediaPlayerEnums::VideoGravity::ResizeAspect;
     if ([videoGravity isEqualToString:AVLayerVideoGravityResize])
-        gravity = MediaPlayerEnums::VideoGravity::Resize;
+        gravity = WebCore::MediaPlayerEnums::VideoGravity::Resize;
     else if ([videoGravity isEqualToString:AVLayerVideoGravityResizeAspect])
-        gravity = MediaPlayerEnums::VideoGravity::ResizeAspect;
+        gravity = WebCore::MediaPlayerEnums::VideoGravity::ResizeAspect;
     else if ([videoGravity isEqualToString:AVLayerVideoGravityResizeAspectFill])
-        gravity = MediaPlayerEnums::VideoGravity::ResizeAspectFill;
+        gravity = WebCore::MediaPlayerEnums::VideoGravity::ResizeAspectFill;
     else
         ASSERT_NOT_REACHED();
 
@@ -389,9 +390,9 @@ static bool NODELETE areFramesEssentiallyEqualWithTolerance(const FloatRect& a, 
     float videoAspectRatio = self.videoDimensions.width / self.videoDimensions.height;
 
     if ([AVLayerVideoGravityResizeAspect isEqualToString:self.videoGravity])
-        return largestRectWithAspectRatioInsideRect(videoAspectRatio, self.bounds);
+        return WebCore::largestRectWithAspectRatioInsideRect(videoAspectRatio, self.bounds);
     if ([AVLayerVideoGravityResizeAspectFill isEqualToString:self.videoGravity])
-        return smallestRectWithAspectRatioAroundRect(videoAspectRatio, self.bounds);
+        return WebCore::smallestRectWithAspectRatioAroundRect(videoAspectRatio, self.bounds);
 
     return self.bounds;
 }
@@ -470,7 +471,7 @@ static bool NODELETE areFramesEssentiallyEqualWithTolerance(const FloatRect& a, 
 
 - (WTFLogChannel*)logChannel
 {
-    return &LogFullscreen;
+    return &WebCore::LogFullscreen;
 }
 @end
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -58,7 +58,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PacketDurationParser);
 
-#if ENABLE(VORBIS)
+#if ENABLE(VORBIS) && !defined(WEBCORE_kAudioFormatVorbis_DEFINED)
+#define WEBCORE_kAudioFormatVorbis_DEFINED
 constexpr uint32_t kAudioFormatVorbis = 'vorb';
 #endif
 

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -462,7 +462,10 @@ Vector<uint8_t> createOpusPrivateData(const AudioStreamBasicDescription& descrip
 }
 
 #if ENABLE(VORBIS)
+#if !defined(WEBCORE_kAudioFormatVorbis_DEFINED)
+#define WEBCORE_kAudioFormatVorbis_DEFINED
 static constexpr uint32_t kAudioFormatVorbis = 'vorb';
+#endif
 
 static Vector<uint8_t> cookieFromVorbisCodecPrivate(std::span<const uint8_t> codecPrivateData)
 {

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -48,7 +48,10 @@ SOFTLINK_AVKIT_FRAMEWORK()
 #endif
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlayerController)
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVTimeRange)
+#if !defined(WebCore_AVValueTiming_SoftLinked)
+#define WebCore_AVValueTiming_SoftLinked
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVValueTiming)
+#endif
 
 OBJC_CLASS AVAssetTrack;
 OBJC_CLASS AVMetadataItem;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -45,7 +45,10 @@
 #define WebCore_AVKitLibrary_SoftLinked
 SOFTLINK_AVKIT_FRAMEWORK()
 #endif
+#if !defined(WebCore_AVValueTiming_SoftLinked)
+#define WebCore_AVValueTiming_SoftLinked
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVValueTiming)
+#endif
 
 namespace WebCore {
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -359,5 +359,6 @@ void RemoteAudioDestinationManager::setSceneIdentifier(RemoteAudioDestinationIde
 } // namespace WebKit
 
 #undef MESSAGE_CHECK
+#undef MESSAGE_CHECK_COMPLETION
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEB_AUDIO)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
@@ -40,7 +40,9 @@ SOFT_LINK_CLASS(libnetworkextension, NEHelperTrackerAppInfoRef)
 SOFT_LINK_CLASS(libnetworkextension, NEHelperTrackerDomainContextRef)
 SOFT_LINK(libnetworkextension, NEHelperTrackerGetDisposition, NEHelperTrackerDisposition_t*, (NEHelperTrackerAppInfoRef *app_info_ref, CFArrayRef domains, NEHelperTrackerDomainContextRef *trackerDomainContextRef, CFIndex *trackerDomainIndex), (app_info_ref, domains, trackerDomainContextRef, trackerDomainIndex))
 
+#ifndef WebKit_libnetworkLibrary_SoftLinked
 SOFT_LINK_LIBRARY_OPTIONAL(libnetwork)
+#endif
 SOFT_LINK_OPTIONAL(libnetwork, nw_parameters_set_attributed_bundle_identifier, void, __cdecl, (nw_parameters_t, const char*))
 
 namespace WebKit {

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -31,6 +31,12 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
 
     "Platform/SourcesCocoa.txt"
 )
+# FIXME: Test building on iOS and then enable on iOS.
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
+        "SourcesCMakeCocoa.txt"
+    )
+endif ()
 
 list(APPEND WebKit_SOURCES
     GPUProcess/media/RemoteAudioDestinationManager.cpp

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm
@@ -53,7 +53,7 @@ bool CoreIPCPlistObject::isPlistType(id value)
     return false;
 }
 
-static PlistValue valueFromID(id object)
+static PlistValue plistValueFromID(id object)
 {
     switch (IPC::typeFromObject(object)) {
     case IPC::NSType::Array:
@@ -74,7 +74,7 @@ static PlistValue valueFromID(id object)
 }
 
 CoreIPCPlistObject::CoreIPCPlistObject(id object)
-    : m_value(makeUniqueRefWithoutFastMallocCheck<PlistValue>(valueFromID(object)))
+    : m_value(makeUniqueRefWithoutFastMallocCheck<PlistValue>(plistValueFromID(object)))
 {
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isInWebProcess());
 }

--- a/Source/WebKit/SourcesCMakeCocoa.txt
+++ b/Source/WebKit/SourcesCMakeCocoa.txt
@@ -1,0 +1,203 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// CMake-only unified source list for the Cocoa ports. The Xcode build compiles
+// these files individually via WebKit.xcodeproj; folding them into the shared
+// SourcesCocoa.txt would require coordinated bundle-count and pbxproj updates.
+//
+// Registered Mac-only for now (see PlatformCocoa.cmake). When iOS adopts,
+// NetworkConnectionToWebProcessMac.mm and the two
+// _WKCaptionStyleMenuController*Mac.mm entries will need #if PLATFORM(MAC)
+// self-guards (the latter already has one) or a separate Mac-only list.
+
+GPUProcess/media/RemoteAudioDestinationManager.cpp
+
+NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm @nonARC
+
+NetworkProcess/cocoa/DeviceManagementSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
+NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm @nonARC
+NetworkProcess/cocoa/NetworkSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
+NetworkProcess/cocoa/WebSocketTaskCocoa.mm @nonARC
+
+NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm @nonARC
+
+NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm @nonARC
+
+Platform/IPC/cocoa/SharedFileHandleCocoa.cpp
+
+Platform/cocoa/_WKWebViewTextInputNotifications.mm @nonARC
+
+Shared/API/Cocoa/WKMain.mm @nonARC
+
+Shared/AdditionalFonts.mm @nonARC
+
+Shared/Cocoa/AnnotatedMachSendRight.mm @nonARC
+Shared/Cocoa/ArgumentCodersCocoa.mm @nonARC
+Shared/Cocoa/BackgroundFetchStateCocoa.mm @nonARC
+Shared/Cocoa/CoreIPCAVOutputContext.mm @nonARC
+Shared/Cocoa/CoreIPCArray.mm @nonARC
+Shared/Cocoa/CoreIPCCFType.mm @nonARC
+Shared/Cocoa/CoreIPCCFURL.mm @nonARC
+Shared/Cocoa/CoreIPCCVPixelBufferRef.mm @nonARC
+Shared/Cocoa/CoreIPCContacts.mm @nonARC
+Shared/Cocoa/CoreIPCDDScannerResult.mm @nonARC
+Shared/Cocoa/CoreIPCDateComponents.mm @nonARC
+Shared/Cocoa/CoreIPCDictionary.mm @nonARC
+Shared/Cocoa/CoreIPCError.mm @nonARC
+Shared/Cocoa/CoreIPCLocale.mm @nonARC
+Shared/Cocoa/CoreIPCNSCFObject.mm @nonARC
+Shared/Cocoa/CoreIPCNSShadow.mm @nonARC
+Shared/Cocoa/CoreIPCNSURLCredential.mm @nonARC
+Shared/Cocoa/CoreIPCNSURLProtectionSpace.mm @nonARC
+Shared/Cocoa/CoreIPCNSURLRequest.mm @nonARC
+Shared/Cocoa/CoreIPCNSValue.mm @nonARC
+Shared/Cocoa/CoreIPCNull.mm @nonARC
+Shared/Cocoa/CoreIPCPKDateComponentsRange.mm @nonARC
+Shared/Cocoa/CoreIPCPKPayment.mm @nonARC
+Shared/Cocoa/CoreIPCPKPaymentMerchantSession.mm @nonARC
+Shared/Cocoa/CoreIPCPKPaymentMethod.mm @nonARC
+Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm @nonARC
+Shared/Cocoa/CoreIPCPKPaymentToken.mm @nonARC
+Shared/Cocoa/CoreIPCPKSecureElementPass.mm @nonARC
+Shared/Cocoa/CoreIPCPKShippingMethod.mm @nonARC
+Shared/Cocoa/CoreIPCPassKit.mm @nonARC
+Shared/Cocoa/CoreIPCPersonNameComponents.mm @nonARC
+Shared/Cocoa/CoreIPCPlistArray.mm @nonARC
+Shared/Cocoa/CoreIPCPlistDictionary.mm @nonARC
+Shared/Cocoa/CoreIPCPlistObject.mm @nonARC
+Shared/Cocoa/CoreIPCPresentationIntent.mm @nonARC
+Shared/Cocoa/CoreIPCSecureCoding.mm @nonARC
+Shared/Cocoa/CoreIPCStringSet.mm @nonARC
+Shared/Cocoa/CoreTextHelpers.mm @nonARC
+Shared/Cocoa/DataDetectionResult.mm @nonARC
+Shared/Cocoa/LaunchLogHook.mm @nonARC
+Shared/Cocoa/WKKeyedCoder.mm @nonARC
+Shared/Cocoa/WKProcessExtension.mm @nonARC
+Shared/Cocoa/WebPushMessageCocoa.mm @nonARC
+Shared/Cocoa/XPCEndpoint.mm @nonARC
+Shared/Cocoa/XPCEndpointClient.mm @nonARC
+
+Shared/cf/CoreIPCCFArray.mm @nonARC
+Shared/cf/CoreIPCCFDictionary.mm @nonARC
+Shared/cf/CoreIPCCGColorSpace.mm @nonARC
+Shared/cf/CoreIPCNumber.mm @nonARC
+Shared/cf/CoreIPCSecTrust.mm @nonARC
+
+UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.mm @nonARC
+UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm @nonARC
+UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm @nonARC
+UIProcess/API/Cocoa/_WKAuthenticatorAttestationResponse.mm @nonARC
+UIProcess/API/Cocoa/_WKAuthenticatorResponse.mm @nonARC
+UIProcess/API/Cocoa/_WKAuthenticatorSelectionCriteria.mm @nonARC
+UIProcess/API/Cocoa/_WKPublicKeyCredentialCreationOptions.mm @nonARC
+UIProcess/API/Cocoa/_WKPublicKeyCredentialDescriptor.mm @nonARC
+UIProcess/API/Cocoa/_WKPublicKeyCredentialEntity.mm @nonARC
+UIProcess/API/Cocoa/_WKPublicKeyCredentialParameters.mm @nonARC
+UIProcess/API/Cocoa/_WKPublicKeyCredentialRelyingPartyEntity.mm @nonARC
+UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.mm @nonARC
+UIProcess/API/Cocoa/_WKPublicKeyCredentialUserEntity.mm @nonARC
+UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstParty.mm @nonARC
+UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdParty.mm @nonARC
+
+UIProcess/Cocoa/AboutSchemeHandlerCocoa.mm @nonARC
+UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm @nonARC
+UIProcess/Cocoa/CSPExtensionUtilities.mm @nonARC
+UIProcess/Cocoa/PreferenceObserver.mm @nonARC
+UIProcess/Cocoa/WKShareSheet.mm @nonARC
+UIProcess/Cocoa/WKStorageAccessAlert.mm @nonARC
+UIProcess/Cocoa/WebInspectorPreferenceObserver.mm @nonARC
+UIProcess/Cocoa/_WKWarningView.mm @nonARC
+
+UIProcess/Downloads/DownloadProxyCocoa.mm @nonARC
+
+UIProcess/EndowmentStateTracker.mm @nonARC
+
+UIProcess/Extensions/WebExtensionCommand.cpp
+UIProcess/Extensions/WebExtensionMenuItem.cpp
+
+UIProcess/Launcher/cocoa/ExtensionProcess.mm @nonARC
+
+UIProcess/PDF/WKPDFPageNumberIndicator.mm @nonARC
+
+UIProcess/RemoteLayerTree/cocoa/RemoteScrollingTreeCocoa.mm @nonARC
+
+UIProcess/WebAuthentication/AuthenticatorManager.cpp
+
+UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm @nonARC @no-unify // SOFT_LINK_*_FOR_SOURCE defines non-inline symbols.
+UIProcess/WebAuthentication/Cocoa/HidConnection.mm @nonARC
+UIProcess/WebAuthentication/Cocoa/HidService.mm @nonARC
+UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm @nonARC
+
+UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.cpp
+UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm @nonARC
+UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
+UIProcess/WebAuthentication/Virtual/VirtualLocalConnection.mm @nonARC
+UIProcess/WebAuthentication/Virtual/VirtualService.mm @nonARC
+
+UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
+UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+
+UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm @nonARC
+UIProcess/mac/_WKCaptionStyleMenuControllerMac.mm @nonARC
+
+WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm @nonARC
+
+WebProcess/Inspector/ServiceWorkerDebuggableFrontendChannel.cpp
+WebProcess/Inspector/ServiceWorkerDebuggableProxy.cpp
+
+WebProcess/Network/WebMockContentFilterManager.cpp
+
+WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm @nonARC
+
+WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+WebProcess/cocoa/LaunchServicesDatabaseManager.mm @nonARC
+WebProcess/cocoa/TextTrackRepresentationCocoa.mm @nonARC
+
+webpushd/ApplePushServiceConnection.mm @nonARC
+webpushd/MockPushServiceConnection.mm @nonARC
+webpushd/PushClientConnection.mm @nonARC
+webpushd/PushService.mm @nonARC
+webpushd/PushServiceConnection.mm @nonARC
+webpushd/WebClipCache.mm @nonARC
+webpushd/WebPushDaemon.mm @nonARC
+webpushd/_WKMockUserNotificationCenter.mm @nonARC
+
+// DerivedSources. The GeneratedSerializers*.mm / GeneratedWebKitSecureCoding.mm
+// / WebKitPlatformGeneratedSerializers.mm outputs of generate-serializers.py are
+// not listed: each emits the same BitsInIncreasingOrder / VirtualTableAndRefCountOverhead
+// helper templates at file scope, and together they total ~134k lines, so they
+// stay as the per-domain TUs the generator already produces.
+AutomationBackendDispatchers.cpp
+AutomationFrontendDispatchers.cpp
+AutomationProtocolObjects.cpp
+MessageArgumentDescriptions.cpp
+SharedPreferencesForWebProcess.cpp
+WebDriverBidiBackendDispatchers.cpp
+WebDriverBidiFrontendDispatchers.cpp
+WebDriverBidiProtocolObjects.cpp
+WebPageUpdatePreferences.cpp
+WebPreferencesFeatures.cpp
+WebPreferencesGetterSetters.cpp
+WebPreferencesKeys.cpp
+WebPreferencesStoreDefaultsMap.cpp

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -947,4 +947,7 @@ std::optional<HmacSecretParameters> CtapAuthenticator::prepareHmacSecretParamete
 
 } // namespace WebKit
 
+#undef CTAP_RELEASE_LOG
+#undef CTAP_RELEASE_LOG_WITH_THIS
+
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
@@ -93,4 +93,6 @@ void FidoService::continueAfterGetInfo(CtapDriver& inputDriver, Vector<uint8_t>&
 
 } // namespace WebKit
 
+#undef CTAP_RELEASE_LOG
+
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKitLegacy/PlatformCocoa.cmake
+++ b/Source/WebKitLegacy/PlatformCocoa.cmake
@@ -24,6 +24,12 @@ list(APPEND WebKitLegacy_PRIVATE_INCLUDE_DIRECTORIES
 list(APPEND WebKitLegacy_UNIFIED_SOURCE_LIST_FILES
     SourcesCocoa.txt
 )
+# FIXME: Test building on iOS and then enable on iOS.
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    list(APPEND WebKitLegacy_UNIFIED_SOURCE_LIST_FILES
+        SourcesCMakeCocoa.txt
+    )
+endif ()
 WEBKIT_COMPUTE_SOURCES(WebKitLegacy)
 
 list(APPEND WebKitLegacy_SOURCES

--- a/Source/WebKitLegacy/PlatformMac.cmake
+++ b/Source/WebKitLegacy/PlatformMac.cmake
@@ -12,114 +12,28 @@ list(APPEND WebKitLegacy_PRIVATE_LIBRARIES
 
 list(APPEND WebKitLegacy_SOURCES
     mac/DefaultDelegates/WebDefaultEditingDelegate.m
-    mac/DefaultDelegates/WebDefaultPolicyDelegate.mm
-    mac/DefaultDelegates/WebDefaultUIDelegate.mm
 
-    mac/History/BackForwardList.mm
-    mac/History/BinaryPropertyList.cpp
-    mac/History/HistoryPropertyList.mm
-    mac/History/WebHistory.mm
-    mac/History/WebHistoryItem.mm
     mac/History/WebURLsWithTitles.m
 
-    mac/Misc/WebCache.mm
-    mac/Misc/WebCoreStatistics.mm
-    mac/Misc/WebDownload.mm
-    mac/Misc/WebElementDictionary.mm
-    mac/Misc/WebIconDatabase.mm
     mac/Misc/WebKitErrors.m
-    mac/Misc/WebKitLogInitialization.mm
     mac/Misc/WebKitLogging.m
-    mac/Misc/WebKitNSStringExtras.mm
     mac/Misc/WebKitStatistics.m
-    mac/Misc/WebKitVersionChecks.mm
-    mac/Misc/WebLocalizableStrings.mm
-    mac/Misc/WebLocalizableStringsInternal.mm
     mac/Misc/WebNSControlExtras.m
-    mac/Misc/WebNSDataExtras.mm
     mac/Misc/WebNSDictionaryExtras.m
     mac/Misc/WebNSEventExtras.m
-    mac/Misc/WebNSFileManagerExtras.mm
     mac/Misc/WebNSImageExtras.m
-    mac/Misc/WebNSObjectExtras.mm
-    mac/Misc/WebNSPasteboardExtras.mm
     mac/Misc/WebNSPrintOperationExtras.m
-    mac/Misc/WebNSURLExtras.mm
     mac/Misc/WebNSURLRequestExtras.m
-    mac/Misc/WebNSUserDefaultsExtras.mm
     mac/Misc/WebNSViewExtras.m
     mac/Misc/WebNSWindowExtras.m
-    mac/Misc/WebStringTruncator.mm
-    mac/Misc/WebUserContentURLPattern.mm
 
     mac/Panels/WebAuthenticationPanel.m
     mac/Panels/WebPanelAuthenticationHandler.m
 
-    mac/Plugins/WebPluginPackage.mm
-
-    mac/Storage/WebDatabaseManager.mm
-    mac/Storage/WebDatabaseManagerClient.mm
-    mac/Storage/WebDatabaseProvider.mm
-    mac/Storage/WebDatabaseQuotaManager.mm
-    mac/Storage/WebStorageManager.mm
-    mac/Storage/WebStorageTrackerClient.mm
-
-    mac/WebCoreSupport/CorrectionPanel.mm
-    mac/WebCoreSupport/LegacyHistoryItemClient.mm
-    mac/WebCoreSupport/PopupMenuMac.mm
-    mac/WebCoreSupport/SearchPopupMenuMac.mm
-    mac/WebCoreSupport/WebAlternativeTextClient.mm
-    mac/WebCoreSupport/WebChromeClient.mm
-    mac/WebCoreSupport/WebContextMenuClient.mm
-    mac/WebCoreSupport/WebDragClient.mm
-    mac/WebCoreSupport/WebEditorClient.mm
-    mac/WebCoreSupport/WebFrameNetworkingContext.mm
-    mac/WebCoreSupport/WebGeolocationClient.mm
-    mac/WebCoreSupport/WebInspectorClient.mm
     mac/WebCoreSupport/WebJavaScriptTextInputPanel.m
-    mac/WebCoreSupport/WebKitFullScreenListener.mm
-    mac/WebCoreSupport/WebMediaKeySystemClient.mm
-    mac/WebCoreSupport/WebNotificationClient.mm
-    mac/WebCoreSupport/WebOpenPanelResultListener.mm
-    mac/WebCoreSupport/WebPaymentCoordinatorClient.mm
-    mac/WebCoreSupport/WebPlatformStrategies.mm
-    mac/WebCoreSupport/WebPluginInfoProvider.mm
-    mac/WebCoreSupport/WebProgressTrackerClient.mm
-    mac/WebCoreSupport/WebSecurityOrigin.mm
-    mac/WebCoreSupport/WebSelectionServiceController.mm
-    mac/WebCoreSupport/WebValidationMessageClient.mm
-    mac/WebCoreSupport/WebVisitedLinkStore.mm
 
-    mac/WebInspector/WebInspectorFrontend.mm
-    mac/WebInspector/WebNodeHighlight.mm
-    mac/WebInspector/WebNodeHighlightView.mm
-    mac/WebInspector/WebNodeHighlighter.mm
-
-    mac/WebView/WebArchive.mm
-    mac/WebView/WebDelegateImplementationCaching.mm
-    mac/WebView/WebDeviceOrientation.mm
-    mac/WebView/WebDeviceOrientationProviderMock.mm
-    mac/WebView/WebDocumentLoaderMac.mm
-    mac/WebView/WebDynamicScrollBarsView.mm
     mac/WebView/WebFeature.m
     mac/WebView/WebFormDelegate.m
-    mac/WebView/WebGeolocationPosition.mm
-    mac/WebView/WebHTMLRepresentation.mm
-    mac/WebView/WebIndicateLayer.mm
-    mac/WebView/WebJSPDFDoc.mm
-    mac/WebView/WebMediaPlaybackTargetPicker.mm
-    mac/WebView/WebNavigationData.mm
-    mac/WebView/WebNotification.mm
-    mac/WebView/WebPDFDocumentExtras.mm
-    mac/WebView/WebPolicyDelegate.mm
-    mac/WebView/WebPreferences.mm
-    mac/WebView/WebPreferencesDefaultValues.mm
-    mac/WebView/WebResource.mm
-    mac/WebView/WebTextCompletionController.mm
-    mac/WebView/WebTextIterator.mm
-    mac/WebView/WebVideoFullscreenController.mm
-    mac/WebView/WebViewData.mm
-    mac/WebView/WebWindowAnimation.mm
 )
 
 set(WebKitLegacy_LEGACY_FORWARDING_HEADERS_FILES

--- a/Source/WebKitLegacy/SourcesCMakeCocoa.txt
+++ b/Source/WebKitLegacy/SourcesCMakeCocoa.txt
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// CMake-only unified source list for the Cocoa ports. The Xcode build compiles
+// these files individually via WebKitLegacy.xcodeproj; folding them into the
+// shared SourcesCocoa.txt would require coordinated bundle-count and pbxproj
+// updates. https://bugs.webkit.org/show_bug.cgi?id=TBD
+//
+// Registered Mac-only for now (see PlatformCocoa.cmake). When iOS adopts,
+// the entries below that PlatformIOS.cmake does not currently compile —
+// CorrectionPanel.mm, PopupMenuMac.mm, SearchPopupMenuMac.mm,
+// WebInspectorClient.mm, WebDynamicScrollBarsView.mm, WebIconDatabase.mm,
+// WebNSPasteboardExtras.mm, WebStringTruncator.mm,
+// WebTextCompletionController.mm, WebVideoFullscreenController.mm,
+// WebWindowAnimation.mm — will need #if PLATFORM(MAC) self-guards or a
+// separate Mac-only list.
+
+Storage/InProcessIDBServer.cpp
+Storage/StorageAreaImpl.cpp
+Storage/StorageAreaSync.cpp
+Storage/StorageNamespaceImpl.cpp
+Storage/StorageSyncManager.cpp
+Storage/StorageThread.cpp
+Storage/StorageTracker.cpp
+Storage/WebDatabaseProvider.cpp
+Storage/WebStorageNamespaceProvider.cpp
+
+WebCoreSupport/LegacySocketProvider.cpp
+WebCoreSupport/LegacyWebPageDebuggable.cpp
+WebCoreSupport/LegacyWebPageInspectorController.cpp
+WebCoreSupport/NetworkStorageSessionMap.cpp
+WebCoreSupport/WebBroadcastChannelRegistry.cpp
+WebCoreSupport/WebCryptoClient.mm @nonARC
+WebCoreSupport/WebResourceLoadScheduler.cpp
+WebCoreSupport/WebViewGroup.mm @nonARC
+
+cf/WebCoreSupport/WebInspectorClientCF.cpp
+
+mac/DefaultDelegates/WebDefaultPolicyDelegate.mm @nonARC
+mac/DefaultDelegates/WebDefaultUIDelegate.mm @nonARC
+
+mac/History/BackForwardList.mm @nonARC
+mac/History/BinaryPropertyList.cpp
+mac/History/HistoryPropertyList.mm @nonARC
+mac/History/WebHistory.mm @nonARC
+mac/History/WebHistoryItem.mm @nonARC
+
+mac/Misc/WebCache.mm @nonARC
+mac/Misc/WebCoreStatistics.mm @nonARC
+mac/Misc/WebDownload.mm @nonARC
+mac/Misc/WebElementDictionary.mm @nonARC
+mac/Misc/WebIconDatabase.mm @nonARC
+mac/Misc/WebKitLogInitialization.mm @nonARC
+mac/Misc/WebKitNSStringExtras.mm @nonARC
+mac/Misc/WebKitVersionChecks.mm @nonARC
+mac/Misc/WebLocalizableStrings.mm @nonARC
+mac/Misc/WebLocalizableStringsInternal.mm @nonARC
+mac/Misc/WebNSDataExtras.mm @nonARC
+mac/Misc/WebNSFileManagerExtras.mm @nonARC
+mac/Misc/WebNSObjectExtras.mm @nonARC
+mac/Misc/WebNSPasteboardExtras.mm @nonARC
+mac/Misc/WebNSURLExtras.mm @nonARC
+mac/Misc/WebNSUserDefaultsExtras.mm @nonARC
+mac/Misc/WebStringTruncator.mm @nonARC
+mac/Misc/WebUserContentURLPattern.mm @nonARC
+
+mac/Plugins/WebPluginPackage.mm @nonARC
+
+mac/Storage/WebDatabaseManager.mm @nonARC
+mac/Storage/WebDatabaseManagerClient.mm @nonARC
+mac/Storage/WebDatabaseProvider.mm @nonARC
+mac/Storage/WebDatabaseQuotaManager.mm @nonARC
+mac/Storage/WebStorageManager.mm @nonARC
+mac/Storage/WebStorageTrackerClient.mm @nonARC
+
+mac/WebCoreSupport/CorrectionPanel.mm @nonARC
+mac/WebCoreSupport/LegacyHistoryItemClient.mm @nonARC
+mac/WebCoreSupport/PopupMenuMac.mm @nonARC
+mac/WebCoreSupport/SearchPopupMenuMac.mm @nonARC
+mac/WebCoreSupport/WebAlternativeTextClient.mm @nonARC
+mac/WebCoreSupport/WebChromeClient.mm @nonARC
+mac/WebCoreSupport/WebContextMenuClient.mm @nonARC
+mac/WebCoreSupport/WebDragClient.mm @nonARC
+mac/WebCoreSupport/WebEditorClient.mm @nonARC
+mac/WebCoreSupport/WebFrameNetworkingContext.mm @nonARC
+mac/WebCoreSupport/WebGeolocationClient.mm @nonARC
+mac/WebCoreSupport/WebInspectorClient.mm @nonARC
+mac/WebCoreSupport/WebKitFullScreenListener.mm @nonARC
+mac/WebCoreSupport/WebMediaKeySystemClient.mm @nonARC
+mac/WebCoreSupport/WebNotificationClient.mm @nonARC
+mac/WebCoreSupport/WebOpenPanelResultListener.mm @nonARC
+mac/WebCoreSupport/WebPaymentCoordinatorClient.mm @nonARC
+mac/WebCoreSupport/WebPlatformStrategies.mm @nonARC
+mac/WebCoreSupport/WebPluginInfoProvider.mm @nonARC
+mac/WebCoreSupport/WebProgressTrackerClient.mm @nonARC
+mac/WebCoreSupport/WebSecurityOrigin.mm @nonARC
+mac/WebCoreSupport/WebSelectionServiceController.mm @nonARC
+mac/WebCoreSupport/WebValidationMessageClient.mm @nonARC
+mac/WebCoreSupport/WebVisitedLinkStore.mm @nonARC
+
+mac/WebInspector/WebInspectorFrontend.mm @nonARC
+mac/WebInspector/WebNodeHighlight.mm @nonARC
+mac/WebInspector/WebNodeHighlighter.mm @nonARC
+mac/WebInspector/WebNodeHighlightView.mm @nonARC
+
+mac/WebView/WebArchive.mm @nonARC
+mac/WebView/WebDelegateImplementationCaching.mm @nonARC
+mac/WebView/WebDeviceOrientation.mm @nonARC
+mac/WebView/WebDeviceOrientationProviderMock.mm @nonARC
+mac/WebView/WebDocumentLoaderMac.mm @nonARC
+mac/WebView/WebDynamicScrollBarsView.mm @nonARC
+mac/WebView/WebGeolocationPosition.mm @nonARC
+mac/WebView/WebHTMLRepresentation.mm @nonARC
+mac/WebView/WebIndicateLayer.mm @nonARC
+mac/WebView/WebJSPDFDoc.mm @nonARC
+mac/WebView/WebMediaPlaybackTargetPicker.mm @nonARC
+mac/WebView/WebNavigationData.mm @nonARC
+mac/WebView/WebNotification.mm @nonARC
+mac/WebView/WebPDFDocumentExtras.mm @nonARC
+mac/WebView/WebPolicyDelegate.mm @nonARC
+mac/WebView/WebPreferences.mm @nonARC
+mac/WebView/WebPreferencesDefaultValues.mm @nonARC
+mac/WebView/WebResource.mm @nonARC
+mac/WebView/WebTextCompletionController.mm @nonARC
+mac/WebView/WebTextIterator.mm @nonARC
+mac/WebView/WebVideoFullscreenController.mm @nonARC
+mac/WebView/WebViewData.mm @nonARC
+mac/WebView/WebWindowAnimation.mm @nonARC
+
+// DerivedSources
+WebViewPreferencesChangedGenerated.mm @nonARC
+WebPreferencesInternalFeatures.mm @nonARC
+WebPreferencesExperimentalFeatures.mm @nonARC

--- a/Source/WebKitLegacy/WebCoreSupport/WebViewGroup.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebViewGroup.mm
@@ -32,7 +32,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringHash.h>
 
-using namespace WebCore;
 
 // Any named groups will live for the lifetime of the process, thanks to the reference held by the RefPtr.
 static HashMap<String, RefPtr<WebViewGroup>>& NODELETE webViewGroups()
@@ -70,7 +69,7 @@ WebViewGroup* WebViewGroup::get(const String& name)
 WebViewGroup::WebViewGroup(const String& name, const String& localStorageDatabasePath)
     : m_name(name)
     , m_localStorageDatabasePath(localStorageDatabasePath)
-    , m_userContentController(UserContentController::create())
+    , m_userContentController(WebCore::UserContentController::create())
     , m_visitedLinkStore(WebVisitedLinkStore::create())
 {
 }
@@ -95,7 +94,7 @@ void WebViewGroup::removeWebView(WebView *webView)
     m_webViews.remove(webView);
 }
 
-StorageNamespaceProvider& WebViewGroup::storageNamespaceProvider()
+WebCore::StorageNamespaceProvider& WebViewGroup::storageNamespaceProvider()
 {
     if (!m_storageNamespaceProvider)
         m_storageNamespaceProvider = WebKit::WebStorageNamespaceProvider::create(m_localStorageDatabasePath);

--- a/Source/WebKitLegacy/mac/History/BackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.mm
@@ -28,7 +28,6 @@
 
 #import <WebCore/BackForwardCache.h>
 
-using namespace WebCore;
 
 static const unsigned DefaultCapacity = 100;
 static const unsigned NoCurrentItemIndex = UINT_MAX;
@@ -47,7 +46,7 @@ BackForwardList::~BackForwardList()
     ASSERT(m_closed);
 }
 
-void BackForwardList::addItem(Ref<HistoryItem>&& newItem)
+void BackForwardList::addItem(Ref<WebCore::HistoryItem>&& newItem)
 {
     if (!m_capacity || !m_enabled)
         return;
@@ -56,19 +55,19 @@ void BackForwardList::addItem(Ref<HistoryItem>&& newItem)
     if (m_current != NoCurrentItemIndex) {
         unsigned targetSize = m_current + 1;
         while (m_entries.size() > targetSize) {
-            Ref<HistoryItem> item = m_entries.takeLast();
+            Ref<WebCore::HistoryItem> item = m_entries.takeLast();
             m_entryHash.remove(item.ptr());
-            BackForwardCache::singleton().remove(item);
+            WebCore::BackForwardCache::singleton().remove(item);
         }
     }
 
     // Toss the first item if the list is getting too big, as long as we're not using it
     // (or even if we are, if we only want 1 entry).
     if (m_entries.size() == m_capacity && (m_current || m_capacity == 1)) {
-        Ref<HistoryItem> item = WTF::move(m_entries[0]);
+        Ref<WebCore::HistoryItem> item = WTF::move(m_entries[0]);
         m_entries.removeAt(0);
         m_entryHash.remove(item.ptr());
-        BackForwardCache::singleton().remove(item);
+        WebCore::BackForwardCache::singleton().remove(item);
         --m_current;
     }
 
@@ -91,7 +90,7 @@ void BackForwardList::goForward()
         m_current++;
 }
 
-void BackForwardList::goToItem(HistoryItem& item)
+void BackForwardList::goToItem(WebCore::HistoryItem& item)
 {
     if (!m_entries.size())
         return;
@@ -106,28 +105,28 @@ void BackForwardList::goToItem(HistoryItem& item)
         m_current = index;
 }
 
-RefPtr<HistoryItem> BackForwardList::backItem()
+RefPtr<WebCore::HistoryItem> BackForwardList::backItem()
 {
     if (m_current && m_current != NoCurrentItemIndex)
         return m_entries[m_current - 1].copyRef();
     return nullptr;
 }
 
-RefPtr<HistoryItem> BackForwardList::currentItem()
+RefPtr<WebCore::HistoryItem> BackForwardList::currentItem()
 {
     if (m_current != NoCurrentItemIndex)
         return m_entries[m_current].copyRef();
     return nullptr;
 }
 
-RefPtr<HistoryItem> BackForwardList::forwardItem()
+RefPtr<WebCore::HistoryItem> BackForwardList::forwardItem()
 {
     if (m_entries.size() && m_current < m_entries.size() - 1)
         return m_entries[m_current + 1].copyRef();
     return nullptr;
 }
 
-void BackForwardList::backListWithLimit(int limit, Vector<Ref<HistoryItem>>& list)
+void BackForwardList::backListWithLimit(int limit, Vector<Ref<WebCore::HistoryItem>>& list)
 {
     list.clear();
     if (m_current != NoCurrentItemIndex) {
@@ -137,7 +136,7 @@ void BackForwardList::backListWithLimit(int limit, Vector<Ref<HistoryItem>>& lis
     }
 }
 
-void BackForwardList::forwardListWithLimit(int limit, Vector<Ref<HistoryItem>>& list)
+void BackForwardList::forwardListWithLimit(int limit, Vector<Ref<WebCore::HistoryItem>>& list)
 {
     ASSERT(limit > -1);
     list.clear();
@@ -161,9 +160,9 @@ int BackForwardList::capacity()
 void BackForwardList::setCapacity(int size)
 {    
     while (size < static_cast<int>(m_entries.size())) {
-        Ref<HistoryItem> item = m_entries.takeLast();
+        Ref<WebCore::HistoryItem> item = m_entries.takeLast();
         m_entryHash.remove(item.ptr());
-        BackForwardCache::singleton().remove(item);
+        WebCore::BackForwardCache::singleton().remove(item);
     }
 
     if (!size)
@@ -199,7 +198,7 @@ unsigned BackForwardList::forwardListCount() const
     return m_current == NoCurrentItemIndex ? 0 : m_entries.size() - m_current - 1;
 }
 
-RefPtr<HistoryItem> BackForwardList::itemAtIndex(int index, WebCore::FrameIdentifier)
+RefPtr<WebCore::HistoryItem> BackForwardList::itemAtIndex(int index, WebCore::FrameIdentifier)
 {
     // Do range checks without doing math on index to avoid overflow.
     if (index < -static_cast<int>(m_current))
@@ -236,7 +235,7 @@ bool BackForwardList::closed()
     return m_closed;
 }
 
-void BackForwardList::removeItem(HistoryItem& item)
+void BackForwardList::removeItem(WebCore::HistoryItem& item)
 {
     for (unsigned i = 0; i < m_entries.size(); ++i) {
         if (m_entries[i].ptr() == &item) {
@@ -256,7 +255,7 @@ void BackForwardList::removeItem(HistoryItem& item)
     }
 }
 
-bool BackForwardList::containsItem(const HistoryItem& entry) const
+bool BackForwardList::containsItem(const WebCore::HistoryItem& entry) const
 {
-    return m_entryHash.contains(const_cast<HistoryItem*>(&entry));
+    return m_entryHash.contains(const_cast<WebCore::HistoryItem*>(&entry));
 }

--- a/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
+++ b/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
@@ -29,7 +29,6 @@
 #import <WebCore/HistoryItem.h>
 #import <wtf/cf/VectorCF.h>
 
-using namespace WebCore;
 
 static const int currentFileVersion = 1;
 
@@ -85,7 +84,7 @@ void HistoryPropertyListWriter::writeObjects(BinaryPropertyListObjectStream& str
 
 void HistoryPropertyListWriter::writeHistoryItem(BinaryPropertyListObjectStream& stream, WebHistoryItem* webHistoryItem)
 {
-    HistoryItem* item = core(webHistoryItem);
+    WebCore::HistoryItem* item = core(webHistoryItem);
 
     size_t itemDictionaryStart = stream.writeDictionaryStart();
 

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -42,7 +42,6 @@
 #import <WebCore/WebCoreThreadMessage.h>
 #endif
 
-using namespace WebCore;
 
 typedef int64_t WebHistoryDateKey;
 typedef HashMap<WebHistoryDateKey, RetainPtr<NSMutableArray>> DateToEntriesMap;
@@ -852,7 +851,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     WebHistoryItem *entry = [_historyPrivate visitedURL:url withTitle:title];
 
-    HistoryItem* item = core(entry);
+    WebCore::HistoryItem* item = core(entry);
     item->setLastVisitWasFailure(wasFailure);
 
     entry->_private->_redirectURLs = nullptr;

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -93,13 +93,12 @@ static NSString *redirectURLsKey = @"redirectURLs";
 // Notification strings.
 NSString *WebHistoryItemChangedNotification = @"WebHistoryItemChangedNotification";
 
-using namespace WebCore;
 
 @implementation WebHistoryItemPrivate
 
 @end
 
-using HistoryItemMap = HashMap<WeakRef<HistoryItem>, WebHistoryItem*>;
+using HistoryItemMap = HashMap<WeakRef<WebCore::HistoryItem>, WebHistoryItem*>;
 
 static inline WebCoreHistoryItem* core(WebHistoryItemPrivate* itemPrivate)
 {
@@ -131,14 +130,14 @@ void WKNotifyHistoryItemChanged()
 
 - (instancetype)init
 {
-    return [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton())];
+    return [self initWithWebCoreHistoryItem:WebCore::HistoryItem::create(LegacyHistoryItemClient::singleton())];
 }
 
 - (instancetype)initWithURLString:(NSString *)URLString title:(NSString *)title lastVisitedTimeInterval:(NSTimeInterval)time
 {
     WebCoreThreadViolationCheckRoundOne();
 
-    SUPPRESS_UNRETAINED_LOCAL auto item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString, title)];
+    SUPPRESS_UNRETAINED_LOCAL auto item = [self initWithWebCoreHistoryItem:WebCore::HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString, title)];
     item->_private->_lastVisitedTime = time;
 
     return item;
@@ -224,7 +223,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSString *)description
 {
-    HistoryItem* coreItem = core(_private);
+    WebCore::HistoryItem* coreItem = core(_private);
     RetainPtr result = [NSMutableString stringWithFormat:@"%@ %@", [super description], coreItem->urlString().createNSString().get()];
     if (!coreItem->target().isEmpty())
         [result appendFormat:@" in \"%@\"", coreItem->target().createNSString().get()];
@@ -239,7 +238,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         int currPos = [result length];
         unsigned size = children.size();
         for (unsigned i = 0; i < size; ++i) {
-            RetainPtr child = kit(const_cast<HistoryItem*>(children[i].ptr()));
+            RetainPtr child = kit(const_cast<WebCore::HistoryItem*>(children[i].ptr()));
             [result appendString:@"\n"];
             [result appendString:[child.get() description]];
         }
@@ -251,7 +250,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return result.autorelease();
 }
 
-HistoryItem* core(WebHistoryItem *item)
+WebCore::HistoryItem* core(WebHistoryItem *item)
 {
     if (!item)
         return nullptr;
@@ -259,7 +258,7 @@ HistoryItem* core(WebHistoryItem *item)
     return core(item->_private);
 }
 
-WebHistoryItem *kit(HistoryItem* item)
+WebHistoryItem *kit(WebCore::HistoryItem* item)
 {
     if (!item)
         return nil;
@@ -275,14 +274,14 @@ WebHistoryItem *kit(HistoryItem* item)
 
 - (id)initWithURLString:(NSString *)URLString title:(NSString *)title displayTitle:(NSString *)displayTitle lastVisitedTimeInterval:(NSTimeInterval)time
 {
-    SUPPRESS_UNRETAINED_LOCAL auto item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString, title, displayTitle)];
+    SUPPRESS_UNRETAINED_LOCAL auto item = [self initWithWebCoreHistoryItem:WebCore::HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString, title, displayTitle)];
     if (!item)
         return nil;
     item->_private->_lastVisitedTime = time;
     return item;
 }
 
-- (id)initWithWebCoreHistoryItem:(Ref<HistoryItem>&&)item
+- (id)initWithWebCoreHistoryItem:(Ref<WebCore::HistoryItem>&&)item
 {   
     WebCoreThreadViolationCheckRoundOne();
 
@@ -352,7 +351,7 @@ WebHistoryItem *kit(HistoryItem* item)
     NSNumber *scrollPointXValue = [dict objectForKey:scrollPointXKey];
     NSNumber *scrollPointYValue = [dict objectForKey:scrollPointYKey];
     if (scrollPointXValue && scrollPointYValue)
-        core(_private)->setScrollPosition(IntPoint([scrollPointXValue intValue], [scrollPointYValue intValue]));
+        core(_private)->setScrollPosition(WebCore::IntPoint([scrollPointXValue intValue], [scrollPointYValue intValue]));
 #endif
 
     return self;
@@ -392,7 +391,7 @@ WebHistoryItem *kit(HistoryItem* item)
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:8];
 
-    HistoryItem* coreItem = core(_private);
+    WebCore::HistoryItem* coreItem = core(_private);
     
     if (!coreItem->urlString().isEmpty())
         [dict setObject:coreItem->urlString().createNSString().get() forKey:@""];
@@ -419,7 +418,7 @@ WebHistoryItem *kit(HistoryItem* item)
         NSMutableArray *childDicts = [NSMutableArray arrayWithCapacity:children.size()];
         
         for (int i = children.size() - 1; i >= 0; i--)
-            [childDicts addObject:[kit(const_cast<HistoryItem*>(children[i].ptr())) dictionaryRepresentation]];
+            [childDicts addObject:[kit(const_cast<WebCore::HistoryItem*>(children[i].ptr())) dictionaryRepresentation]];
         [dict setObject: childDicts forKey:childrenKey];
     }
 
@@ -431,7 +430,7 @@ WebHistoryItem *kit(HistoryItem* item)
     if (viewportArguments)
         [dict setObject:viewportArguments forKey:@"WebViewportArguments"];
 
-    IntPoint scrollPosition = core(_private)->scrollPosition();
+    WebCore::IntPoint scrollPosition = core(_private)->scrollPosition();
     [dict setObject:@(scrollPosition.x()) forKey:scrollPointXKey];
     [dict setObject:@(scrollPosition.y()) forKey:scrollPointYKey];
 #endif
@@ -466,7 +465,7 @@ WebHistoryItem *kit(HistoryItem* item)
         return nil;
 
     return createNSArray(children, [] (auto& item) {
-        return kit(const_cast<HistoryItem*>(item.ptr()));
+        return kit(const_cast<WebCore::HistoryItem*>(item.ptr()));
     }).autorelease();
 }
 
@@ -516,7 +515,7 @@ WebHistoryItem *kit(HistoryItem* item)
 
 - (NSDictionary *)_viewportArguments
 {
-    const ViewportArguments& viewportArguments = core(_private)->viewportArguments();
+    const WebCore::ViewportArguments& viewportArguments = core(_private)->viewportArguments();
     NSMutableDictionary *argumentsDictionary = [NSMutableDictionary dictionary];
     [argumentsDictionary setObject:[NSNumber numberWithFloat:viewportArguments.zoom] forKey:WebViewportInitialScaleKey];
     [argumentsDictionary setObject:[NSNumber numberWithFloat:viewportArguments.minZoom] forKey:WebViewportMinimumScaleKey];
@@ -530,7 +529,7 @@ WebHistoryItem *kit(HistoryItem* item)
 
 - (void)_setViewportArguments:(NSDictionary *)arguments
 {
-    ViewportArguments viewportArguments;
+    WebCore::ViewportArguments viewportArguments;
     viewportArguments.zoom = [[arguments objectForKey:WebViewportInitialScaleKey] floatValue];
     viewportArguments.minZoom = [[arguments objectForKey:WebViewportMinimumScaleKey] floatValue];
     viewportArguments.maxZoom = [[arguments objectForKey:WebViewportMaximumScaleKey] floatValue];
@@ -548,7 +547,7 @@ WebHistoryItem *kit(HistoryItem* item)
 
 - (void)_setScrollPoint:(CGPoint)scrollPoint
 {
-    core(_private)->setScrollPosition(IntPoint(scrollPoint));
+    core(_private)->setScrollPosition(WebCore::IntPoint(scrollPoint));
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -46,7 +46,6 @@
 #import <WebCore/RenderTreeAsText.h>
 #import <WebCore/RenderView.h>
 
-using namespace WebCore;
 
 @implementation WebCoreStatistics
 
@@ -57,26 +56,26 @@ using namespace WebCore;
 
 + (size_t)javaScriptObjectsCount
 {
-    JSC::JSLockHolder lock(commonVM());
-    return commonVM().heap.objectCount();
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    return WebCore::commonVM().heap.objectCount();
 }
 
 + (size_t)javaScriptGlobalObjectsCount
 {
-    JSC::JSLockHolder lock(commonVM());
-    return commonVM().heap.globalObjectCount();
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    return WebCore::commonVM().heap.globalObjectCount();
 }
 
 + (size_t)javaScriptProtectedObjectsCount
 {
-    JSC::JSLockHolder lock(commonVM());
-    return commonVM().heap.protectedObjectCount();
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    return WebCore::commonVM().heap.protectedObjectCount();
 }
 
 + (size_t)javaScriptProtectedGlobalObjectsCount
 {
-    JSC::JSLockHolder lock(commonVM());
-    return commonVM().heap.protectedGlobalObjectCount();
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    return WebCore::commonVM().heap.protectedGlobalObjectCount();
 }
 
 static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILiteral>& set)
@@ -92,29 +91,29 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (NSCountedSet *)javaScriptProtectedObjectTypeCounts
 {
-    JSC::JSLockHolder lock(commonVM());
-    return createNSCountedSet(commonVM().heap.protectedObjectTypeCounts()).autorelease();
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    return createNSCountedSet(WebCore::commonVM().heap.protectedObjectTypeCounts()).autorelease();
 }
 
 + (NSCountedSet *)javaScriptObjectTypeCounts
 {
-    JSC::JSLockHolder lock(commonVM());
-    return createNSCountedSet(commonVM().heap.objectTypeCounts()).autorelease();
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    return createNSCountedSet(WebCore::commonVM().heap.objectTypeCounts()).autorelease();
 }
 
 + (void)garbageCollectJavaScriptObjects
 {
-    GarbageCollectionController::singleton().garbageCollectNow();
+    WebCore::GarbageCollectionController::singleton().garbageCollectNow();
 }
 
 + (void)garbageCollectJavaScriptObjectsOnAlternateThreadForDebugging:(BOOL)waitUntilDone
 {
-    GarbageCollectionController::singleton().garbageCollectOnAlternateThreadForDebugging(waitUntilDone);
+    WebCore::GarbageCollectionController::singleton().garbageCollectOnAlternateThreadForDebugging(waitUntilDone);
 }
 
 + (void)setJavaScriptGarbageCollectorTimerEnabled:(BOOL)enable
 {
-    GarbageCollectionController::singleton().setJavaScriptGarbageCollectorTimerEnabled(enable);
+    WebCore::GarbageCollectionController::singleton().setJavaScriptGarbageCollectorTimerEnabled(enable);
 }
 
 + (size_t)iconPageURLMappingCount
@@ -139,34 +138,34 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (size_t)cachedFontDataCount
 {
-    return protect(FontCache::forCurrentThread())->fontCount();
+    return protect(WebCore::FontCache::forCurrentThread())->fontCount();
 }
 
 + (size_t)cachedFontDataInactiveCount
 {
-    return protect(FontCache::forCurrentThread())->inactiveFontCount();
+    return protect(WebCore::FontCache::forCurrentThread())->inactiveFontCount();
 }
 
 + (void)purgeInactiveFontData
 {
-    protect(FontCache::forCurrentThread())->purgeInactiveFontData();
+    protect(WebCore::FontCache::forCurrentThread())->purgeInactiveFontData();
 }
 
 + (size_t)glyphPageCount
 {
-    return GlyphPage::count();
+    return WebCore::GlyphPage::count();
 }
 
 + (BOOL)shouldPrintExceptions
 {
-    JSC::JSLockHolder lock(commonVM());
-    return FrameConsoleClient::shouldPrintExceptions();
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    return WebCore::FrameConsoleClient::shouldPrintExceptions();
 }
 
 + (void)setShouldPrintExceptions:(BOOL)print
 {
-    JSC::JSLockHolder lock(commonVM());
-    FrameConsoleClient::setShouldPrintExceptions(print);
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    WebCore::FrameConsoleClient::setShouldPrintExceptions(print);
 }
 
 + (void)emptyCache
@@ -182,9 +181,9 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 + (NSDictionary *)memoryStatistics
 {
     auto fastMallocStatistics = WTF::fastMallocStatistics();
-    JSC::JSLockHolder lock(commonVM());
-    size_t heapSize = commonVM().heap.size();
-    size_t heapFree = commonVM().heap.capacity() - heapSize;
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    size_t heapSize = WebCore::commonVM().heap.size();
+    size_t heapFree = WebCore::commonVM().heap.capacity() - heapSize;
     auto globalMemoryStats = JSC::globalMemoryStatistics();
     return @{
         @"FastMallocReservedVMBytes": @(fastMallocStatistics.reservedVMBytes),
@@ -204,12 +203,12 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (int)cachedPageCount
 {
-    return BackForwardCache::singleton().pageCount();
+    return WebCore::BackForwardCache::singleton().pageCount();
 }
 
 + (int)cachedFrameCount
 {
-    return BackForwardCache::singleton().frameCount();
+    return WebCore::BackForwardCache::singleton().frameCount();
 }
 
 // Deprecated
@@ -226,8 +225,8 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (size_t)javaScriptReferencedObjectsCount
 {
-    JSC::JSLockHolder lock(commonVM());
-    return commonVM().heap.protectedObjectCount();
+    JSC::JSLockHolder lock(WebCore::commonVM());
+    return WebCore::commonVM().heap.protectedObjectCount();
 }
 
 + (NSSet *)javaScriptRootObjectClasses
@@ -251,25 +250,25 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 - (NSString *)renderTreeAsExternalRepresentationForPrinting
 {
-    return externalRepresentation(_private->coreFrame, { RenderAsTextFlag::PrintingMode }).createNSString().autorelease();
+    return externalRepresentation(_private->coreFrame, { WebCore::RenderAsTextFlag::PrintingMode }).createNSString().autorelease();
 }
 
-static OptionSet<RenderAsTextFlag> NODELETE toRenderAsTextFlags(WebRenderTreeAsTextOptions options)
+static OptionSet<WebCore::RenderAsTextFlag> NODELETE toRenderAsTextFlags(WebRenderTreeAsTextOptions options)
 {
-    OptionSet<RenderAsTextFlag> flags;
+    OptionSet<WebCore::RenderAsTextFlag> flags;
 
     if (options & WebRenderTreeAsTextShowAllLayers)
-        flags.add(RenderAsTextFlag::ShowAllLayers);
+        flags.add(WebCore::RenderAsTextFlag::ShowAllLayers);
     if (options & WebRenderTreeAsTextShowLayerNesting)
-        flags.add(RenderAsTextFlag::ShowLayerNesting);
+        flags.add(WebCore::RenderAsTextFlag::ShowLayerNesting);
     if (options & WebRenderTreeAsTextShowCompositedLayers)
-        flags.add(RenderAsTextFlag::ShowCompositedLayers);
+        flags.add(WebCore::RenderAsTextFlag::ShowCompositedLayers);
     if (options & WebRenderTreeAsTextShowOverflow)
-        flags.add(RenderAsTextFlag::ShowOverflow);
+        flags.add(WebCore::RenderAsTextFlag::ShowOverflow);
     if (options & WebRenderTreeAsTextShowSVGGeometry)
-        flags.add(RenderAsTextFlag::ShowSVGGeometry);
+        flags.add(WebCore::RenderAsTextFlag::ShowSVGGeometry);
     if (options & WebRenderTreeAsTextShowLayerFragments)
-        flags.add(RenderAsTextFlag::ShowLayerFragments);
+        flags.add(WebCore::RenderAsTextFlag::ShowLayerFragments);
 
     return flags;
 }
@@ -285,7 +284,7 @@ static OptionSet<RenderAsTextFlag> NODELETE toRenderAsTextFlags(WebRenderTreeAsT
     if (!coreFrame)
         return -1;
 
-    return PrintContext::numberOfPages(*coreFrame, FloatSize(pageWidthInPixels, pageHeightInPixels));
+    return WebCore::PrintContext::numberOfPages(*coreFrame, WebCore::FloatSize(pageWidthInPixels, pageHeightInPixels));
 }
 
 - (void)printToCGContext:(CGContextRef)cgContext pageWidth:(float)pageWidthInPixels pageHeight:(float)pageHeightInPixels
@@ -294,8 +293,8 @@ static OptionSet<RenderAsTextFlag> NODELETE toRenderAsTextFlags(WebRenderTreeAsT
     if (!coreFrame)
         return;
 
-    GraphicsContextCG graphicsContext(cgContext);
-    PrintContext::spoolAllPagesWithBoundaries(*coreFrame, graphicsContext, FloatSize(pageWidthInPixels, pageHeightInPixels));
+    WebCore::GraphicsContextCG graphicsContext(cgContext);
+    WebCore::PrintContext::spoolAllPagesWithBoundaries(*coreFrame, graphicsContext, WebCore::FloatSize(pageWidthInPixels, pageHeightInPixels));
 }
 
 @end

--- a/Source/WebKitLegacy/mac/Misc/WebDownload.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebDownload.mm
@@ -72,7 +72,6 @@ static void callOnDelegateThreadAndWait(Callable&& work)
     }
 }
 
-using namespace WebCore;
 
 @interface WebDownloadInternal : NSObject <NSURLDownloadDelegate> {
     RetainPtr<id> realDelegate;
@@ -132,7 +131,7 @@ using namespace WebCore;
 #if !PLATFORM(IOS_FAMILY)
     // Try previously stored credential first.
     if (![challenge previousFailureCount]) {
-        RetainPtr credential = NetworkStorageSessionMap::defaultStorageSession().credentialStorage().get(emptyString(), ProtectionSpace([challenge protectionSpace])).nsCredential();
+        RetainPtr credential = NetworkStorageSessionMap::defaultStorageSession().credentialStorage().get(emptyString(), WebCore::ProtectionSpace([challenge protectionSpace])).nsCredential();
         if (credential) {
             [[challenge sender] useCredential:credential.get() forAuthenticationChallenge:challenge];
             return;

--- a/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
@@ -49,7 +49,6 @@
 #import <wtf/MainThread.h>
 #import <wtf/RunLoop.h>
 
-using namespace WebCore;
 
 static RetainPtr<CFMutableDictionaryRef>& NODELETE lookupTable()
 {
@@ -103,13 +102,13 @@ static void cacheValueForKey(const void *key, const void *value, void *self)
     addLookupKey(WebElementIsInScrollBarKey, @selector(_isInScrollBar));
 }
 
-- (id)initWithHitTestResult:(const HitTestResult&)result
+- (id)initWithHitTestResult:(const WebCore::HitTestResult&)result
 {
     [[self class] initializeLookupTable];
     self = [super init];
     if (!self)
         return nil;
-    _result = new HitTestResult(result);
+    _result = new WebCore::HitTestResult(result);
     return self;
 }
 
@@ -197,7 +196,7 @@ static NSString* NSStringOrNil(String coreString)
 
 - (NSString *)_spellingToolTip
 {
-    TextDirection dir;
+    WebCore::TextDirection dir;
     return NSStringOrNil(_result->spellingToolTip(dir));
 }
 
@@ -205,13 +204,13 @@ static NSString* NSStringOrNil(String coreString)
 
 - (NSImage *)_image
 {
-    Image* image = _result->image();
+    WebCore::Image* image = _result->image();
     return image ? image->adapter().nsImage() : nil;
 }
 
 - (NSValue *)_imageRect
 {
-    IntRect rect = _result->imageRect();
+    WebCore::IntRect rect = _result->imageRect();
     return rect.isEmpty() ? nil : [NSValue valueWithRect:rect];
 }
 
@@ -234,7 +233,7 @@ static NSString* NSStringOrNil(String coreString)
 
 - (NSString *)_title
 {
-    TextDirection dir;
+    WebCore::TextDirection dir;
     return NSStringOrNil(_result->title(dir));
 }
 
@@ -245,7 +244,7 @@ static NSString* NSStringOrNil(String coreString)
 
 - (WebFrame *)_targetWebFrame
 {
-    return kit(dynamicDowncast<LocalFrame>(_result->targetFrame().get()));
+    return kit(dynamicDowncast<WebCore::LocalFrame>(_result->targetFrame().get()));
 }
 
 - (NSString *)_titleDisplayString
@@ -260,7 +259,7 @@ static NSString* NSStringOrNil(String coreString)
 
 - (NSNumber *)_isLiveLink
 {
-    Element* urlElement = _result->URLElement();
+    WebCore::Element* urlElement = _result->URLElement();
     return [NSNumber numberWithBool:(urlElement && isDraggableLink(*urlElement))];
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
@@ -40,7 +40,6 @@
 #import <wtf/RunLoop.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
-using namespace WebCore;
 
 NSString *WebIconDatabaseDidAddIconNotification =          @"WebIconDatabaseDidAddIconNotification";
 NSString *WebIconNotificationUserInfoURLKey =              @"WebIconNotificationUserInfoURLKey";

--- a/Source/WebKitLegacy/mac/Misc/WebKitLogInitialization.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitLogInitialization.mm
@@ -66,7 +66,7 @@ void ReportDiscardedDelegateException(SEL delegateSelector, id exception)
 {
     if ([exception isKindOfClass:[NSException class]]) {
         NSLog(@"*** WebKit discarded an uncaught exception in the %s delegate: <%@> %@",
-            sel_getName(delegateSelector), [exception name], [exception reason]);
+            sel_getName(delegateSelector), [(NSException *)exception name], [(NSException *)exception reason]);
     } else {
         NSLog(@"*** WebKit discarded an uncaught exception in the %s delegate: %@",
             sel_getName(delegateSelector), exception);

--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -40,7 +40,6 @@
 NSString *WebKitLocalCacheDefaultsKey = @"WebKitLocalCache";
 NSString *WebKitResourceLoadStatisticsDirectoryDefaultsKey = @"WebKitResourceLoadStatisticsDirectory";
 
-using namespace WebCore;
 
 @implementation NSString (WebKitExtras)
 
@@ -68,8 +67,8 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
     [self getCharacters:buffer.mutableSpan().data()];
 
     if (canUseFastRenderer(buffer)) {
-        FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
-        TextRun run(StringView(spanReinterpretCast<const char16_t>(std::span { buffer })));
+        WebCore::FontCascade webCoreFont(WebCore::FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
+        WebCore::TextRun run(StringView(spanReinterpretCast<const char16_t>(std::span { buffer })));
 
         // The following is a half-assed attempt to match AppKit's rounding rules for drawAtPoint.
         // If you change it, be sure to test all the text drawn this way in Safari, including
@@ -78,15 +77,15 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
 
         NSGraphicsContext *nsContext = [NSGraphicsContext currentContext];
         RetainPtr cgContext = [nsContext CGContext];
-        GraphicsContextCG graphicsContext { cgContext.get() };
+        WebCore::GraphicsContextCG graphicsContext { cgContext.get() };
 
         // WebCore requires a flipped graphics context.
         bool flipped = [nsContext isFlipped];
         if (!flipped)
             CGContextScaleCTM(cgContext.get(), 1, -1);
 
-        graphicsContext.setFillColor(colorFromCocoaColor(textColor));
-        webCoreFont.drawText(graphicsContext, run, FloatPoint(point.x, flipped ? point.y : -point.y));
+        graphicsContext.setFillColor(WebCore::colorFromCocoaColor(textColor));
+        webCoreFont.drawText(graphicsContext, run, WebCore::FloatPoint(point.x, flipped ? point.y : -point.y));
 
         if (!flipped)
             CGContextScaleCTM(cgContext.get(), 1, -1);
@@ -108,8 +107,8 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
     [self getCharacters:buffer.mutableSpan().data()];
 
     if (canUseFastRenderer(buffer)) {
-        FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
-        TextRun run(StringView(spanReinterpretCast<const char16_t>(std::span { buffer })));
+        WebCore::FontCascade webCoreFont(WebCore::FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
+        WebCore::TextRun run(StringView(spanReinterpretCast<const char16_t>(std::span { buffer })));
         return webCoreFont.width(run);
     }
 

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.mm
@@ -27,10 +27,9 @@
 
 #import <WebCore/LocalizedStrings.h>
 
-using namespace WebCore;
 
 NSString *WebLocalizedStringInternal(const char* key)
 {
     auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(0, key, kCFStringEncodingUTF8, kCFAllocatorNull));
-    return localizedNSString(bridge_cast(keyString.get()));
+    return WebCore::localizedNSString(bridge_cast(keyString.get()));
 }

--- a/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
@@ -54,7 +54,6 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
 
-using namespace WebCore;
 
 NSString *WebURLPboardType = @"public.url";
 NSString *WebURLNamePboardType = @"public.url-name";
@@ -65,10 +64,10 @@ NSString *WebURLNamePboardType = @"public.url-name";
 {
     static NSArray *types = [[NSArray alloc] initWithObjects:
         WebURLsWithTitlesPboardType,
-        legacyURLPasteboardTypeSingleton(),
+        WebCore::legacyURLPasteboardTypeSingleton(),
         WebURLPboardType,
         WebURLNamePboardType,
-        legacyStringPasteboardTypeSingleton(),
+        WebCore::legacyStringPasteboardTypeSingleton(),
         nil];
     return types;
 }
@@ -76,7 +75,7 @@ NSString *WebURLNamePboardType = @"public.url-name";
 static NSArray *writableTypesForImageWithoutArchive()
 {
     static NeverDestroyed types = [] {
-        auto types = adoptNS([[NSMutableArray alloc] initWithObjects:legacyTIFFPasteboardTypeSingleton(), nil]);
+        auto types = adoptNS([[NSMutableArray alloc] initWithObjects:WebCore::legacyTIFFPasteboardTypeSingleton(), nil]);
         [types addObjectsFromArray:[NSPasteboard _web_writableTypesForURL]];
         return types;
     }();
@@ -87,7 +86,7 @@ static NSArray *writableTypesForImageWithArchive()
 {
     static NeverDestroyed types = [] {
         auto types = adoptNS([writableTypesForImageWithoutArchive() mutableCopy]);
-        [types addObject:legacyRTFDPasteboardTypeSingleton()];
+        [types addObject:WebCore::legacyRTFDPasteboardTypeSingleton()];
         [types addObject:WebArchivePboardType];
         return types;
     }();
@@ -103,12 +102,12 @@ static NSArray *writableTypesForImageWithArchive()
 {
     return @[
         WebURLsWithTitlesPboardType,
-        legacyURLPasteboardTypeSingleton(),
+        WebCore::legacyURLPasteboardTypeSingleton(),
         WebURLPboardType,
         WebURLNamePboardType,
-        legacyStringPasteboardTypeSingleton(),
-        legacyFilenamesPasteboardTypeSingleton(),
-        legacyFilesPromisePasteboardTypeSingleton(),
+        WebCore::legacyStringPasteboardTypeSingleton(),
+        WebCore::legacyFilenamesPasteboardTypeSingleton(),
+        WebCore::legacyFilesPromisePasteboardTypeSingleton(),
     ];
 }
 
@@ -116,7 +115,7 @@ static NSArray *writableTypesForImageWithArchive()
 {
     NSArray *types = [self types];
 
-    if ([types containsObject:legacyURLPasteboardTypeSingleton()]) {
+    if ([types containsObject:WebCore::legacyURLPasteboardTypeSingleton()]) {
         NSURL *URLFromPasteboard = [NSURL URLFromPasteboard:self];
         NSString *scheme = [URLFromPasteboard scheme];
         if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
@@ -124,8 +123,8 @@ static NSArray *writableTypesForImageWithArchive()
         }
     }
 
-    if ([types containsObject:legacyStringPasteboardTypeSingleton()]) {
-        NSString *URLString = [self stringForType:legacyStringPasteboardTypeSingleton()];
+    if ([types containsObject:WebCore::legacyStringPasteboardTypeSingleton()]) {
+        NSString *URLString = [self stringForType:WebCore::legacyStringPasteboardTypeSingleton()];
         if ([URLString _webkit_looksLikeAbsoluteURL]) {
             NSURL *URL = [[NSURL _webkit_URLWithUserTypedString:URLString] _webkit_canonicalize];
             if (URL) {
@@ -134,8 +133,8 @@ static NSArray *writableTypesForImageWithArchive()
         }
     }
 
-    if ([types containsObject:legacyFilenamesPasteboardTypeSingleton()]) {
-        NSArray *files = [self propertyListForType:legacyFilenamesPasteboardTypeSingleton()];
+    if ([types containsObject:WebCore::legacyFilenamesPasteboardTypeSingleton()]) {
+        NSArray *files = [self propertyListForType:WebCore::legacyFilenamesPasteboardTypeSingleton()];
         // FIXME: Maybe it makes more sense to allow multiple files and only use the first one?
         if ([files count] == 1) {
             NSString *file = [files objectAtIndex:0];
@@ -163,14 +162,14 @@ static NSArray *writableTypesForImageWithArchive()
             title = [URL _web_userVisibleString];
     }
     
-    if ([types containsObject:legacyURLPasteboardTypeSingleton()])
+    if ([types containsObject:WebCore::legacyURLPasteboardTypeSingleton()])
         [URL writeToPasteboard:self];
     if ([types containsObject:WebURLPboardType])
         [self setString:[URL _web_originalDataAsString] forType:WebURLPboardType];
     if ([types containsObject:WebURLNamePboardType])
         [self setString:title forType:WebURLNamePboardType];
-    if ([types containsObject:legacyStringPasteboardTypeSingleton()])
-        [self setString:[URL _web_userVisibleString] forType:legacyStringPasteboardTypeSingleton()];
+    if ([types containsObject:WebCore::legacyStringPasteboardTypeSingleton()])
+        [self setString:[URL _web_userVisibleString] forType:WebCore::legacyStringPasteboardTypeSingleton()];
     if ([types containsObject:WebURLsWithTitlesPboardType])
         [WebURLsWithTitles writeURLs:@[URL] andTitles:@[title] toPasteboard:self];
 }
@@ -178,8 +177,8 @@ static NSArray *writableTypesForImageWithArchive()
 + (int)_web_setFindPasteboardString:(NSString *)string withOwner:(id)owner
 {
     NSPasteboard *findPasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameFind];
-    [findPasteboard declareTypes:@[legacyStringPasteboardTypeSingleton()] owner:owner];
-    [findPasteboard setString:string forType:legacyStringPasteboardTypeSingleton()];
+    [findPasteboard declareTypes:@[WebCore::legacyStringPasteboardTypeSingleton()] owner:owner];
+    [findPasteboard setString:string forType:WebCore::legacyStringPasteboardTypeSingleton()];
     return [findPasteboard changeCount];
 }
 
@@ -189,7 +188,7 @@ static NSArray *writableTypesForImageWithArchive()
     NSAttributedString *string = [NSAttributedString attributedStringWithAttachment:attachment.get()];
     
     NSData *RTFDData = [string RTFDFromRange:NSMakeRange(0, [string length]) documentAttributes:@{ }];
-    [self setData:RTFDData forType:legacyRTFDPasteboardTypeSingleton()];
+    [self setData:RTFDData forType:WebCore::legacyRTFDPasteboardTypeSingleton()];
 }
 
 
@@ -203,26 +202,26 @@ static NSArray *writableTypesForImageWithArchive()
     if (containsImage && [subresources count] > 0) {
         WebResource *subresource = [subresources objectAtIndex:0];
         NSString *subresourceMIMEType = [subresource MIMEType];
-        if (MIMETypeRegistry::isSupportedImageMIMEType(subresourceMIMEType) || MIMETypeRegistry::isPDFMIMEType(subresourceMIMEType))
+        if (WebCore::MIMETypeRegistry::isSupportedImageMIMEType(subresourceMIMEType) || WebCore::MIMETypeRegistry::isPDFMIMEType(subresourceMIMEType))
             resource = subresource;
     }
     ASSERT(resource);
 
-    ASSERT(!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource.get() MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource.get() MIMEType]));
-    if (!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource.get() MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource.get() MIMEType]))
+    ASSERT(!containsImage || WebCore::MIMETypeRegistry::isSupportedImageMIMEType([resource.get() MIMEType]) || WebCore::MIMETypeRegistry::isPDFMIMEType([resource.get() MIMEType]));
+    if (!containsImage || WebCore::MIMETypeRegistry::isSupportedImageMIMEType([resource.get() MIMEType]) || WebCore::MIMETypeRegistry::isPDFMIMEType([resource.get() MIMEType]))
         [self _web_writeFileWrapperAsRTFDAttachment:[resource.get() _fileWrapperRepresentation]];
     
 }
 
-static CachedImage* imageFromElement(DOMElement *domElement)
+static WebCore::CachedImage* imageFromElement(DOMElement *domElement)
 {
     auto* element = core(domElement);
     if (!element)
         return nullptr;
     auto* renderer = element->renderer();
-    if (!is<RenderImage>(renderer))
+    if (!is<WebCore::RenderImage>(renderer))
         return nullptr;
-    auto* image = downcast<RenderImage>(*renderer).cachedImage();
+    auto* image = downcast<WebCore::RenderImage>(*renderer).cachedImage();
     if (!image || image->errorOccurred())
         return nullptr;
     return image;
@@ -241,13 +240,13 @@ static CachedImage* imageFromElement(DOMElement *domElement)
 
     [self _web_writeURL:URL andTitle:title types:types];
     
-    if ([types containsObject:legacyTIFFPasteboardTypeSingleton()]) {
+    if ([types containsObject:WebCore::legacyTIFFPasteboardTypeSingleton()]) {
         if (image)
-            [self setData:[image TIFFRepresentation] forType:legacyTIFFPasteboardTypeSingleton()];
+            [self setData:[image TIFFRepresentation] forType:WebCore::legacyTIFFPasteboardTypeSingleton()];
         else if (source && element)
             [source setPromisedDragTIFFDataSource:imageFromElement(element)];
         else if (element)
-            [self setData:[element _imageTIFFRepresentation] forType:legacyTIFFPasteboardTypeSingleton()];
+            [self setData:[element _imageTIFFRepresentation] forType:WebCore::legacyTIFFPasteboardTypeSingleton()];
     }
     
     if (archive) {
@@ -257,7 +256,7 @@ static CachedImage* imageFromElement(DOMElement *domElement)
     }
 
     // We should not have declared types that we aren't going to write (4031826).
-    ASSERT(![types containsObject:legacyRTFDPasteboardTypeSingleton()]);
+    ASSERT(![types containsObject:WebCore::legacyRTFDPasteboardTypeSingleton()]);
     ASSERT(![types containsObject:WebArchivePboardType]);
 }
 
@@ -270,19 +269,19 @@ static CachedImage* imageFromElement(DOMElement *domElement)
     ASSERT(self == [NSPasteboard pasteboardWithName:NSPasteboardNameDrag]);
 
     RetainPtr<NSString> extension = @"";
-    RetainPtr<NSMutableArray> types = adoptNS([[NSMutableArray alloc] initWithObjects:legacyFilesPromisePasteboardTypeSingleton(), nil]);
+    RetainPtr<NSMutableArray> types = adoptNS([[NSMutableArray alloc] initWithObjects:WebCore::legacyFilesPromisePasteboardTypeSingleton(), nil]);
     RetainPtr originIdentifier = core(element)->document().originIdentifierForPasteboard().createNSString();
     RetainPtr<NSData> customDataBuffer;
     if (originIdentifier.get().length) {
-        [types addObject:@(PasteboardCustomData::cocoaType().characters())];
-        PasteboardCustomData customData;
+        [types addObject:@(WebCore::PasteboardCustomData::cocoaType().characters())];
+        WebCore::PasteboardCustomData customData;
         customData.setOrigin(originIdentifier.get());
         customDataBuffer = customData.createSharedBuffer()->createNSData();
     }
 
     if (auto* renderer = core(element)->renderer()) {
-        if (is<RenderImage>(*renderer)) {
-            if (auto* image = downcast<RenderImage>(*renderer).cachedImage()) {
+        if (is<WebCore::RenderImage>(*renderer)) {
+            if (auto* image = downcast<WebCore::RenderImage>(*renderer).cachedImage()) {
                 // FIXME: This doesn't check errorOccured the way imageFromElement does.
                 extension = image->image()->filenameExtension().createNSString();
                 if (![extension length])
@@ -292,20 +291,20 @@ static CachedImage* imageFromElement(DOMElement *domElement)
             }
         }
 #if ENABLE(ATTACHMENT_ELEMENT)
-        else if (is<RenderAttachment>(*renderer)) {
+        else if (is<WebCore::RenderAttachment>(*renderer)) {
             extension = URL.pathExtension;
             [types addObjectsFromArray:[NSPasteboard _web_dragTypesForURL]];
             [self declareTypes:types.get() owner:source];
-            [self setPropertyList:@[title] forType:legacyFilenamesPasteboardTypeSingleton()];
+            [self setPropertyList:@[title] forType:WebCore::legacyFilenamesPasteboardTypeSingleton()];
         }
 #endif
     }
 
     [self _web_writeImage:nil element:element URL:URL title:title archive:archive types:types.get() source:source];
     if (customDataBuffer)
-        [self setData:customDataBuffer.get() forType:@(PasteboardCustomData::cocoaType().characters())];
+        [self setData:customDataBuffer.get() forType:@(WebCore::PasteboardCustomData::cocoaType().characters())];
 
-    [self setPropertyList:@[extension.get()] forType:legacyFilesPromisePasteboardTypeSingleton()];
+    [self setPropertyList:@[extension.get()] forType:WebCore::legacyFilesPromisePasteboardTypeSingleton()];
 
     return source;
 }

--- a/Source/WebKitLegacy/mac/Misc/WebUserContentURLPattern.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebUserContentURLPattern.mm
@@ -27,12 +27,11 @@
 #import <WebCore/UserContentURLPattern.h>
 #import <wtf/URL.h>
 
-using namespace WebCore;
 
 @interface WebUserContentURLPatternPrivate : NSObject
 {
 @public
-    UserContentURLPattern pattern;
+    WebCore::UserContentURLPattern pattern;
 }
 @end
 
@@ -48,7 +47,7 @@ using namespace WebCore;
         return nil;
 
     _private = [[WebUserContentURLPatternPrivate alloc] init];
-    _private->pattern = UserContentURLPattern(String(patternString));
+    _private->pattern = WebCore::UserContentURLPattern(String(patternString));
 
     return self;
 }

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginPackage.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginPackage.mm
@@ -30,6 +30,7 @@
 
 #import <WebKitLegacy/WebKitLogging.h>
 #import <WebKitLegacy/WebKitNSStringExtras.h>
+#import <WebKitLegacy/WebPluginViewFactory.h>
 
 NSString *WebPlugInBaseURLKey =                 @"WebPlugInBaseURLKey";
 NSString *WebPlugInAttributesKey =              @"WebPlugInAttributesKey";
@@ -117,6 +118,11 @@ NSString *WebPlugInContainingElementKey =       @"WebPlugInContainingElementKey"
 
 @end
 
+// This category supplies default implementations for only the two `isExcluded`
+// halves of the WebScripting informal protocol; the remaining methods declared
+// in WebScriptObject.h are intentionally left to subclasses.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincomplete-implementation"
 @implementation NSObject (WebScripting)
 
 + (BOOL)isSelectorExcludedFromWebScript:(SEL)aSelector
@@ -130,3 +136,4 @@ NSString *WebPlugInContainingElementKey =       @"WebPlugInContainingElementKey"
 }
 
 @end
+#pragma clang diagnostic pop

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm
@@ -44,7 +44,6 @@
 #import <WebCore/WebCoreThread.h>
 #endif
 
-using namespace WebCore;
 
 NSString *WebDatabaseDirectoryDefaultsKey = @"WebDatabaseDirectory";
 
@@ -77,7 +76,7 @@ static NSString *databasesDirectoryPath();
 
     WebPlatformStrategies::initializeIfNecessary();
 
-    DatabaseManager& dbManager = DatabaseManager::singleton();
+    WebCore::DatabaseManager& dbManager = WebCore::DatabaseManager::singleton();
 
     // Set the database root path in WebCore
     dbManager.initialize(databasesDirectoryPath());
@@ -90,7 +89,7 @@ static NSString *databasesDirectoryPath();
 
 - (NSArray *)origins
 {
-    return createNSArray(DatabaseTracker::singleton().origins(), [] (auto&& origin) {
+    return createNSArray(WebCore::DatabaseTracker::singleton().origins(), [] (auto&& origin) {
         return adoptNS([[WebSecurityOrigin alloc] _initWithWebCoreSecurityOrigin:origin.securityOrigin().ptr()]);
     }).autorelease();
 }
@@ -99,7 +98,7 @@ static NSString *databasesDirectoryPath();
 {
     if (!origin)
         return nil;
-    return createNSArray(DatabaseTracker::singleton().databaseNames([origin _core]->data())).autorelease();
+    return createNSArray(WebCore::DatabaseTracker::singleton().databaseNames([origin _core]->data())).autorelease();
 }
 
 - (NSDictionary *)detailsForDatabase:(NSString *)databaseIdentifier withOrigin:(WebSecurityOrigin *)origin
@@ -107,7 +106,7 @@ static NSString *databasesDirectoryPath();
     if (!origin)
         return nil;
 
-    auto details = DatabaseManager::singleton().detailsForNameAndOrigin(databaseIdentifier, *[origin _core]);
+    auto details = WebCore::DatabaseManager::singleton().detailsForNameAndOrigin(databaseIdentifier, *[origin _core]);
     if (details.name().isNull())
         return nil;
 
@@ -120,7 +119,7 @@ static NSString *databasesDirectoryPath();
 
 - (void)deleteAllDatabases
 {
-    DatabaseTracker::singleton().deleteAllDatabasesImmediately();
+    WebCore::DatabaseTracker::singleton().deleteAllDatabasesImmediately();
 #if PLATFORM(IOS_FAMILY)
     // FIXME: This needs to be removed once DatabaseTrackers in multiple processes
     // are in sync: <rdar://problem/9567500> Remove Website Data pane is not kept in sync with Safari
@@ -130,12 +129,12 @@ static NSString *databasesDirectoryPath();
 
 - (BOOL)deleteOrigin:(WebSecurityOrigin *)origin
 {
-    return origin && DatabaseTracker::singleton().deleteOrigin([origin _core]->data());
+    return origin && WebCore::DatabaseTracker::singleton().deleteOrigin([origin _core]->data());
 }
 
 - (BOOL)deleteDatabase:(NSString *)databaseIdentifier withOrigin:(WebSecurityOrigin *)origin
 {
-    return origin && DatabaseTracker::singleton().deleteDatabase([origin _core]->data(), databaseIdentifier);
+    return origin && WebCore::DatabaseTracker::singleton().deleteDatabase([origin _core]->data(), databaseIdentifier);
 }
 
 // For DumpRenderTree support only
@@ -193,7 +192,7 @@ static bool isFileHidden(NSString *file)
             if (![fileManager fileExistsAtPath:dbFilePath isDirectory:&isDirectory] || isDirectory)
                 continue;
             
-            if (DatabaseTracker::deleteDatabaseFileIfEmpty(dbFilePath))
+            if (WebCore::DatabaseTracker::deleteDatabaseFileIfEmpty(dbFilePath))
                 ++deletedDatabaseFileCount;
         }
         
@@ -207,11 +206,11 @@ static bool isFileHidden(NSString *file)
 
 + (void)scheduleEmptyDatabaseRemoval
 {
-    DatabaseTracker::emptyDatabaseFilesRemovalTaskWillBeScheduled();
+    WebCore::DatabaseTracker::emptyDatabaseFilesRemovalTaskWillBeScheduled();
     
     dispatch_async(globalDispatchQueueSingleton(0, 0), ^{
         [WebDatabaseManager removeEmptyDatabaseFiles];
-        DatabaseTracker::emptyDatabaseFilesRemovalTaskDidFinish();
+        WebCore::DatabaseTracker::emptyDatabaseFilesRemovalTaskDidFinish();
     });
 }
 

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
@@ -37,7 +37,6 @@
 #import <WebCore/WebCoreThread.h>
 #endif
 
-using namespace WebCore;
 
 #if PLATFORM(IOS_FAMILY)
 static const CFStringRef WebDatabaseOriginWasAddedNotification = CFSTR("com.apple.MobileSafariSettings.WebDatabaseOriginWasAddedNotification");
@@ -99,7 +98,7 @@ WebDatabaseManagerClient::~WebDatabaseManagerClient()
 class DidModifyOriginData {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(DidModifyOriginData);
 public:
-    static void dispatchToMainThread(WebDatabaseManagerClient& client, const SecurityOriginData& origin)
+    static void dispatchToMainThread(WebDatabaseManagerClient& client, const WebCore::SecurityOriginData& origin)
     {
         auto context = makeUnique<DidModifyOriginData>(client, origin);
         callOnMainThread([context = WTF::move(context)] {
@@ -107,7 +106,7 @@ public:
         });
     }
 
-    DidModifyOriginData(WebDatabaseManagerClient& client, const SecurityOriginData& origin)
+    DidModifyOriginData(WebDatabaseManagerClient& client, const WebCore::SecurityOriginData& origin)
         : client(client)
         , origin(origin.isolatedCopy())
     {
@@ -115,10 +114,10 @@ public:
 
 private:
     WeakRef<WebDatabaseManagerClient> client;
-    SecurityOriginData origin;
+    WebCore::SecurityOriginData origin;
 };
 
-void WebDatabaseManagerClient::dispatchDidModifyOrigin(const SecurityOriginData& origin)
+void WebDatabaseManagerClient::dispatchDidModifyOrigin(const WebCore::SecurityOriginData& origin)
 {
     if (!isMainThread()) {
         DidModifyOriginData::dispatchToMainThread(*this, origin);
@@ -130,7 +129,7 @@ void WebDatabaseManagerClient::dispatchDidModifyOrigin(const SecurityOriginData&
     [[NSNotificationCenter defaultCenter] postNotificationName:WebDatabaseDidModifyOriginNotification object:webSecurityOrigin.get()];
 }
 
-void WebDatabaseManagerClient::dispatchDidModifyDatabase(const SecurityOriginData& origin, const String& databaseIdentifier)
+void WebDatabaseManagerClient::dispatchDidModifyDatabase(const WebCore::SecurityOriginData& origin, const String& databaseIdentifier)
 {
     if (!isMainThread()) {
         DidModifyOriginData::dispatchToMainThread(*this, origin);
@@ -192,7 +191,7 @@ void WebDatabaseManagerClient::databaseWasDeleted()
         return;
     }
     
-    DatabaseTracker::singleton().removeDeletedOpenedDatabases();
+    WebCore::DatabaseTracker::singleton().removeDeletedOpenedDatabases();
 }
 
 void WebDatabaseManagerClient::databaseOriginWasDeleted()

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseQuotaManager.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseQuotaManager.mm
@@ -29,7 +29,6 @@
 #import <WebCore/DatabaseTracker.h>
 #import <WebCore/SecurityOriginData.h>
 
-using namespace WebCore;
 
 @implementation WebDatabaseQuotaManager
 
@@ -55,12 +54,12 @@ using namespace WebCore;
 
 - (unsigned long long)usage
 {
-    return DatabaseTracker::singleton().usage([_origin _core]->data());
+    return WebCore::DatabaseTracker::singleton().usage([_origin _core]->data());
 }
 
 - (unsigned long long)quota
 {
-    return DatabaseTracker::singleton().quota([_origin _core]->data());
+    return WebCore::DatabaseTracker::singleton().quota([_origin _core]->data());
 }
 
 // If the quota is set to a value lower than the current usage, that quota will
@@ -68,7 +67,7 @@ using namespace WebCore;
 // prevent new data from being added to databases in that origin.
 - (void)setQuota:(unsigned long long)quota
 {
-    DatabaseTracker::singleton().setQuota([_origin _core]->data(), quota);
+    WebCore::DatabaseTracker::singleton().setQuota([_origin _core]->data(), quota);
 }
 
 @end

--- a/Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
@@ -34,7 +34,6 @@
 #import <WebCore/SecurityOriginData.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-using namespace WebCore;
 
 NSString * const WebStorageDirectoryDefaultsKey = @"WebKitLocalStorageDatabasePathPreferenceKey";
 NSString * const WebStorageDidModifyOriginNotification = @"WebStorageDidModifyOriginNotification";

--- a/Source/WebKitLegacy/mac/Storage/WebStorageTrackerClient.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebStorageTrackerClient.mm
@@ -33,7 +33,6 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/text/WTFString.h>
 
-using namespace WebCore;
 
 WebStorageTrackerClient* WebStorageTrackerClient::sharedWebStorageTrackerClient()
 {
@@ -45,7 +44,7 @@ WebStorageTrackerClient::WebStorageTrackerClient() = default;
 
 WebStorageTrackerClient::~WebStorageTrackerClient() = default;
 
-void WebStorageTrackerClient::dispatchDidModifyOrigin(SecurityOrigin* origin)
+void WebStorageTrackerClient::dispatchDidModifyOrigin(WebCore::SecurityOrigin* origin)
 {
     RetainPtr<WebSecurityOrigin> webSecurityOrigin = adoptNS([[WebSecurityOrigin alloc] _initWithWebCoreSecurityOrigin:origin]);
 
@@ -55,7 +54,7 @@ void WebStorageTrackerClient::dispatchDidModifyOrigin(SecurityOrigin* origin)
 
 void WebStorageTrackerClient::dispatchDidModifyOrigin(const String& originIdentifier)
 {
-    auto origin = SecurityOriginData::fromDatabaseIdentifier(originIdentifier);
+    auto origin = WebCore::SecurityOriginData::fromDatabaseIdentifier(originIdentifier);
 
     if (!origin) {
         ASSERT_NOT_REACHED();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
@@ -31,22 +31,21 @@
 
 #if USE(AUTOCORRECTION_PANEL)
 
-using namespace WebCore;
 
 CorrectionPanel::CorrectionPanel()
     : m_wasDismissedExternally(false)
-    , m_reasonForDismissing(ReasonForDismissingAlternativeText::Ignored)
+    , m_reasonForDismissing(WebCore::ReasonForDismissingAlternativeText::Ignored)
 {
 }
 
 CorrectionPanel::~CorrectionPanel()
 {
-    dismissInternal(ReasonForDismissingAlternativeText::Ignored, false);
+    dismissInternal(WebCore::ReasonForDismissingAlternativeText::Ignored, false);
 }
 
-void CorrectionPanel::show(WebView* view, AlternativeTextType type, const FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings)
+void CorrectionPanel::show(WebView* view, WebCore::AlternativeTextType type, const WebCore::FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings)
 {
-    dismissInternal(ReasonForDismissingAlternativeText::Ignored, false);
+    dismissInternal(WebCore::ReasonForDismissingAlternativeText::Ignored, false);
     
     if (!view)
         return;
@@ -65,12 +64,12 @@ void CorrectionPanel::show(WebView* view, AlternativeTextType type, const FloatR
     }];
 }
 
-String CorrectionPanel::dismiss(ReasonForDismissingAlternativeText reason)
+String CorrectionPanel::dismiss(WebCore::ReasonForDismissingAlternativeText reason)
 {
     return dismissInternal(reason, true);
 }
 
-String CorrectionPanel::dismissInternal(ReasonForDismissingAlternativeText reason, bool dismissingExternally)
+String CorrectionPanel::dismissInternal(WebCore::ReasonForDismissingAlternativeText reason, bool dismissingExternally)
 {
     if (!isShowing())
         return String();
@@ -99,7 +98,7 @@ void CorrectionPanel::handleAcceptedReplacement(NSString* acceptedReplacement, N
         if (acceptedReplacement)
             recordAutocorrectionResponse(documentTag, NSCorrectionResponseAccepted, replaced, acceptedReplacement);
         else {
-            if (!m_wasDismissedExternally || m_reasonForDismissing == ReasonForDismissingAlternativeText::Cancelled)
+            if (!m_wasDismissedExternally || m_reasonForDismissing == WebCore::ReasonForDismissingAlternativeText::Cancelled)
                 recordAutocorrectionResponse(documentTag, NSCorrectionResponseRejected, replaced, proposedReplacement);
             else
                 recordAutocorrectionResponse(documentTag, NSCorrectionResponseIgnored, replaced, proposedReplacement);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -39,9 +39,8 @@
 #import <pal/system/mac/PopupMenu.h>
 #import <wtf/BlockObjCExceptions.h>
 
-using namespace WebCore;
 
-PopupMenuMac::PopupMenuMac(PopupMenuClient* client)
+PopupMenuMac::PopupMenuMac(WebCore::PopupMenuClient* client)
     : m_client(client)
 {
 }
@@ -71,8 +70,8 @@ void PopupMenuMac::populate()
     if (m_client && !protect(m_client)->shouldPopOver())
         [m_popup addItemWithTitle:@""];
 
-    TextDirection menuTextDirection = protect(m_client)->menuStyle().textDirection();
-    [m_popup setUserInterfaceLayoutDirection:menuTextDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
+    WebCore::TextDirection menuTextDirection = protect(m_client)->menuStyle().textDirection();
+    [m_popup setUserInterfaceLayoutDirection:menuTextDirection == WebCore::TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
 
     int size = protect(m_client)->listSize();
 
@@ -82,9 +81,9 @@ void PopupMenuMac::populate()
             continue;
         }
 
-        PopupMenuStyle style = protect(m_client)->itemStyle(i);
+        WebCore::PopupMenuStyle style = protect(m_client)->itemStyle(i);
         RetainPtr<NSMutableDictionary> attributes = adoptNS([[NSMutableDictionary alloc] init]);
-        if (style.font() != FontCascade()) {
+        if (style.font() != WebCore::FontCascade()) {
             RetainPtr font = style.font().primaryFont().ctFont();
             if (!font) {
                 CGFloat size = style.font().primaryFont().platformData().size();
@@ -94,8 +93,8 @@ void PopupMenuMac::populate()
         }
 
         RetainPtr<NSMutableParagraphStyle> paragraphStyle = adoptNS([[NSParagraphStyle defaultParagraphStyle] mutableCopy]);
-        [paragraphStyle setAlignment:menuTextDirection == TextDirection::LTR ? NSTextAlignmentLeft : NSTextAlignmentRight];
-        NSWritingDirection writingDirection = style.textDirection() == TextDirection::LTR ? NSWritingDirectionLeftToRight : NSWritingDirectionRightToLeft;
+        [paragraphStyle setAlignment:menuTextDirection == WebCore::TextDirection::LTR ? NSTextAlignmentLeft : NSTextAlignmentRight];
+        NSWritingDirection writingDirection = style.textDirection() == WebCore::TextDirection::LTR ? NSWritingDirectionLeftToRight : NSWritingDirectionRightToLeft;
         [paragraphStyle setBaseWritingDirection:writingDirection];
         if (style.hasTextDirectionOverride()) {
             auto writingDirectionValue = static_cast<NSInteger>(writingDirection) + static_cast<NSInteger>(NSWritingDirectionOverride);
@@ -120,7 +119,7 @@ void PopupMenuMac::populate()
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         // Allow the accessible text of the item to be overridden if necessary.
-        if (AXObjectCache::accessibilityEnabled()) {
+        if (WebCore::AXObjectCache::accessibilityEnabled()) {
             RetainPtr accessibilityOverride = protect(m_client)->itemAccessibilityText(i).createNSString();
             if ([accessibilityOverride length])
                 [menuItem accessibilitySetOverrideValue:accessibilityOverride.get() forAttribute:NSAccessibilityDescriptionAttribute];
@@ -129,7 +128,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 }
 
-void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selectedIndex)
+void PopupMenuMac::show(const WebCore::IntRect& r, WebCore::LocalFrameView& frameView, int selectedIndex)
 {
     populate();
     int numItems = [m_popup numberOfItems];
@@ -146,14 +145,14 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
 
     RetainPtr view = frameView.documentView();
 
-    TextDirection textDirection = protect(m_client)->menuStyle().textDirection();
+    WebCore::TextDirection textDirection = protect(m_client)->menuStyle().textDirection();
 
     [m_popup attachPopUpWithFrame:r inView:view.get()];
     [m_popup selectItemAtIndex:selectedIndex];
-    [m_popup setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
+    [m_popup setUserInterfaceLayoutDirection:textDirection == WebCore::TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
 
     NSMenu *menu = [m_popup menu];
-    [menu setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
+    [menu setUserInterfaceLayoutDirection:textDirection == WebCore::TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
 
     NSPoint location;
 
@@ -172,12 +171,12 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
         auto defaultFont = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, CTFontGetSize(font.get()), nil));
         vertOffset += CTFontGetDescent(font.get()) - CTFontGetDescent(defaultFont.get());
         vertOffset = fminf(NSHeight(r), vertOffset);
-        if (textDirection == TextDirection::LTR)
+        if (textDirection == WebCore::TextDirection::LTR)
             location = NSMakePoint(NSMinX(r) + popOverHorizontalAdjust, NSMaxY(r) - vertOffset);
         else
             location = NSMakePoint(NSMaxX(r) - popOverHorizontalAdjust, NSMaxY(r) - vertOffset);
     } else {
-        if (textDirection == TextDirection::LTR)
+        if (textDirection == WebCore::TextDirection::LTR)
             location = NSMakePoint(NSMinX(r) + popUnderHorizontalAdjust, NSMaxY(r) + popUnderVerticalAdjust);
         else
             location = NSMakePoint(NSMaxX(r) - popUnderHorizontalAdjust, NSMaxY(r) + popUnderVerticalAdjust);
@@ -190,11 +189,11 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
     Ref<PopupMenuMac> protector(*this);
 
     RetainPtr<NSView> dummyView = adoptNS([[NSView alloc] initWithFrame:r]);
-    [dummyView.get() setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
+    [dummyView.get() setUserInterfaceLayoutDirection:textDirection == WebCore::TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
     [view.get() addSubview:dummyView.get()];
     location = [dummyView convertPoint:location fromView:view.get()];
     
-    if (Page* page = frame->page()) {
+    if (WebCore::Page* page = frame->page()) {
         RetainPtr webView = kit(page);
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         CallUIDelegate(webView.get(), @selector(webView:willPopupMenu:), menu);
@@ -203,16 +202,16 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
 
     NSControlSize controlSize;
     switch (protect(m_client)->menuStyle().menuSize()) {
-    case PopupMenuStyle::Size::Normal:
+    case WebCore::PopupMenuStyle::Size::Normal:
         controlSize = NSControlSizeRegular;
         break;
-    case PopupMenuStyle::Size::Small:
+    case WebCore::PopupMenuStyle::Size::Small:
         controlSize = NSControlSizeSmall;
         break;
-    case PopupMenuStyle::Size::Mini:
+    case WebCore::PopupMenuStyle::Size::Mini:
         controlSize = NSControlSizeMini;
         break;
-    case PopupMenuStyle::Size::Large:
+    case WebCore::PopupMenuStyle::Size::Large:
         controlSize = NSControlSizeLarge;
         break;
     }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm
@@ -28,7 +28,6 @@
 #import "WebViewInternal.h"
 #import <wtf/TZoneMallocInlines.h>
 
-using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebAlternativeTextClient);
 
@@ -40,27 +39,27 @@ WebAlternativeTextClient::WebAlternativeTextClient(WebView* webView)
 WebAlternativeTextClient::~WebAlternativeTextClient()
 {
 #if USE(AUTOCORRECTION_PANEL)
-    dismissAlternative(ReasonForDismissingAlternativeText::Ignored);
+    dismissAlternative(WebCore::ReasonForDismissingAlternativeText::Ignored);
 #endif
 }
 
 #if USE(AUTOCORRECTION_PANEL)
-void WebAlternativeTextClient::showCorrectionAlternative(AlternativeTextType type, const FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings, WebCore::FrameIdentifier)
+void WebAlternativeTextClient::showCorrectionAlternative(WebCore::AlternativeTextType type, const WebCore::FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings, WebCore::FrameIdentifier)
 {
     m_correctionPanel.show(m_webView, type, boundingBoxOfReplacedString, replacedString, replacementString, alternativeReplacementStrings);
 }
 
-void WebAlternativeTextClient::dismissAlternative(ReasonForDismissingAlternativeText reason)
+void WebAlternativeTextClient::dismissAlternative(WebCore::ReasonForDismissingAlternativeText reason)
 {
     m_correctionPanel.dismiss(reason);
 }
 
-String WebAlternativeTextClient::dismissAlternativeSoon(ReasonForDismissingAlternativeText reason)
+String WebAlternativeTextClient::dismissAlternativeSoon(WebCore::ReasonForDismissingAlternativeText reason)
 {
     return m_correctionPanel.dismiss(reason);
 }
 
-static inline NSCorrectionResponse NODELETE toCorrectionResponse(AutocorrectionResponse response)
+static inline NSCorrectionResponse NODELETE toCorrectionResponse(WebCore::AutocorrectionResponse response)
 {
     switch (response) {
     case WebCore::AutocorrectionResponse::Reverted:
@@ -75,23 +74,23 @@ static inline NSCorrectionResponse NODELETE toCorrectionResponse(AutocorrectionR
     return NSCorrectionResponseAccepted;
 }
 
-void WebAlternativeTextClient::recordAutocorrectionResponse(AutocorrectionResponse response, const String& replacedString, const String& replacementString)
+void WebAlternativeTextClient::recordAutocorrectionResponse(WebCore::AutocorrectionResponse response, const String& replacedString, const String& replacementString)
 {
     CorrectionPanel::recordAutocorrectionResponse([m_webView spellCheckerDocumentTag], toCorrectionResponse(response), replacedString, replacementString);
 }
 #endif
 
-void WebAlternativeTextClient::removeDictationAlternatives(DictationContext dictationContext)
+void WebAlternativeTextClient::removeDictationAlternatives(WebCore::DictationContext dictationContext)
 {
     [m_webView _removeDictationAlternatives:dictationContext];
 }
 
-void WebAlternativeTextClient::showDictationAlternativeUI(const WebCore::FloatRect& boundingBoxOfDictatedText, DictationContext dictationContext)
+void WebAlternativeTextClient::showDictationAlternativeUI(const WebCore::FloatRect& boundingBoxOfDictatedText, WebCore::DictationContext dictationContext)
 {
     [m_webView _showDictationAlternativeUI:boundingBoxOfDictatedText forDictationContext:dictationContext];
 }
 
-Vector<String> WebAlternativeTextClient::dictationAlternatives(DictationContext dictationContext)
+Vector<String> WebAlternativeTextClient::dictationAlternatives(WebCore::DictationContext dictationContext)
 {
     return [m_webView _dictationAlternatives:dictationContext];
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -170,8 +170,7 @@ NSString *WebConsoleMessageErrorMessageLevel = @"ErrorMessageLevel";
 - (void)setIsSelected:(BOOL)isSelected;
 @end
 
-using namespace WebCore;
-using namespace HTMLNames;
+using namespace WebCore::HTMLNames;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebChromeClient);
 
@@ -187,7 +186,7 @@ void WebChromeClient::chromeDestroyed()
 // These functions scale between window and WebView coordinates because JavaScript/DOM operations 
 // assume that the WebView and the window share the same coordinate system.
 
-void WebChromeClient::setWindowRect(const FloatRect& rect)
+void WebChromeClient::setWindowRect(const WebCore::FloatRect& rect)
 {
 #if !PLATFORM(IOS_FAMILY)
     NSRect windowRect = toDeviceSpace(rect, [m_webView window]);
@@ -195,18 +194,18 @@ void WebChromeClient::setWindowRect(const FloatRect& rect)
 #endif
 }
 
-FloatRect WebChromeClient::windowRect() const
+WebCore::FloatRect WebChromeClient::windowRect() const
 {
 #if !PLATFORM(IOS_FAMILY)
     NSRect windowRect = [[m_webView _UIDelegateForwarder] webViewFrame:m_webView];
-    return toUserSpace(windowRect, [m_webView window]);
+    return WebCore::toUserSpace(windowRect, [m_webView window]);
 #else
-    return FloatRect();
+    return WebCore::FloatRect();
 #endif
 }
 
 // FIXME: We need to add API for setting and getting this.
-FloatRect WebChromeClient::pageRect() const
+WebCore::FloatRect WebChromeClient::pageRect() const
 {
     return [m_webView frame];
 }
@@ -221,17 +220,17 @@ void WebChromeClient::unfocus()
     [[m_webView _UIDelegateForwarder] webViewUnfocus:m_webView];
 }
 
-bool WebChromeClient::canTakeFocus(FocusDirection) const
+bool WebChromeClient::canTakeFocus(WebCore::FocusDirection) const
 {
     // There's unfortunately no way to determine if we will become first responder again
     // once we give it up, so we just have to guess that we won't.
     return true;
 }
 
-void WebChromeClient::takeFocus(FocusDirection direction)
+void WebChromeClient::takeFocus(WebCore::FocusDirection direction)
 {
 #if !PLATFORM(IOS_FAMILY)
-    if (direction == FocusDirection::Forward) {
+    if (direction == WebCore::FocusDirection::Forward) {
         // Since we're trying to move focus out of m_webView, and because
         // m_webView may contain subviews within it, we ask it for the next key
         // view of the last view in its key view loop. This makes m_webView
@@ -250,23 +249,23 @@ void WebChromeClient::takeFocus(FocusDirection direction)
 #endif
 }
 
-void WebChromeClient::focusedElementChanged(Element* element, LocalFrame*, FocusOptions, BroadcastFocusedElement)
+void WebChromeClient::focusedElementChanged(WebCore::Element* element, WebCore::LocalFrame*, WebCore::FocusOptions, WebCore::BroadcastFocusedElement)
 {
-    if (!is<HTMLInputElement>(element))
+    if (!is<WebCore::HTMLInputElement>(element))
         return;
 
-    auto& inputElement = downcast<HTMLInputElement>(*element);
+    auto& inputElement = downcast<WebCore::HTMLInputElement>(*element);
     if (!inputElement.isText())
         return;
 
     CallFormDelegate(m_webView, @selector(didFocusTextField:inFrame:), kit(&inputElement), kit(inputElement.document().frame()));
 }
 
-void WebChromeClient::focusedFrameChanged(Frame*)
+void WebChromeClient::focusedFrameChanged(WebCore::Frame*)
 {
 }
 
-RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& features, const NavigationAction&)
+RefPtr<WebCore::Page> WebChromeClient::createWindow(WebCore::LocalFrame& frame, const String& openedMainFrameName, const WebCore::WindowFeatures& features, const WebCore::NavigationAction&)
 {
     RetainPtr<id> delegate = [m_webView UIDelegate];
     RetainPtr<WebView> newWebView;
@@ -477,7 +476,7 @@ bool WebChromeClient::canRunBeforeUnloadConfirmPanel()
     return [[m_webView UIDelegate] respondsToSelector:@selector(webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:)];
 }
 
-bool WebChromeClient::runBeforeUnloadConfirmPanel(String&& message, LocalFrame& frame)
+bool WebChromeClient::runBeforeUnloadConfirmPanel(String&& message, WebCore::LocalFrame& frame)
 {
     return CallUIDelegateReturningBoolean(true, m_webView, @selector(webView:runBeforeUnloadConfirmPanelWithMessage:initiatedByFrame:), message.createNSString().get(), kit(&frame));
 }
@@ -502,7 +501,7 @@ void WebChromeClient::closeWindow()
     [m_webView _closeWindow];
 }
 
-void WebChromeClient::runJavaScriptAlert(LocalFrame& frame, const String& message)
+void WebChromeClient::runJavaScriptAlert(WebCore::LocalFrame& frame, const String& message)
 {
     RetainPtr<id> delegate = [m_webView UIDelegate];
     SEL selector = @selector(webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:);
@@ -519,7 +518,7 @@ void WebChromeClient::runJavaScriptAlert(LocalFrame& frame, const String& messag
     }
 }
 
-bool WebChromeClient::runJavaScriptConfirm(LocalFrame& frame, const String& message)
+bool WebChromeClient::runJavaScriptConfirm(WebCore::LocalFrame& frame, const String& message)
 {
     RetainPtr<id> delegate = [m_webView UIDelegate];
     SEL selector = @selector(webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:);
@@ -534,7 +533,7 @@ bool WebChromeClient::runJavaScriptConfirm(LocalFrame& frame, const String& mess
     return NO;
 }
 
-bool WebChromeClient::runJavaScriptPrompt(LocalFrame& frame, const String& prompt, const String& defaultText, String& result)
+bool WebChromeClient::runJavaScriptPrompt(WebCore::LocalFrame& frame, const String& prompt, const String& defaultText, String& result)
 {
     RetainPtr<id> delegate = [m_webView UIDelegate];
     SEL selector = @selector(webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:);
@@ -555,52 +554,52 @@ bool WebChromeClient::runJavaScriptPrompt(LocalFrame& frame, const String& promp
     return !result.isNull();
 }
 
-void WebChromeClient::invalidateRootView(const IntRect&)
+void WebChromeClient::invalidateRootView(const WebCore::IntRect&)
 {
 }
 
-void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
+void WebChromeClient::invalidateContentsAndRootView(const WebCore::IntRect& rect)
 {
 }
 
-void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
+void WebChromeClient::invalidateContentsForSlowScroll(const WebCore::IntRect& rect)
 {
     invalidateContentsAndRootView(rect);
 }
 
-void WebChromeClient::scroll(const IntSize&, const IntRect&, const IntRect&)
+void WebChromeClient::scroll(const WebCore::IntSize&, const WebCore::IntRect&, const WebCore::IntRect&)
 {
 }
 
-IntPoint WebChromeClient::screenToRootView(const IntPoint& p) const
-{
-    // FIXME: Implement this.
-    return p;
-}
-
-IntPoint WebChromeClient::rootViewToScreen(const IntPoint& p) const
+WebCore::IntPoint WebChromeClient::screenToRootView(const WebCore::IntPoint& p) const
 {
     // FIXME: Implement this.
     return p;
 }
 
-IntRect WebChromeClient::rootViewToScreen(const IntRect& r) const
+WebCore::IntPoint WebChromeClient::rootViewToScreen(const WebCore::IntPoint& p) const
+{
+    // FIXME: Implement this.
+    return p;
+}
+
+WebCore::IntRect WebChromeClient::rootViewToScreen(const WebCore::IntRect& r) const
 {
     // FIXME: Implement this.
     return r;
 }
 
-IntPoint WebChromeClient::accessibilityScreenToRootView(const IntPoint& p) const
+WebCore::IntPoint WebChromeClient::accessibilityScreenToRootView(const WebCore::IntPoint& p) const
 {
     return screenToRootView(p);
 }
 
-IntRect WebChromeClient::rootViewToAccessibilityScreen(const IntRect& r) const
+WebCore::IntRect WebChromeClient::rootViewToAccessibilityScreen(const WebCore::IntRect& r) const
 {
     return rootViewToScreen(r);
 }
 
-void WebChromeClient::didFinishLoadingImageForElement(HTMLImageElement&)
+void WebChromeClient::didFinishLoadingImageForElement(WebCore::HTMLImageElement&)
 {
 }
 
@@ -609,11 +608,11 @@ PlatformPageClient WebChromeClient::platformPageClient() const
     return 0;
 }
 
-void WebChromeClient::contentsSizeChanged(LocalFrame&, const IntSize&) const
+void WebChromeClient::contentsSizeChanged(WebCore::LocalFrame&, const WebCore::IntSize&) const
 {
 }
 
-void WebChromeClient::scrollContainingScrollViewsToRevealRect(const IntRect& r) const
+void WebChromeClient::scrollContainingScrollViewsToRevealRect(const WebCore::IntRect& r) const
 {
     // FIXME: This scrolling behavior should be under the control of the embedding client,
     // perhaps in a delegate method, rather than something WebKit does unconditionally.
@@ -630,23 +629,23 @@ void WebChromeClient::scrollContainingScrollViewsToRevealRect(const IntRect& r) 
 
 // End host window methods.
 
-bool WebChromeClient::shouldUnavailablePluginMessageBeButton(PluginUnavailabilityReason pluginUnavailabilityReason) const
+bool WebChromeClient::shouldUnavailablePluginMessageBeButton(WebCore::PluginUnavailabilityReason pluginUnavailabilityReason) const
 {
-    if (pluginUnavailabilityReason == PluginUnavailabilityReason::PluginMissing)
+    if (pluginUnavailabilityReason == WebCore::PluginUnavailabilityReason::PluginMissing)
         return [[m_webView UIDelegate] respondsToSelector:@selector(webView:didPressMissingPluginButton:)];
 
     return false;
 }
 
-void WebChromeClient::unavailablePluginButtonClicked(Element& element, PluginUnavailabilityReason pluginUnavailabilityReason) const
+void WebChromeClient::unavailablePluginButtonClicked(WebCore::Element& element, WebCore::PluginUnavailabilityReason pluginUnavailabilityReason) const
 {
     ASSERT(element.hasTagName(objectTag) || element.hasTagName(embedTag) || element.hasTagName(appletTag));
 
-    ASSERT(pluginUnavailabilityReason == PluginUnavailabilityReason::PluginMissing);
+    ASSERT(pluginUnavailabilityReason == WebCore::PluginUnavailabilityReason::PluginMissing);
     CallUIDelegate(m_webView, @selector(webView:didPressMissingPluginButton:), kit(&element));
 }
 
-void WebChromeClient::mouseDidMoveOverElement(const HitTestResult& result, OptionSet<WebCore::PlatformEventModifier> modifiers, const String& toolTip, TextDirection)
+void WebChromeClient::mouseDidMoveOverElement(const WebCore::HitTestResult& result, OptionSet<WebCore::PlatformEventModifier> modifiers, const String& toolTip, WebCore::TextDirection)
 {
     auto element = adoptNS([[WebElementDictionary alloc] initWithHitTestResult:result]);
     [m_webView _mouseDidMoveOverElement:element.get() modifierFlags:modifiers.toRaw()];
@@ -660,7 +659,7 @@ void WebChromeClient::setToolTip(const String& toolTip)
         [(WebHTMLView *)documentView.get() _setToolTip:toolTip.createNSString().get()];
 }
 
-void WebChromeClient::print(LocalFrame& frame, const StringWithDirection&)
+void WebChromeClient::print(WebCore::LocalFrame& frame, const WebCore::StringWithDirection&)
 {
     RetainPtr webFrame = kit(&frame);
     if ([[m_webView UIDelegate] respondsToSelector:@selector(webView:printFrame:)])
@@ -669,7 +668,7 @@ void WebChromeClient::print(LocalFrame& frame, const StringWithDirection&)
         CallUIDelegate(m_webView, @selector(webView:printFrameView:), [webFrame.get() frameView]);
 }
 
-void WebChromeClient::exceededDatabaseQuota(LocalFrame& frame, const String& databaseName, DatabaseDetails)
+void WebChromeClient::exceededDatabaseQuota(WebCore::LocalFrame& frame, const String& databaseName, WebCore::DatabaseDetails)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -679,30 +678,30 @@ void WebChromeClient::exceededDatabaseQuota(LocalFrame& frame, const String& dat
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-RefPtr<ColorChooser> WebChromeClient::createColorChooser(ColorChooserClient& client, const Color& initialColor)
+RefPtr<WebCore::ColorChooser> WebChromeClient::createColorChooser(WebCore::ColorChooserClient& client, const WebCore::Color& initialColor)
 {
     // FIXME: Implement <input type='color'> for WK1 (Bug 119094).
     ASSERT_NOT_REACHED();
     return nullptr;
 }
 
-RefPtr<DataListSuggestionPicker> WebChromeClient::createDataListSuggestionPicker(DataListSuggestionsClient& client)
+RefPtr<WebCore::DataListSuggestionPicker> WebChromeClient::createDataListSuggestionPicker(WebCore::DataListSuggestionsClient& client)
 {
     ASSERT_NOT_REACHED();
     return nullptr;
 }
 
-RefPtr<DateTimeChooser> WebChromeClient::createDateTimeChooser(DateTimeChooserClient&)
+RefPtr<WebCore::DateTimeChooser> WebChromeClient::createDateTimeChooser(WebCore::DateTimeChooserClient&)
 {
     ASSERT_NOT_REACHED();
     return nullptr;
 }
 
-void WebChromeClient::setTextIndicator(RefPtr<TextIndicator>&& textIndicator) const
+void WebChromeClient::setTextIndicator(RefPtr<WebCore::TextIndicator>&& textIndicator) const
 {
 }
 
-void WebChromeClient::updateTextIndicator(RefPtr<TextIndicator>&& textIndicator) const
+void WebChromeClient::updateTextIndicator(RefPtr<WebCore::TextIndicator>&& textIndicator) const
 {
 }
 
@@ -740,7 +739,7 @@ void WebChromeClient::requestPointerUnlock(CompletionHandler<void(bool)>&& compl
 }
 #endif
 
-void WebChromeClient::runOpenPanel(LocalFrame&, FileChooser& chooser)
+void WebChromeClient::runOpenPanel(WebCore::LocalFrame&, WebCore::FileChooser& chooser)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     BOOL allowMultipleFiles = chooser.settings().allowsMultipleFiles;
@@ -755,18 +754,18 @@ void WebChromeClient::runOpenPanel(LocalFrame&, FileChooser& chooser)
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-void WebChromeClient::showShareSheet(ShareDataWithParsedURL&&, CompletionHandler<void(bool)>&&)
+void WebChromeClient::showShareSheet(WebCore::ShareDataWithParsedURL&&, CompletionHandler<void(bool)>&&)
 {
 }
 
-void WebChromeClient::loadIconForFiles(const Vector<String>& filenames, FileIconLoader& iconLoader)
+void WebChromeClient::loadIconForFiles(const Vector<String>& filenames, WebCore::FileIconLoader& iconLoader)
 {
     iconLoader.iconLoaded(createIconForFiles(filenames));
 }
 
-RefPtr<Icon> WebChromeClient::createIconForFiles(const Vector<String>& filenames)
+RefPtr<WebCore::Icon> WebChromeClient::createIconForFiles(const Vector<String>& filenames)
 {
-    return Icon::createIconForFiles(filenames);
+    return WebCore::Icon::createIconForFiles(filenames);
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -802,12 +801,12 @@ void WebChromeClient::setCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
 
 #endif
 
-KeyboardUIMode WebChromeClient::keyboardUIMode()
+WebCore::KeyboardUIMode WebChromeClient::keyboardUIMode()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     return [m_webView _keyboardUIMode];
     END_BLOCK_OBJC_EXCEPTIONS
-    return KeyboardAccessDefault;
+    return WebCore::KeyboardAccessDefault;
 }
 
 NSResponder *WebChromeClient::firstResponder()
@@ -881,7 +880,7 @@ bool WebChromeClient::shouldPaintEntireContents() const
 #endif
 }
 
-void WebChromeClient::attachRootGraphicsLayer(LocalFrame& frame, GraphicsLayer* graphicsLayer)
+void WebChromeClient::attachRootGraphicsLayer(WebCore::LocalFrame& frame, WebCore::GraphicsLayer* graphicsLayer)
 {
 #if !PLATFORM(MAC)
     UNUSED_PARAM(frame);
@@ -905,7 +904,7 @@ void WebChromeClient::attachRootGraphicsLayer(LocalFrame& frame, GraphicsLayer* 
 #endif
 }
 
-void WebChromeClient::attachViewOverlayGraphicsLayer(GraphicsLayer*)
+void WebChromeClient::attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*)
 {
     // FIXME: If we want view-relative page overlays in Legacy WebKit, this would be the place to hook them up.
 }
@@ -926,7 +925,7 @@ void WebChromeClient::triggerRenderingUpdate()
 
 #if ENABLE(VIDEO)
 
-bool WebChromeClient::canEnterVideoFullscreen(HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const
+bool WebChromeClient::canEnterVideoFullscreen(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const
 {
 #if !PLATFORM(IOS_FAMILY) || HAVE(AVKIT)
     return true;
@@ -935,7 +934,7 @@ bool WebChromeClient::canEnterVideoFullscreen(HTMLVideoElement&, WebCore::HTMLMe
 #endif
 }
 
-bool WebChromeClient::supportsVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode)
+bool WebChromeClient::supportsVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode)
 {
 #if !PLATFORM(IOS_FAMILY) || HAVE(AVKIT)
     return true;
@@ -951,10 +950,10 @@ void WebChromeClient::setMockVideoPresentationModeEnabled(bool enabled)
     m_mockVideoPresentationModeEnabled = enabled;
 }
 
-void WebChromeClient::enterVideoFullscreenForVideoElement(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode, bool standby)
+void WebChromeClient::enterVideoFullscreenForVideoElement(WebCore::HTMLVideoElement& videoElement, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode, bool standby)
 {
     ASSERT_UNUSED(standby, !standby);
-    ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
+    ASSERT(mode != WebCore::HTMLMediaElementEnums::VideoFullscreenModeNone);
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (m_mockVideoPresentationModeEnabled)
         videoElement.didBecomeFullscreenElement();
@@ -974,7 +973,7 @@ void WebChromeClient::exitVideoFullscreenForVideoElement(WebCore::HTMLVideoEleme
     completionHandler(true);
 }
 
-void WebChromeClient::exitVideoFullscreenToModeWithoutAnimation(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode targetMode)
+void WebChromeClient::exitVideoFullscreenToModeWithoutAnimation(WebCore::HTMLVideoElement& videoElement, WebCore::HTMLMediaElementEnums::VideoFullscreenMode targetMode)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (m_mockVideoPresentationModeEnabled)
@@ -990,7 +989,7 @@ void WebChromeClient::exitVideoFullscreenToModeWithoutAnimation(HTMLVideoElement
 
 #if ENABLE(VIDEO) && PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
 
-void WebChromeClient::setUpPlaybackControlsManager(HTMLMediaElement& element)
+void WebChromeClient::setUpPlaybackControlsManager(WebCore::HTMLMediaElement& element)
 {
     [m_webView _setUpPlaybackControlsManagerForMediaElement:element];
 }
@@ -1009,7 +1008,7 @@ void WebChromeClient::mediaEngineChanged(WebCore::HTMLMediaElement&)
 
 #if ENABLE(FULLSCREEN_API)
 
-bool WebChromeClient::supportsFullScreenForElement(const Element& element, bool withKeyboard)
+bool WebChromeClient::supportsFullScreenForElement(const WebCore::Element& element, bool withKeyboard)
 {
     SEL selector = @selector(webView:supportsFullScreenForElement:withKeyboard:);
     if ([[m_webView UIDelegate] respondsToSelector:selector])
@@ -1022,7 +1021,7 @@ bool WebChromeClient::supportsFullScreenForElement(const Element& element, bool 
 }
 
 // FIXME: Remove this when rdar://144645925 is resolved.
-void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaElementEnums::VideoFullscreenMode, CompletionHandler<void(ExceptionOr<void>)>&& willEnterFullscreen, CompletionHandler<bool(bool)>&& didEnterFullscreen)
+void WebChromeClient::enterFullScreenForElement(WebCore::Element& element, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, CompletionHandler<void(WebCore::ExceptionOr<void>)>&& willEnterFullscreen, CompletionHandler<bool(bool)>&& didEnterFullscreen)
 {
     SEL selector = @selector(webView:enterFullScreenForElement:listener:);
     if ([[m_webView UIDelegate] respondsToSelector:selector]) {
@@ -1039,7 +1038,7 @@ void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaEleme
 #endif
 }
 
-void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandler<void()>&& completionHandler)
+void WebChromeClient::exitFullScreenForElement(WebCore::Element* element, CompletionHandler<void()>&& completionHandler)
 {
     SEL selector = @selector(webView:exitFullScreenForElement:listener:);
     if ([[m_webView UIDelegate] respondsToSelector:selector]) {
@@ -1072,22 +1071,22 @@ bool WebChromeClient::hasRelevantSelectionServices(bool isTextOnly) const
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
 
-void WebChromeClient::addPlaybackTargetPickerClient(PlaybackTargetClientContextIdentifier contextId)
+void WebChromeClient::addPlaybackTargetPickerClient(WebCore::PlaybackTargetClientContextIdentifier contextId)
 {
     [m_webView _addPlaybackTargetPickerClient:contextId];
 }
 
-void WebChromeClient::removePlaybackTargetPickerClient(PlaybackTargetClientContextIdentifier contextId)
+void WebChromeClient::removePlaybackTargetPickerClient(WebCore::PlaybackTargetClientContextIdentifier contextId)
 {
     [m_webView _removePlaybackTargetPickerClient:contextId];
 }
 
-void WebChromeClient::showPlaybackTargetPicker(PlaybackTargetClientContextIdentifier contextId, const WebCore::IntPoint& location, bool hasVideo)
+void WebChromeClient::showPlaybackTargetPicker(WebCore::PlaybackTargetClientContextIdentifier contextId, const WebCore::IntPoint& location, bool hasVideo)
 {
     [m_webView _showPlaybackTargetPicker:contextId location:location hasVideo:hasVideo];
 }
 
-void WebChromeClient::playbackTargetPickerClientStateDidChange(PlaybackTargetClientContextIdentifier contextId, MediaProducerMediaStateFlags state)
+void WebChromeClient::playbackTargetPickerClientStateDidChange(WebCore::PlaybackTargetClientContextIdentifier contextId, WebCore::MediaProducerMediaStateFlags state)
 {
     [m_webView _playbackTargetPickerClientStateDidChange:contextId state:state];
 }
@@ -1097,7 +1096,7 @@ void WebChromeClient::setMockMediaPlaybackTargetPickerEnabled(bool enabled)
     [m_webView _setMockMediaPlaybackTargetPickerEnabled:enabled];
 }
 
-void WebChromeClient::setMockMediaPlaybackTargetPickerState(const String& name, MediaPlaybackTargetMockState state)
+void WebChromeClient::setMockMediaPlaybackTargetPickerState(const String& name, WebCore::MediaPlaybackTargetMockState state)
 {
     [m_webView _setMockMediaPlaybackTargetPickerName:name.createNSString().get() state:state];
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -62,7 +62,6 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 
-using namespace WebCore;
 
 @interface NSApplication ()
 - (BOOL)isSpeaking;
@@ -94,12 +93,12 @@ void WebContextMenuClient::downloadURL(const URL& url)
     [m_webView _downloadURL:url.createNSURL().get()];
 }
 
-void WebContextMenuClient::searchWithGoogle(const LocalFrame*)
+void WebContextMenuClient::searchWithGoogle(const WebCore::LocalFrame*)
 {
     [m_webView _searchWithGoogleFromMenu:nil];
 }
 
-void WebContextMenuClient::lookUpInDictionary(LocalFrame* frame)
+void WebContextMenuClient::lookUpInDictionary(WebCore::LocalFrame* frame)
 {
     WebHTMLView* htmlView = (WebHTMLView*)[[kit(frame) frameView] documentView];
     if(![htmlView isKindOfClass:[WebHTMLView class]])
@@ -122,21 +121,21 @@ void WebContextMenuClient::stopSpeaking()
     [NSApp stopSpeaking:nil];
 }
 
-bool WebContextMenuClient::clientFloatRectForNode(Node& node, FloatRect& rect) const
+bool WebContextMenuClient::clientFloatRectForNode(WebCore::Node& node, WebCore::FloatRect& rect) const
 {
-    RenderObject* renderer = node.renderer();
+    WebCore::RenderObject* renderer = node.renderer();
     if (!renderer) {
         // This method shouldn't be called in cases where the controlled node hasn't rendered.
         ASSERT_NOT_REACHED();
         return false;
     }
 
-    if (!is<RenderBox>(*renderer))
+    if (!is<WebCore::RenderBox>(*renderer))
         return false;
-    auto& renderBox = downcast<RenderBox>(*renderer);
+    auto& renderBox = downcast<WebCore::RenderBox>(*renderer);
 
-    LayoutRect layoutRect = renderBox.clientBoxRect();
-    FloatQuad floatQuad = renderBox.localToAbsoluteQuad(FloatQuad(layoutRect));
+    WebCore::LayoutRect layoutRect = renderBox.clientBoxRect();
+    WebCore::FloatQuad floatQuad = renderBox.localToAbsoluteQuad(WebCore::FloatQuad(layoutRect));
     rect = floatQuad.boundingBox();
 
     return true;
@@ -144,7 +143,7 @@ bool WebContextMenuClient::clientFloatRectForNode(Node& node, FloatRect& rect) c
 
 #if HAVE(TRANSLATION_UI_SERVICES)
 
-void WebContextMenuClient::handleTranslation(const TranslationContextMenuInfo& info)
+void WebContextMenuClient::handleTranslation(const WebCore::TranslationContextMenuInfo& info)
 {
     [m_webView _handleContextMenuTranslation:info];
 }
@@ -160,11 +159,11 @@ void WebContextMenuClient::sharingServicePickerWillBeDestroyed(WebSharingService
 
 WebCore::FloatRect WebContextMenuClient::screenRectForCurrentSharingServicePickerItem(WebSharingServicePickerController &)
 {
-    Page* page = [m_webView page];
+    WebCore::Page* page = [m_webView page];
     if (!page)
         return NSZeroRect;
 
-    Node* node = page->contextMenuController().context().hitTestResult().innerNode();
+    WebCore::Node* node = page->contextMenuController().context().hitTestResult().innerNode();
     if (!node)
         return NSZeroRect;
 
@@ -175,14 +174,14 @@ WebCore::FloatRect WebContextMenuClient::screenRectForCurrentSharingServicePicke
         return NSZeroRect;
     }
 
-    FloatRect rect;
+    WebCore::FloatRect rect;
     if (!clientFloatRectForNode(*node, rect))
         return NSZeroRect;
 
     // FIXME: https://webkit.org/b/132915
     // Ideally we'd like to convert the content rect to screen coordinates without the lossy float -> int conversion.
     // Creating a rounded int rect works well in practice, but might still lead to off-by-one-pixel problems in edge cases.
-    IntRect intRect = roundedIntRect(rect);
+    WebCore::IntRect intRect = roundedIntRect(rect);
     return frameView->contentsToScreen(intRect);
 }
 
@@ -203,22 +202,22 @@ RetainPtr<NSImage> WebContextMenuClient::imageForCurrentSharingServicePickerItem
         return nil;
     }
 
-    FloatRect rect;
+    WebCore::FloatRect rect;
     if (!clientFloatRectForNode(*node, rect))
         return nil;
 
     // This is effectively a snapshot, and will be painted in an unaccelerated fashion in line with FrameSnapshotting.
-    auto buffer = ImageBuffer::create(rect.size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    auto buffer = WebCore::ImageBuffer::create(rect.size(), WebCore::RenderingMode::Unaccelerated, WebCore::RenderingPurpose::Unspecified, 1, WebCore::DestinationColorSpace::SRGB(), WebCore::PixelFormat::BGRA8);
     if (!buffer)
         return nil;
 
     Ref localFrame = frameView->frame();
 
     auto oldSelection = localFrame->selection().selection();
-    localFrame->selection().setSelection(*makeRangeSelectingNode(*node), FrameSelection::SetSelectionOption::DoNotSetFocus);
+    localFrame->selection().setSelection(*makeRangeSelectingNode(*node), WebCore::FrameSelection::SetSelectionOption::DoNotSetFocus);
 
     auto oldPaintBehavior = frameView->paintBehavior();
-    frameView->setPaintBehavior(PaintBehavior::SelectionOnly);
+    frameView->setPaintBehavior(WebCore::PaintBehavior::SelectionOnly);
 
     buffer->context().translate(-toFloatSize(rect.location()));
     frameView->paintContents(buffer->context(), roundedIntRect(rect));
@@ -226,7 +225,7 @@ RetainPtr<NSImage> WebContextMenuClient::imageForCurrentSharingServicePickerItem
     localFrame->selection().setSelection(oldSelection);
     frameView->setPaintBehavior(oldPaintBehavior);
 
-    auto image = BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTF::move(buffer)));
+    auto image = WebCore::BitmapImage::create(WebCore::ImageBuffer::sinkIntoNativeImage(WTF::move(buffer)));
     if (!image)
         return nil;
 
@@ -239,12 +238,12 @@ NSMenu *WebContextMenuClient::contextMenuForEvent(NSEvent *event, NSView *view, 
 {
     isServicesMenu = false;
 
-    Page* page = [m_webView page];
+    WebCore::Page* page = [m_webView page];
     if (!page)
         return nil;
 
 #if ENABLE(SERVICE_CONTROLS)
-    if (Image* image = page->contextMenuController().context().controlledImage()) {
+    if (WebCore::Image* image = page->contextMenuController().context().controlledImage()) {
         ASSERT(page->contextMenuController().context().hitTestResult().innerNode());
 
         // FIXME: <rdar://165255055> Migrate from deprecated NSItemProvider APIs
@@ -276,7 +275,7 @@ void WebContextMenuClient::showContextMenu()
         return;
 
     RetainPtr view = frameView->documentView();
-    IntPoint point = frameView->contentsToWindow(page->contextMenuController().hitTestResult().roundedPointInInnerNodeFrame());
+    WebCore::IntPoint point = frameView->contentsToWindow(page->contextMenuController().hitTestResult().roundedPointInInnerNodeFrame());
     NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown location:point modifierFlags:0 timestamp:0 windowNumber:[[view.get() window] windowNumber] context:0 eventNumber:0 clickCount:1 pressure:1];
 
     // Show the contextual menu for this event.

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -66,7 +66,6 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
-using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDragClient);
 
@@ -117,7 +116,7 @@ void WebDragClient::didConcludeEditDrag()
 {
 }
 
-static WebHTMLView *getTopHTMLView(LocalFrame* frame)
+static WebHTMLView *getTopHTMLView(WebCore::LocalFrame* frame)
 {
     ASSERT(frame);
     ASSERT(frame->page());
@@ -130,7 +129,7 @@ void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAct
 }
 
 
-OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const IntPoint& rootViewPoint)
+OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const WebCore::IntPoint& rootViewPoint)
 {
     NSPoint viewPoint = [m_webView _convertPointFromRootView:rootViewPoint];
     return coreDragSourceActionMask([[m_webView _UIDelegateForwarder] webView:m_webView dragSourceActionMaskForPoint:viewPoint]);
@@ -141,16 +140,16 @@ void WebDragClient::willPerformDragSourceAction(WebCore::DragSourceAction action
     [[m_webView _UIDelegateForwarder] webView:m_webView willPerformDragSourceAction:kit(action) fromPoint:mouseDownPoint withPasteboard:[NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()]];
 }
 
-void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Frame& frame, const std::optional<NodeIdentifier>& nodeID)
+void WebDragClient::startDrag(WebCore::DragItem dragItem, WebCore::DataTransfer& dataTransfer, WebCore::Frame& frame, const std::optional<WebCore::NodeIdentifier>& nodeID)
 {
     auto& dragImage = dragItem.image;
     auto dragLocationInContentCoordinates = dragItem.dragLocationInContentCoordinates;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+    auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frame);
     if (!localFrame)
         return;
 
-    RefPtr<LocalFrame> localMainFrame = localFrame->localMainFrame();
+    RefPtr<WebCore::LocalFrame> localMainFrame = localFrame->localMainFrame();
     if (!localMainFrame)
         return;
 
@@ -158,7 +157,7 @@ void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Fra
     if (![htmlView.get() isKindOfClass:[WebHTMLView class]])
         return;
     
-    RetainPtr event = (dragItem.sourceAction && *dragItem.sourceAction == DragSourceAction::Link) ? localMainFrame->eventHandler().currentNSEvent() : [htmlView.get() _mouseDownEvent];
+    RetainPtr event = (dragItem.sourceAction && *dragItem.sourceAction == WebCore::DragSourceAction::Link) ? localMainFrame->eventHandler().currentNSEvent() : [htmlView.get() _mouseDownEvent];
     RetainPtr topHTMLView = getTopHTMLView(localMainFrame);
     RetainPtr<WebHTMLView> topViewProtector = topHTMLView;
     
@@ -168,7 +167,7 @@ void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Fra
     RetainPtr dragNSImage = dragImage.get().unsafeGet();
     RetainPtr sourceHTMLView = htmlView.get();
 
-    IntSize size([dragNSImage.get() size]);
+    WebCore::IntSize size([dragNSImage.get() size]);
     size.scale(1 / localMainFrame->page()->deviceScaleFactor());
     [dragNSImage.get() setSize:size];
 
@@ -186,7 +185,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
-void WebDragClient::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoint& mouseDownPosition, const IntPoint& mouseDraggedPosition, DataTransfer& dataTransfer, DragSourceAction dragSourceAction)
+void WebDragClient::beginDrag(WebCore::DragItem dragItem, WebCore::LocalFrame& frame, const WebCore::IntPoint& mouseDownPosition, const WebCore::IntPoint& mouseDraggedPosition, WebCore::DataTransfer& dataTransfer, WebCore::DragSourceAction dragSourceAction)
 {
     ASSERT(!dataTransfer.pasteboard().hasData());
 
@@ -197,7 +196,7 @@ void WebDragClient::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoi
 
     auto draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:createPasteboardWriter(dragItem.data).get()]);
 
-    auto dragImageSize = IntSize { [dragItem.image.get() size] };
+    auto dragImageSize = WebCore::IntSize { [dragItem.image.get() size] };
 
     dragImageSize.scale(1 / frame.page()->deviceScaleFactor());
     [dragItem.image.get() setSize:dragImageSize];
@@ -210,7 +209,7 @@ void WebDragClient::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoi
     [topWebHTMLView.get() beginDraggingSessionWithItems:@[ draggingItem.get() ] event:event.get() source:topWebHTMLView.get()];
 }
 
-void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Element& element, const URL& url, const String& title, WebCore::LocalFrame* frame)
+void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, WebCore::Element& element, const URL& url, const String& title, WebCore::LocalFrame* frame)
 {
     ASSERT(pasteboardName);
     [[NSPasteboard pasteboardWithName:pasteboardName.createNSString().get()] _web_declareAndWriteDragImageForElement:kit(&element) URL:url.createNSURL().get() title:title.createNSString().get() archive:[kit(&element) webArchive] source:getTopHTMLView(frame)];
@@ -262,32 +261,32 @@ bool WebDragClient::useLegacyDragClient()
     return true;
 }
 
-void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const DragData&)
+void WebDragClient::willPerformDragDestinationAction(WebCore::DragDestinationAction, const WebCore::DragData&)
 {
 }
 
-OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const IntPoint&)
+OptionSet<WebCore::DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const WebCore::IntPoint&)
 {
     return WebCore::anyDragSourceAction();
 }
 
-void WebDragClient::willPerformDragSourceAction(WebCore::DragSourceAction, const IntPoint&, DataTransfer&)
+void WebDragClient::willPerformDragSourceAction(WebCore::DragSourceAction, const WebCore::IntPoint&, WebCore::DataTransfer&)
 {
 }
 
-void WebDragClient::startDrag(DragItem dragItem, DataTransfer&, Frame&, const std::optional<NodeIdentifier>&)
+void WebDragClient::startDrag(WebCore::DragItem dragItem, WebCore::DataTransfer&, WebCore::Frame&, const std::optional<WebCore::NodeIdentifier>&)
 {
     [m_webView _startDrag:dragItem];
 }
 
-void WebDragClient::beginDrag(DragItem, LocalFrame&, const IntPoint&, const IntPoint&, DataTransfer&, DragSourceAction)
+void WebDragClient::beginDrag(WebCore::DragItem, WebCore::LocalFrame&, const WebCore::IntPoint&, const WebCore::IntPoint&, WebCore::DataTransfer&, WebCore::DragSourceAction)
 {
 }
 
-void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Element& element, const URL& url, const String& label, LocalFrame*)
+void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, WebCore::Element& element, const URL& url, const String& label, WebCore::LocalFrame*)
 {
     if (RefPtr frame = element.document().frame())
-        frame->editor().writeImageToPasteboard(*Pasteboard::createForDragAndDrop(PagePasteboardContext::create(frame->pageID())), element, url, label);
+        frame->editor().writeImageToPasteboard(*WebCore::Pasteboard::createForDragAndDrop(WebCore::PagePasteboardContext::create(frame->pageID())), element, url, label);
 }
 
 void WebDragClient::didConcludeEditDrag()

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -102,9 +102,8 @@
 #import "WebUIKitDelegate.h"
 #endif
 
-using namespace WebCore;
 
-using namespace HTMLNames;
+using namespace WebCore::HTMLNames;
 
 // FIXME: Seems likely we can get rid of this legacy code for watchOS and tvOS.
 #if PLATFORM(WATCHOS) || PLATFORM(APPLETV)
@@ -113,25 +112,25 @@ using namespace HTMLNames;
 @end
 #endif
 
-static WebViewInsertAction NODELETE kit(EditorInsertAction action)
+static WebViewInsertAction NODELETE kit(WebCore::EditorInsertAction action)
 {
     switch (action) {
-    case EditorInsertAction::Typed:
+    case WebCore::EditorInsertAction::Typed:
         return WebViewInsertActionTyped;
-    case EditorInsertAction::Pasted:
+    case WebCore::EditorInsertAction::Pasted:
         return WebViewInsertActionPasted;
-    case EditorInsertAction::Dropped:
+    case WebCore::EditorInsertAction::Dropped:
         return WebViewInsertActionDropped;
     }
 }
 
 @interface WebUndoStep : NSObject
 {
-    RefPtr<UndoStep> m_step;   
+    RefPtr<WebCore::UndoStep> m_step;   
 }
 
-+ (WebUndoStep *)stepWithUndoStep:(Ref<UndoStep>&&)step;
-- (UndoStep&)step;
++ (WebUndoStep *)stepWithUndoStep:(Ref<WebCore::UndoStep>&&)step;
+- (WebCore::UndoStep&)step;
 
 @end
 
@@ -142,7 +141,7 @@ static WebViewInsertAction NODELETE kit(EditorInsertAction action)
     WebCore::initializeMainThreadIfNeeded();
 }
 
-- (id)initWithUndoStep:(Ref<UndoStep>&&)step
+- (id)initWithUndoStep:(Ref<WebCore::UndoStep>&&)step
 {
     self = [super init];
     if (!self)
@@ -159,12 +158,12 @@ static WebViewInsertAction NODELETE kit(EditorInsertAction action)
     [super dealloc];
 }
 
-+ (WebUndoStep *)stepWithUndoStep:(Ref<UndoStep>&&)step
++ (WebUndoStep *)stepWithUndoStep:(Ref<WebCore::UndoStep>&&)step
 {
     return adoptNS([[WebUndoStep alloc] initWithUndoStep:WTF::move(step)]).autorelease();
 }
 
-- (UndoStep&)step
+- (WebCore::UndoStep&)step
 {
     return *m_step;
 }
@@ -233,14 +232,14 @@ int WebEditorClient::spellCheckerDocumentTag()
 
 #endif
 
-bool WebEditorClient::shouldDeleteRange(const std::optional<SimpleRange>& range)
+bool WebEditorClient::shouldDeleteRange(const std::optional<WebCore::SimpleRange>& range)
 {
     return [[m_webView _editingDelegateForwarder] webView:m_webView shouldDeleteDOMRange:kit(range)];
 }
 
 bool WebEditorClient::smartInsertDeleteEnabled()
 {
-    Page* page = [m_webView page];
+    WebCore::Page* page = [m_webView page];
     if (!page)
         return false;
     return page->settings().smartInsertDeleteEnabled();
@@ -248,13 +247,13 @@ bool WebEditorClient::smartInsertDeleteEnabled()
 
 bool WebEditorClient::isSelectTrailingWhitespaceEnabled() const
 {
-    Page* page = [m_webView page];
+    WebCore::Page* page = [m_webView page];
     if (!page)
         return false;
     return page->settings().selectTrailingWhitespaceEnabled();
 }
 
-bool WebEditorClient::shouldApplyStyle(const StyleProperties& style, const std::optional<SimpleRange>& range)
+bool WebEditorClient::shouldApplyStyle(const WebCore::StyleProperties& style, const std::optional<WebCore::SimpleRange>& range)
 {
     return [[m_webView _editingDelegateForwarder] webView:m_webView
         shouldApplyStyle:kit(&style.mutableCopy()->ensureCSSStyleProperties())
@@ -277,29 +276,29 @@ void WebEditorClient::didApplyStyle()
     updateFontPanel(m_webView);
 }
 
-bool WebEditorClient::shouldMoveRangeAfterDelete(const SimpleRange& range, const SimpleRange& rangeToBeReplaced)
+bool WebEditorClient::shouldMoveRangeAfterDelete(const WebCore::SimpleRange& range, const WebCore::SimpleRange& rangeToBeReplaced)
 {
     return [[m_webView _editingDelegateForwarder] webView:m_webView
         shouldMoveRangeAfterDelete:kit(range) replacingRange:kit(rangeToBeReplaced)];
 }
 
-bool WebEditorClient::shouldBeginEditing(const SimpleRange& range)
+bool WebEditorClient::shouldBeginEditing(const WebCore::SimpleRange& range)
 {
     return [[m_webView _editingDelegateForwarder] webView:m_webView shouldBeginEditingInDOMRange:kit(range)];
 }
 
-bool WebEditorClient::shouldEndEditing(const SimpleRange& range)
+bool WebEditorClient::shouldEndEditing(const WebCore::SimpleRange& range)
 {
     return [[m_webView _editingDelegateForwarder] webView:m_webView shouldEndEditingInDOMRange:kit(range)];
 }
 
-bool WebEditorClient::shouldInsertText(const String& text, const std::optional<SimpleRange>& range, EditorInsertAction action)
+bool WebEditorClient::shouldInsertText(const String& text, const std::optional<WebCore::SimpleRange>& range, WebCore::EditorInsertAction action)
 {
     RetainPtr webView = m_webView;
     return [[webView.get() _editingDelegateForwarder] webView:webView.get() shouldInsertText:text.createNSString().get() replacingDOMRange:kit(range) givenAction:kit(action)];
 }
 
-bool WebEditorClient::shouldChangeSelectedRange(const std::optional<SimpleRange>& fromRange, const std::optional<SimpleRange>& toRange, Affinity selectionAffinity, bool stillSelecting)
+bool WebEditorClient::shouldChangeSelectedRange(const std::optional<WebCore::SimpleRange>& fromRange, const std::optional<WebCore::SimpleRange>& toRange, WebCore::Affinity selectionAffinity, bool stillSelecting)
 {
     return [m_webView _shouldChangeSelectedDOMRange:kit(fromRange) toDOMRange:kit(toRange) affinity:kit(selectionAffinity) stillSelecting:stillSelecting];
 }
@@ -346,7 +345,7 @@ void WebEditorClient::respondToChangedContents()
 #endif
 }
 
-void WebEditorClient::respondToChangedSelection(LocalFrame* frame)
+void WebEditorClient::respondToChangedSelection(WebCore::LocalFrame* frame)
 {
     if (!frame || frame->editor().isGettingDictionaryPopupInfo())
         return;
@@ -379,7 +378,7 @@ void WebEditorClient::respondToChangedSelection(LocalFrame* frame)
 
         if (m_lastSelectionWasPainted || selectionIsPainted) {
             if (auto* page = frame->page())
-                page->scheduleRenderingUpdate({ RenderingUpdateStep::LayerFlush });
+                page->scheduleRenderingUpdate({ WebCore::RenderingUpdateStep::LayerFlush });
         }
 
         m_lastSelectionWasPainted = selectionIsPainted;
@@ -387,7 +386,7 @@ void WebEditorClient::respondToChangedSelection(LocalFrame* frame)
 #endif // ENABLE(TEXT_CARET)
 }
 
-void WebEditorClient::discardedComposition(const Document&)
+void WebEditorClient::discardedComposition(const WebCore::Document&)
 {
     // The effects of this function are currently achieved via -[WebHTMLView _updateSelectionForInputManager].
 }
@@ -415,12 +414,12 @@ void WebEditorClient::didWriteSelectionToPasteboard()
 #endif
 }
 
-void WebEditorClient::willWriteSelectionToPasteboard(const std::optional<SimpleRange>&)
+void WebEditorClient::willWriteSelectionToPasteboard(const std::optional<WebCore::SimpleRange>&)
 {
     // Not implemented WebKit, only WebKit2.
 }
 
-void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>&, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData)
+void WebEditorClient::getClientPasteboardData(const std::optional<WebCore::SimpleRange>&, Vector<std::pair<String, RefPtr<WebCore::SharedBuffer>>>& pasteboardTypesAndData)
 {
     // Not implemented WebKit, only WebKit2.
 }
@@ -431,7 +430,7 @@ void WebEditorClient::getClientPasteboardData(const std::optional<SimpleRange>&,
 // FIXME: Remove both this stub and the real version of this function below once we don't need the real version on any supported platform.
 // This stub is not used outside WebKit, but it's here so we won't get a linker error.
 __attribute__((__noreturn__))
-void _WebCreateFragment(Document&, NSAttributedString *, FragmentAndResources&)
+void _WebCreateFragment(WebCore::Document&, NSAttributedString *, WebCore::FragmentAndResources&)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -457,14 +456,14 @@ static NSDictionary *attributesForAttributedStringConversion()
         nil]);
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    if (!DeprecatedGlobalSettings::attachmentElementEnabled())
+    if (!WebCore::DeprecatedGlobalSettings::attachmentElementEnabled())
         [excludedElements addObject:@"object"];
 #endif
 
     return @{ NSExcludedElementsDocumentAttribute: excludedElements.get() };
 }
 
-void _WebCreateFragment(Document& document, NSAttributedString *string, FragmentAndResources& result)
+void _WebCreateFragment(WebCore::Document& document, NSAttributedString *string, WebCore::FragmentAndResources& result)
 {
     static NeverDestroyed<RetainPtr<NSDictionary>> documentAttributes = attributesForAttributedStringConversion();
     NSArray *subresources;
@@ -609,12 +608,12 @@ void WebEditorClient::toggleSmartLists()
 
 #endif // USE(AUTOMATIC_TEXT_REPLACEMENT)
 
-bool WebEditorClient::shouldInsertNode(Node& node, const std::optional<SimpleRange>& replacingRange, EditorInsertAction givenAction)
+bool WebEditorClient::shouldInsertNode(WebCore::Node& node, const std::optional<WebCore::SimpleRange>& replacingRange, WebCore::EditorInsertAction givenAction)
 { 
     return [[m_webView _editingDelegateForwarder] webView:m_webView shouldInsertNode:kit(&node) replacingDOMRange:kit(replacingRange) givenAction:(WebViewInsertAction)givenAction];
 }
 
-void WebEditorClient::registerUndoOrRedoStep(UndoStep& step, bool isRedo)
+void WebEditorClient::registerUndoOrRedoStep(WebCore::UndoStep& step, bool isRedo)
 {
     NSUndoManager *undoManager = [m_webView undoManager];
 
@@ -653,12 +652,12 @@ void WebEditorClient::updateEditorStateAfterLayoutIfEditabilityChanged()
         [m_webView updateTouchBar];
 }
 
-void WebEditorClient::registerUndoStep(UndoStep& command)
+void WebEditorClient::registerUndoStep(WebCore::UndoStep& command)
 {
     registerUndoOrRedoStep(command, false);
 }
 
-void WebEditorClient::registerRedoStep(UndoStep& command)
+void WebEditorClient::registerRedoStep(WebCore::UndoStep& command)
 {
     registerUndoOrRedoStep(command, true);
 }
@@ -683,12 +682,12 @@ void WebEditorClient::clearUndoRedoOperations()
     }    
 }
 
-bool WebEditorClient::canCopyCut(LocalFrame*, bool defaultValue) const
+bool WebEditorClient::canCopyCut(WebCore::LocalFrame*, bool defaultValue) const
 {
     return defaultValue;
 }
 
-bool WebEditorClient::canPaste(LocalFrame*, bool defaultValue) const
+bool WebEditorClient::canPaste(WebCore::LocalFrame*, bool defaultValue) const
 {
     return defaultValue;
 }
@@ -715,9 +714,9 @@ void WebEditorClient::redo()
         [[m_webView undoManager] redo];    
 }
 
-void WebEditorClient::handleKeyboardEvent(KeyboardEvent& event)
+void WebEditorClient::handleKeyboardEvent(WebCore::KeyboardEvent& event)
 {
-    auto* frame = downcast<Node>(event.target())->document().frame();
+    auto* frame = downcast<WebCore::Node>(event.target())->document().frame();
 #if !PLATFORM(IOS_FAMILY)
     WebHTMLView *webHTMLView = (WebHTMLView *)[[kit(frame) frameView] documentView];
     if ([webHTMLView _interpretKeyEvent:&event savingCommands:NO])
@@ -729,11 +728,11 @@ void WebEditorClient::handleKeyboardEvent(KeyboardEvent& event)
 #endif
 }
 
-void WebEditorClient::handleInputMethodKeydown(KeyboardEvent& event)
+void WebEditorClient::handleInputMethodKeydown(WebCore::KeyboardEvent& event)
 {
 #if !PLATFORM(IOS_FAMILY)
     // FIXME: Switch to WebKit2 model, interpreting the event before it's sent down to WebCore.
-    auto* frame = downcast<Node>(event.target())->document().frame();
+    auto* frame = downcast<WebCore::Node>(event.target())->document().frame();
     WebHTMLView *webHTMLView = (WebHTMLView *)[[kit(frame) frameView] documentView];
     if ([webHTMLView _interpretKeyEvent:&event savingCommands:YES])
         event.setDefaultHandled();
@@ -745,7 +744,7 @@ void WebEditorClient::handleInputMethodKeydown(KeyboardEvent& event)
 #define FormDelegateLog(ctrl)  LOG(FormDelegate, "control=%@", ctrl)
 
 template <typename T>
-static DOMElement *dynamicDowncastToKit(Element& element)
+static DOMElement *dynamicDowncastToKit(WebCore::Element& element)
 {
     auto* coreInputElement = dynamicDowncast<T>(element);
     if (!coreInputElement)
@@ -754,9 +753,9 @@ static DOMElement *dynamicDowncastToKit(Element& element)
     return kit(coreInputElement);
 }
 
-void WebEditorClient::textFieldDidBeginEditing(Element& element)
+void WebEditorClient::textFieldDidBeginEditing(WebCore::Element& element)
 {
-    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<WebCore::HTMLInputElement>(element);
     if (!inputElement)
         return;
 
@@ -764,9 +763,9 @@ void WebEditorClient::textFieldDidBeginEditing(Element& element)
     CallFormDelegate(m_webView, @selector(textFieldDidBeginEditing:inFrame:), inputElement.get(), kit(element.document().frame()));
 }
 
-void WebEditorClient::textFieldDidEndEditing(Element& element)
+void WebEditorClient::textFieldDidEndEditing(WebCore::Element& element)
 {
-    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<WebCore::HTMLInputElement>(element);
     if (!inputElement)
         return;
 
@@ -774,14 +773,14 @@ void WebEditorClient::textFieldDidEndEditing(Element& element)
     CallFormDelegate(m_webView, @selector(textFieldDidEndEditing:inFrame:), inputElement.get(), kit(element.document().frame()));
 }
 
-void WebEditorClient::textDidChangeInTextField(Element& element)
+void WebEditorClient::textDidChangeInTextField(WebCore::Element& element)
 {
-    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<WebCore::HTMLInputElement>(element);
     if (!inputElement)
         return;
 
 #if !PLATFORM(IOS_FAMILY)
-    if (!UserTypingGestureIndicator::processingUserTypingGesture() || UserTypingGestureIndicator::focusedElementAtGestureStart() != &element)
+    if (!WebCore::UserTypingGestureIndicator::processingUserTypingGesture() || WebCore::UserTypingGestureIndicator::focusedElementAtGestureStart() != &element)
         return;
 #endif
 
@@ -789,7 +788,7 @@ void WebEditorClient::textDidChangeInTextField(Element& element)
     CallFormDelegate(m_webView, @selector(textDidChangeInTextField:inFrame:), inputElement.get(), kit(element.document().frame()));
 }
 
-static SEL selectorForKeyEvent(KeyboardEvent* event)
+static SEL selectorForKeyEvent(WebCore::KeyboardEvent* event)
 {
     // FIXME: This helper function is for the auto-fill code so we can pass a selector to the form delegate.  
     // Eventually, we should move all of the auto-fill code down to WebKit and remove the need for this function by
@@ -814,9 +813,9 @@ IGNORE_WARNINGS_END
     return 0;
 }
 
-bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEvent* event)
+bool WebEditorClient::doTextFieldCommandFromEvent(WebCore::Element& element, WebCore::KeyboardEvent* event)
 {
-    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<WebCore::HTMLInputElement>(element);
     if (!inputElement)
         return NO;
 
@@ -826,9 +825,9 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEven
     return NO;
 }
 
-void WebEditorClient::textWillBeDeletedInTextField(Element& element)
+void WebEditorClient::textWillBeDeletedInTextField(WebCore::Element& element)
 {
-    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<WebCore::HTMLInputElement>(element);
     if (!inputElement)
         return;
 
@@ -837,9 +836,9 @@ void WebEditorClient::textWillBeDeletedInTextField(Element& element)
     CallFormDelegateReturningBoolean(NO, m_webView, @selector(textField:doCommandBySelector:inFrame:), inputElement.get(), @selector(deleteBackward:), kit(element.document().frame()));
 }
 
-void WebEditorClient::textDidChangeInTextArea(Element& element)
+void WebEditorClient::textDidChangeInTextArea(WebCore::Element& element)
 {
-    RetainPtr textAreaElement = dynamicDowncastToKit<HTMLTextAreaElement>(element);
+    RetainPtr textAreaElement = dynamicDowncastToKit<WebCore::HTMLTextAreaElement>(element);
     if (!textAreaElement)
         return;
 
@@ -898,7 +897,7 @@ bool WebEditorClient::performsTwoStepPaste(WebCore::DocumentFragment* fragment)
     return false;
 }
 
-bool WebEditorClient::performTwoStepDrop(DocumentFragment& fragment, const SimpleRange& destination, bool isMove)
+bool WebEditorClient::performTwoStepDrop(WebCore::DocumentFragment& fragment, const WebCore::SimpleRange& destination, bool isMove)
 {
     if ([[m_webView _UIKitDelegateForwarder] respondsToSelector:@selector(performTwoStepDrop:atDestination:isMove:)])
         return [[m_webView _UIKitDelegateForwarder] performTwoStepDrop:kit(&fragment) atDestination:kit(destination) isMove:isMove];
@@ -906,18 +905,18 @@ bool WebEditorClient::performTwoStepDrop(DocumentFragment& fragment, const Simpl
     return false;
 }
 
-Vector<TextCheckingResult> WebEditorClient::checkTextOfParagraph(StringView string, OptionSet<TextCheckingType> checkingTypes, const VisibleSelection&)
+Vector<WebCore::TextCheckingResult> WebEditorClient::checkTextOfParagraph(StringView string, OptionSet<WebCore::TextCheckingType> checkingTypes, const WebCore::VisibleSelection&)
 {
-    ASSERT(checkingTypes.contains(TextCheckingType::Spelling));
+    ASSERT(checkingTypes.contains(WebCore::TextCheckingType::Spelling));
 
-    Vector<TextCheckingResult> results;
+    Vector<WebCore::TextCheckingResult> results;
 
     NSArray *incomingResults = [[m_webView _UIKitDelegateForwarder] checkSpellingOfString:string.createNSStringWithoutCopying().get()];
     for (NSValue *incomingResult in incomingResults) {
         ASSERT(incomingResult.rangeValue.location != NSNotFound);
         ASSERT(incomingResult.rangeValue.length > 0);
-        TextCheckingResult result;
-        result.type = TextCheckingType::Spelling;
+        WebCore::TextCheckingResult result;
+        result.type = WebCore::TextCheckingType::Spelling;
         result.range = incomingResult.rangeValue;
         results.append(result);
     }
@@ -929,15 +928,15 @@ Vector<TextCheckingResult> WebEditorClient::checkTextOfParagraph(StringView stri
 
 #if !PLATFORM(IOS_FAMILY)
 
-bool WebEditorClient::performTwoStepDrop(DocumentFragment&, const SimpleRange&, bool)
+bool WebEditorClient::performTwoStepDrop(WebCore::DocumentFragment&, const WebCore::SimpleRange&, bool)
 {
     return false;
 }
 
-bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(TextCheckingType type) const
+bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(WebCore::TextCheckingType type) const
 {
     // This prevents erasing spelling markers on OS X Lion or later to match AppKit on these Mac OS X versions.
-    return type != TextCheckingType::Spelling;
+    return type != WebCore::TextCheckingType::Spelling;
 }
 
 void WebEditorClient::ignoreWordInSpellDocument(const String& text)
@@ -966,7 +965,7 @@ void WebEditorClient::checkSpellingOfString(StringView text, int* misspellingLoc
         *misspellingLength = range.length;
 }
 
-void WebEditorClient::checkGrammarOfString(StringView text, Vector<GrammarDetail>& details, int* badGrammarLocation, int* badGrammarLength)
+void WebEditorClient::checkGrammarOfString(StringView text, Vector<WebCore::GrammarDetail>& details, int* badGrammarLocation, int* badGrammarLength)
 {
     NSArray *grammarDetails;
     NSRange range = [[NSSpellChecker sharedSpellChecker] checkGrammarOfString:text.createNSStringWithoutCopying().get() startingAt:0 language:nil wrap:NO inSpellDocumentWithTag:spellCheckerDocumentTag() details:&grammarDetails];
@@ -977,7 +976,7 @@ void WebEditorClient::checkGrammarOfString(StringView text, Vector<GrammarDetail
         *badGrammarLength = range.length;
     for (NSDictionary *detail in grammarDetails) {
         ASSERT(detail);
-        GrammarDetail grammarDetail;
+        WebCore::GrammarDetail grammarDetail;
         NSValue *detailRangeAsNSValue = [detail objectForKey:NSGrammarRange];
         ASSERT(detailRangeAsNSValue);
         ASSERT(detailRangeAsNSValue.rangeValue.location != NSNotFound);
@@ -991,28 +990,28 @@ void WebEditorClient::checkGrammarOfString(StringView text, Vector<GrammarDetail
     }
 }
 
-static Vector<TextCheckingResult> core(NSArray *incomingResults, OptionSet<TextCheckingType> checkingTypes)
+static Vector<WebCore::TextCheckingResult> core(NSArray *incomingResults, OptionSet<WebCore::TextCheckingType> checkingTypes)
 {
-    Vector<TextCheckingResult> results;
+    Vector<WebCore::TextCheckingResult> results;
 
     for (NSTextCheckingResult *incomingResult in incomingResults) {
         NSTextCheckingType resultType = [incomingResult resultType];
         ASSERT(incomingResult.range.location != NSNotFound);
         ASSERT(incomingResult.range.length > 0);
         auto resultRange = incomingResult.range;
-        if (resultType == NSTextCheckingTypeSpelling && checkingTypes.contains(TextCheckingType::Spelling)) {
-            TextCheckingResult result;
-            result.type = TextCheckingType::Spelling;
+        if (resultType == NSTextCheckingTypeSpelling && checkingTypes.contains(WebCore::TextCheckingType::Spelling)) {
+            WebCore::TextCheckingResult result;
+            result.type = WebCore::TextCheckingType::Spelling;
             result.range = resultRange;
             results.append(result);
-        } else if (resultType == NSTextCheckingTypeGrammar && checkingTypes.contains(TextCheckingType::Grammar)) {
-            TextCheckingResult result;
+        } else if (resultType == NSTextCheckingTypeGrammar && checkingTypes.contains(WebCore::TextCheckingType::Grammar)) {
+            WebCore::TextCheckingResult result;
             NSArray *details = [incomingResult grammarDetails];
-            result.type = TextCheckingType::Grammar;
+            result.type = WebCore::TextCheckingType::Grammar;
             result.range = resultRange;
             for (NSDictionary *incomingDetail in details) {
                 ASSERT(incomingDetail);
-                GrammarDetail detail;
+                WebCore::GrammarDetail detail;
                 NSValue *detailRangeAsNSValue = [incomingDetail objectForKey:NSGrammarRange];
                 ASSERT(detailRangeAsNSValue);
                 NSRange detailNSRange = [detailRangeAsNSValue rangeValue];
@@ -1027,33 +1026,33 @@ static Vector<TextCheckingResult> core(NSArray *incomingResults, OptionSet<TextC
                 result.details.append(detail);
             }
             results.append(result);
-        } else if (resultType == NSTextCheckingTypeLink && checkingTypes.contains(TextCheckingType::Link)) {
-            TextCheckingResult result;
-            result.type = TextCheckingType::Link;
+        } else if (resultType == NSTextCheckingTypeLink && checkingTypes.contains(WebCore::TextCheckingType::Link)) {
+            WebCore::TextCheckingResult result;
+            result.type = WebCore::TextCheckingType::Link;
             result.range = resultRange;
             result.replacement = [[incomingResult URL] absoluteString];
             results.append(result);
-        } else if (resultType == NSTextCheckingTypeQuote && checkingTypes.contains(TextCheckingType::Quote)) {
-            TextCheckingResult result;
-            result.type = TextCheckingType::Quote;
+        } else if (resultType == NSTextCheckingTypeQuote && checkingTypes.contains(WebCore::TextCheckingType::Quote)) {
+            WebCore::TextCheckingResult result;
+            result.type = WebCore::TextCheckingType::Quote;
             result.range = resultRange;
             result.replacement = [incomingResult replacementString];
             results.append(result);
-        } else if (resultType == NSTextCheckingTypeDash && checkingTypes.contains(TextCheckingType::Dash)) {
-            TextCheckingResult result;
-            result.type = TextCheckingType::Dash;
+        } else if (resultType == NSTextCheckingTypeDash && checkingTypes.contains(WebCore::TextCheckingType::Dash)) {
+            WebCore::TextCheckingResult result;
+            result.type = WebCore::TextCheckingType::Dash;
             result.range = resultRange;
             result.replacement = [incomingResult replacementString];
             results.append(result);
-        } else if (resultType == NSTextCheckingTypeReplacement && checkingTypes.contains(TextCheckingType::Replacement)) {
-            TextCheckingResult result;
-            result.type = TextCheckingType::Replacement;
+        } else if (resultType == NSTextCheckingTypeReplacement && checkingTypes.contains(WebCore::TextCheckingType::Replacement)) {
+            WebCore::TextCheckingResult result;
+            result.type = WebCore::TextCheckingType::Replacement;
             result.range = resultRange;
             result.replacement = [incomingResult replacementString];
             results.append(result);
-        } else if (resultType == NSTextCheckingTypeCorrection && checkingTypes.contains(TextCheckingType::Correction)) {
-            TextCheckingResult result;
-            result.type = TextCheckingType::Correction;
+        } else if (resultType == NSTextCheckingTypeCorrection && checkingTypes.contains(WebCore::TextCheckingType::Correction)) {
+            WebCore::TextCheckingResult result;
+            result.type = WebCore::TextCheckingType::Correction;
             result.range = resultRange;
             result.replacement = [incomingResult replacementString];
             results.append(result);
@@ -1063,7 +1062,7 @@ static Vector<TextCheckingResult> core(NSArray *incomingResults, OptionSet<TextC
     return results;
 }
 
-static NSUInteger insertionPointFromCurrentSelection(const VisibleSelection& selection)
+static NSUInteger insertionPointFromCurrentSelection(const WebCore::VisibleSelection& selection)
 {
     auto selectionStart = selection.visibleStart();
     auto range = makeSimpleRange(startOfParagraph(selectionStart), selectionStart);
@@ -1072,13 +1071,13 @@ static NSUInteger insertionPointFromCurrentSelection(const VisibleSelection& sel
     return characterCount(*range);
 }
 
-Vector<TextCheckingResult> WebEditorClient::checkTextOfParagraph(StringView string, OptionSet<TextCheckingType> coreCheckingTypes, const VisibleSelection& currentSelection)
+Vector<WebCore::TextCheckingResult> WebEditorClient::checkTextOfParagraph(StringView string, OptionSet<WebCore::TextCheckingType> coreCheckingTypes, const WebCore::VisibleSelection& currentSelection)
 {
     NSDictionary *options = @{ NSTextCheckingInsertionPointKey : @(insertionPointFromCurrentSelection(currentSelection)) };
     return core([[NSSpellChecker sharedSpellChecker] checkString:string.createNSStringWithoutCopying().get() range:NSMakeRange(0, string.length()) types:(nsTextCheckingTypes(coreCheckingTypes) | NSTextCheckingTypeOrthography) options:options inSpellDocumentWithTag:spellCheckerDocumentTag() orthography:NULL wordCount:NULL], coreCheckingTypes);
 }
 
-void WebEditorClient::updateSpellingUIWithGrammarString(const String& badGrammarPhrase, const GrammarDetail& grammarDetail)
+void WebEditorClient::updateSpellingUIWithGrammarString(const String& badGrammarPhrase, const WebCore::GrammarDetail& grammarDetail)
 {
     RetainPtr dictionary = @{
         NSGrammarRange: [NSValue valueWithRange:grammarDetail.range],
@@ -1132,7 +1131,7 @@ void WebEditorClient::setInputMethodState(WebCore::Element*)
 
 #if PLATFORM(MAC)
 
-void WebEditorClient::requestCandidatesForSelection(const VisibleSelection& selection)
+void WebEditorClient::requestCandidatesForSelection(const WebCore::VisibleSelection& selection)
 {
     if (![m_webView shouldRequestCandidates])
         return;
@@ -1178,7 +1177,7 @@ void WebEditorClient::handleRequestedCandidates(NSInteger sequenceNumber, NSArra
     if (!frame)
         return;
 
-    const VisibleSelection& selection = frame->selection().selection();
+    const WebCore::VisibleSelection& selection = frame->selection().selection();
     if (selection != m_lastSelectionForRequestedCandidates)
         return;
 
@@ -1186,8 +1185,8 @@ void WebEditorClient::handleRequestedCandidates(NSInteger sequenceNumber, NSArra
     if (!selectedRange)
         return;
 
-    IntRect rectForSelectionCandidates;
-    auto quads = RenderObject::absoluteTextQuads(*selectedRange);
+    WebCore::IntRect rectForSelectionCandidates;
+    auto quads = WebCore::RenderObject::absoluteTextQuads(*selectedRange);
     if (!quads.isEmpty())
         rectForSelectionCandidates = frame->view()->contentsToWindow(quads[0].enclosingBoundingBox());
     else {
@@ -1199,13 +1198,13 @@ void WebEditorClient::handleRequestedCandidates(NSInteger sequenceNumber, NSArra
     [m_webView showCandidates:candidates forString:m_paragraphContextForCandidateRequest.get() inRect:rectForSelectionCandidates forSelectedRange:m_rangeForCandidates view:m_webView completionHandler:nil];
 }
 
-void WebEditorClient::handleAcceptedCandidateWithSoftSpaces(TextCheckingResult acceptedCandidate)
+void WebEditorClient::handleAcceptedCandidateWithSoftSpaces(WebCore::TextCheckingResult acceptedCandidate)
 {
     auto* frame = core([m_webView _selectedOrMainFrame]);
     if (!frame)
         return;
 
-    const VisibleSelection& selection = frame->selection().selection();
+    const WebCore::VisibleSelection& selection = frame->selection().selection();
     if (selection != m_lastSelectionForRequestedCandidates)
         return;
 
@@ -1230,15 +1229,15 @@ void WebEditorClient::handleAcceptedCandidateWithSoftSpaces(TextCheckingResult a
 @interface WebEditorSpellCheckResponder : NSObject
 {
     WeakPtr<WebEditorClient> _client;
-    Markable<TextCheckingRequestIdentifier> _identifier;
+    Markable<WebCore::TextCheckingRequestIdentifier> _identifier;
     RetainPtr<NSArray> _results;
 }
-- (id)initWithClient:(WeakPtr<WebEditorClient>)client identifier:(TextCheckingRequestIdentifier)identifier results:(NSArray *)results;
+- (id)initWithClient:(WeakPtr<WebEditorClient>)client identifier:(WebCore::TextCheckingRequestIdentifier)identifier results:(NSArray *)results;
 - (void)perform;
 @end
 
 @implementation WebEditorSpellCheckResponder
-- (id)initWithClient:(WeakPtr<WebEditorClient>)client identifier:(TextCheckingRequestIdentifier)identifier results:(NSArray *)results
+- (id)initWithClient:(WeakPtr<WebEditorClient>)client identifier:(WebCore::TextCheckingRequestIdentifier)identifier results:(NSArray *)results
 {
     self = [super init];
     if (!self)
@@ -1257,7 +1256,7 @@ void WebEditorClient::handleAcceptedCandidateWithSoftSpaces(TextCheckingResult a
 
 @end
 
-void WebEditorClient::didCheckSucceed(TextCheckingRequestIdentifier identifier, NSArray *results)
+void WebEditorClient::didCheckSucceed(WebCore::TextCheckingRequestIdentifier identifier, NSArray *results)
 {
     auto request = m_requestsInFlight.take(identifier);
     ASSERT(request);
@@ -1270,7 +1269,7 @@ void WebEditorClient::didCheckSucceed(TextCheckingRequestIdentifier identifier, 
 
 #endif
 
-void WebEditorClient::requestCheckingOfString(TextCheckingRequest& request, const VisibleSelection& currentSelection)
+void WebEditorClient::requestCheckingOfString(WebCore::TextCheckingRequest& request, const WebCore::VisibleSelection& currentSelection)
 {
 #if !PLATFORM(IOS_FAMILY)
     ASSERT(request.data().identifier());
@@ -1293,7 +1292,7 @@ void WebEditorClient::requestCheckingOfString(TextCheckingRequest& request, cons
 #endif
 }
 
-void WebEditorClient::requestExtendedCheckingOfString(TextCheckingRequest& request, const VisibleSelection& currentSelection)
+void WebEditorClient::requestExtendedCheckingOfString(WebCore::TextCheckingRequest& request, const WebCore::VisibleSelection& currentSelection)
 {
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
@@ -45,9 +45,8 @@
 #import <WebKitLegacy/WebFrameLoadDelegate.h>
 #endif
 
-using namespace WebCore;
 
-NetworkStorageSession& WebFrameNetworkingContext::ensurePrivateBrowsingSession()
+WebCore::NetworkStorageSession& WebFrameNetworkingContext::ensurePrivateBrowsingSession()
 {
     ASSERT(isMainThread());
     NetworkStorageSessionMap::ensureSession(PAL::SessionID::legacyPrivateSessionID(), [[NSBundle mainBundle] bundleIdentifier]);
@@ -89,12 +88,12 @@ String WebFrameNetworkingContext::sourceApplicationIdentifier() const
     return emptyString();
 }
 
-ResourceError WebFrameNetworkingContext::blockedError(const ResourceRequest& request) const
+WebCore::ResourceError WebFrameNetworkingContext::blockedError(const WebCore::ResourceRequest& request) const
 {
     return WebResourceLoadScheduler::blockedErrorFromRequest(request);
 }
 
-NetworkStorageSession* WebFrameNetworkingContext::storageSession() const
+WebCore::NetworkStorageSession* WebFrameNetworkingContext::storageSession() const
 {
     ASSERT(isMainThread());
     if (frame() && frame()->page() && frame()->page()->sessionID().isEphemeral()) {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.mm
@@ -45,31 +45,30 @@
 #import <WebKitLegacy/WebCoreThreadRun.h>
 #endif
 
-using namespace WebCore;
 
 #if !PLATFORM(IOS_FAMILY)
 @interface WebGeolocationPolicyListener : NSObject <WebAllowDenyPolicyListener>
 {
-    RefPtr<Geolocation> _geolocation;
+    RefPtr<WebCore::Geolocation> _geolocation;
 }
-- (id)initWithGeolocation:(std::reference_wrapper<Geolocation>)geolocation;
+- (id)initWithGeolocation:(std::reference_wrapper<WebCore::Geolocation>)geolocation;
 @end
 #else
 @interface WebGeolocationPolicyListener : NSObject <WebAllowDenyPolicyListener>
 {
-    RefPtr<Geolocation> _geolocation;
+    RefPtr<WebCore::Geolocation> _geolocation;
     RetainPtr<WebView> _webView;
 }
-- (id)initWithGeolocation:(NakedPtr<Geolocation>)geolocation forWebView:(WebView*)webView;
+- (id)initWithGeolocation:(NakedPtr<WebCore::Geolocation>)geolocation forWebView:(WebView*)webView;
 @end
 #endif
 
 #if PLATFORM(IOS_FAMILY)
 @interface WebGeolocationProviderInitializationListener : NSObject <WebGeolocationProviderInitializationListener> {
 @private
-    RefPtr<Geolocation> m_geolocation;
+    RefPtr<WebCore::Geolocation> m_geolocation;
 }
-- (id)initWithGeolocation:(std::reference_wrapper<Geolocation>)geolocation;
+- (id)initWithGeolocation:(std::reference_wrapper<WebCore::Geolocation>)geolocation;
 @end
 #endif
 
@@ -107,7 +106,7 @@ void WebGeolocationClient::setEnableHighAccuracy(bool wantsHighAccuracy)
 }
 #endif
 
-void WebGeolocationClient::requestPermission(Geolocation& geolocation)
+void WebGeolocationClient::requestPermission(WebCore::Geolocation& geolocation)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -136,7 +135,7 @@ void WebGeolocationClient::requestPermission(Geolocation& geolocation)
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
+std::optional<WebCore::GeolocationPositionData> WebGeolocationClient::lastPosition()
 {
     return core([[m_webView _geolocationProvider] lastPosition]);
 }
@@ -144,7 +143,7 @@ std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
 #if !PLATFORM(IOS_FAMILY)
 @implementation WebGeolocationPolicyListener
 
-- (id)initWithGeolocation:(std::reference_wrapper<Geolocation>)geolocation
+- (id)initWithGeolocation:(std::reference_wrapper<WebCore::Geolocation>)geolocation
 {
     if (!(self = [super init]))
         return nil;
@@ -166,7 +165,7 @@ std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
 
 #else
 @implementation WebGeolocationPolicyListener
-- (id)initWithGeolocation:(NakedPtr<Geolocation>)geolocation forWebView:(WebView*)webView
+- (id)initWithGeolocation:(NakedPtr<WebCore::Geolocation>)geolocation forWebView:(WebView*)webView
 {
     self = [super init];
     if (!self)
@@ -210,7 +209,7 @@ std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
 @end
 
 @implementation WebGeolocationProviderInitializationListener
-- (id)initWithGeolocation:(std::reference_wrapper<Geolocation>)geolocation
+- (id)initWithGeolocation:(std::reference_wrapper<WebCore::Geolocation>)geolocation
 {
     self = [super init];
     if (self)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -59,7 +59,6 @@
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/Base64.h>
 
-using namespace WebCore;
 using namespace Inspector;
 
 static const CGFloat minimumWindowWidth = 500;
@@ -108,7 +107,7 @@ void WebInspectorClient::inspectedPageDestroyed()
 {
 }
 
-FrontendChannel* WebInspectorClient::openLocalFrontend(PageInspectorController* inspectedPageController)
+FrontendChannel* WebInspectorClient::openLocalFrontend(WebCore::PageInspectorController* inspectedPageController)
 {
     RetainPtr<WebInspectorWindowController> windowController = adoptNS([[WebInspectorWindowController alloc] initWithInspectedWebView:m_inspectedWebView.get().get() isUnderTest:inspectedPageController->isUnderTest()]);
     [windowController.get() setInspectorClient:this];
@@ -133,7 +132,7 @@ void WebInspectorClient::bringFrontendToFront()
     m_frontendClient->bringToFront();
 }
 
-void WebInspectorClient::didResizeMainFrame(LocalFrame*)
+void WebInspectorClient::didResizeMainFrame(WebCore::LocalFrame*)
 {
     if (m_frontendClient)
         m_frontendClient->attachAvailabilityChanged(canAttach());
@@ -180,7 +179,7 @@ void WebInspectorClient::releaseFrontend()
     m_frontendPage = nullptr;
 }
 
-WebInspectorFrontendClient::WebInspectorFrontendClient(WebView* inspectedWebView, LegacyWebPageInspectorController& webPageInspectorController, WebInspectorWindowController* frontendWindowController, PageInspectorController* inspectedPageController, Page* frontendPage, std::unique_ptr<Settings> settings)
+WebInspectorFrontendClient::WebInspectorFrontendClient(WebView* inspectedWebView, LegacyWebPageInspectorController& webPageInspectorController, WebInspectorWindowController* frontendWindowController, WebCore::PageInspectorController* inspectedPageController, WebCore::Page* frontendPage, std::unique_ptr<Settings> settings)
     : InspectorFrontendClientLocal(inspectedPageController, frontendPage, WTF::move(settings))
     , m_inspectedWebView(inspectedWebView)
     , m_webPageInspectorController(&webPageInspectorController)
@@ -334,7 +333,7 @@ void WebInspectorFrontendClient::setAttachedWindowWidth(unsigned)
     // Dock to right is not implemented in WebKit 1.
 }
 
-void WebInspectorFrontendClient::setSheetRect(const FloatRect& rect)
+void WebInspectorFrontendClient::setSheetRect(const WebCore::FloatRect& rect)
 {
     m_sheetRect = rect;
 }
@@ -345,7 +344,7 @@ void WebInspectorFrontendClient::inspectedURLChanged(const String& newURL)
     updateWindowTitle();
 }
 
-void WebInspectorFrontendClient::showCertificate(const CertificateInfo& certificateInfo)
+void WebInspectorFrontendClient::showCertificate(const WebCore::CertificateInfo& certificateInfo)
 {
     ASSERT(!certificateInfo.isEmpty());
 
@@ -372,10 +371,10 @@ bool WebInspectorFrontendClient::supportsDiagnosticLogging()
     return page ? page->settings().diagnosticLoggingEnabled() : false;
 }
 
-void WebInspectorFrontendClient::logDiagnosticEvent(const String& eventName, const DiagnosticLoggingClient::ValueDictionary& dictionary)
+void WebInspectorFrontendClient::logDiagnosticEvent(const String& eventName, const WebCore::DiagnosticLoggingClient::ValueDictionary& dictionary)
 {
     if (auto* page = frontendPage())
-        page->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(eventName, "Legacy Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
+        page->diagnosticLoggingClient().logDiagnosticMessageWithValueDictionary(eventName, "Legacy Web Inspector Frontend Diagnostics"_s, dictionary, WebCore::ShouldSample::No);
 }
 #endif
 
@@ -635,7 +634,7 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
 
 - (IBAction)attachWindow:(id)sender
 {
-    _frontendClient->attachWindow(InspectorFrontendClient::DockSide::Bottom);
+    _frontendClient->attachWindow(WebCore::InspectorFrontendClient::DockSide::Bottom);
 }
 
 - (IBAction)showWindow:(id)sender
@@ -682,7 +681,7 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
         return;
 
     _inspectorClient->setInspectorStartsAttached(true);
-    _frontendClient->setAttachedWindow(InspectorFrontendClient::DockSide::Bottom);
+    _frontendClient->setAttachedWindow(WebCore::InspectorFrontendClient::DockSide::Bottom);
 
     [self close];
     [self showWindow:nil];
@@ -694,7 +693,7 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
         return;
 
     _inspectorClient->setInspectorStartsAttached(false);
-    _frontendClient->setAttachedWindow(InspectorFrontendClient::DockSide::Undocked);
+    _frontendClient->setAttachedWindow(WebCore::InspectorFrontendClient::DockSide::Undocked);
 
     [self close];
     [self showWindow:nil];
@@ -747,7 +746,7 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
 {
     RetainPtr<WebInspectorWindowController> protect(self);
 
-    if (Page* frontendPage = _frontendClient->frontendPage())
+    if (WebCore::Page* frontendPage = _frontendClient->frontendPage())
         frontendPage->inspectorController().setInspectorFrontendClient(nullptr);
     RefPtr { [_inspectedWebView.get() inspectorController] }->disconnectFrontend(*_inspectorClient);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
@@ -33,7 +33,6 @@
 
 #import <WebCore/DocumentFullscreen.h>
 
-using namespace WebCore;
 
 @implementation WebKitFullScreenListener
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
@@ -32,7 +32,6 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/TZoneMallocInlines.h>
 
-using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMediaKeySystemClient);
 
@@ -42,7 +41,7 @@ WebMediaKeySystemClient& WebMediaKeySystemClient::singleton()
     return client;
 }
 
-void WebMediaKeySystemClient::requestMediaKeySystem(MediaKeySystemRequest& request)
+void WebMediaKeySystemClient::requestMediaKeySystem(WebCore::MediaKeySystemRequest& request)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
@@ -41,13 +41,12 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-using namespace WebCore;
 
 @interface WebNotificationPolicyListener : NSObject <WebAllowDenyPolicyListener>
 {
-    NotificationClient::PermissionHandler _permissionHandler;
+    WebCore::NotificationClient::PermissionHandler _permissionHandler;
 }
-- (id)initWithPermissionHandler:(NotificationClient::PermissionHandler&&)permissionHandler;
+- (id)initWithPermissionHandler:(WebCore::NotificationClient::PermissionHandler&&)permissionHandler;
 @end
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebNotificationClient);
@@ -57,7 +56,7 @@ WebNotificationClient::WebNotificationClient(WebView *webView)
 {
 }
 
-bool WebNotificationClient::show(ScriptExecutionContext&, NotificationData&& notification, RefPtr<NotificationResources>&&, CompletionHandler<void()>&& callback)
+bool WebNotificationClient::show(WebCore::ScriptExecutionContext&, WebCore::NotificationData&& notification, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&& callback)
 {
     auto scope = makeScopeExit([&callback] { callback(); });
 
@@ -72,7 +71,7 @@ bool WebNotificationClient::show(ScriptExecutionContext&, NotificationData&& not
     return true;
 }
 
-void WebNotificationClient::cancel(NotificationData&& notification)
+void WebNotificationClient::cancel(WebCore::NotificationData&& notification)
 {
     RetainPtr webNotification = m_notificationMap.get(notification.notificationID);
     if (!webNotification)
@@ -81,7 +80,7 @@ void WebNotificationClient::cancel(NotificationData&& notification)
     [[m_webView _notificationProvider] cancelNotification:webNotification.get()];
 }
 
-void WebNotificationClient::notificationObjectDestroyed(NotificationData&& notification)
+void WebNotificationClient::notificationObjectDestroyed(WebCore::NotificationData&& notification)
 {
     RetainPtr<WebNotification> webNotification = m_notificationMap.take(notification.notificationID);
     if (!webNotification)
@@ -100,7 +99,7 @@ void WebNotificationClient::clearNotificationPermissionState()
     m_notificationPermissionRequesters.clear();
 }
 
-void WebNotificationClient::requestPermission(ScriptExecutionContext& context, WebNotificationPolicyListener *listener)
+void WebNotificationClient::requestPermission(WebCore::ScriptExecutionContext& context, WebNotificationPolicyListener *listener)
 {
     SEL selector = @selector(webView:decidePolicyForNotificationRequestFromOrigin:listener:);
     if (![[m_webView UIDelegate] respondsToSelector:selector])
@@ -116,7 +115,7 @@ void WebNotificationClient::requestPermission(ScriptExecutionContext& context, W
     CallUIDelegate(m_webView, selector, webOrigin.get(), listener);
 }
 
-void WebNotificationClient::requestPermission(ScriptExecutionContext& context, PermissionHandler&& permissionHandler)
+void WebNotificationClient::requestPermission(WebCore::ScriptExecutionContext& context, PermissionHandler&& permissionHandler)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     auto listener = adoptNS([[WebNotificationPolicyListener alloc] initWithPermissionHandler:WTF::move(permissionHandler)]);
@@ -124,7 +123,7 @@ void WebNotificationClient::requestPermission(ScriptExecutionContext& context, P
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-NotificationClient::Permission WebNotificationClient::checkPermission(ScriptExecutionContext* context)
+WebCore::NotificationClient::Permission WebNotificationClient::checkPermission(WebCore::ScriptExecutionContext* context)
 {
     if (!context || !context->isDocument())
         return NotificationClient::Permission::Denied;
@@ -152,7 +151,7 @@ NotificationClient::Permission WebNotificationClient::checkPermission(ScriptExec
 
 @implementation WebNotificationPolicyListener
 
-- (id)initWithPermissionHandler:(NotificationClient::PermissionHandler&&)permissionHandler
+- (id)initWithPermissionHandler:(WebCore::NotificationClient::PermissionHandler&&)permissionHandler
 {
     if (!(self = [super init]))
         return nil;
@@ -164,13 +163,13 @@ NotificationClient::Permission WebNotificationClient::checkPermission(ScriptExec
 - (void)allow
 {
     if (_permissionHandler)
-        _permissionHandler(NotificationClient::Permission::Granted);
+        _permissionHandler(WebCore::NotificationClient::Permission::Granted);
 }
 
 - (void)deny
 {
     if (_permissionHandler)
-        _permissionHandler(NotificationClient::Permission::Denied);
+        _permissionHandler(WebCore::NotificationClient::Permission::Denied);
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebOpenPanelResultListener.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebOpenPanelResultListener.mm
@@ -33,11 +33,10 @@
 #import <WebCore/Icon.h>
 #endif
 
-using namespace WebCore;
 
 @implementation WebOpenPanelResultListener
 
-- (id)initWithChooser:(FileChooser&)chooser
+- (id)initWithChooser:(WebCore::FileChooser&)chooser
 {
     self = [super init];
     if (!self)
@@ -82,7 +81,7 @@ using namespace WebCore;
     if (!_chooser)
         return;
 
-    _chooser->chooseMediaFiles(makeVector<String>(filenames), displayString, Icon::create(imageRef).get());
+    _chooser->chooseMediaFiles(makeVector<String>(filenames), displayString, WebCore::Icon::create(imageRef).get());
     _chooser = nullptr;
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
@@ -42,7 +42,6 @@
 #import <WebCore/SubframeLoader.h>
 #import <wtf/NeverDestroyed.h>
 
-using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPlatformStrategies);
 
@@ -58,216 +57,216 @@ void WebPlatformStrategies::initializeIfNecessary()
 
 WebPlatformStrategies::WebPlatformStrategies() = default;
 
-LoaderStrategy* WebPlatformStrategies::createLoaderStrategy()
+WebCore::LoaderStrategy* WebPlatformStrategies::createLoaderStrategy()
 {
     return new WebResourceLoadScheduler;
 }
 
-PasteboardStrategy* WebPlatformStrategies::createPasteboardStrategy()
+WebCore::PasteboardStrategy* WebPlatformStrategies::createPasteboardStrategy()
 {
     return this;
 }
 
-class WebMediaStrategy final : public MediaStrategy {
+class WebMediaStrategy final : public WebCore::MediaStrategy {
 private:
 #if ENABLE(WEB_AUDIO)
-    Ref<AudioDestination> createAudioDestination(const AudioDestinationCreationOptions& options) override
+    Ref<WebCore::AudioDestination> createAudioDestination(const WebCore::AudioDestinationCreationOptions& options) override
     {
-        return AudioDestination::create(options);
+        return WebCore::AudioDestination::create(options);
     }
 #endif
 
     bool enableWebMMediaPlayer() const final { return false; }
 };
 
-MediaStrategy* WebPlatformStrategies::createMediaStrategy()
+WebCore::MediaStrategy* WebPlatformStrategies::createMediaStrategy()
 {
     return new WebMediaStrategy;
 }
 
-class WebBlobRegistry final : public BlobRegistry {
+class WebBlobRegistry final : public WebCore::BlobRegistry {
     WTF_MAKE_TZONE_ALLOCATED(WebBlobRegistry);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebBlobRegistry);
 private:
-    void registerInternalFileBlobURL(const URL& url, Ref<BlobDataFileReference>&& reference, const String&, const String& contentType) final { m_blobRegistry.registerInternalFileBlobURL(url, WTF::move(reference), contentType); }
-    void registerInternalBlobURL(const URL& url, Vector<BlobPart>&& parts, const String& contentType) final { m_blobRegistry.registerInternalBlobURL(url, WTF::move(parts), contentType); }
-    void registerBlobURL(const URL& url, const URL& srcURL, const PolicyContainer& policyContainer, const std::optional<WebCore::SecurityOriginData>& topOrigin) final { m_blobRegistry.registerBlobURL(url, srcURL, policyContainer, topOrigin); }
-    void registerInternalBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<BlobDataFileReference>&& reference, const String& contentType) final { m_blobRegistry.registerInternalBlobURLOptionallyFileBacked(url, srcURL, WTF::move(reference), contentType, { }); }
+    void registerInternalFileBlobURL(const URL& url, Ref<WebCore::BlobDataFileReference>&& reference, const String&, const String& contentType) final { m_blobRegistry.registerInternalFileBlobURL(url, WTF::move(reference), contentType); }
+    void registerInternalBlobURL(const URL& url, Vector<WebCore::BlobPart>&& parts, const String& contentType) final { m_blobRegistry.registerInternalBlobURL(url, WTF::move(parts), contentType); }
+    void registerBlobURL(const URL& url, const URL& srcURL, const WebCore::PolicyContainer& policyContainer, const std::optional<WebCore::SecurityOriginData>& topOrigin) final { m_blobRegistry.registerBlobURL(url, srcURL, policyContainer, topOrigin); }
+    void registerInternalBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<WebCore::BlobDataFileReference>&& reference, const String& contentType) final { m_blobRegistry.registerInternalBlobURLOptionallyFileBacked(url, srcURL, WTF::move(reference), contentType, { }); }
     void registerInternalBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType) final { m_blobRegistry.registerInternalBlobURLForSlice(url, srcURL, start, end, contentType); }
     void unregisterBlobURL(const URL& url, const std::optional<WebCore::SecurityOriginData>& topOrigin) final { m_blobRegistry.unregisterBlobURL(url, topOrigin); }
     String blobType(const URL& url) final { return m_blobRegistry.blobType(url); }
     unsigned long long blobSize(const URL& url) final { return m_blobRegistry.blobSize(url); }
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler) final { m_blobRegistry.writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTF::move(completionHandler)); }
-    void registerBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin) final { m_blobRegistry.registerBlobURLHandle(url, topOrigin); }
-    void unregisterBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin) final { m_blobRegistry.unregisterBlobURLHandle(url, topOrigin); }
+    void registerBlobURLHandle(const URL& url, const std::optional<WebCore::SecurityOriginData>& topOrigin) final { m_blobRegistry.registerBlobURLHandle(url, topOrigin); }
+    void unregisterBlobURLHandle(const URL& url, const std::optional<WebCore::SecurityOriginData>& topOrigin) final { m_blobRegistry.unregisterBlobURLHandle(url, topOrigin); }
 
-    BlobRegistryImpl* blobRegistryImpl() final { return &m_blobRegistry; }
+    WebCore::BlobRegistryImpl* blobRegistryImpl() final { return &m_blobRegistry; }
 
-    BlobRegistryImpl m_blobRegistry;
+    WebCore::BlobRegistryImpl m_blobRegistry;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebBlobRegistry);
 
-BlobRegistry* WebPlatformStrategies::createBlobRegistry()
+WebCore::BlobRegistry* WebPlatformStrategies::createBlobRegistry()
 {
     return new WebBlobRegistry;
 }
 
-void WebPlatformStrategies::getTypes(Vector<String>& types, const String& pasteboardName, const PasteboardContext*)
+void WebPlatformStrategies::getTypes(Vector<String>& types, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    PlatformPasteboard(pasteboardName).getTypes(types);
+    WebCore::PlatformPasteboard(pasteboardName).getTypes(types);
 }
 
-RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::bufferForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
+RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::bufferForType(const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    auto pasteboardBuffer = PlatformPasteboard(pasteboardName).bufferForType(pasteboardType);
-    return Pasteboard::bufferConvertedToPasteboardType(pasteboardBuffer, pasteboardType);
+    auto pasteboardBuffer = WebCore::PlatformPasteboard(pasteboardName).bufferForType(pasteboardType);
+    return WebCore::Pasteboard::bufferConvertedToPasteboardType(pasteboardBuffer, pasteboardType);
 }
 
-void WebPlatformStrategies::getPathnamesForType(Vector<String>& pathnames, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
+void WebPlatformStrategies::getPathnamesForType(Vector<String>& pathnames, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    PlatformPasteboard(pasteboardName).getPathnamesForType(pathnames, pasteboardType);
+    WebCore::PlatformPasteboard(pasteboardName).getPathnamesForType(pathnames, pasteboardType);
 }
 
-Vector<String> WebPlatformStrategies::allStringsForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
+Vector<String> WebPlatformStrategies::allStringsForType(const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).allStringsForType(pasteboardType);
+    return WebCore::PlatformPasteboard(pasteboardName).allStringsForType(pasteboardType);
 }
 
-String WebPlatformStrategies::stringForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
+String WebPlatformStrategies::stringForType(const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).stringForType(pasteboardType);
+    return WebCore::PlatformPasteboard(pasteboardName).stringForType(pasteboardType);
 }
 
-int64_t WebPlatformStrategies::changeCount(const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::changeCount(const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).changeCount();
+    return WebCore::PlatformPasteboard(pasteboardName).changeCount();
 }
 
-Color WebPlatformStrategies::color(const String& pasteboardName, const PasteboardContext*)
+WebCore::Color WebPlatformStrategies::color(const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).color();    
+    return WebCore::PlatformPasteboard(pasteboardName).color();    
 }
 
-URL WebPlatformStrategies::url(const String& pasteboardName, const PasteboardContext*)
+URL WebPlatformStrategies::url(const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).url();
+    return WebCore::PlatformPasteboard(pasteboardName).url();
 }
 
-int64_t WebPlatformStrategies::addTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::addTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).addTypes(pasteboardTypes);
+    return WebCore::PlatformPasteboard(pasteboardName).addTypes(pasteboardTypes);
 }
 
-int64_t WebPlatformStrategies::setTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::setTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).setTypes(pasteboardTypes);
+    return WebCore::PlatformPasteboard(pasteboardName).setTypes(pasteboardTypes);
 }
 
-int64_t WebPlatformStrategies::setBufferForType(SharedBuffer* buffer, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::setBufferForType(WebCore::SharedBuffer* buffer, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).setBufferForType(buffer, pasteboardType);
+    return WebCore::PlatformPasteboard(pasteboardName).setBufferForType(buffer, pasteboardType);
 }
 
-int64_t WebPlatformStrategies::setURL(const PasteboardURL& pasteboardURL, const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::setURL(const WebCore::PasteboardURL& pasteboardURL, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).setURL(pasteboardURL);
+    return WebCore::PlatformPasteboard(pasteboardName).setURL(pasteboardURL);
 }
 
-int64_t WebPlatformStrategies::setColor(const Color& color, const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::setColor(const WebCore::Color& color, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).setColor(color);
+    return WebCore::PlatformPasteboard(pasteboardName).setColor(color);
 }
 
-int64_t WebPlatformStrategies::setStringForType(const String& string, const String& pasteboardType, const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::setStringForType(const String& string, const String& pasteboardType, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).setStringForType(string, pasteboardType);
+    return WebCore::PlatformPasteboard(pasteboardName).setStringForType(string, pasteboardType);
 }
 
-int WebPlatformStrategies::getNumberOfFiles(const String& pasteboardName, const PasteboardContext*)
+int WebPlatformStrategies::getNumberOfFiles(const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).numberOfFiles();
+    return WebCore::PlatformPasteboard(pasteboardName).numberOfFiles();
 }
 
-Vector<String> WebPlatformStrategies::typesSafeForDOMToReadAndWrite(const String& pasteboardName, const String& origin, const PasteboardContext*)
+Vector<String> WebPlatformStrategies::typesSafeForDOMToReadAndWrite(const String& pasteboardName, const String& origin, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).typesSafeForDOMToReadAndWrite(origin);
+    return WebCore::PlatformPasteboard(pasteboardName).typesSafeForDOMToReadAndWrite(origin);
 }
 
-int64_t WebPlatformStrategies::writeCustomData(const Vector<WebCore::PasteboardCustomData>& data, const String& pasteboardName, const PasteboardContext*)
+int64_t WebPlatformStrategies::writeCustomData(const Vector<WebCore::PasteboardCustomData>& data, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).write(data);
+    return WebCore::PlatformPasteboard(pasteboardName).write(data);
 }
 
-bool WebPlatformStrategies::containsStringSafeForDOMToReadForType(const String& pasteboardName, const String& type, const PasteboardContext*)
+bool WebPlatformStrategies::containsStringSafeForDOMToReadForType(const String& pasteboardName, const String& type, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).containsStringSafeForDOMToReadForType(type);
+    return WebCore::PlatformPasteboard(pasteboardName).containsStringSafeForDOMToReadForType(type);
 }
 
-std::optional<WebCore::PasteboardItemInfo> WebPlatformStrategies::informationForItemAtIndex(size_t index, const String& pasteboardName, int64_t changeCount, const PasteboardContext*)
+std::optional<WebCore::PasteboardItemInfo> WebPlatformStrategies::informationForItemAtIndex(size_t index, const String& pasteboardName, int64_t changeCount, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).informationForItemAtIndex(index, changeCount);
+    return WebCore::PlatformPasteboard(pasteboardName).informationForItemAtIndex(index, changeCount);
 }
 
-std::optional<Vector<WebCore::PasteboardItemInfo>> WebPlatformStrategies::allPasteboardItemInfo(const String& pasteboardName, int64_t changeCount, const PasteboardContext*)
+std::optional<Vector<WebCore::PasteboardItemInfo>> WebPlatformStrategies::allPasteboardItemInfo(const String& pasteboardName, int64_t changeCount, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).allPasteboardItemInfo(changeCount);
+    return WebCore::PlatformPasteboard(pasteboardName).allPasteboardItemInfo(changeCount);
 }
 
-int WebPlatformStrategies::getPasteboardItemsCount(const String& pasteboardName, const PasteboardContext*)
+int WebPlatformStrategies::getPasteboardItemsCount(const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).count();
+    return WebCore::PlatformPasteboard(pasteboardName).count();
 }
 
-RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::readBufferFromPasteboard(std::optional<size_t> index, const String& type, const String& pasteboardName, const PasteboardContext*)
+RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::readBufferFromPasteboard(std::optional<size_t> index, const String& type, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).readBuffer(index, type);
+    return WebCore::PlatformPasteboard(pasteboardName).readBuffer(index, type);
 }
 
-URL WebPlatformStrategies::readURLFromPasteboard(size_t index, const String& pasteboardName, String& title, const PasteboardContext*)
+URL WebPlatformStrategies::readURLFromPasteboard(size_t index, const String& pasteboardName, String& title, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).readURL(index, title);
+    return WebCore::PlatformPasteboard(pasteboardName).readURL(index, title);
 }
 
-String WebPlatformStrategies::readStringFromPasteboard(size_t index, const String& type, const String& pasteboardName, const PasteboardContext*)
+String WebPlatformStrategies::readStringFromPasteboard(size_t index, const String& type, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).readString(index, type);
+    return WebCore::PlatformPasteboard(pasteboardName).readString(index, type);
 }
 
-bool WebPlatformStrategies::containsURLStringSuitableForLoading(const String& pasteboardName, const PasteboardContext*)
+bool WebPlatformStrategies::containsURLStringSuitableForLoading(const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).containsURLStringSuitableForLoading();
+    return WebCore::PlatformPasteboard(pasteboardName).containsURLStringSuitableForLoading();
 }
 
-String WebPlatformStrategies::urlStringSuitableForLoading(const String& pasteboardName, String& title, const PasteboardContext*)
+String WebPlatformStrategies::urlStringSuitableForLoading(const String& pasteboardName, String& title, const WebCore::PasteboardContext*)
 {
-    return PlatformPasteboard(pasteboardName).urlStringSuitableForLoading(title);
+    return WebCore::PlatformPasteboard(pasteboardName).urlStringSuitableForLoading(title);
 }
 
 #if PLATFORM(IOS_FAMILY)
 
-void WebPlatformStrategies::writeToPasteboard(const PasteboardURL& url, const String& pasteboardName, const PasteboardContext*)
+void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardURL& url, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    PlatformPasteboard(pasteboardName).write(url);
+    WebCore::PlatformPasteboard(pasteboardName).write(url);
 }
 
-void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardWebContent& content, const String& pasteboardName, const PasteboardContext*)
+void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardWebContent& content, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    PlatformPasteboard(pasteboardName).write(content);
+    WebCore::PlatformPasteboard(pasteboardName).write(content);
 }
 
-void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardImage& image, const String& pasteboardName, const PasteboardContext*)
+void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardImage& image, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    PlatformPasteboard(pasteboardName).write(image);
+    WebCore::PlatformPasteboard(pasteboardName).write(image);
 }
 
-void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, const String& text, const String& pasteboardName, const PasteboardContext*)
+void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, const String& text, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    PlatformPasteboard(pasteboardName).write(pasteboardType, text);
+    WebCore::PlatformPasteboard(pasteboardName).write(pasteboardType, text);
 }
 
-void WebPlatformStrategies::updateSupportedTypeIdentifiers(const Vector<String>& identifiers, const String& pasteboardName, const PasteboardContext*)
+void WebPlatformStrategies::updateSupportedTypeIdentifiers(const Vector<String>& identifiers, const String& pasteboardName, const WebCore::PasteboardContext*)
 {
-    PlatformPasteboard(pasteboardName).updateSupportedTypeIdentifiers(identifiers);
+    WebCore::PlatformPasteboard(pasteboardName).updateSupportedTypeIdentifiers(identifiers);
 }
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPluginInfoProvider.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPluginInfoProvider.mm
@@ -32,7 +32,6 @@
 #import <WebCore/Page.h>
 #import <wtf/BlockObjCExceptions.h>
 
-using namespace WebCore;
 
 WebPluginInfoProvider& WebPluginInfoProvider::singleton()
 {
@@ -50,7 +49,7 @@ void WebPluginInfoProvider::refreshPlugins()
     [[WebPluginDatabase sharedDatabaseIfExists] refresh];
 }
 
-Vector<WebCore::PluginInfo> WebPluginInfoProvider::pluginInfo(WebCore::Page& page, std::optional<Vector<SupportedPluginIdentifier>>&)
+Vector<WebCore::PluginInfo> WebPluginInfoProvider::pluginInfo(WebCore::Page& page, std::optional<Vector<WebCore::SupportedPluginIdentifier>>&)
 {
     Vector<WebCore::PluginInfo> plugins;
 
@@ -58,7 +57,7 @@ Vector<WebCore::PluginInfo> WebPluginInfoProvider::pluginInfo(WebCore::Page& pag
 
 
     // WebKit1 has no application plug-ins, so we don't need to add them here.
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page.mainFrame());
     if (!localMainFrame)
         return plugins;
 
@@ -71,6 +70,6 @@ Vector<WebCore::PluginInfo> WebPluginInfoProvider::pluginInfo(WebCore::Page& pag
 
 Vector<WebCore::PluginInfo> WebPluginInfoProvider::webVisiblePluginInfo(WebCore::Page& page, const URL&)
 {
-    std::optional<Vector<SupportedPluginIdentifier>> supportedPluginIdentifiers;
+    std::optional<Vector<WebCore::SupportedPluginIdentifier>> supportedPluginIdentifiers;
     return pluginInfo(page, supportedPluginIdentifiers);
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebProgressTrackerClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebProgressTrackerClient.mm
@@ -32,7 +32,6 @@
 #import <WebCore/WebCoreThreadMessage.h>
 #endif
 
-using namespace WebCore;
 
 WebProgressTrackerClient::WebProgressTrackerClient(WebView *webView)
     : m_webView(webView)
@@ -79,7 +78,7 @@ void WebProgressTrackerClient::progressEstimateChanged(WebCore::LocalFrame&)
 #endif
 }
 
-void WebProgressTrackerClient::progressFinished(LocalFrame&)
+void WebProgressTrackerClient::progressFinished(WebCore::LocalFrame&)
 {
 #if !PLATFORM(IOS_FAMILY)
     [[NSNotificationCenter defaultCenter] postNotificationName:WebViewProgressFinishedNotification object:m_webView];

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
@@ -35,7 +35,6 @@
 #import <WebCore/SecurityOriginData.h>
 #import <wtf/URL.h>
 
-using namespace WebCore;
 
 @implementation WebSecurityOrigin
 
@@ -43,7 +42,7 @@ using namespace WebCore;
 {
     WTF::initializeMainThread();
 
-    auto origin = SecurityOriginData::fromDatabaseIdentifier(String { databaseIdentifier });
+    auto origin = WebCore::SecurityOriginData::fromDatabaseIdentifier(String { databaseIdentifier });
     if (!origin)
         return nil;
 
@@ -58,40 +57,40 @@ using namespace WebCore;
     if (!self)
         return nil;
 
-    _private = reinterpret_cast<WebSecurityOriginPrivate *>(&SecurityOrigin::create(URL([url absoluteURL])).leakRef());
+    _private = reinterpret_cast<WebSecurityOriginPrivate *>(&WebCore::SecurityOrigin::create(URL([url absoluteURL])).leakRef());
     return self;
 }
 
 - (NSString *)protocol
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->protocol().createNSString().autorelease();
+    return reinterpret_cast<WebCore::SecurityOrigin*>(_private)->protocol().createNSString().autorelease();
 }
 
 - (NSString *)host
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->host().createNSString().autorelease();
+    return reinterpret_cast<WebCore::SecurityOrigin*>(_private)->host().createNSString().autorelease();
 }
 
 - (NSString *)databaseIdentifier
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->data().databaseIdentifier().createNSString().autorelease();
+    return reinterpret_cast<WebCore::SecurityOrigin*>(_private)->data().databaseIdentifier().createNSString().autorelease();
 }
 
 #if PLATFORM(IOS_FAMILY)
 - (NSString *)toString
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->toString().createNSString().autorelease();
+    return reinterpret_cast<WebCore::SecurityOrigin*>(_private)->toString().createNSString().autorelease();
 }
 #endif
 
 - (NSString *)stringValue
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->toString().createNSString().autorelease();
+    return reinterpret_cast<WebCore::SecurityOrigin*>(_private)->toString().createNSString().autorelease();
 }
 
 - (unsigned short)port
 {
-    return reinterpret_cast<SecurityOrigin*>(_private)->port().value_or(0);
+    return reinterpret_cast<WebCore::SecurityOrigin*>(_private)->port().value_or(0);
 }
 
 // FIXME: Overriding isEqual: without overriding hash will cause trouble if this ever goes into an NSSet or is the key in an NSDictionary,
@@ -107,7 +106,7 @@ using namespace WebCore;
 - (void)dealloc
 {
     if (_private)
-        reinterpret_cast<SecurityOrigin*>(_private)->deref();
+        reinterpret_cast<WebCore::SecurityOrigin*>(_private)->deref();
     if (_databaseQuotaManager)
         [(NSObject *)_databaseQuotaManager release];
     [super dealloc];
@@ -117,7 +116,7 @@ using namespace WebCore;
 
 @implementation WebSecurityOrigin (WebInternal)
 
-- (id)_initWithWebCoreSecurityOrigin:(SecurityOrigin*)origin
+- (id)_initWithWebCoreSecurityOrigin:(WebCore::SecurityOrigin*)origin
 {
     ASSERT(origin);
     self = [super init];
@@ -132,13 +131,13 @@ using namespace WebCore;
 
 - (id)_initWithString:(NSString *)originString
 {
-    auto origin = SecurityOrigin::createFromString(originString);
+    auto origin = WebCore::SecurityOrigin::createFromString(originString);
     return adoptNS([[WebSecurityOrigin alloc] _initWithWebCoreSecurityOrigin:origin.ptr()]).autorelease();
 }
 
-- (SecurityOrigin *)_core
+- (WebCore::SecurityOrigin *)_core
 {
-    return reinterpret_cast<SecurityOrigin*>(_private);
+    return reinterpret_cast<WebCore::SecurityOrigin*>(_private);
 }
 
 @end
@@ -169,17 +168,17 @@ using namespace WebCore;
 
 - (unsigned long long)usage
 {
-    return DatabaseTracker::singleton().usage(reinterpret_cast<SecurityOrigin*>(_private)->data());
+    return WebCore::DatabaseTracker::singleton().usage(reinterpret_cast<WebCore::SecurityOrigin*>(_private)->data());
 }
 
 - (unsigned long long)quota
 {
-    return DatabaseTracker::singleton().quota(reinterpret_cast<SecurityOrigin*>(_private)->data());
+    return WebCore::DatabaseTracker::singleton().quota(reinterpret_cast<WebCore::SecurityOrigin*>(_private)->data());
 }
 
 - (void)setQuota:(unsigned long long)quota
 {
-    DatabaseTracker::singleton().setQuota(reinterpret_cast<SecurityOrigin*>(_private)->data(), quota);
+    WebCore::DatabaseTracker::singleton().setQuota(reinterpret_cast<WebCore::SecurityOrigin*>(_private)->data(), quota);
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
@@ -36,7 +36,6 @@
 #import <pal/spi/mac/NSSharingServiceSPI.h>
 #import <wtf/TZoneMallocInlines.h>
 
-using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSelectionServiceController);
 
@@ -47,7 +46,7 @@ WebSelectionServiceController::WebSelectionServiceController(WebView *webView)
 
 void WebSelectionServiceController::handleSelectionServiceClick(WebCore::FrameSelection& selection, const Vector<String>& /*telephoneNumbers*/, const WebCore::IntPoint& point)
 {
-    Page* page = [m_webView page];
+    WebCore::Page* page = [m_webView page];
     if (!page)
         return;
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebValidationMessageClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebValidationMessageClient.mm
@@ -31,7 +31,6 @@
 #import <WebCore/NodeDocument.h>
 #import <wtf/TZoneMallocInlines.h>
 
-using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebValidationMessageClient);
 
@@ -46,7 +45,7 @@ WebValidationMessageClient::~WebValidationMessageClient()
         hideValidationMessage(*m_currentAnchor);
 }
 
-void WebValidationMessageClient::documentDetached(Document& document)
+void WebValidationMessageClient::documentDetached(WebCore::Document& document)
 {
     if (!m_currentAnchor)
         return;
@@ -54,7 +53,7 @@ void WebValidationMessageClient::documentDetached(Document& document)
         hideValidationMessage(*m_currentAnchor);
 }
 
-void WebValidationMessageClient::showValidationMessage(const Element& anchor, String&& message)
+void WebValidationMessageClient::showValidationMessage(const WebCore::Element& anchor, String&& message)
 {
     if (m_currentAnchor)
         hideValidationMessage(*m_currentAnchor);
@@ -64,7 +63,7 @@ void WebValidationMessageClient::showValidationMessage(const Element& anchor, St
     [m_view showFormValidationMessage:message.createNSString().get() withAnchorRect:m_currentAnchorRect];
 }
 
-void WebValidationMessageClient::hideValidationMessage(const Element& anchor)
+void WebValidationMessageClient::hideValidationMessage(const WebCore::Element& anchor)
 {
     if (!isValidationMessageVisible(anchor))
         return;
@@ -84,7 +83,7 @@ void WebValidationMessageClient::hideAnyValidationMessage()
     [m_view hideFormValidationMessage];
 }
 
-bool WebValidationMessageClient::isValidationMessageVisible(const Element& anchor)
+bool WebValidationMessageClient::isValidationMessageVisible(const WebCore::Element& anchor)
 {
     return m_currentAnchor == &anchor;
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -35,7 +35,6 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/NeverDestroyed.h>
 
-using namespace WebCore;
 
 static bool s_shouldTrackVisitedLinks;
 
@@ -86,19 +85,19 @@ void WebVisitedLinkStore::addVisitedLink(NSString *urlString)
     size_t length = urlString.length;
 
     if (auto characters = CFStringGetCharactersPtr((__bridge CFStringRef)urlString)) {
-        addVisitedLinkHash(computeSharedStringHash(std::span { reinterpret_cast<const char16_t*>(characters), length }));
+        addVisitedLinkHash(WebCore::computeSharedStringHash(std::span { reinterpret_cast<const char16_t*>(characters), length }));
         return;
     }
 
     Vector<UniChar, 512> buffer(length);
     [urlString getCharacters:buffer.mutableSpan().data()];
 
-    addVisitedLinkHash(computeSharedStringHash(spanReinterpretCast<const char16_t>(buffer.span())));
+    addVisitedLinkHash(WebCore::computeSharedStringHash(spanReinterpretCast<const char16_t>(buffer.span())));
 }
 
 void WebVisitedLinkStore::removeVisitedLink(NSString *urlString)
 {
-    auto linkHash = computeSharedStringHash(urlString);
+    auto linkHash = WebCore::computeSharedStringHash(urlString);
 
     ASSERT(m_visitedLinkHashes.contains(linkHash));
     m_visitedLinkHashes.remove(linkHash);
@@ -106,14 +105,14 @@ void WebVisitedLinkStore::removeVisitedLink(NSString *urlString)
     invalidateStylesForLink(linkHash);
 }
 
-bool WebVisitedLinkStore::isLinkVisited(Page& page, SharedStringHash linkHash, const URL& baseURL, const AtomString& attributeURL)
+bool WebVisitedLinkStore::isLinkVisited(WebCore::Page& page, WebCore::SharedStringHash linkHash, const URL& baseURL, const AtomString& attributeURL)
 {
     populateVisitedLinksIfNeeded(page);
 
     return m_visitedLinkHashes.contains(linkHash);
 }
 
-void WebVisitedLinkStore::addVisitedLink(Page& sourcePage, SharedStringHash linkHash)
+void WebVisitedLinkStore::addVisitedLink(WebCore::Page& sourcePage, WebCore::SharedStringHash linkHash)
 {
     if (!s_shouldTrackVisitedLinks)
         return;
@@ -121,7 +120,7 @@ void WebVisitedLinkStore::addVisitedLink(Page& sourcePage, SharedStringHash link
     addVisitedLinkHash(linkHash);
 }
 
-void WebVisitedLinkStore::populateVisitedLinksIfNeeded(Page& page)
+void WebVisitedLinkStore::populateVisitedLinksIfNeeded(WebCore::Page& page)
 {
     if (m_visitedLinksPopulated)
         return;
@@ -145,7 +144,7 @@ void WebVisitedLinkStore::populateVisitedLinksIfNeeded(Page& page)
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-void WebVisitedLinkStore::addVisitedLinkHash(SharedStringHash linkHash)
+void WebVisitedLinkStore::addVisitedLinkHash(WebCore::SharedStringHash linkHash)
 {
     ASSERT(s_shouldTrackVisitedLinks);
 

--- a/Source/WebKitLegacy/mac/WebInspector/WebInspectorFrontend.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebInspectorFrontend.mm
@@ -28,7 +28,6 @@
 #import "WebInspectorClient.h"
 #import <WebCore/InspectorFrontendClient.h>
 
-using namespace WebCore;
 
 @implementation WebInspectorFrontend
 
@@ -43,7 +42,7 @@ using namespace WebCore;
 
 - (void)attach
 {
-    m_frontendClient->attachWindow(InspectorFrontendClient::DockSide::Bottom);
+    m_frontendClient->attachWindow(WebCore::InspectorFrontendClient::DockSide::Bottom);
 }
 
 - (void)detach

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
@@ -41,7 +41,6 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #endif
 
-using namespace WebCore;
 
 #if !PLATFORM(IOS_FAMILY)
 @interface WebNodeHighlight (FileInternal)
@@ -81,7 +80,7 @@ using namespace WebCore;
 
 @implementation WebNodeHighlight
 
-- (id)initWithTargetView:(NSView *)targetView inspectorController:(NakedPtr<PageInspectorController>)inspectorController
+- (id)initWithTargetView:(NSView *)targetView inspectorController:(NakedPtr<WebCore::PageInspectorController>)inspectorController
 {
     self = [super init];
     if (!self)
@@ -252,7 +251,7 @@ using namespace WebCore;
     return _targetView;
 }
 
-- (NakedPtr<PageInspectorController>)inspectorController
+- (NakedPtr<WebCore::PageInspectorController>)inspectorController
 {
     return _inspectorController;
 }

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
@@ -41,7 +41,6 @@
 #import <WebCore/WebCoreThread.h>
 #endif
 
-using namespace WebCore;
 
 @implementation WebNodeHighlightView
 
@@ -98,13 +97,20 @@ using namespace WebCore;
 
         ASSERT([[NSGraphicsContext currentContext] isFlipped]);
 
-        GraphicsContextCG context([[NSGraphicsContext currentContext] CGContext]);
+        WebCore::GraphicsContextCG context([[NSGraphicsContext currentContext] CGContext]);
         if (CheckedPtr controller = [_webNodeHighlight inspectorController].get())
             controller->drawHighlight(context);
         [NSGraphicsContext restoreGraphicsState];
     }
 }
 #else
+
+using WebCore::FloatPoint;
+using WebCore::FloatQuad;
+using WebCore::InspectorOverlay;
+using WebCore::cachedCGColor;
+using WebCore::findIntersection;
+
 - (void)_attach:(CALayer *)parent numLayers:(NSUInteger)numLayers
 {
     ASSERT(numLayers);

--- a/Source/WebKitLegacy/mac/WebView/WebArchive.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebArchive.mm
@@ -43,7 +43,6 @@
 #import <wtf/RunLoop.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-using namespace WebCore;
 
 NSString *WebArchivePboardType = @"Apple Web Archive pasteboard type";
 
@@ -57,12 +56,12 @@ static NSString * const WebSubframeArchivesKey = @"WebSubframeArchives";
     RetainPtr<NSArray> cachedSubresources;
     RetainPtr<NSArray> cachedSubframeArchives;
 @private
-    RefPtr<LegacyWebArchive> coreArchive;
+    RefPtr<WebCore::LegacyWebArchive> coreArchive;
 }
 
-- (instancetype)initWithCoreArchive:(RefPtr<LegacyWebArchive>&&)coreArchive;
-- (LegacyWebArchive*)coreArchive;
-- (void)setCoreArchive:(Ref<LegacyWebArchive>&&)newCoreArchive;
+- (instancetype)initWithCoreArchive:(RefPtr<WebCore::LegacyWebArchive>&&)coreArchive;
+- (WebCore::LegacyWebArchive*)coreArchive;
+- (void)setCoreArchive:(Ref<WebCore::LegacyWebArchive>&&)newCoreArchive;
 @end
 
 @implementation WebArchivePrivate
@@ -80,7 +79,7 @@ static NSString * const WebSubframeArchivesKey = @"WebSubframeArchives";
     return self;
 }
 
-- (instancetype)initWithCoreArchive:(RefPtr<LegacyWebArchive>&&)_coreArchive
+- (instancetype)initWithCoreArchive:(RefPtr<WebCore::LegacyWebArchive>&&)_coreArchive
 {
     self = [super init];
     if (!self|| !_coreArchive) {
@@ -91,12 +90,12 @@ static NSString * const WebSubframeArchivesKey = @"WebSubframeArchives";
     return self;
 }
 
-- (LegacyWebArchive*)coreArchive
+- (WebCore::LegacyWebArchive*)coreArchive
 {
     return coreArchive.get();
 }
 
-- (void)setCoreArchive:(Ref<LegacyWebArchive>&&)newCoreArchive
+- (void)setCoreArchive:(Ref<WebCore::LegacyWebArchive>&&)newCoreArchive
 {
     coreArchive = WTF::move(newCoreArchive);
 }
@@ -166,15 +165,15 @@ static BOOL isArrayOfClass(id object, Class elementClass)
         return nil;
     }
 
-    Vector<Ref<ArchiveResource>> coreResources;
+    Vector<Ref<WebCore::ArchiveResource>> coreResources;
     for (WebResource *subresource in subresources)
         coreResources.append([subresource _coreResource].get());
 
-    Vector<Ref<LegacyWebArchive>> coreArchives;
+    Vector<Ref<WebCore::LegacyWebArchive>> coreArchives;
     for (WebArchive *subframeArchive in subframeArchives)
         coreArchives.append(*[subframeArchive->_private coreArchive]);
 
-    [_private setCoreArchive:LegacyWebArchive::create([mainResource _coreResource].get(), WTF::move(coreResources), WTF::move(coreArchives), std::nullopt)];
+    [_private setCoreArchive:WebCore::LegacyWebArchive::create([mainResource _coreResource].get(), WTF::move(coreResources), WTF::move(coreArchives), std::nullopt)];
     return self;
 }
 
@@ -191,7 +190,7 @@ static BOOL isArrayOfClass(id object, Class elementClass)
 #endif
 
     _private = [[WebArchivePrivate alloc] init];
-    auto coreArchive = LegacyWebArchive::create(SharedBuffer::create(data));
+    auto coreArchive = WebCore::LegacyWebArchive::create(WebCore::SharedBuffer::create(data));
     if (!coreArchive) {
         [self release];
         return nil;
@@ -304,7 +303,7 @@ static BOOL isArrayOfClass(id object, Class elementClass)
             _private->cachedSubframeArchives = adoptNS([[NSArray alloc] init]);
         else {
             _private->cachedSubframeArchives = createNSArray(coreArchive->subframeArchives(), [] (auto& archive) {
-                return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:downcast<LegacyWebArchive>(archive.ptr())]);
+                return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:downcast<WebCore::LegacyWebArchive>(archive.ptr())]);
             });
         }
     }

--- a/Source/WebKitLegacy/mac/WebView/WebDeviceOrientation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDeviceOrientation.mm
@@ -25,11 +25,10 @@
 
 #import "WebDeviceOrientationInternal.h"
 
-using namespace WebCore;
 
 @implementation WebDeviceOrientationInternal
 
-- (id)initWithCoreDeviceOrientation:(RefPtr<DeviceOrientationData>&&)coreDeviceOrientation
+- (id)initWithCoreDeviceOrientation:(RefPtr<WebCore::DeviceOrientationData>&&)coreDeviceOrientation
 {
     self = [super init];
     if (!self)
@@ -55,7 +54,7 @@ using namespace WebCore;
 
 @implementation WebDeviceOrientation
 
-DeviceOrientationData* core(WebDeviceOrientation* orientation)
+WebCore::DeviceOrientationData* core(WebDeviceOrientation* orientation)
 {
     return orientation ? orientation->m_internal->m_orientation.get() : 0;
 }
@@ -75,9 +74,9 @@ static std::optional<double> NODELETE convert(bool canProvide, double value)
 #if PLATFORM(IOS_FAMILY)
     // We don't use this API, but make sure that it compiles with the new
     // compass parameters.
-    m_internal = [[WebDeviceOrientationInternal alloc] initWithCoreDeviceOrientation:DeviceOrientationData::create(convert(canProvideAlpha, alpha), convert(canProvideBeta, beta), convert(canProvideGamma, gamma), std::nullopt, std::nullopt)];
+    m_internal = [[WebDeviceOrientationInternal alloc] initWithCoreDeviceOrientation:WebCore::DeviceOrientationData::create(convert(canProvideAlpha, alpha), convert(canProvideBeta, beta), convert(canProvideGamma, gamma), std::nullopt, std::nullopt)];
 #else
-    m_internal = [[WebDeviceOrientationInternal alloc] initWithCoreDeviceOrientation:DeviceOrientationData::create(convert(canProvideAlpha, alpha), convert(canProvideBeta, beta), convert(canProvideGamma, gamma), std::nullopt)];
+    m_internal = [[WebDeviceOrientationInternal alloc] initWithCoreDeviceOrientation:WebCore::DeviceOrientationData::create(convert(canProvideAlpha, alpha), convert(canProvideBeta, beta), convert(canProvideGamma, gamma), std::nullopt)];
 #endif
     return self;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm
@@ -29,7 +29,6 @@
 #import <WebCore/SecurityOriginData.h>
 #import <wtf/RetainPtr.h>
 
-using namespace WebCore;
 
 @implementation WebDeviceOrientationProviderMockInternal
 
@@ -38,7 +37,7 @@ using namespace WebCore;
     self = [super init];
     if (!self)
         return nil;
-    m_core = makeUnique<DeviceOrientationClientMock>();
+    m_core = makeUnique<WebCore::DeviceOrientationClientMock>();
     return self;
 }
 
@@ -47,7 +46,7 @@ using namespace WebCore;
     m_core->setOrientation(core(orientation));
 }
 
-- (void)setController:(DeviceOrientationController*)controller
+- (void)setController:(WebCore::DeviceOrientationController*)controller
 {
     m_core->setController(controller);
 }

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
@@ -32,16 +32,15 @@
 #import "WebView.h"
 #import <WebCore/FrameDestructionObserverInlines.h>
 
-using namespace WebCore;
 
-WebDocumentLoaderMac::WebDocumentLoaderMac(ResourceRequest&& request, SubstituteData&& substituteData, ResourceRequest&& originalRequest)
+WebDocumentLoaderMac::WebDocumentLoaderMac(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData, WebCore::ResourceRequest&& originalRequest)
     : DocumentLoader(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest))
     , m_dataSource(nil)
     , m_isDataSourceRetained(false)
 {
 }
 
-WebDocumentLoaderMac::WebDocumentLoaderMac(ResourceRequest&& request, SubstituteData&& substituteData)
+WebDocumentLoaderMac::WebDocumentLoaderMac(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData)
     : WebDocumentLoaderMac(WTF::move(request), WTF::move(substituteData), { })
 {
 }
@@ -87,7 +86,7 @@ void WebDocumentLoaderMac::attachToFrame()
     retainDataSource();
 }
 
-void WebDocumentLoaderMac::detachFromFrame(LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
+void WebDocumentLoaderMac::detachFromFrame(WebCore::LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     DocumentLoader::detachFromFrame(loadWillContinueInAnotherProcess);
 

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
@@ -36,7 +36,6 @@
 #import <WebCore/PlatformEventFactoryMac.h>
 #import <wtf/StdLibExtras.h>
 
-using namespace WebCore;
 
 #ifndef __OBJC2__
 // In <rdar://problem/7814899> we saw crashes because WebDynamicScrollBarsView increased in size, breaking ABI compatiblity.
@@ -86,7 +85,7 @@ static Class customScrollerClass;
 
 + (Class)_horizontalScrollerClass
 {
-    if (DeprecatedGlobalSettings::mockScrollbarsEnabled() && customScrollerClass)
+    if (WebCore::DeprecatedGlobalSettings::mockScrollbarsEnabled() && customScrollerClass)
         return customScrollerClass;
 
     return [super _horizontalScrollerClass];
@@ -94,7 +93,7 @@ static Class customScrollerClass;
 
 + (Class)_verticalScrollerClass
 {
-    if (DeprecatedGlobalSettings::mockScrollbarsEnabled() && customScrollerClass)
+    if (WebCore::DeprecatedGlobalSettings::mockScrollbarsEnabled() && customScrollerClass)
         return customScrollerClass;
 
     return [super _horizontalScrollerClass];
@@ -135,10 +134,10 @@ static Class customScrollerClass;
 {
     if (_private->hScrollModeLocked)
         return;
-    if (flag && _private->hScroll == ScrollbarMode::AlwaysOff)
-        _private->hScroll = ScrollbarMode::Auto;
-    else if (!flag && _private->hScroll != ScrollbarMode::AlwaysOff)
-        _private->hScroll = ScrollbarMode::AlwaysOff;
+    if (flag && _private->hScroll == WebCore::ScrollbarMode::AlwaysOff)
+        _private->hScroll = WebCore::ScrollbarMode::Auto;
+    else if (!flag && _private->hScroll != WebCore::ScrollbarMode::AlwaysOff)
+        _private->hScroll = WebCore::ScrollbarMode::AlwaysOff;
     [self updateScrollers];
 }
 
@@ -302,12 +301,12 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
         newHasVerticalScroller = NO;
     }
 
-    if (_private->hScroll != ScrollbarMode::Auto)
-        newHasHorizontalScroller = (_private->hScroll == ScrollbarMode::AlwaysOn);
-    if (_private->vScroll != ScrollbarMode::Auto)
-        newHasVerticalScroller = (_private->vScroll == ScrollbarMode::AlwaysOn);
+    if (_private->hScroll != WebCore::ScrollbarMode::Auto)
+        newHasHorizontalScroller = (_private->hScroll == WebCore::ScrollbarMode::AlwaysOn);
+    if (_private->vScroll != WebCore::ScrollbarMode::Auto)
+        newHasVerticalScroller = (_private->vScroll == WebCore::ScrollbarMode::AlwaysOn);
 
-    if (!documentView || _private->suppressLayout || _private->suppressScrollers || (_private->hScroll != ScrollbarMode::Auto && _private->vScroll != ScrollbarMode::Auto)) {
+    if (!documentView || _private->suppressLayout || _private->suppressScrollers || (_private->hScroll != WebCore::ScrollbarMode::Auto && _private->vScroll != WebCore::ScrollbarMode::Auto)) {
         _private->horizontalScrollingAllowedButScrollerHidden = newHasHorizontalScroller && _private->alwaysHideHorizontalScroller;
         if (_private->horizontalScrollingAllowedButScrollerHidden)
             newHasHorizontalScroller = NO;
@@ -344,13 +343,13 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
     frameSize.width = ceilf(frameSize.width);
     frameSize.height = ceilf(frameSize.height);
 
-    if (_private->hScroll == ScrollbarMode::Auto) {
+    if (_private->hScroll == WebCore::ScrollbarMode::Auto) {
         newHasHorizontalScroller = documentSize.width > visibleSize.width;
         if (newHasHorizontalScroller && !_private->inUpdateScrollersLayoutPass && documentSize.height <= frameSize.height && documentSize.width <= frameSize.width)
             newHasHorizontalScroller = NO;
     }
 
-    if (_private->vScroll == ScrollbarMode::Auto) {
+    if (_private->vScroll == WebCore::ScrollbarMode::Auto) {
         newHasVerticalScroller = documentSize.height > visibleSize.height;
         if (newHasVerticalScroller && !_private->inUpdateScrollersLayoutPass && documentSize.height <= frameSize.height && documentSize.width <= frameSize.width)
             newHasVerticalScroller = NO;
@@ -358,9 +357,9 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
 
     // Unless in ScrollbarsAlwaysOn mode, if we ever turn one scrollbar off, always turn the other one off too.
     // Never ever try to both gain/lose a scrollbar in the same pass.
-    if (!newHasHorizontalScroller && hasHorizontalScroller && _private->vScroll != ScrollbarMode::AlwaysOn)
+    if (!newHasHorizontalScroller && hasHorizontalScroller && _private->vScroll != WebCore::ScrollbarMode::AlwaysOn)
         newHasVerticalScroller = NO;
-    if (!newHasVerticalScroller && hasVerticalScroller && _private->hScroll != ScrollbarMode::AlwaysOn)
+    if (!newHasVerticalScroller && hasVerticalScroller && _private->hScroll != WebCore::ScrollbarMode::AlwaysOn)
         newHasHorizontalScroller = NO;
 
     _private->horizontalScrollingAllowedButScrollerHidden = newHasHorizontalScroller && _private->alwaysHideHorizontalScroller;
@@ -450,12 +449,12 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
 
 - (BOOL)allowsHorizontalScrolling
 {
-    return _private->hScroll != ScrollbarMode::AlwaysOff;
+    return _private->hScroll != WebCore::ScrollbarMode::AlwaysOff;
 }
 
 - (BOOL)allowsVerticalScrolling
 {
-    return _private->vScroll != ScrollbarMode::AlwaysOff;
+    return _private->vScroll != WebCore::ScrollbarMode::AlwaysOff;
 }
 
 - (void)scrollingModes:(WebCore::ScrollbarMode*)hMode vertical:(WebCore::ScrollbarMode*)vMode
@@ -464,33 +463,33 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
     *vMode = _private->vScroll;
 }
 
-- (ScrollbarMode)horizontalScrollingMode
+- (WebCore::ScrollbarMode)horizontalScrollingMode
 {
     return _private->hScroll;
 }
 
-- (ScrollbarMode)verticalScrollingMode
+- (WebCore::ScrollbarMode)verticalScrollingMode
 {
     return _private->vScroll;
 }
 
-- (void)setHorizontalScrollingMode:(ScrollbarMode)horizontalMode andLock:(BOOL)lock
+- (void)setHorizontalScrollingMode:(WebCore::ScrollbarMode)horizontalMode andLock:(BOOL)lock
 {
     [self setScrollingModes:horizontalMode vertical:[self verticalScrollingMode] andLock:lock];
 }
 
-- (void)setVerticalScrollingMode:(ScrollbarMode)verticalMode andLock:(BOOL)lock
+- (void)setVerticalScrollingMode:(WebCore::ScrollbarMode)verticalMode andLock:(BOOL)lock
 {
     [self setScrollingModes:[self horizontalScrollingMode] vertical:verticalMode andLock:lock];
 }
 
 // Mail uses this method, so we cannot remove it. 
-- (void)setVerticalScrollingMode:(ScrollbarMode)verticalMode 
+- (void)setVerticalScrollingMode:(WebCore::ScrollbarMode)verticalMode 
 { 
     [self setScrollingModes:[self horizontalScrollingMode] vertical:verticalMode andLock:NO]; 
 } 
 
-- (void)setScrollingModes:(ScrollbarMode)horizontalMode vertical:(ScrollbarMode)verticalMode andLock:(BOOL)lock
+- (void)setScrollingModes:(WebCore::ScrollbarMode)horizontalMode vertical:(WebCore::ScrollbarMode)verticalMode andLock:(BOOL)lock
 {
     BOOL update = NO;
     if (verticalMode != _private->vScroll && !_private->vScrollModeLocked) {
@@ -545,7 +544,7 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
     float deltaX;
     float deltaY;
     BOOL isContinuous;
-    getWheelEventDeltas(event, deltaX, deltaY, isContinuous);
+    WebCore::getWheelEventDeltas(event, deltaX, deltaY, isContinuous);
 
     NSEventPhase momentumPhase = [event momentumPhase];
     BOOL isLatchingEvent = momentumPhase & NSEventPhaseBegan || momentumPhase & NSEventPhaseStationary;

--- a/Source/WebKitLegacy/mac/WebView/WebGeolocationPosition.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebGeolocationPosition.mm
@@ -29,20 +29,19 @@
 #import <WebCore/GeolocationPositionData.h>
 #import <wtf/RefPtr.h>
 
-using namespace WebCore;
 
 @interface WebGeolocationPositionInternal : NSObject
 {
 @public
-    GeolocationPositionData _position;
+    WebCore::GeolocationPositionData _position;
 }
 
-- (id)initWithCoreGeolocationPosition:(GeolocationPositionData&&)coreGeolocationPosition;
+- (id)initWithCoreGeolocationPosition:(WebCore::GeolocationPositionData&&)coreGeolocationPosition;
 @end
 
 @implementation WebGeolocationPositionInternal
 
-- (id)initWithCoreGeolocationPosition:(GeolocationPositionData&&)coreGeolocationPosition
+- (id)initWithCoreGeolocationPosition:(WebCore::GeolocationPositionData&&)coreGeolocationPosition
 {
     self = [super init];
     if (!self)
@@ -55,7 +54,7 @@ using namespace WebCore;
 
 @implementation WebGeolocationPosition
 
-std::optional<GeolocationPositionData> core(WebGeolocationPosition *position)
+std::optional<WebCore::GeolocationPositionData> core(WebGeolocationPosition *position)
 {
     if (!position)
         return std::nullopt;
@@ -67,11 +66,11 @@ std::optional<GeolocationPositionData> core(WebGeolocationPosition *position)
     self = [super init];
     if (!self)
         return nil;
-    _internal = [[WebGeolocationPositionInternal alloc] initWithCoreGeolocationPosition:GeolocationPositionData { timestamp, latitude, longitude, accuracy }];
+    _internal = [[WebGeolocationPositionInternal alloc] initWithCoreGeolocationPosition:WebCore::GeolocationPositionData { timestamp, latitude, longitude, accuracy }];
     return self;
 }
 
-- (id)initWithGeolocationPosition:(GeolocationPositionData&&)coreGeolocationPosition
+- (id)initWithGeolocationPosition:(WebCore::GeolocationPositionData&&)coreGeolocationPosition
 {
     self = [super init];
     if (!self)

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -74,8 +74,7 @@
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/StringBuilder.h>
 
-using namespace WebCore;
-using namespace HTMLNames;
+using namespace WebCore::HTMLNames;
 using JSC::Yarr::RegularExpression;
 
 @interface WebHTMLRepresentationPrivate : NSObject {
@@ -104,25 +103,25 @@ using JSC::Yarr::RegularExpression;
 
 + (NSArray *)supportedMediaMIMETypes
 {
-    static NeverDestroyed<RetainPtr<NSArray>> staticSupportedMediaMIMETypes = createNSArray(MIMETypeRegistry::supportedMediaMIMETypes());
+    static NeverDestroyed<RetainPtr<NSArray>> staticSupportedMediaMIMETypes = createNSArray(WebCore::MIMETypeRegistry::supportedMediaMIMETypes());
     return staticSupportedMediaMIMETypes.get().get();
 }
 
 + (NSArray *)supportedNonImageMIMETypes
 {
-    static NeverDestroyed<RetainPtr<NSArray>> staticSupportedNonImageMIMETypes = createNSArray(MIMETypeRegistry::supportedNonImageMIMETypes());
+    static NeverDestroyed<RetainPtr<NSArray>> staticSupportedNonImageMIMETypes = createNSArray(WebCore::MIMETypeRegistry::supportedNonImageMIMETypes());
     return staticSupportedNonImageMIMETypes.get().get();
 }
 
 + (NSArray *)supportedImageMIMETypes
 {
-    static NeverDestroyed<RetainPtr<NSArray>> staticSupportedImageMIMETypes = createNSArray(MIMETypeRegistry::supportedImageMIMETypes());
+    static NeverDestroyed<RetainPtr<NSArray>> staticSupportedImageMIMETypes = createNSArray(WebCore::MIMETypeRegistry::supportedImageMIMETypes());
     return staticSupportedImageMIMETypes.get().get();
 }
 
 + (NSArray *)unsupportedTextMIMETypes
 {
-    static NeverDestroyed<RetainPtr<NSArray>> staticUnsupportedTextMIMETypes = createNSArray(MIMETypeRegistry::unsupportedTextMIMETypes());
+    static NeverDestroyed<RetainPtr<NSArray>> staticUnsupportedTextMIMETypes = createNSArray(WebCore::MIMETypeRegistry::unsupportedTextMIMETypes());
     return staticUnsupportedTextMIMETypes.get().get();
 }
 
@@ -236,10 +235,10 @@ using JSC::Yarr::RegularExpression;
     auto* coreFrame = core([_private->dataSource webFrame]);
     if (!coreFrame)
         return nil;
-    Document* document = coreFrame->document();
+    WebCore::Document* document = coreFrame->document();
     if (!document)
         return nil;
-    TextResourceDecoder* decoder = document->decoder();
+    WebCore::TextResourceDecoder* decoder = document->decoder();
     if (!decoder)
         return nil;
     NSData *data = [_private->dataSource data];
@@ -269,25 +268,25 @@ using JSC::Yarr::RegularExpression;
 {
     if (!startNode || !endNode)
         return adoptNS([[NSAttributedString alloc] init]).autorelease();
-    auto range = SimpleRange { { *core(startNode), static_cast<unsigned>(startOffset) }, { *core(endNode), static_cast<unsigned>(endOffset) } };
+    auto range = WebCore::SimpleRange { { *core(startNode), static_cast<unsigned>(startOffset) }, { *core(endNode), static_cast<unsigned>(endOffset) } };
     return editingAttributedString(range).nsAttributedString().autorelease();
 }
 
 #endif
 
-static HTMLFormElement* formElementFromDOMElement(DOMElement *element)
+static WebCore::HTMLFormElement* formElementFromDOMElement(DOMElement *element)
 {
-    Element* node = core(element);
-    return node && node->hasTagName(formTag) ? static_cast<HTMLFormElement*>(node) : nullptr;
+    WebCore::Element* node = core(element);
+    return node && node->hasTagName(formTag) ? static_cast<WebCore::HTMLFormElement*>(node) : nullptr;
 }
 
 - (DOMElement *)elementWithName:(NSString *)name inForm:(DOMElement *)form
 {
-    HTMLFormElement* formElement = formElementFromDOMElement(form);
+    WebCore::HTMLFormElement* formElement = formElementFromDOMElement(form);
     if (!formElement)
         return nil;
 
-    ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+    WebCore::ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     AtomString targetName = name;
     for (auto& weakElement : formElement->unsafeListedElements()) {
         RefPtr element { weakElement.get() };
@@ -297,15 +296,15 @@ static HTMLFormElement* formElementFromDOMElement(DOMElement *element)
     return nil;
 }
 
-static HTMLInputElement* inputElementFromDOMElement(DOMElement* element)
+static WebCore::HTMLInputElement* inputElementFromDOMElement(DOMElement* element)
 {
-    Element* node = core(element);
-    return dynamicDowncast<HTMLInputElement>(node);
+    WebCore::Element* node = core(element);
+    return dynamicDowncast<WebCore::HTMLInputElement>(node);
 }
 
 - (BOOL)elementDoesAutoComplete:(DOMElement *)element
 {
-    HTMLInputElement* inputElement = inputElementFromDOMElement(element);
+    WebCore::HTMLInputElement* inputElement = inputElementFromDOMElement(element);
     return inputElement
         && inputElement->isTextField()
         && !inputElement->isPasswordField()
@@ -314,7 +313,7 @@ static HTMLInputElement* inputElementFromDOMElement(DOMElement* element)
 
 - (BOOL)elementIsPassword:(DOMElement *)element
 {
-    HTMLInputElement* inputElement = inputElementFromDOMElement(element);
+    WebCore::HTMLInputElement* inputElement = inputElementFromDOMElement(element);
     return inputElement && inputElement->isPasswordField();
 }
 
@@ -335,7 +334,7 @@ static HTMLInputElement* inputElementFromDOMElement(DOMElement* element)
     if (!formElement)
         return nil;
 
-    ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+    WebCore::ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     auto result = createNSArray(formElement->unsafeListedElements(), [] (auto& weakElement) -> DOMElement * {
         RefPtr coreElement { weakElement.get() };
         if (!coreElement || !coreElement->asFormListedElement()->isEnumeratable()) // Skip option elements, other duds
@@ -409,7 +408,7 @@ static RegularExpression* regExpForLabels(NSArray *labels)
 }
 
 // FIXME: This should take an Element&.
-static RetainPtr<NSString> searchForLabelsBeforeElement(LocalFrame* frame, NSArray* labels, Element* element, size_t* resultDistance, bool* resultIsInCellAbove)
+static RetainPtr<NSString> searchForLabelsBeforeElement(WebCore::LocalFrame* frame, NSArray* labels, WebCore::Element* element, size_t* resultDistance, bool* resultIsInCellAbove)
 {
     ASSERT(element);
     RegularExpression* regExp = regExpForLabels(labels);
@@ -419,7 +418,7 @@ static RetainPtr<NSString> searchForLabelsBeforeElement(LocalFrame* frame, NSArr
     // charsSearchedThreshold, to make it more likely that we'll search whole nodes.
     constexpr unsigned maxCharsSearched = 600;
     // If the starting element is within a table, the cell that contains it
-    HTMLTableCellElement* startingTableCell = nullptr;
+    WebCore::HTMLTableCellElement* startingTableCell = nullptr;
     bool searchedCellAbove = false;
     
     if (resultDistance)
@@ -429,14 +428,14 @@ static RetainPtr<NSString> searchForLabelsBeforeElement(LocalFrame* frame, NSArr
 
     // walk backwards in the node tree, until another element, or form, or end of tree
     unsigned lengthSearched = 0;
-    Node* n;
-    for (n = NodeTraversal::previous(*element); n && lengthSearched < charsSearchedThreshold; n = NodeTraversal::previous(*n)) {
-        if (is<HTMLFormElement>(*n) || is<HTMLFormControlElement>(*n)) {
+    WebCore::Node* n;
+    for (n = WebCore::NodeTraversal::previous(*element); n && lengthSearched < charsSearchedThreshold; n = WebCore::NodeTraversal::previous(*n)) {
+        if (is<WebCore::HTMLFormElement>(*n) || is<WebCore::HTMLFormControlElement>(*n)) {
             // We hit another form element or the start of the form - bail out
             break;
         }
         if (n->hasTagName(tdTag) && !startingTableCell) {
-            startingTableCell = downcast<HTMLTableCellElement>(n);
+            startingTableCell = downcast<WebCore::HTMLTableCellElement>(n);
         } else if (n->hasTagName(trTag) && startingTableCell) {
             RetainPtr result = frame->searchForLabelsAboveCell(*regExp, startingTableCell, resultDistance).createNSString();
             if ([result length]) {
@@ -445,7 +444,7 @@ static RetainPtr<NSString> searchForLabelsBeforeElement(LocalFrame* frame, NSArr
                 return result;
             }
             searchedCellAbove = true;
-        } else if (auto* renderText = dynamicDowncast<RenderText>(n->renderer()); renderText && renderText->style().usedVisibility() == Visibility::Visible) {
+        } else if (auto* renderText = dynamicDowncast<WebCore::RenderText>(n->renderer()); renderText && renderText->style().usedVisibility() == WebCore::Visibility::Visible) {
             // For each text chunk, run the regexp
             String nodeString = n->nodeValue();
             // add 100 for slop, to make it more likely that we'll search whole nodes
@@ -510,7 +509,7 @@ static RetainPtr<NSString> matchLabelsAgainstString(NSArray *labels, const Strin
     return nil;
 }
 
-static RetainPtr<NSString> matchLabelsAgainstElement(NSArray *labels, Element* element)
+static RetainPtr<NSString> matchLabelsAgainstElement(NSArray *labels, WebCore::Element* element)
 {
     if (!element)
         return nil;

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -655,7 +655,7 @@ static std::optional<NSInteger> NODELETE toTag(WebCore::ContextMenuAction action
 
 - (void)forwardContextMenuAction:(id)sender
 {
-    auto action = toAction([sender tag]);
+    auto action = toAction([(NSMenuItem *)sender tag]);
     if (!action)
         return;
 
@@ -1193,7 +1193,6 @@ static NSControlStateValue NODELETE kit(TriState state)
 
 - (DOMDocumentFragment *)_documentFragmentFromPasteboard:(NSPasteboard *)pasteboard inContext:(DOMRange *)context allowPlainText:(BOOL)allowPlainText
 {
-    using namespace WebCore;
     NSArray *types = [pasteboard types];
     DOMDocumentFragment *fragment = nil;
 
@@ -5514,7 +5513,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (![self _canEdit])
         return;
     
-    NSWritingDirection writingDirection = static_cast<NSWritingDirection>([sender tag]);
+    NSWritingDirection writingDirection = static_cast<NSWritingDirection>([(NSMenuItem *)sender tag]);
     
     // We disable the menu item that performs this action because we can't implement
     // NSWritingDirectionNatural's behavior using CSS.

--- a/Source/WebKitLegacy/mac/WebView/WebIndicateLayer.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebIndicateLayer.mm
@@ -34,7 +34,6 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/NeverDestroyed.h>
 
-using namespace WebCore;
 
 @implementation WebIndicateLayer
 
@@ -50,8 +49,8 @@ using namespace WebCore;
     self.contentsScale = [[_webView window] screenScale];
 
     // Blue highlight color.
-    constexpr auto highlightColor = SRGBA<uint8_t> { 111, 168, 220, 168 };
-    self.backgroundColor = cachedCGColor(highlightColor).get();
+    constexpr auto highlightColor = WebCore::SRGBA<uint8_t> { 111, 168, 220, 168 };
+    self.backgroundColor = WebCore::cachedCGColor(highlightColor).get();
 
     return self;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebNotification.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebNotification.mm
@@ -37,14 +37,13 @@
 #import <WebCore/ScriptExecutionContext.h>
 #import <wtf/RefPtr.h>
 
-using namespace WebCore;
 #endif
 
 @interface WebNotificationPrivate : NSObject
 {
 @public
 #if ENABLE(NOTIFICATIONS)
-    std::optional<NotificationData> _internal;
+    std::optional<WebCore::NotificationData> _internal;
 #endif
 }
 @end
@@ -55,7 +54,7 @@ using namespace WebCore;
 #if ENABLE(NOTIFICATIONS)
 @implementation WebNotification (WebNotificationInternal)
 
-- (id)initWithCoreNotification:(NotificationData&&)coreNotification
+- (id)initWithCoreNotification:(WebCore::NotificationData&&)coreNotification
 {
     if (!(self = [super init]))
         return nil;
@@ -127,11 +126,11 @@ using namespace WebCore;
 {
 #if ENABLE(NOTIFICATIONS)
     switch (_private->_internal->direction) {
-        case Notification::Direction::Auto:
+        case WebCore::Notification::Direction::Auto:
             return @"auto";
-        case Notification::Direction::Ltr:
+        case WebCore::Notification::Direction::Ltr:
             return @"ltr";
-        case Notification::Direction::Rtl:
+        case WebCore::Notification::Direction::Rtl:
             return @"rtl";
     }
 #else
@@ -160,7 +159,7 @@ using namespace WebCore;
 - (void)dispatchShowEvent
 {
 #if ENABLE(NOTIFICATIONS)
-    Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
+    WebCore::Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
         if (notification)
             notification->dispatchShowEvent();
     });
@@ -170,7 +169,7 @@ using namespace WebCore;
 - (void)dispatchCloseEvent
 {
 #if ENABLE(NOTIFICATIONS)
-    Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
+    WebCore::Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
         if (notification)
             notification->dispatchCloseEvent();
     });
@@ -180,7 +179,7 @@ using namespace WebCore;
 - (void)dispatchClickEvent
 {
 #if ENABLE(NOTIFICATIONS)
-    Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
+    WebCore::Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
         if (notification)
             notification->dispatchClickEvent();
     });
@@ -190,7 +189,7 @@ using namespace WebCore;
 - (void)dispatchErrorEvent
 {
 #if ENABLE(NOTIFICATIONS)
-    Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
+    WebCore::Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
         if (notification)
             notification->dispatchErrorEvent();
     });
@@ -200,7 +199,7 @@ using namespace WebCore;
 - (void)finalize
 {
 #if ENABLE(NOTIFICATIONS)
-    Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
+    WebCore::Notification::ensureOnNotificationThread(*_private->_internal, [](auto* notification) {
         if (notification)
             notification->finalize();
     });

--- a/Source/WebKitLegacy/mac/WebView/WebPolicyDelegate.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPolicyDelegate.mm
@@ -31,7 +31,6 @@
 #import <WebCore/FrameLoaderTypes.h>
 #import <wtf/ObjCRuntimeExtras.h>
 
-using namespace WebCore;
 
 NSString *WebActionButtonKey = @"WebActionButtonKey"; 
 NSString *WebActionElementKey = @"WebActionElementKey";
@@ -82,7 +81,7 @@ NSString *WebActionOriginalURLKey = @"WebActionOriginalURLKey";
     [super dealloc];
 }
 
-- (void)_usePolicy:(PolicyAction)policy
+- (void)_usePolicy:(WebCore::PolicyAction)policy
 {
     if (_private->target)
         wtfObjCMsgSend<void>(_private->target.get(), _private->action, policy);
@@ -97,17 +96,17 @@ NSString *WebActionOriginalURLKey = @"WebActionOriginalURLKey";
 
 - (void)use
 {
-    [self _usePolicy:PolicyAction::Use];
+    [self _usePolicy:WebCore::PolicyAction::Use];
 }
 
 - (void)ignore
 {
-    [self _usePolicy:PolicyAction::Ignore];
+    [self _usePolicy:WebCore::PolicyAction::Ignore];
 }
 
 - (void)download
 {
-    [self _usePolicy:PolicyAction::Download];
+    [self _usePolicy:WebCore::PolicyAction::Download];
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -58,7 +58,6 @@
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/darwin/DispatchOSObject.h>
 
-using namespace WebCore;
 
 #if PLATFORM(IOS_FAMILY)
 #import <WebCore/GraphicsContext.h>
@@ -306,6 +305,14 @@ public:
 {
     WebCore::initializeMainThreadIfNeeded();
 
+    // Default-value expressions in UnifiedWebPreferences.yaml use these types
+    // unqualified inside INITIALIZE_DEFAULT_PREFERENCES_DICTIONARY_FROM_GENERATED_PREFERENCES.
+#if ENABLE(DATA_DETECTION)
+    using WebCore::DataDetectorType;
+#endif
+    using WebCore::TextDirection;
+    using WebCore::UserInterfaceDirectionPolicy;
+
     RetainPtr dict = [NSDictionary dictionaryWithObjectsAndKeys:
         INITIALIZE_DEFAULT_PREFERENCES_DICTIONARY_FROM_GENERATED_PREFERENCES
 
@@ -336,9 +343,9 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
         @NO, WebKitStorageTrackerEnabledPreferenceKey,
-        @(static_cast<unsigned>(AudioSession::CategoryType::None)), WebKitAudioSessionCategoryOverride,
+        @(static_cast<unsigned>(WebCore::AudioSession::CategoryType::None)), WebKitAudioSessionCategoryOverride,
         @NO, WebKitAlwaysRequestGeolocationPermissionPreferenceKey,
-        @(static_cast<int>(InterpolationQuality::Low)), WebKitInterpolationQualityPreferenceKey,
+        @(static_cast<int>(WebCore::InterpolationQuality::Low)), WebKitInterpolationQualityPreferenceKey,
         @"", WebKitNetworkInterfaceNamePreferenceKey,
 #endif
         nil];
@@ -1825,30 +1832,30 @@ static RetainPtr<NSString>& NODELETE classIBCreatorID()
 
 - (void)setAudioSessionCategoryOverride:(unsigned)override
 {
-    if (override > static_cast<unsigned>(AudioSession::CategoryType::AudioProcessing)) {
+    if (override > static_cast<unsigned>(WebCore::AudioSession::CategoryType::AudioProcessing)) {
         // Clients are passing us OSTypes values from AudioToolbox/AudioSession.h,
         // which need to be translated into AudioSession::CategoryType:
         switch (override) {
         case WebKitAudioSessionCategoryAmbientSound:
-            override = static_cast<unsigned>(AudioSession::CategoryType::AmbientSound);
+            override = static_cast<unsigned>(WebCore::AudioSession::CategoryType::AmbientSound);
             break;
         case WebKitAudioSessionCategorySoloAmbientSound:
-            override = static_cast<unsigned>(AudioSession::CategoryType::SoloAmbientSound);
+            override = static_cast<unsigned>(WebCore::AudioSession::CategoryType::SoloAmbientSound);
             break;
         case WebKitAudioSessionCategoryMediaPlayback:
-            override = static_cast<unsigned>(AudioSession::CategoryType::MediaPlayback);
+            override = static_cast<unsigned>(WebCore::AudioSession::CategoryType::MediaPlayback);
             break;
         case WebKitAudioSessionCategoryRecordAudio:
-            override = static_cast<unsigned>(AudioSession::CategoryType::RecordAudio);
+            override = static_cast<unsigned>(WebCore::AudioSession::CategoryType::RecordAudio);
             break;
         case WebKitAudioSessionCategoryPlayAndRecord:
-            override = static_cast<unsigned>(AudioSession::CategoryType::PlayAndRecord);
+            override = static_cast<unsigned>(WebCore::AudioSession::CategoryType::PlayAndRecord);
             break;
         case WebKitAudioSessionCategoryAudioProcessing:
-            override = static_cast<unsigned>(AudioSession::CategoryType::AudioProcessing);
+            override = static_cast<unsigned>(WebCore::AudioSession::CategoryType::AudioProcessing);
             break;
         default:
-            override = static_cast<unsigned>(AudioSession::CategoryType::None);
+            override = static_cast<unsigned>(WebCore::AudioSession::CategoryType::None);
             break;
         }
     }

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -48,7 +48,6 @@
 #import <wtf/RunLoop.h>
 #import <wtf/RuntimeApplicationChecks.h>
 
-using namespace WebCore;
 
 static NSString * const WebResourceDataKey =              @"WebResourceData";
 static NSString * const WebResourceFrameNameKey =         @"WebResourceFrameName";
@@ -59,9 +58,9 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
 @interface WebResourcePrivate : NSObject {
 @public
-    RefPtr<ArchiveResource> coreResource;
+    RefPtr<WebCore::ArchiveResource> coreResource;
 }
-- (instancetype)initWithCoreResource:(Ref<ArchiveResource>&&)coreResource;
+- (instancetype)initWithCoreResource:(Ref<WebCore::ArchiveResource>&&)coreResource;
 @end
 
 @implementation WebResourcePrivate
@@ -77,7 +76,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     return self;
 }
 
-- (instancetype)initWithCoreResource:(Ref<ArchiveResource>&&)passedResource
+- (instancetype)initWithCoreResource:(Ref<WebCore::ArchiveResource>&&)passedResource
 {
     self = [super init];
     if (!self)
@@ -150,7 +149,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
         return nil;
     }
 
-    auto coreResource = ArchiveResource::create(SharedBuffer::create(data.get()), url.get(), mimeType.get(), textEncoding.get(), frameName.get(), response.get());
+    auto coreResource = WebCore::ArchiveResource::create(WebCore::SharedBuffer::create(data.get()), url.get(), mimeType.get(), textEncoding.get(), frameName.get(), response.get());
     if (!coreResource) {
         [self release];
         return nil;
@@ -252,7 +251,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
 @implementation WebResource (WebResourceInternal)
 
-- (id)_initWithCoreResource:(Ref<ArchiveResource>&&)coreResource
+- (id)_initWithCoreResource:(Ref<WebCore::ArchiveResource>&&)coreResource
 {
     self = [super init];
     if (!self)
@@ -301,7 +300,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
         return nil;
     }
 
-    auto coreResource = ArchiveResource::create(SharedBuffer::create(copyData ? adoptNS([data copy]).get() : data), URL, MIMEType, textEncodingName, frameName, response);
+    auto coreResource = WebCore::ArchiveResource::create(WebCore::SharedBuffer::create(copyData ? adoptNS([data copy]).get() : data), URL, MIMEType, textEncodingName, frameName, response);
     if (!coreResource) {
         [self release];
         return nil;

--- a/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
@@ -40,7 +40,6 @@
 - (void)_setForceActiveControls:(BOOL)flag;
 @end
 
-using namespace WebCore;
 
 // This class handles the complete: operation.
 // It counts on its host view to call endRevertingChange: whenever the current completion needs to be aborted.
@@ -171,8 +170,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // Get preceeding word stem
         WebFrame *frame = [_htmlView _frame];
         RetainPtr selection = kit(core(frame)->selection().selection().toNormalizedRange());
-        DOMRange *wholeWord = [frame _rangeByAlteringCurrentSelection:FrameSelection::Alteration::Extend
-            direction:SelectionDirection::Backward granularity:TextGranularity::WordGranularity];
+        DOMRange *wholeWord = [frame _rangeByAlteringCurrentSelection:WebCore::FrameSelection::Alteration::Extend
+            direction:WebCore::SelectionDirection::Backward granularity:WebCore::TextGranularity::WordGranularity];
         DOMRange *prefix = [wholeWord cloneRange];
         [prefix setEnd:[selection.get() startContainer] offset:[selection.get() startOffset]];
 
@@ -202,7 +201,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             ASSERT(!_originalString);       // this should only be set IFF we have a popup window
             _originalString = [[frame _stringForRange:selection.get()] retain];
             [self _buildUI];
-            NSRect wordRect = [frame _caretRectAtPosition:Position(core([wholeWord startContainer]), [wholeWord startOffset], Position::PositionIsOffsetInAnchor) affinity:NSSelectionAffinityDownstream];
+            NSRect wordRect = [frame _caretRectAtPosition:WebCore::Position(core([wholeWord startContainer]), [wholeWord startOffset], WebCore::Position::PositionIsOffsetInAnchor) affinity:NSSelectionAffinityDownstream];
             // +1 to be under the word, not the caret
             // FIXME - 3769652 - Wrong positioning for right to left languages.  We should line up the upper
             // right corner with the caret instead of upper left, and the +1 would be a -1.

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -42,7 +42,10 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
+#if !defined(WebKitLegacy_AVKitLibrary_SoftLinked)
+#define WebKitLegacy_AVKitLibrary_SoftLinked
 SOFTLINK_AVKIT_FRAMEWORK()
+#endif
 SOFT_LINK_CLASS(AVKit, AVPlayerView)
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -397,7 +397,10 @@
 #endif
 
 #if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
+#if !defined(WebKitLegacy_AVKitLibrary_SoftLinked)
+#define WebKitLegacy_AVKitLibrary_SoftLinked
 SOFT_LINK_FRAMEWORK(AVKit)
+#endif
 SOFT_LINK_CLASS(AVKit, AVTouchBarPlaybackControlsProvider)
 SOFT_LINK_CLASS(AVKit, AVTouchBarScrubber)
 #endif


### PR DESCRIPTION
#### 42e97c29d4e528aa1814d03877a5aae41de3e852
<pre>
[CMake][Mac] Add straggler files to the unified build in WebKitLegacy/WebKit/WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=317212">https://bugs.webkit.org/show_bug.cgi?id=317212</a>
<a href="https://rdar.apple.com/179833643">rdar://179833643</a>

Reviewed by Mike Wyrzykowski.

Saves ~16s (5%) in a clean build.

Translation-unit counts:
  WebKitLegacy   131 -&gt;  33
  WebKit         256 -&gt; 126
  WebCore        238 -&gt; 148
  Total          625 -&gt; 307

This patch excludes iOS for now to reduce the build qualification burden.

* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp: Unified build name
ambiguity fix.

* Source/WebCore/PlatformCocoa.cmake: Include the new unified source list in the build.

* Source/WebCore/SourcesCMakeCocoa.txt: New unified source list.

* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm: Drop using namespace WebCore
to avoid unified name collisions.

* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
* Source/WebCore/platform/ios/WebAVPlayerController.mm
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm: Use #ifdefs and/or #undef
to guard double definition.

* Source/WebKit/PlatformCocoa.cmake: Include the new unified source list in the build.

* Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm: Avoid name conflict in the unified
build.

* Source/WebKit/SourcesCMakeCocoa.txt: New unified source list.

* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp: Use #ifdefs and/or #undef
to guard double definition.

* Source/WebKitLegacy/PlatformCocoa.cmake: Include the new unified source list in the build.

* Source/WebKitLegacy/SourcesCMakeCocoa.txt: New unified source list.

* Source/WebKitLegacy/WebCoreSupport/WebViewGroup.mm
* Source/WebKitLegacy/mac/History/BackForwardList.mm
* Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
* Source/WebKitLegacy/mac/History/WebHistory.mm
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
* Source/WebKitLegacy/mac/Misc/WebDownload.mm
* Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
* Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
* Source/WebKitLegacy/mac/Misc/WebKitLogInitialization.mm
* Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
* Source/WebKitLegacy/mac/Misc/WebLocalizableStringsInternal.mm
* Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
* Source/WebKitLegacy/mac/Misc/WebUserContentURLPattern.mm
* Source/WebKitLegacy/mac/Plugins/WebPluginPackage.mm
* Source/WebKitLegacy/mac/Storage/WebDatabaseManager.mm
* Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.mm
* Source/WebKitLegacy/mac/Storage/WebDatabaseQuotaManager.mm
* Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
* Source/WebKitLegacy/mac/Storage/WebStorageTrackerClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebGeolocationClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebNotificationClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebOpenPanelResultListener.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebPluginInfoProvider.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebProgressTrackerClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebSecurityOrigin.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebSelectionServiceController.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebValidationMessageClient.mm
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
* Source/WebKitLegacy/mac/WebInspector/WebInspectorFrontend.mm
* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
* Source/WebKitLegacy/mac/WebView/WebArchive.mm
* Source/WebKitLegacy/mac/WebView/WebDeviceOrientation.mm
* Source/WebKitLegacy/mac/WebView/WebDeviceOrientationProviderMock.mm
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
* Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
* Source/WebKitLegacy/mac/WebView/WebGeolocationPosition.mm
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
* Source/WebKitLegacy/mac/WebView/WebIndicateLayer.mm
* Source/WebKitLegacy/mac/WebView/WebNotification.mm
* Source/WebKitLegacy/mac/WebView/WebPolicyDelegate.mm
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm
* Source/WebKitLegacy/mac/WebView/WebResource.mm
* Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
* Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm: Drop using namespace
WebCore, and use WebCore::, to prevent name conflicts when bundling.

* Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
* Source/WebKitLegacy/mac/WebView/WebView.mm: Use #ifdef guards to avoid duplicate
definition when bundling.

Canonical link: <a href="https://commits.webkit.org/315332@main">https://commits.webkit.org/315332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bb86ae6cefa0a097c2d0cb820dcfaf7df267744

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168691 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126398 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/416f9f85-4b5c-49ae-a335-8460d94fd45f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131335 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00f5e091-c02f-4ed7-9ebd-e0bb3b5d4085) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33787 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111839 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b689c088-a95c-4e99-8680-afda0b0608ed) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26717 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180623 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139777 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42262 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139626 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42951 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106678 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25696 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34907 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114718 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41454 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6070 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40851 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40996 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->