### PR TITLE
WebGamepadProvider::setInitialGamepads stops at the first empty slot instead of skipping it

### DIFF
--- a/LayoutTests/http/tests/gamepad/initial-gamepads-skips-empty-slot-expected.txt
+++ b/LayoutTests/http/tests/gamepad/initial-gamepads-skips-empty-slot-expected.txt
@@ -1,0 +1,3 @@
+Iframe in a separate process: true
+Gamepad indices visible to the iframe: 0, 2, 3
+

--- a/LayoutTests/http/tests/gamepad/initial-gamepads-skips-empty-slot.html
+++ b/LayoutTests/http/tests/gamepad/initial-gamepads-skips-empty-slot.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+testRunner.dumpAsText();
+testRunner.waitUntilDone();
+
+function log(message) { document.getElementById("console").textContent += message + "\n"; }
+
+function waitForGamepadEvent(type, index) {
+    return new Promise(resolve => {
+        addEventListener(type, function handler(event) {
+            if (event.gamepad.index !== index)
+                return;
+            removeEventListener(type, handler);
+            resolve();
+        });
+    });
+}
+
+onmessage = (event) => {
+    if (event.data.type === "ready") {
+        log("Iframe in a separate process: " + (event.data.pid !== internals.processIdentifier));
+        testRunner.setMockGamepadDetails(3, "3", "", 0, 0, false);
+        testRunner.connectMockGamepad(3);
+    } else if (event.data.type === "result") {
+        log("Gamepad indices visible to the iframe: " + event.data.indices.join(", "));
+        testRunner.notifyDone();
+    }
+};
+
+async function runTest() {
+    for (const index of [0, 1, 2]) {
+        const connected = waitForGamepadEvent("gamepadconnected", index);
+        testRunner.setMockGamepadDetails(index, "" + index, "", 0, 0, false);
+        testRunner.connectMockGamepad(index);
+        await connected;
+    }
+
+    const disconnected = waitForGamepadEvent("gamepaddisconnected", 1);
+    testRunner.disconnectMockGamepad(1);
+    await disconnected;
+
+    const iframe = document.createElement("iframe");
+    iframe.allow = "gamepad";
+    iframe.src = "http://localhost:8000/gamepad/resources/initial-gamepads-iframe.html";
+    document.body.appendChild(iframe);
+}
+</script>
+<body onload="runTest()"><pre id="console"></pre></body>

--- a/LayoutTests/http/tests/gamepad/resources/initial-gamepads-iframe.html
+++ b/LayoutTests/http/tests/gamepad/resources/initial-gamepads-iframe.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script>
+addEventListener("gamepadconnected", (event) => {
+    if (event.gamepad.index !== 3)
+        return;
+    const indices = navigator.getGamepads().flatMap((gamepad, index) => gamepad ? [index] : []);
+    parent.postMessage({ type: "result", indices }, "*");
+});
+onload = () => parent.postMessage({ type: "ready", pid: internals.processIdentifier }, "*");
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3679,6 +3679,7 @@ fast/zooming/ios [ Skip ]
 # Needs site isolation drawing implementation
 http/tests/site-isolation [ Skip ]
 http/tests/contentextensions/cross-origin-content-rules.html [ Skip ]
+http/tests/gamepad/initial-gamepads-skips-empty-slot.html [ Skip ]
 
 # Tests behavior specific to MediaSessionManagerCocoa
 media/audio-session-category.html [ Skip ]

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp
@@ -65,7 +65,7 @@ void WebGamepadProvider::setInitialGamepads(const Vector<std::optional<GamepadDa
     m_rawGamepads.resize(gamepadDatas.size());
     for (size_t i = 0; i < gamepadDatas.size(); ++i) {
         if (!gamepadDatas[i])
-            return;
+            continue;
 
         m_gamepads[i] = makeUnique<WebGamepad>(*gamepadDatas[i]);
         m_rawGamepads[i] = m_gamepads[i].get();


### PR DESCRIPTION
#### 14e114dfe9593b8ad94eb21ace9923e9968b21b2
<pre>
WebGamepadProvider::setInitialGamepads stops at the first empty slot instead of skipping it
<a href="https://bugs.webkit.org/show_bug.cgi?id=317217">https://bugs.webkit.org/show_bug.cgi?id=317217</a>
<a href="https://rdar.apple.com/179838322">rdar://179838322</a>

Reviewed by Brady Eidson.

setInitialGamepads() returned at the first empty (std::nullopt) slot, dropping every gamepad at a
later index. It only runs with a populated snapshot in a process that starts monitoring after
gamepads are already connected, and the first such process always gets an empty snapshot. So the
test enables site isolation: the main frame connects gamepads at indices 0 and 2 (index 1 empty),
then a cross-origin iframe&apos;s separate process gets the gapped snapshot via SetInitialGamepads() and
reports a missing index 2.

Test: http/tests/gamepad/initial-gamepads-skips-empty-slot.html
* LayoutTests/http/tests/gamepad/initial-gamepads-skips-empty-slot-expected.txt: Added.
* LayoutTests/http/tests/gamepad/initial-gamepads-skips-empty-slot.html: Added.
* LayoutTests/http/tests/gamepad/resources/initial-gamepads-iframe.html: Added.
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.cpp:
(WebKit::WebGamepadProvider::setInitialGamepads):

Canonical link: <a href="https://commits.webkit.org/315393@main">https://commits.webkit.org/315393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e8b8c2ae126860457f0d0db720d8a486ebfe650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126481 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8443aa3-c898-4534-b545-f4a7db3f7b7e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131410 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca00b73d-5bd9-467c-9eeb-8e2602a92404) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111914 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/670538fa-8837-402b-830d-9912c79f0eef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32851 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31564 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26800 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180706 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139858 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139702 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43034 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106780 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25729 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34984 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114801 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41537 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6140 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40934 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41188 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41079 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->