### PR TITLE
BorderShape: add corner-shape curvature support to BorderShape class interface

### DIFF
--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -71,6 +71,12 @@ static RectEdges<LayoutUnit> applyClosedEdges(const RectEdges<LayoutUnit>& width
     };
 }
 
+static RectCorners<float> cornerCurvaturesFromStyle(const Style::ComputedStyle&)
+{
+    // TODO: read corner-shape from style.
+    return { 1.0f, 1.0f, 1.0f, 1.0f };
+}
+
 BorderShape BorderShape::shapeForBorderRect(const Style::ComputedStyle& style, const LayoutRect& borderRect, RectEdges<bool> closedEdges)
 {
     auto borderWidths = RectEdges<LayoutUnit>::map(style.usedBorderWidths(), [&](auto width) {
@@ -91,7 +97,7 @@ BorderShape BorderShape::shapeForBorderRect(const Style::ComputedStyle& style, c
         if (!radii.areRenderableInRect(borderRect))
             radii.makeRenderableInRect(borderRect);
 
-        return BorderShape { borderRect, usedBorderWidths, radii };
+        return BorderShape { borderRect, usedBorderWidths, radii, cornerCurvaturesFromStyle(style) };
     }
 
     return BorderShape { borderRect, usedBorderWidths };
@@ -115,7 +121,7 @@ BorderShape BorderShape::shapeForOffsetRect(const Style::ComputedStyle& style, c
         if (!radii.areRenderableInRect(offsetRect))
             radii.makeRenderableInRect(offsetRect);
 
-        return BorderShape { offsetRect, usedEdgeWidths, radii };
+        return BorderShape { offsetRect, usedEdgeWidths, radii, cornerCurvaturesFromStyle(style) };
     }
 
     return BorderShape { offsetRect, usedEdgeWidths };
@@ -137,9 +143,19 @@ BorderShape::BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUni
     ASSERT(m_borderRect.isRenderable());
 }
 
+BorderShape::BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii& radii, const RectCorners<float>& cornerCurvatures)
+    : m_borderRect(borderRect, radii)
+    , m_innerEdgeRect(computeInnerEdgeRoundedRect(m_borderRect, borderWidths))
+    , m_borderWidths(borderWidths)
+    , m_cornerCurvatures(cornerCurvatures)
+{
+    // The caller should have adjusted the radii already.
+    ASSERT(m_borderRect.isRenderable());
+}
+
 BorderShape BorderShape::shapeWithBorderWidths(const RectEdges<LayoutUnit>& borderWidths) const
 {
-    return BorderShape(m_borderRect.rect(), borderWidths, m_borderRect.radii());
+    return BorderShape(m_borderRect.rect(), borderWidths, m_borderRect.radii(), m_cornerCurvatures);
 }
 
 LayoutRoundedRect BorderShape::deprecatedRoundedRect() const
@@ -246,7 +262,14 @@ static void addRoundedRectToPath(const FloatRoundedRect& roundedRect, Path& path
         path.addRect(roundedRect.rect());
 }
 
-Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
+bool BorderShape::hasNonRoundCornerShape() const
+{
+    // TODO: return true when corner-shape rendering is implemented.
+    // Must also check hasNonZeroRadii() since zero radii have no corner to shape.
+    return false;
+}
+
+Path BorderShape::pathForOuterRoundedRect(float deviceScaleFactor) const
 {
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     Path path;
@@ -254,24 +277,63 @@ Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
     return path;
 }
 
-Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
+Path BorderShape::pathForInnerRoundedRect(float deviceScaleFactor) const
 {
     auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(pixelSnappedRect.isRenderable());
-
     Path path;
     addRoundedRectToPath(pixelSnappedRect, path);
     return path;
 }
 
+Path BorderShape::pathForOuterCornerShape(float deviceScaleFactor) const
+{
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    // TODO: implement corner-shape path generation using outerSnapped.
+    UNUSED_PARAM(outerSnapped);
+    return pathForOuterRoundedRect(deviceScaleFactor);
+}
+
+Path BorderShape::pathForInnerCornerShape(float deviceScaleFactor) const
+{
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    // TODO: implement corner-shape path generation using outerSnapped and innerSnapped.
+    UNUSED_PARAM(outerSnapped);
+    UNUSED_PARAM(innerSnapped);
+    return pathForInnerRoundedRect(deviceScaleFactor);
+}
+
+Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
+{
+    if (hasNonRoundCornerShape())
+        return pathForOuterCornerShape(deviceScaleFactor);
+    return pathForOuterRoundedRect(deviceScaleFactor);
+}
+
+Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
+{
+    if (hasNonRoundCornerShape())
+        return pathForInnerCornerShape(deviceScaleFactor);
+    return pathForInnerRoundedRect(deviceScaleFactor);
+}
+
 void BorderShape::addOuterShapeToPath(Path& path, float deviceScaleFactor) const
 {
+    if (hasNonRoundCornerShape()) {
+        // TODO: addOuterCornerShapeToPath(path, deviceScaleFactor);
+        return;
+    }
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     addRoundedRectToPath(pixelSnappedRect, path);
 }
 
 void BorderShape::addInnerShapeToPath(Path& path, float deviceScaleFactor) const
 {
+    if (hasNonRoundCornerShape()) {
+        // TODO: addInnerCornerShapeToPath(path, deviceScaleFactor);
+        return;
+    }
     auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(pixelSnappedRect.isRenderable());
     addRoundedRectToPath(pixelSnappedRect, path);
@@ -293,6 +355,11 @@ Path BorderShape::pathForBorderArea(float deviceScaleFactor) const
 void BorderShape::clipToOuterShape(GraphicsContext& context, float deviceScaleFactor) const
 {
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (hasNonRoundCornerShape()) {
+        context.clipPath(pathForOuterCornerShape(deviceScaleFactor));
+        return;
+    }
+
     if (pixelSnappedRect.hasNonZeroRadii())
         context.clipRoundedRect(pixelSnappedRect);
     else
@@ -301,6 +368,11 @@ void BorderShape::clipToOuterShape(GraphicsContext& context, float deviceScaleFa
 
 void BorderShape::clipToInnerShape(GraphicsContext& context, float deviceScaleFactor) const
 {
+    if (hasNonRoundCornerShape()) {
+        context.clipPath(pathForInnerCornerShape(deviceScaleFactor));
+        return;
+    }
+
     auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(pixelSnappedRect.isRenderable());
     if (pixelSnappedRect.hasNonZeroRadii())
@@ -315,6 +387,11 @@ void BorderShape::clipOutOuterShape(GraphicsContext& context, float deviceScaleF
     if (pixelSnappedRect.isEmpty())
         return;
 
+    if (hasNonRoundCornerShape()) {
+        context.clipOut(pathForOuterCornerShape(deviceScaleFactor));
+        return;
+    }
+
     if (pixelSnappedRect.hasNonZeroRadii())
         context.clipOutRoundedRect(pixelSnappedRect);
     else
@@ -327,6 +404,11 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
     if (pixelSnappedRect.isEmpty())
         return;
 
+    if (hasNonRoundCornerShape()) {
+        context.clipOut(pathForInnerCornerShape(deviceScaleFactor));
+        return;
+    }
+
     if (pixelSnappedRect.hasNonZeroRadii())
         context.clipOutRoundedRect(pixelSnappedRect);
     else
@@ -335,6 +417,11 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
 
 void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, float deviceScaleFactor) const
 {
+    if (hasNonRoundCornerShape()) {
+        // TODO: implement corner-shape fill.
+        return;
+    }
+
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (pixelSnappedRect.hasNonZeroRadii())
         context.fillRoundedRect(pixelSnappedRect, color);
@@ -344,6 +431,11 @@ void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, f
 
 void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, float deviceScaleFactor) const
 {
+    if (hasNonRoundCornerShape()) {
+        // TODO: implement corner-shape fill.
+        return;
+    }
+
     auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(pixelSnappedRect.isRenderable());
     if (pixelSnappedRect.hasNonZeroRadii())
@@ -355,6 +447,12 @@ void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, f
 void BorderShape::fillRectWithInnerHoleShape(GraphicsContext& context, const LayoutRect& outerRect, const Color& color, float deviceScaleFactor) const
 {
     auto pixelSnappedOuterRect = snapRectToDevicePixels(outerRect, deviceScaleFactor);
+
+    if (hasNonRoundCornerShape()) {
+        // TODO: implement corner-shape fill.
+        return;
+    }
+
     auto innerSnappedRoundedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(innerSnappedRoundedRect.isRenderable());
     context.fillRectWithRoundedHole(pixelSnappedOuterRect, innerSnappedRoundedRect, color);

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "LayoutRoundedRect.h"
+#include "RectCorners.h"
 #include "RectEdges.h"
 #include "RenderStyleConstants.h"
 
@@ -61,6 +62,7 @@ public:
 
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii&);
+    BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii&, const RectCorners<float>& cornerCurvatures);
 
     BorderShape(const BorderShape&) = default;
 
@@ -128,9 +130,19 @@ public:
 private:
     static LayoutRoundedRect computeInnerEdgeRoundedRect(const LayoutRoundedRect& borderRoundedRect, const RectEdges<LayoutUnit>& borderWidths);
 
+    // True if any corner uses a non-`round` shape (curvature != 1), so the shape
+    bool hasNonRoundCornerShape() const;
+
+    Path pathForOuterRoundedRect(float deviceScaleFactor) const;
+    Path pathForInnerRoundedRect(float deviceScaleFactor) const;
+
+    Path pathForOuterCornerShape(float deviceScaleFactor) const;
+    Path pathForInnerCornerShape(float deviceScaleFactor) const;
+
     LayoutRoundedRect m_borderRect;
     LayoutRoundedRect m_innerEdgeRect;
     RectEdges<LayoutUnit> m_borderWidths;
+    RectCorners<float> m_cornerCurvatures { 1.0f, 1.0f, 1.0f, 1.0f };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 5e5b9a5b875832422ab40ba53d59c25a916d8372
<pre>
BorderShape: add corner-shape curvature support to BorderShape class interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=317216">https://bugs.webkit.org/show_bug.cgi?id=317216</a>
<a href="https://rdar.apple.com/179838167">rdar://179838167</a>

Reviewed by Simon Fraser.

Extends BorderShape with per-corner curvature support for CSS corner-shape.
Adds a new constructor taking curvatures defaulting to {1,1,1,1} so all existing call sites
are unaffected, and a cornerCurvaturesFromStyle helper pending the follow-up that wires up the style read. Adds private helpers
as stubs, all path, clip, and fill methods dispatch through them when any corner has a non-round curvature,
with the rounded-rect fast path preserved for the common case.

No behavioral change — hasNonRoundCornerShape() returns false and cornerCurvaturesFromStyle returns all-round until the follow-up implements them.

* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::cornerCurvaturesFromStyle):
(WebCore::BorderShape::shapeForBorderRect):
(WebCore::BorderShape::shapeForOffsetRect):
(WebCore::BorderShape::BorderShape):
(WebCore::BorderShape::shapeWithBorderWidths const):
(WebCore::BorderShape::hasNonRoundCornerShape const):
(WebCore::BorderShape::pathForOuterRoundedRect const):
(WebCore::BorderShape::pathForInnerRoundedRect const):
(WebCore::BorderShape::pathForOuterCornerShape const):
(WebCore::BorderShape::pathForInnerCornerShape const):
(WebCore::BorderShape::pathForOuterShape const):
(WebCore::BorderShape::pathForInnerShape const):
(WebCore::BorderShape::addOuterShapeToPath const):
(WebCore::BorderShape::addInnerShapeToPath const):
(WebCore::BorderShape::clipToOuterShape const):
(WebCore::BorderShape::clipToInnerShape const):
(WebCore::BorderShape::clipOutOuterShape const):
(WebCore::BorderShape::clipOutInnerShape const):
(WebCore::BorderShape::fillOuterShape const):
(WebCore::BorderShape::fillInnerShape const):
(WebCore::BorderShape::fillRectWithInnerHoleShape const):
* Source/WebCore/rendering/BorderShape.h:

Canonical link: <a href="https://commits.webkit.org/315501@main">https://commits.webkit.org/315501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a8b9bfb57cd31df6e591a6381e447f920e72ff4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126739 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131630 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92610 "8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33075 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31779 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180982 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140079 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42605 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139921 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37694 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43294 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28280 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107132 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35201 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115059 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41803 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6367 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41197 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->