### PR TITLE
Crash can occur when a video is playing in fullscreen and a second video gets fullscreen'ed in visionOS

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -2208,7 +2208,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         allowSceneGeometryUpdates = page->preferences().updateSceneGeometryEnabled() && shouldAnimateResizeScene;
 #endif
 
-    WeakObjCPtr<WKFullScreenWindowController> weakSelf { self };
     auto resizeCompletionBlock = makeBlockPtr([controller = retainPtr(controller), inWindow = retainPtr(inWindow), originalState = retainPtr(originalState), enter, completionHandler = WTF::move(completionHandler)] mutable {
         Class inWindowClass = enter ? [UIWindow class] : [originalState windowClass];
         object_setClass(inWindow.get(), inWindowClass);
@@ -2240,16 +2239,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         completionHandler();
     });
 
-    auto animationCompletionBlock = makeBlockPtr([enter, inWindow, targetSceneSize, shouldAnimateResizeScene, resizeCompletionBlock = WTF::move(resizeCompletionBlock)] (BOOL finished) mutable {
+    auto animationCompletionBlock = makeBlockPtr([enter, inWindow = retainPtr(inWindow), targetSceneSize, shouldAnimateResizeScene, resizeCompletionBlock = WTF::move(resizeCompletionBlock)] (BOOL finished) mutable {
         if (!shouldAnimateResizeScene || enter)
             WebKit::resizeScene([inWindow windowScene], targetSceneSize, 0, !shouldAnimateResizeScene, WTF::move(resizeCompletionBlock));
         else
             resizeCompletionBlock();
     });
 
-    auto animationBlock = makeBlockPtr([inWindow, outWindow, originalState, enter, allowSceneGeometryUpdates, shouldAnimateResizeScene, self, weakSelf = WTF::move(weakSelf), animationCompletionBlock = WTF::move(animationCompletionBlock)] mutable {
+    auto animationBlock = makeBlockPtr([inWindow = retainPtr(inWindow), outWindow = retainPtr(outWindow), originalState = retainPtr(originalState), enter, allowSceneGeometryUpdates, shouldAnimateResizeScene, strongSelf = retainPtr(self), animationCompletionBlock = WTF::move(animationCompletionBlock)] mutable {
         if (shouldAnimateResizeScene && !enter)
-            [self _updateFullscreenWindowOrigin];
+            [strongSelf _updateFullscreenWindowOrigin];
 
 #if ENABLE(SCENE_GEOMETRY_UPDATE)
         [UIView animateWithDuration:kOutgoingWindowFadeDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
@@ -2262,21 +2261,21 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         [UIView animateWithDuration:kOutgoingWindowFadeDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
             if (enter)
-                [self _setOrnamentsHidden:YES];
+                [strongSelf _setOrnamentsHidden:YES];
 
-            outWindow.alpha = 0;
+            [outWindow setAlpha:0];
         } completion:nil];
 
         [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-            outWindow.transform3D = CATransform3DTranslate(outWindow.transform3D, 0, 0, kOutgoingWindowZOffset);
+            [outWindow setTransform3D:CATransform3DTranslate([outWindow transform3D], 0, 0, kOutgoingWindowZOffset)];
         } completion:nil];
 
         [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-            inWindow.transform3D = originalState.transform3D;
+            [inWindow setTransform3D:[originalState transform3D]];
         } completion:nil];
 
-        for (MRUIPlatterOrnament *ornament in originalState.ornamentProperties) {
-            CGFloat originalDepth = [[originalState.ornamentProperties objectForKey:ornament] depthDisplacement];
+        for (MRUIPlatterOrnament *ornament in [originalState ornamentProperties]) {
+            CGFloat originalDepth = [[[originalState ornamentProperties] objectForKey:ornament] depthDisplacement];
             CGFloat finalDepth = originalDepth;
             if (enter)
                 finalDepth += kOutgoingWindowZOffset;
@@ -2289,10 +2288,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
 
         [UIView animateWithDuration:kIncomingWindowFadeDuration delay:kIncomingWindowFadeDelay options:UIViewAnimationOptionCurveEaseInOut animations:^{
-            if (!enter && self._shouldShowOrnaments)
-                [self _setOrnamentsHidden:NO];
+            if (!enter && [strongSelf _shouldShowOrnaments])
+                [strongSelf _setOrnamentsHidden:NO];
 
-            inWindow.alpha = 1;
+            [inWindow setAlpha:1];
         } completion:animationCompletionBlock.get()];
     });
 


### PR DESCRIPTION
#### 4d4fbca02bc3bd88fc79eba08bfd926127e907eb
<pre>
Crash can occur when a video is playing in fullscreen and a second video gets fullscreen&apos;ed in visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=317218">https://bugs.webkit.org/show_bug.cgi?id=317218</a>
<a href="https://rdar.apple.com/171215079">rdar://171215079</a>

Reviewed by Aditya Keerthi.

The animationBlock and animationCompletionBlock C++ lambdas in
_performSpatialFullScreenTransition: captured self, inWindow, outWindow, and
originalState as raw Objective-C pointers. When the controller&apos;s owning ivars
were released while the animation chain was still in flight, those captures
dangled and UIKit hit a use-after-free in objc_msgSend. Capture them as
RetainPtr&lt;&gt; instead, matching the resizeCompletionBlock pattern right
above.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/315357@main">https://commits.webkit.org/315357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf22154aabd985564560915208445d549a3a80f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126388 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131325 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92381 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111829 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32767 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31478 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180613 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139769 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42252 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139618 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37617 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42941 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106665 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34898 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114708 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41444 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6059 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40841 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->