### PR TITLE
<link rel=preload as=json> should not trigger a preload

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/preload/preload-type-match-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/preload-type-match-expected.txt
@@ -34,9 +34,9 @@ PASS Preload with {as=style; type=text/plain} should timeout when retrieved reso
 PASS Preload with {as=track; type=text/vtt} should load when retrieved resource is a track
 PASS Preload with {as=track; type=text/plain} should timeout when retrieved resource is a track
 PASS Preload with {as=track; type=not-a-mime} should timeout when retrieved resource is a track
-FAIL Preload with {as=json; type=application/json} should timeout when retrieved resource is a json assert_equals: expected "timeout" but got "load"
-FAIL Preload with {as=json; type=text/json} should timeout when retrieved resource is a json assert_equals: expected "timeout" but got "load"
-FAIL Preload with {as=json; type=application/geo+json} should timeout when retrieved resource is a json assert_equals: expected "timeout" but got "load"
+PASS Preload with {as=json; type=application/json} should timeout when retrieved resource is a json
+PASS Preload with {as=json; type=text/json} should timeout when retrieved resource is a json
+PASS Preload with {as=json; type=application/geo+json} should timeout when retrieved resource is a json
 PASS Preload with {as=json; type=text/plain} should timeout when retrieved resource is a json
 PASS Preload with {as=json; type=application/javascript} should timeout when retrieved resource is a json
 PASS Preload with {as=text; type=text/plain} should timeout when retrieved resource is a text

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/supported-as-values_as=json&expected=0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/supported-as-values_as=json&expected=0-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test the supported value for <link rel=preload as="..."> assert_equals: expected 0 but got 1
+PASS Test the supported value for <link rel=preload as="...">
 

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -147,7 +147,7 @@ void LinkLoader::loadLinksFromHeader(const String& headerValue, const URL& baseU
     }
 }
 
-std::optional<CachedResource::Type> LinkLoader::resourceTypeFromAsAttribute(const String& as, Document& document, ShouldLog shouldLogError)
+std::optional<CachedResource::Type> LinkLoader::resourceTypeFromAsAttribute(const String& as, Document& document, ShouldLog shouldLogError, IsModulePreload isModulePreload)
 {
     if (equalLettersIgnoringASCIICase(as, "fetch"_s))
         return CachedResource::Type::RawResource;
@@ -181,7 +181,11 @@ std::optional<CachedResource::Type> LinkLoader::resourceTypeFromAsAttribute(cons
     case FetchRequestDestination::Iframe:
         return std::nullopt;
     case FetchRequestDestination::Json:
-        return CachedResource::Type::JSON;
+        if (isModulePreload == IsModulePreload::Yes)
+            return CachedResource::Type::JSON;
+        if (shouldLogError == ShouldLog::Yes)
+            document.addConsoleMessage(MessageSource::Other, MessageLevel::Error, "<link rel=preload> does not support `json` as `as` value"_s);
+        return std::nullopt;
     case FetchRequestDestination::Manifest:
         return std::nullopt;
     case FetchRequestDestination::Model:
@@ -341,7 +345,7 @@ RefPtr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const LinkLoadPara
         return nullptr;
 
     if (params.relAttribute.isLinkModulePreload) {
-        type = LinkLoader::resourceTypeFromAsAttribute(params.as, document, ShouldLog::No);
+        type = LinkLoader::resourceTypeFromAsAttribute(params.as, document, ShouldLog::No, IsModulePreload::Yes);
         if (!type)
             type = CachedResource::Type::Script;
         if (type && type != CachedResource::Type::Script && type != CachedResource::Type::JSON) {

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -64,7 +64,8 @@ public:
 
     void loadLink(const LinkLoadParameters&, Document&);
     enum class ShouldLog : bool { No, Yes };
-    static std::optional<CachedResource::Type> resourceTypeFromAsAttribute(const String&, Document&, ShouldLog = ShouldLog::No);
+    enum class IsModulePreload : bool { No, Yes };
+    static std::optional<CachedResource::Type> resourceTypeFromAsAttribute(const String&, Document&, ShouldLog = ShouldLog::No, IsModulePreload = IsModulePreload::No);
 
     enum class MediaAttributeCheck { MediaAttributeEmpty, MediaAttributeNotEmpty, SkipMediaAttributeCheck };
     static void loadLinksFromHeader(const String& headerValue, const URL& baseURL, Document&, MediaAttributeCheck);


### PR DESCRIPTION
#### 4952aceefed640808291ab3768c7a960fd3224c2
<pre>
&lt;link rel=preload as=json&gt; should not trigger a preload
<a href="https://bugs.webkit.org/show_bug.cgi?id=317223">https://bugs.webkit.org/show_bug.cgi?id=317223</a>
<a href="https://rdar.apple.com/179843455">rdar://179843455</a>

Reviewed by Chris Dumez.

`json` is a module preload destination [1], not a valid destination for
&lt;link rel=preload&gt;; so reject it. WebKit was nonetheless issuing the fetch.

LinkLoader::resourceTypeFromAsAttribute() unconditionally mapped
FetchRequestDestination::Json to CachedResource::Type::JSON. That mapping
was added for &lt;link rel=modulepreload&gt;, but the function is shared by the
plain preload path, the Link HTTP header path, and the speculative
HTMLPreloadScanner, so all of them inherited the json destination.

Thread an IsModulePreload flag through resourceTypeFromAsAttribute() and
only honor `as=json` when the link is a module preload; otherwise log a
console error and return nullopt so no resource is fetched. The
rel=modulepreload caller opts in with IsModulePreload::Yes; all other
callers keep the default.

[1] <a href="https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload">https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload</a>
A module preload destination is &quot;json&quot;, &quot;style&quot;, &quot;text&quot;, or a
script-like destination.

* LayoutTests/imported/w3c/web-platform-tests/preload/preload-type-match-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/preload/supported-as-values_as=json&amp;expected=0-expected.txt: Ditto
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::resourceTypeFromAsAttribute):
(WebCore::LinkLoader::preloadIfNeeded):
* Source/WebCore/loader/LinkLoader.h:

Canonical link: <a href="https://commits.webkit.org/315422@main">https://commits.webkit.org/315422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d70a065ec667ad5073adf7dc06c1e425968c1c09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126397 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b215f61-6eb8-4103-89b9-0a96e1a8c92c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131336 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92387 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6fb5346-9fca-4446-9211-e3007716e400) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111840 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a760ecd7-f779-47b7-bd75-14094ba98521) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32771 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31487 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26716 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180622 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139778 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42261 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139627 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37651 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42950 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27981 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106677 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34906 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114717 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41453 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6069 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40850 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40995 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->