### PR TITLE
FontCustomPlatformDataCoreText: Use defaultVariationValues to detect the wght axis

### DIFF
--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -40,23 +40,6 @@ namespace WebCore {
 
 FontCustomPlatformData::~FontCustomPlatformData() = default;
 
-static bool fontHasWeightVariationAxis(CTFontRef font)
-{
-    constexpr uint32_t wghtAxisIdentifier = ('w' << 24) | ('g' << 16) | ('h' << 8) | 't';
-    RetainPtr axes = adoptCF(CTFontCopyVariationAxes(font));
-    if (!axes)
-        return false;
-    auto count = CFArrayGetCount(axes.get());
-    for (CFIndex axisIndex = 0; axisIndex < count; ++axisIndex) {
-        RetainPtr axis = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(axes.get(), axisIndex));
-        RetainPtr axisIdentifier = static_cast<CFNumberRef>(CFDictionaryGetValue(axis.get(), kCTFontVariationAxisIdentifierKey));
-        uint32_t rawAxisIdentifier = 0;
-        if (CFNumberGetValue(axisIdentifier.get(), kCFNumberSInt32Type, &rawAxisIdentifier) && rawAxisIdentifier == wghtAxisIdentifier)
-            return true;
-    }
-    return false;
-}
-
 FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription& fontDescription, bool italic, const FontCreationContext& fontCreationContext)
 {
     auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
@@ -72,7 +55,8 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     auto font = preparePlatformFont(WTF::move(unrealizedFont), fontDescription, fontCreationContext);
     ASSERT(font);
 
-    FontPlatformData platformData(font.get(), size, computeSyntheticBold(fontHasWeightVariationAxis(font.get()), fontDescription, fontCreationContext), italic, orientation, widthVariant, fontDescription.textRenderingMode(), this);
+    bool hasWeightVariationAxis = defaultVariationValues(font.get(), ShouldLocalizeAxisNames::No).contains(FontVariationAxisTag::wght);
+    FontPlatformData platformData(font.get(), size, computeSyntheticBold(hasWeightVariationAxis, fontDescription, fontCreationContext), italic, orientation, widthVariant, fontDescription.textRenderingMode(), this);
 
     platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
     return platformData;


### PR DESCRIPTION
#### 06267d4b624ddfeda12cc6b4847c4515f92406ca
<pre>
FontCustomPlatformDataCoreText: Use defaultVariationValues to detect the wght axis
<a href="https://bugs.webkit.org/show_bug.cgi?id=317221">https://bugs.webkit.org/show_bug.cgi?id=317221</a>
<a href="https://rdar.apple.com/179843188">rdar://179843188</a>

Reviewed by Simon Fraser.

fontHasWeightVariationAxis open-coded a CTFontCopyVariationAxes scan with
CFNumberGetValue extraction, duplicating the existing defaultVariationValues
helper. Use defaultVariationValues(font, ShouldLocalizeAxisNames::No).contains(
FontVariationAxisTag::wght) instead, matching the Skia and FreeType paths. No
behavior change.

* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):

Canonical link: <a href="https://commits.webkit.org/315318@main">https://commits.webkit.org/315318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a515a5ea3ac51dee77bf9dab1c5ece17955bd3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126401 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70d08445-9af6-46bb-a21b-b5f640005e98) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131339 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51c2895e-d7f0-4889-aa1f-01c89edc8e28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33789 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111843 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fea01d93-786f-4564-b23e-8d1835600b40) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26720 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180626 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139780 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42265 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139629 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37592 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42954 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106681 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34910 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/114721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41457 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6071 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40854 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41108 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40999 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->