### PR TITLE
[JSC][Temporal] Align Temporal.Instant with spec abstract operations

### DIFF
--- a/JSTests/stress/temporal-instant-totemporalinstant.js
+++ b/JSTests/stress/temporal-instant-totemporalinstant.js
@@ -1,0 +1,192 @@
+//@ requireOptions("--useTemporal=1")
+
+// Tests ToTemporalInstant — https://tc39.es/proposal-temporal/#sec-temporal-totemporalinstant
+// Exercised via Temporal.Instant.from and the indirect entry points (equals/until/since/compare).
+
+function shouldThrow(fn, expectedType, label) {
+    let error;
+    try { fn(); } catch (e) { error = e; }
+    if (!(error instanceof expectedType))
+        throw new Error(`${label}: expected ${expectedType.name} but got ${error?.constructor.name ?? 'no error'}: ${error?.message ?? ''}`);
+}
+
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${String(expected)} but got ${String(actual)}`);
+}
+
+// Object input: existing Instant / ZonedDateTime returns a NEW Instant with the same epochNs.
+
+{
+    const original = new Temporal.Instant(1234567890n);
+    const result = Temporal.Instant.from(original);
+    shouldBe(result.epochNanoseconds, 1234567890n, "Instant.from(Instant): epochNs preserved");
+    if (result === original)
+        throw new Error("Instant.from(Instant): must return a NEW instance, not same identity");
+}
+
+{
+    const zdt = Temporal.ZonedDateTime.from("2024-06-15T12:00:00[UTC]");
+    shouldBe(Temporal.Instant.from(zdt).epochNanoseconds, zdt.epochNanoseconds, "Instant.from(ZonedDateTime)");
+}
+
+// Object input without a slot → ToPrimitive(item, STRING) coercion.
+
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return 42; } }), TypeError, "→Number");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return -7.5; } }), TypeError, "→negative Number");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return true; } }), TypeError, "→Boolean true");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return false; } }), TypeError, "→Boolean false");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return 1234567890n; } }), TypeError, "→BigInt");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return Symbol("x"); } }), TypeError, "→Symbol");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return null; } }), TypeError, "→null");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return undefined; } }), TypeError, "→undefined");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return { x: 1 }; } }), TypeError, "→Object");
+shouldThrow(() => Temporal.Instant.from({ [Symbol.toPrimitive]() { return []; } }), TypeError, "→Array");
+
+{
+    const sentinel = new Error("custom");
+    let caught;
+    try { Temporal.Instant.from({ [Symbol.toPrimitive]() { throw sentinel; } }); } catch (e) { caught = e; }
+    shouldBe(caught, sentinel, "Symbol.toPrimitive throw propagates");
+}
+
+{
+    let receivedHint;
+    Temporal.Instant.from({ [Symbol.toPrimitive](hint) { receivedHint = hint; return "2024-01-15T12:00:00Z"; } });
+    shouldBe(receivedHint, "string", "Symbol.toPrimitive hint is 'string'");
+}
+
+// No Symbol.toPrimitive → toString first, valueOf second.
+shouldBe(Temporal.Instant.from({
+    toString() { return "2024-01-15T12:00:00Z"; },
+    valueOf() { return 999; },
+}).epochNanoseconds, 1705320000000000000n, "toString String wins over valueOf");
+
+shouldBe(Temporal.Instant.from({
+    toString() { return { x: 1 }; },
+    valueOf() { return "2024-01-15T12:00:00Z"; },
+}).epochNanoseconds, 1705320000000000000n, "valueOf used when toString returns Object");
+
+shouldThrow(() => Temporal.Instant.from({ toString() { return {}; }, valueOf() { return {}; } }),
+    TypeError, "Both toString and valueOf return Object");
+shouldThrow(() => Temporal.Instant.from({ toString() { return 42; }, valueOf() { return 99; } }),
+    TypeError, "Both return non-String primitives");
+
+// Bare non-String primitives → TypeError.
+
+shouldThrow(() => Temporal.Instant.from(42), TypeError, "bare Number");
+shouldThrow(() => Temporal.Instant.from(0), TypeError, "bare Number 0");
+shouldThrow(() => Temporal.Instant.from(NaN), TypeError, "bare NaN");
+shouldThrow(() => Temporal.Instant.from(Infinity), TypeError, "bare Infinity");
+shouldThrow(() => Temporal.Instant.from(true), TypeError, "bare Boolean true");
+shouldThrow(() => Temporal.Instant.from(false), TypeError, "bare Boolean false");
+shouldThrow(() => Temporal.Instant.from(1234567890n), TypeError, "bare BigInt");
+shouldThrow(() => Temporal.Instant.from(null), TypeError, "null");
+shouldThrow(() => Temporal.Instant.from(undefined), TypeError, "undefined");
+shouldThrow(() => Temporal.Instant.from(Symbol("x")), TypeError, "bare Symbol");
+
+// Valid TemporalInstantString formats.
+
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z").epochNanoseconds, 1705320000000000000n, "T separator + Z");
+shouldBe(Temporal.Instant.from("2024-01-15 12:00:00Z").epochNanoseconds, 1705320000000000000n, "space separator + Z");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05:30").epochNanoseconds, 1705300200000000000n, "+05:30");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00-14:00").epochNanoseconds, 1705370400000000000n, "-14:00 max");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+14:00").epochNanoseconds, 1705269600000000000n, "+14:00 max");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00.123456789Z").epochNanoseconds, 1705320000123456789n, "9 frac digits");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00.5Z").epochNanoseconds, 1705320000500000000n, "1 frac digit");
+
+// Invalid string / missing offset → RangeError.
+
+shouldThrow(() => Temporal.Instant.from(""), RangeError, "empty");
+shouldThrow(() => Temporal.Instant.from("garbage"), RangeError, "garbage");
+shouldThrow(() => Temporal.Instant.from("2024-01-15"), RangeError, "Date only");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00"), RangeError, "no offset/Z");
+shouldThrow(() => Temporal.Instant.from("2024-13-15T12:00:00Z"), RangeError, "month=13");
+shouldThrow(() => Temporal.Instant.from("2024-00-15T12:00:00Z"), RangeError, "month=0");
+shouldThrow(() => Temporal.Instant.from("2024-01-32T12:00:00Z"), RangeError, "day=32");
+shouldThrow(() => Temporal.Instant.from("2024-02-30T12:00:00Z"), RangeError, "Feb 30");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T25:00:00Z"), RangeError, "hour=25");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:60:00Z"), RangeError, "minute=60");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00Z extra"), RangeError, "trailing junk");
+
+// Offset format variants.
+
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+00:00").epochNanoseconds,
+    Temporal.Instant.from("2024-01-15T12:00:00Z").epochNanoseconds, "+00:00 == Z");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00-00:00").epochNanoseconds,
+    Temporal.Instant.from("2024-01-15T12:00:00Z").epochNanoseconds, "-00:00 == Z");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05").epochNanoseconds, 1705302000000000000n, "bare ±HH");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05:30:15").epochNanoseconds, 1705300185000000000n, "offset with seconds");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05:30:15.123456789").epochNanoseconds, 1705300184876543211n, "fractional offset");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+5:30"), RangeError, "+5:30");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+05:3"), RangeError, "+05:3");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+25:00"), RangeError, "+25:00");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+05:60"), RangeError, "+05:60");
+
+// Epoch range (IsValidEpochNanoseconds): max ±8.64e21 ns.
+
+shouldBe(Temporal.Instant.from("+275760-09-13T00:00:00Z").epochNanoseconds, 8640000000000000000000n, "max year");
+shouldBe(Temporal.Instant.from("-271821-04-20T00:00:00Z").epochNanoseconds, -8640000000000000000000n, "min year");
+shouldThrow(() => Temporal.Instant.from("+275760-09-14T00:00:00Z"), RangeError, "+1 day past max");
+shouldThrow(() => Temporal.Instant.from("-271821-04-19T00:00:00Z"), RangeError, "-1 day before min");
+shouldThrow(() => Temporal.Instant.from("+999999-01-01T00:00:00Z"), RangeError, "far future");
+shouldThrow(() => Temporal.Instant.from("-999999-01-01T00:00:00Z"), RangeError, "far past");
+
+shouldBe(Temporal.Instant.from("1969-12-31T23:59:59Z").epochNanoseconds, -1000000000n, "1 second before epoch");
+shouldBe(Temporal.Instant.from("1969-12-31T23:59:59.999999999Z").epochNanoseconds, -1n, "1 ns before epoch");
+shouldBe(Temporal.Instant.from("1969-12-31T23:59:59.999999999+00:00").epochNanoseconds, -1n, "negative epoch via +00:00");
+
+// Round-trip: parsed string equals constructor with the same epochNs.
+
+{
+    const fromString = Temporal.Instant.from("2024-01-15T12:00:00Z");
+    const fromCtor = new Temporal.Instant(1705320000000000000n);
+    shouldBe(fromString.epochNanoseconds, fromCtor.epochNanoseconds, "from(string) == new Instant(ns)");
+}
+
+// RFC 9557 annotations: u-ca is a recognized key so the critical flag is a no-op;
+// bracket TZ is ignored when offset/Z is present; bracket TZ alone (no offset/Z) is rejected.
+
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z[u-ca=iso8601]").epochNanoseconds, 1705320000000000000n, "[u-ca=iso8601]");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z[u-ca=hebrew]").epochNanoseconds, 1705320000000000000n, "[u-ca=hebrew]");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z[!u-ca=hebrew]").epochNanoseconds, 1705320000000000000n, "[!u-ca=hebrew]");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z[America/New_York]").epochNanoseconds, 1705320000000000000n, "Z + named TZ");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05:00[America/New_York]").epochNanoseconds, 1705302000000000000n, "offset + named TZ");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00-05:00[!America/New_York]").epochNanoseconds, 1705338000000000000n, "[!TZ] + offset");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00[America/New_York]"), RangeError, "TZ alone (no offset/Z)");
+
+// Fractional digit sweep: all forms encode 0.1 sec = 1e8 ns regardless of trailing zeros; >9 digits rejected.
+for (let digits = 1; digits <= 9; ++digits) {
+    const frac = "1".padEnd(digits, "0");
+    shouldBe(Temporal.Instant.from(`1970-01-01T00:00:00.${frac}Z`).epochNanoseconds, 100000000n, `${digits} frac digit(s)`);
+}
+shouldThrow(() => Temporal.Instant.from("1970-01-01T00:00:00.1234567890Z"), RangeError, "10 frac digits");
+
+// Time grammar: 24:00 rejected (Hour ::= 00..23). Leap second :60 clamped to :59 (same instant).
+shouldThrow(() => Temporal.Instant.from("2024-01-15T24:00:00Z"), RangeError, "24:00:00");
+shouldBe(Temporal.Instant.from("2024-06-30T23:59:60Z").epochNanoseconds, 1719791999000000000n, ":60 → :59");
+
+// T/Z designators are case-insensitive per spec grammar.
+shouldBe(Temporal.Instant.from("2024-01-15t12:00:00Z").epochNanoseconds, 1705320000000000000n, "lowercase t");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00z").epochNanoseconds, 1705320000000000000n, "lowercase z");
+
+// Indirect entry points: equals / until / since / compare all call ToTemporalInstant on the other operand.
+{
+    const a = new Temporal.Instant(1000n);
+    shouldBe(a.equals("1970-01-01T00:00:00.000001Z"), true, "equals(string)");
+    shouldBe(a.until("1970-01-01T00:00:00.000002Z").total('nanoseconds'), 1000, "until(string)");
+    shouldBe(a.since("1970-01-01T00:00:00Z").total('nanoseconds'), 1000, "since(string)");
+    shouldBe(Temporal.Instant.compare("1970-01-01T00:00:00Z", "1970-01-01T00:00:00.000001Z"), -1, "compare strings");
+    shouldThrow(() => a.equals({ [Symbol.toPrimitive]() { return 42; } }), TypeError, "equals(→Number)");
+    shouldThrow(() => a.until({ [Symbol.toPrimitive]() { return 42; } }), TypeError, "until(→Number)");
+    shouldThrow(() => Temporal.Instant.compare({ [Symbol.toPrimitive]() { return 42; } }, a), TypeError, "compare(→Number)");
+}
+
+// Result class identity.
+{
+    const r = Temporal.Instant.from("2024-01-15T12:00:00Z");
+    if (r.constructor !== Temporal.Instant)
+        throw new Error("constructor must be Temporal.Instant");
+    if (!(r instanceof Temporal.Instant))
+        throw new Error("instanceof Temporal.Instant must be true");
+}

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1426,34 +1426,6 @@ std::optional<TimeZone> parseTimeZoneIdentifierStrict(StringView string)
     return std::nullopt;
 }
 
-std::optional<ExactTime> parseInstant(StringView string)
-{
-    // https://tc39.es/proposal-temporal/#prod-TemporalInstantString
-    // TemporalInstantString :
-    //     Date TimeZoneOffsetRequired
-    //     Date DateTimeSeparator TimeSpec TimeZoneOffsetRequired
-
-    // https://tc39.es/proposal-temporal/#prod-TimeZoneOffsetRequired
-    // TimeZoneOffsetRequired :
-    //     TimeZoneUTCOffset TimeZoneBracketedAnnotation_opt
-
-    return readCharactersForParsing(string, [](auto buffer) -> std::optional<ExactTime> {
-        auto datetime = parseCalendarDateTime(buffer, TemporalDateFormat::Date);
-        if (!datetime)
-            return std::nullopt;
-        auto [plainDate, plainTimeOptional, timeZoneOptional, calendarOptional] = WTF::move(datetime.value());
-        if (!timeZoneOptional || (!timeZoneOptional->m_z && !timeZoneOptional->m_offset))
-            return std::nullopt;
-        if (!buffer.atEnd())
-            return std::nullopt;
-
-        PlainTime plainTime = plainTimeOptional.value_or(PlainTime());
-
-        int64_t offset = timeZoneOptional->m_z ? 0 : *timeZoneOptional->m_offset;
-        return { ExactTime::fromISOPartsAndOffset(plainDate.year(), plainDate.month(), plainDate.day(), plainTime.hour(), plainTime.minute(), plainTime.second(), plainTime.millisecond(), plainTime.microsecond(), plainTime.nanosecond(), offset) };
-    });
-}
-
 uint8_t dayOfWeek(PlainDate plainDate)
 {
     Int128 dateDays = static_cast<Int128>(dateToDaysFrom1970(plainDate.year(), plainDate.month() - 1, plainDate.day()));

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -501,7 +501,6 @@ bool NODELETE isValidDuration(const Duration&);
 bool NODELETE isValidISODate(double, double, double);
 PlainDate NODELETE createISODateRecord(double, double, double);
 
-std::optional<ExactTime> parseInstant(StringView);
 std::optional<ParsedMonthCode> NODELETE parseMonthCode(StringView);
 std::optional<TimeZone> JS_EXPORT_PRIVATE parseTemporalTimeZoneIdentifier(StringView);
 

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -27,20 +27,13 @@
 #include "config.h"
 #include "TemporalInstant.h"
 
-#include "AuxiliaryBarrierInlines.h"
 #include "Error.h"
-#include "InstantCore.h"
-#include "IntlObjectInlines.h"
 #include "ISO8601.h"
 #include "JSBigInt.h"
 #include "JSGlobalObject.h"
-#include "JSObjectInlines.h"
 #include "MathCommon.h"
-#include "StructureCreateInlines.h"
-#include "TemporalDuration.h"
 #include "TemporalObject.h"
 #include "TemporalZonedDateTime.h"
-#include "TimeZoneICUBridge.h"
 
 #include <wtf/text/MakeString.h>
 namespace JSC {
@@ -64,36 +57,6 @@ TemporalInstant* TemporalInstant::create(VM& vm, Structure* structure, ISO8601::
     auto* object = new (NotNull, allocateCell<TemporalInstant>(vm)) TemporalInstant(vm, structure, exactTime);
     object->finishCreation(vm);
     return object;
-}
-
-// CreateTemporalInstant ( epochNanoseconds [ , newTarget ] )
-// https://tc39.es/proposal-temporal/#sec-temporal-createtemporalinstant
-TemporalInstant* TemporalInstant::tryCreateIfValid(JSGlobalObject* globalObject, ISO8601::ExactTime exactTime, Structure* structure)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (!exactTime.isValid()) [[unlikely]] {
-        throwRangeError(globalObject, scope, makeString(exactTime.asString(), " epoch nanoseconds is outside of supported range for Temporal.Instant"_s));
-        return nullptr;
-    }
-
-    return create(vm, structure ? structure : globalObject->instantStructure(), exactTime);
-}
-
-TemporalInstant* TemporalInstant::tryCreateIfValid(JSGlobalObject* globalObject, JSValue value, Structure* structure)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue bigIntValue = value.toBigInt(globalObject);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-
-    auto exactTime = bigIntValueToExactTime(globalObject, bigIntValue, "Temporal.Instant"_s);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    if (!exactTime)
-        return nullptr;
-    return create(vm, structure ? structure : globalObject->instantStructure(), *exactTime);
 }
 
 std::optional<ISO8601::ExactTime> bigIntValueToExactTime(JSGlobalObject* globalObject, JSValue bigIntValue, ASCIILiteral typeName)
@@ -153,49 +116,75 @@ TemporalInstant* TemporalInstant::toInstant(JSGlobalObject* globalObject, JSValu
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: If item is not an Object and not a String, throw TypeError.
-    if (!itemValue.isObject() && !itemValue.isString()) [[unlikely]] {
+    // Step 1: If item is an Object, then
+    if (itemValue.isObject()) {
+        // Step 1.a: If item has [[InitializedTemporalInstant]] or [[InitializedTemporalZonedDateTime]],
+        //   return ! CreateTemporalInstant(item.[[EpochNanoseconds]]). Spec returns a NEW instance.
+        if (itemValue.inherits<TemporalInstant>())
+            return create(vm, globalObject->instantStructure(), uncheckedDowncast<TemporalInstant>(itemValue)->exactTime());
+        if (itemValue.inherits<TemporalZonedDateTime>())
+            return create(vm, globalObject->instantStructure(), uncheckedDowncast<TemporalZonedDateTime>(itemValue)->exactTime());
+
+        // Step 1.c: Set item to ? ToPrimitive(item, STRING).
+        itemValue = itemValue.toPrimitive(globalObject, PreferString);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+    }
+
+    // Step 2: If item is not a String, throw a TypeError exception.
+    if (!itemValue.isString()) [[unlikely]] {
         throwTypeError(globalObject, scope, "can only convert to Instant from object or string values"_s);
         return nullptr;
     }
-
-    // Step 2: If item has [[InitializedTemporalInstant]], return item.
-    if (itemValue.inherits<TemporalInstant>())
-        return uncheckedDowncast<TemporalInstant>(itemValue);
-
-    // Step 3: If item has [[InitializedTemporalZonedDateTime]], return CreateTemporalInstant(item.[[EpochNanoseconds]]).
-    if (itemValue.inherits<TemporalZonedDateTime>())
-        return TemporalInstant::create(vm, globalObject->instantStructure(), uncheckedDowncast<TemporalZonedDateTime>(itemValue)->exactTime());
-
-    // Step 4: Let string be ? ToString(item).
-    String string = itemValue.toWTFString(globalObject);
+    String string = asString(itemValue)->value(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    // Step 5: Let epochNanoseconds be ? ParseTemporalInstantString(string).
-    auto parsedExactTime = ISO8601::parseInstant(string);
-    if (!parsedExactTime) [[unlikely]] {
+    // Step 3: Let parsed be ? ParseISODateTime(item, « TemporalInstantString »).
+    //   parseCalendarDateTime accepts a superset; the Time-present and Offset/Z-present guards
+    //   below restrict the accepted set to the TemporalInstantString production.
+    // FIXME: Replace with a unified ParseISODateTime(string, ProductionMask) that bakes in
+    //   per-production grammar restrictions, matching the spec abstract op 1:1. Today the four
+    //   parsers (parseCalendarDateTime, parseCalendarTime, parseDateTime, parseTime) each cover
+    //   a subset, forcing every consumer to re-implement production guards. See ISO8601.h.
+    auto parsedOpt = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
+    if (!parsedOpt) [[unlikely]] {
+        throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, string), "' is not a valid Temporal.Instant string"_s));
+        return nullptr;
+    }
+    auto [plainDate, plainTimeOpt, timeZoneOpt, calendarOpt] = WTF::move(*parsedOpt);
+    if (!plainTimeOpt || !timeZoneOpt || (!timeZoneOpt->m_z && !timeZoneOpt->m_offset)) [[unlikely]] {
         throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, string), "' is not a valid Temporal.Instant string"_s));
         return nullptr;
     }
 
-    // Step 6: Return ? CreateTemporalInstant(epochNanoseconds).
-    RELEASE_AND_RETURN(scope, tryCreateIfValid(globalObject, parsedExactTime.value()));
-}
+    // Step 4: Assert: parsed.[[TimeZone]].[[OffsetString]] is not empty XOR parsed.[[TimeZone]].[[Z]] is true.
+    //   No-op: the grammar `DateTimeUTCOffset[+Z]` makes Z and offset mutually exclusive.
 
-// Temporal.Instant.from ( item )
-// https://tc39.es/proposal-temporal/#sec-temporal.instant.from
-TemporalInstant* TemporalInstant::from(JSGlobalObject* globalObject, JSValue itemValue)
-{
-    VM& vm = globalObject->vm();
+    // Step 5: offsetNanoseconds = Z ? 0 : ParseDateTimeUTCOffset(OffsetString).
+    int64_t offsetNanoseconds = timeZoneOpt->m_z ? 0 : *timeZoneOpt->m_offset;
 
-    // Step 1: If item has [[InitializedTemporalInstant]], return CreateTemporalInstant(item.[[EpochNanoseconds]]).
-    if (itemValue.inherits<TemporalInstant>()) {
-        ISO8601::ExactTime exactTime = uncheckedDowncast<TemporalInstant>(itemValue)->exactTime();
-        return TemporalInstant::create(vm, globalObject->instantStructure(), exactTime);
+    // Step 6: Let time be parsed.[[Time]].
+    const ISO8601::PlainTime& plainTime = *plainTimeOpt;
+
+    // Step 7: Assert: time is not start-of-day. (No-op: parser guarantees this.)
+
+    // Steps 8 + 10: BalanceISODateTime + GetUTCEpochNanoseconds collapsed.
+    //   BalanceISODateTime preserves the sum days×nsPerDay + Σ(timeFields). We only need the
+    //   sum (epochNs); intermediate balanced fields are unread, so the rebalance is unobservable.
+    auto exactTime = ISO8601::ExactTime::fromISOPartsAndOffset(
+        plainDate.year(), plainDate.month(), plainDate.day(),
+        plainTime.hour(), plainTime.minute(), plainTime.second(),
+        plainTime.millisecond(), plainTime.microsecond(), plainTime.nanosecond(),
+        offsetNanoseconds);
+
+    // Steps 9 + 11: CheckISODaysRange + IsValidEpochNanoseconds collapsed.
+    //   |dateDays| ≤ 10⁸ ↔ |epochNs| ≤ 8.64×10²¹ at the boundary; isValid() covers both.
+    if (!exactTime.isValid()) [[unlikely]] {
+        throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, string), "' is not a valid Temporal.Instant string"_s));
+        return nullptr;
     }
 
-    // Step 2: Return ? ToTemporalInstant(item).
-    return toInstant(globalObject, itemValue);
+    // Step 12: Return ! CreateTemporalInstant(epochNanoseconds).
+    return create(vm, globalObject->instantStructure(), exactTime);
 }
 
 // Temporal.Instant.fromEpochMilliseconds ( epochMilliseconds )
@@ -205,27 +194,51 @@ TemporalInstant* TemporalInstant::fromEpochMilliseconds(JSGlobalObject* globalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: Let epochMilliseconds be ? ToNumber(epochMilliseconds).
+    // Step 1: Set epochMilliseconds to ? ToNumber(epochMilliseconds).
     double epochMilliseconds = epochMillisecondsValue.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    // Step 2: If IsIntegralNumber(epochMilliseconds) is false, throw RangeError.
+    // Step 2: Set epochMilliseconds to ? NumberToBigInt(epochMilliseconds).
+    //   NumberToBigInt's two effects (RangeError if !IsIntegralNumber, then ℤ-conversion) are
+    //   inlined as isInteger() + the int64_t cast in fromEpochMilliseconds — no JSBigInt needed.
     if (!isInteger(epochMilliseconds)) [[unlikely]] {
         throwRangeError(globalObject, scope, makeString(epochMilliseconds, " is not a valid integer number of epoch milliseconds"_s));
         return nullptr;
     }
 
-    // Steps 3-4: Let epochNanoseconds = epochMilliseconds × 10^6; return ? CreateTemporalInstant(epochNanoseconds).
+    // Step 3: Let epochNanoseconds be epochMilliseconds × 10^6ℤ.
     ISO8601::ExactTime exactTime = ISO8601::ExactTime::fromEpochMilliseconds(epochMilliseconds);
-    RELEASE_AND_RETURN(scope, tryCreateIfValid(globalObject, exactTime));
+
+    // Step 4: If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError exception.
+    if (!exactTime.isValid()) [[unlikely]] {
+        throwRangeError(globalObject, scope, makeString(exactTime.asString(), " epoch nanoseconds is outside of supported range for Temporal.Instant"_s));
+        return nullptr;
+    }
+
+    // Step 5: Return ! CreateTemporalInstant(epochNanoseconds).
+    return create(vm, globalObject->instantStructure(), exactTime);
 }
 
 // Temporal.Instant.fromEpochNanoseconds ( epochNanoseconds )
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochnanoseconds
 TemporalInstant* TemporalInstant::fromEpochNanoseconds(JSGlobalObject* globalObject, JSValue epochNanosecondsValue)
 {
-    // Step 1: Return ? CreateTemporalInstant(? ToBigInt(epochNanoseconds)).
-    return tryCreateIfValid(globalObject, epochNanosecondsValue);
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Step 1: Set epochNanoseconds to ? ToBigInt(epochNanoseconds).
+    JSValue bigIntValue = epochNanosecondsValue.toBigInt(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    // Step 2: If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError exception.
+    //   bigIntValueToExactTime does both the BigInt → Int128 narrowing and the validity check;
+    //   nullopt only after throwing.
+    auto exactTimeOpt = bigIntValueToExactTime(globalObject, bigIntValue, "Temporal.Instant"_s);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    ASSERT(exactTimeOpt);
+
+    // Step 3: Return ! CreateTemporalInstant(epochNanoseconds).
+    return create(vm, globalObject->instantStructure(), *exactTimeOpt);
 }
 
 // Temporal.Instant.compare ( one, two )
@@ -249,187 +262,6 @@ JSValue TemporalInstant::compare(JSGlobalObject* globalObject, JSValue oneValue,
     if (one->exactTime() < two->exactTime())
         return jsNumber(-1);
     return jsNumber(0);
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalinstant
-ISO8601::Duration TemporalInstant::difference(JSGlobalObject* globalObject, TemporalInstant* other, JSValue optionsValue) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Steps 1-2: RequireInternalSlot + ToTemporalInstant done by caller (until/since prototype functions).
-    // Step 3: GetDifferenceSettings.
-    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Time, TemporalUnit::Nanosecond, TemporalUnit::Second);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 4: DifferenceInstant + RoundRelativeDuration.
-    ISO8601::InternalDuration internalDuration = exactTime().difference(globalObject, other->exactTime(), increment, smallestUnit, roundingMode);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 5: Return CreateTemporalDuration from the balanced result.
-    auto durResult = TemporalCore::temporalDurationFromInternal(internalDuration, largestUnit);
-    if (!durResult) [[unlikely]] {
-        throwTemporalError(globalObject, scope, durResult.error());
-        return { };
-    }
-    return *durResult;
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round
-ISO8601::ExactTime TemporalInstant::round(JSGlobalObject* globalObject, JSValue optionsValue) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Steps 1-2: branding check done by the caller (temporalInstantPrototypeFuncRound).
-
-    // Step 3: If roundTo is undefined, throw a TypeError exception.
-    if (optionsValue.isUndefined()) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Temporal.Instant.prototype.round requires a roundTo option"_s);
-        return { };
-    }
-
-    JSObject* options = nullptr;
-    std::optional<TemporalUnit> smallest;
-
-    if (optionsValue.isString()) {
-        // Step 4: Let paramString be roundTo. Set roundTo to OrdinaryObjectCreate(null).
-        //         Perform ! CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
-        // NOTE: We skip the object wrapper and parse the unit directly as an optimisation.
-        auto string = optionsValue.toWTFString(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        smallest = temporalUnitType(string);
-        if (!smallest) [[unlikely]] {
-            throwRangeError(globalObject, scope, "smallestUnit is an invalid Temporal unit"_s);
-            return { };
-        }
-    } else {
-        // Step 5: Set roundTo to ? GetOptionsObject(roundTo).
-        options = intlGetOptionsObject(globalObject, optionsValue);
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-
-    // Step 6: NOTE: The following steps read options in alphabetical order.
-    // Step 7: Let roundingIncrement be ? GetRoundingIncrementOption(roundTo).
-    double roundingIncrement = temporalRoundingIncrement(globalObject, options);
-    RETURN_IF_EXCEPTION(scope, { });
-    // Step 8: Let roundingMode be ? GetRoundingModeOption(roundTo, ~half-expand~).
-    RoundingMode roundingMode = temporalRoundingMode(globalObject, options, RoundingMode::HalfExpand);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    if (!smallest) {
-        // Step 9: Let smallestUnit be ? GetTemporalUnitValuedOption(roundTo, "smallestUnit", ~required~).
-        auto smallestUnitMaybeAuto = temporalUnitValued(globalObject, options, vm.propertyNames->smallestUnit, TemporalUnitDefault::Required);
-        RETURN_IF_EXCEPTION(scope, { });
-        // Step 10: Perform ? ValidateTemporalUnitValue(smallestUnit, ~time~).
-        validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
-        RETURN_IF_EXCEPTION(scope, { });
-        smallest = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
-    } else {
-        // Step 10 (string path): Perform ? ValidateTemporalUnitValue(smallestUnit, ~time~).
-        validateTemporalUnitValue(globalObject, smallest.value(), UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-
-    TemporalUnit smallestUnit = smallest.value();
-
-    // Steps 11-16: Let maximum be the per-unit maximum rounding increment.
-    // Step 17: Perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, true).
-    validateTemporalRoundingIncrement(globalObject, roundingIncrement, TemporalCore::maximumInstantIncrement(smallestUnit), Inclusivity::Inclusive);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 18: Let roundedNs be RoundTemporalInstant(instant.[[EpochNanoseconds]], roundingIncrement, smallestUnit, roundingMode).
-    // Step 19: Return ! CreateTemporalInstant(roundedNs).
-    RELEASE_AND_RETURN(scope, exactTime().round(globalObject, roundingIncrement, smallestUnit, roundingMode));
-}
-
-// Temporal.Instant.prototype.toString( [ options ] )
-// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tostring
-String TemporalInstant::toString(JSGlobalObject* globalObject, JSValue optionsValue) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Steps 1-2: branding check done by the caller (temporalInstantPrototypeFuncToString).
-
-    // Step 3: Let resolvedOptions be ? GetOptionsObject(options).
-    JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    if (!options)
-        return toString();
-
-    // Step 4: NOTE: The following steps read options and perform independent validation
-    //         in alphabetical order.
-    // Step 5: Let digits be ? GetTemporalFractionalSecondDigitsOption(resolvedOptions).
-    auto digits = temporalFractionalSecondDigits(globalObject, options);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 6: Let roundingMode be ? GetRoundingModeOption(resolvedOptions, ~trunc~).
-    RoundingMode roundingMode = temporalRoundingMode(globalObject, options, RoundingMode::Trunc);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 7: Let smallestUnit be ? GetTemporalUnitValuedOption(resolvedOptions, "smallestUnit", ~unset~).
-    auto smallestUnitResult = temporalUnitValued(globalObject, options, vm.propertyNames->smallestUnit);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 8: Let timeZone be ? Get(resolvedOptions, "timeZone").
-    JSValue timeZoneValue = options->get(globalObject, vm.propertyNames->timeZone);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 9: Perform ? ValidateTemporalUnitValue(smallestUnit, ~time~).
-    validateTemporalUnitValue(globalObject, smallestUnitResult, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
-    RETURN_IF_EXCEPTION(scope, { });
-    auto smallestUnit = std::get<std::optional<TemporalUnit>>(smallestUnitResult);
-    // Step 10: If smallestUnit is ~hour~, throw a RangeError exception.
-    if (smallestUnit == TemporalUnit::Hour) [[unlikely]] {
-        throwRangeError(globalObject, scope, "smallestUnit cannot be \"hour\" for Instant.toString"_s);
-        return { };
-    }
-
-    // Step 11: If timeZone is not undefined, set timeZone to ? ToTemporalTimeZoneIdentifier(timeZone).
-    std::optional<TimeZone> timeZone;
-    if (!timeZoneValue.isUndefined()) {
-        timeZone = toTemporalTimeZoneIdentifier(globalObject, timeZoneValue);
-        RETURN_IF_EXCEPTION(scope, { });
-        ASSERT(timeZone);
-    }
-
-    // Step 12: Let precision be ToSecondsStringPrecisionRecord(smallestUnit, digits).
-    auto data = toSecondsStringPrecisionRecord(smallestUnit, digits);
-
-    // Steps 13-15: RoundTemporalInstant + CreateTemporalInstant + TemporalInstantToString.
-    // Precision::Auto means increment=1 ns — a no-op for any mode; skip steps 13-14.
-    if (std::get<0>(data.precision) == Precision::Auto) {
-        std::optional<int64_t> offsetNs;
-        if (timeZone) {
-            auto offsetResult = TemporalCore::getOffsetNanosecondsFor(*timeZone, exactTime());
-            if (!offsetResult) [[unlikely]] {
-                throwRangeError(globalObject, scope, offsetResult.error().message);
-                return { };
-            }
-            offsetNs = *offsetResult;
-        }
-        return TemporalCore::instantToString(exactTime(), offsetNs, data);
-    }
-
-    // Step 13: Let roundedNs be RoundTemporalInstant(instant.[[EpochNanoseconds]], precision.[[Increment]], precision.[[Unit]], roundingMode).
-    auto newExactTime = exactTime().round(globalObject, data.increment, data.unit, roundingMode);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 14: Let roundedInstant be ! CreateTemporalInstant(roundedNs).
-    // Step 15: Return TemporalInstantToString(roundedInstant, timeZone, precision.[[Precision]]).
-    // Pass newExactTime directly — elides the CreateTemporalInstant allocation.
-    std::optional<int64_t> outputOffsetNs;
-    if (timeZone) {
-        auto offsetResult = TemporalCore::getOffsetNanosecondsFor(*timeZone, newExactTime);
-        if (!offsetResult) [[unlikely]] {
-            throwRangeError(globalObject, scope, offsetResult.error().message);
-            return { };
-        }
-        outputOffsetNs = *offsetResult;
-    }
-    return TemporalCore::instantToString(newExactTime, outputOffsetNs, data);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalInstant.h
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.h
@@ -48,23 +48,17 @@ public:
     }
 
     static TemporalInstant* create(VM&, Structure*, ISO8601::ExactTime);
-    static TemporalInstant* tryCreateIfValid(JSGlobalObject*, ISO8601::ExactTime, Structure* = nullptr);
-    static TemporalInstant* tryCreateIfValid(JSGlobalObject*, JSValue, Structure* = nullptr);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
 
     static TemporalInstant* toInstant(JSGlobalObject*, JSValue);
-    static TemporalInstant* from(JSGlobalObject*, JSValue);
     static TemporalInstant* fromEpochMilliseconds(JSGlobalObject*, JSValue);
     static TemporalInstant* fromEpochNanoseconds(JSGlobalObject*, JSValue);
     static JSValue compare(JSGlobalObject*, JSValue, JSValue);
 
     ISO8601::ExactTime exactTime() const { return m_exactTime; }
 
-    ISO8601::Duration difference(JSGlobalObject*, TemporalInstant*, JSValue options) const;
-    ISO8601::ExactTime round(JSGlobalObject*, JSValue options) const;
-    String toString(JSGlobalObject*, JSValue options) const;
     String toString(PrecisionData precision = { { Precision::Auto, 0 }, TemporalUnit::Nanosecond, 1 }) const
     {
         return TemporalCore::instantToString(exactTime(), std::nullopt, precision);
@@ -72,12 +66,6 @@ public:
 
 private:
     TemporalInstant(VM&, Structure*, ISO8601::ExactTime);
-
-    template<typename CharacterType>
-    static std::optional<ISO8601::ExactTime> parse(StringParsingBuffer<CharacterType>&);
-    static ISO8601::ExactTime fromObject(JSGlobalObject*, JSObject*);
-
-    static String toString(ISO8601::ExactTime, JSObject* timeZone, PrecisionData);
 
     ISO8601::ExactTime m_exactTime;
 };

--- a/Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantConstructor.cpp
@@ -84,19 +84,28 @@ void TemporalInstantConstructor::finishCreation(VM& vm, TemporalInstantPrototype
     instantPrototype->putDirectWithoutTransition(vm, vm.propertyNames->constructor, this, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal.instant
 JSC_DEFINE_HOST_FUNCTION(constructTemporalInstant, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: NewTarget check done by JSC dispatch.
     JSObject* newTarget = asObject(callFrame->newTarget());
     Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, instantStructure, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (callFrame->argumentCount() < 1) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Missing required epochNanoseconds argument to Temporal.Instant"_s);
+    // Step 2: Set epochNanoseconds to ? ToBigInt(epochNanoseconds).
+    JSValue bigIntValue = callFrame->argument(0).toBigInt(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalInstant::tryCreateIfValid(globalObject, callFrame->uncheckedArgument(0), structure)));
+    // Step 3: If IsValidEpochNanoseconds(epochNanoseconds) is false, throw RangeError.
+    auto exactTimeOpt = bigIntValueToExactTime(globalObject, bigIntValue, "Temporal.Instant"_s);
+    RETURN_IF_EXCEPTION(scope, { });
+    ASSERT(exactTimeOpt);
+
+    // Step 4: Return ! CreateTemporalInstant(epochNanoseconds, NewTarget).
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalInstant::create(vm, structure, *exactTimeOpt)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(callTemporalInstant, (JSGlobalObject* globalObject, CallFrame*))
@@ -107,9 +116,10 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalInstant, (JSGlobalObject* globalObject, Cal
     return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "Instant"_s));
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal.instant.from
 JSC_DEFINE_HOST_FUNCTION(temporalInstantConstructorFuncFrom, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return JSValue::encode(TemporalInstant::from(globalObject, callFrame->argument(0)));
+    return JSValue::encode(TemporalInstant::toInstant(globalObject, callFrame->argument(0)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(temporalInstantConstructorFuncFromEpochMilliseconds, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
@@ -28,11 +28,14 @@
 #include "TemporalInstantPrototype.h"
 
 #include "ISO8601.h"
+#include "InstantCore.h"
 #include "IntlDateTimeFormat.h"
+#include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "TemporalInstant.h"
 #include "TemporalObject.h"
 #include "TemporalZonedDateTime.h"
+#include "TimeZoneICUBridge.h"
 #include <wtf/text/MakeString.h>
 
 namespace JSC {
@@ -108,30 +111,50 @@ static constexpr std::initializer_list<TemporalUnit> disallowedAdditionUnits = {
     TemporalUnit::Day,
 };
 
+// AddDurationToInstant ( operation, instant, temporalDurationLike )
+// https://tc39.es/proposal-temporal/#sec-temporal-adddurationtoinstant
+enum class AddInstantOperation : uint8_t { Add, Subtract };
+
+template<AddInstantOperation operation>
+static TemporalInstant* addDurationToInstant(JSGlobalObject* globalObject, TemporalInstant* instant, JSValue durationLike)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Steps 1, 3-4: ToTemporalDuration + reject date-category units (fused into toLimitedDuration).
+    ISO8601::Duration duration = TemporalDuration::toLimitedDuration(globalObject, durationLike, disallowedAdditionUnits);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    // Step 2: If operation is SUBTRACT, set duration to CreateNegatedTemporalDuration(duration).
+    if constexpr (operation == AddInstantOperation::Subtract)
+        duration = -duration;
+
+    // Steps 5-6: ToInternalDurationRecordWith24HourDays + AddInstant (both done by ExactTime::add).
+    std::optional<ISO8601::ExactTime> newExactTime = instant->exactTime().add(duration);
+    if (!newExactTime) [[unlikely]] {
+        throwRangeError(globalObject, scope, operation == AddInstantOperation::Add
+            ? "Addition is outside of supported range for Temporal.Instant"_s
+            : "Subtraction is outside of supported range for Temporal.Instant"_s);
+        return nullptr;
+    }
+
+    // Step 7: Return ! CreateTemporalInstant(ns). Range already validated by ExactTime::add.
+    return TemporalInstant::create(vm, globalObject->instantStructure(), *newExactTime);
+}
+
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.add
 JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncAdd, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.add called on value that's not a Instant"_s);
 
-    // Steps 2-3: ToTemporalDuration + validate no calendar units.
-    ISO8601::Duration duration = TemporalDuration::toLimitedDuration(globalObject, callFrame->argument(0), disallowedAdditionUnits);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 4: AddInstant(instant.[[EpochNanoseconds]], duration).
-    std::optional<ISO8601::ExactTime> newExactTime = instant->exactTime().add(duration);
-    if (!newExactTime) [[unlikely]] {
-        throwRangeError(globalObject, scope, "Addition is outside of supported range for Temporal.Instant"_s);
-        return { };
-    }
-
-    // Step 5: CreateTemporalInstant(result).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalInstant::tryCreateIfValid(globalObject, *newExactTime)));
+    // Step 3: Return ? AddDurationToInstant(ADD, instant, temporalDurationLike).
+    RELEASE_AND_RETURN(scope, JSValue::encode(addDurationToInstant<AddInstantOperation::Add>(globalObject, instant, callFrame->argument(0))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.subtract
@@ -140,24 +163,49 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncSubtract, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.subtract called on value that's not a Instant"_s);
 
-    // Steps 2-3: ToTemporalDuration + validate no calendar units.
-    ISO8601::Duration duration = TemporalDuration::toLimitedDuration(globalObject, callFrame->argument(0), disallowedAdditionUnits);
-    RETURN_IF_EXCEPTION(scope, { });
+    // Step 3: Return ? AddDurationToInstant(SUBTRACT, instant, temporalDurationLike).
+    RELEASE_AND_RETURN(scope, JSValue::encode(addDurationToInstant<AddInstantOperation::Subtract>(globalObject, instant, callFrame->argument(0))));
+}
 
-    // Step 4: AddInstant(instant.[[EpochNanoseconds]], -duration).
-    std::optional<ISO8601::ExactTime> newExactTime = instant->exactTime().add(-duration);
-    if (!newExactTime) [[unlikely]] {
-        throwRangeError(globalObject, scope, "Subtraction is outside of supported range for Temporal.Instant"_s);
-        return { };
+// DifferenceTemporalInstant ( operation, instant, other, options )
+// https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalinstant
+template<DifferenceOperation operation>
+static TemporalDuration* differenceTemporalInstant(JSGlobalObject* globalObject, TemporalInstant* instant, JSValue otherValue, JSValue optionsValue)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Step 1: Set other to ? ToTemporalInstant(other).
+    TemporalInstant* other = TemporalInstant::toInstant(globalObject, otherValue);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    // Steps 2-3: GetOptionsObject + GetDifferenceSettings (NegateRoundingMode for SINCE applied inside).
+    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Time, TemporalUnit::Nanosecond, TemporalUnit::Second, operation);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    // Step 4: Let internalDuration be DifferenceInstant(instant.[[EpochNanoseconds]], other.[[EpochNanoseconds]], ...).
+    ISO8601::InternalDuration internalDuration = instant->exactTime().difference(globalObject, other->exactTime(), increment, smallestUnit, roundingMode);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    // Step 5: Let result be ! TemporalDurationFromInternal(internalDuration, settings.[[LargestUnit]]).
+    auto durResult = TemporalCore::temporalDurationFromInternal(internalDuration, largestUnit);
+    if (!durResult) [[unlikely]] {
+        throwTemporalError(globalObject, scope, durResult.error());
+        return nullptr;
     }
+    ISO8601::Duration result = *durResult;
 
-    // Step 5: CreateTemporalInstant(result).
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalInstant::tryCreateIfValid(globalObject, *newExactTime)));
+    // Step 6: If operation is SINCE, set result to CreateNegatedTemporalDuration(result).
+    if constexpr (operation == DifferenceOperation::Since)
+        result = -result;
+
+    // Step 7: Return ! CreateTemporalDuration(result).
+    return TemporalDuration::create(vm, globalObject->durationStructure(), WTF::move(result));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.until
@@ -166,21 +214,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncUntil, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.until called on value that's not a Instant"_s);
 
-    // Step 2: ToTemporalInstant(other).
-    TemporalInstant* other = TemporalInstant::toInstant(globalObject, callFrame->argument(0));
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Steps 3-7: GetDifferenceSettings + DifferenceTemporalInstant (delegated to difference()).
-    JSValue options = callFrame->argument(1);
-    ISO8601::Duration result = instant->difference(globalObject, other, options);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    return JSValue::encode(TemporalDuration::create(vm, globalObject->durationStructure(), WTF::move(result)));
+    // Step 3: Return ? DifferenceTemporalInstant(UNTIL, instant, other, options).
+    RELEASE_AND_RETURN(scope, JSValue::encode(differenceTemporalInstant<DifferenceOperation::Until>(globalObject, instant, callFrame->argument(0), callFrame->argument(1))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.since
@@ -189,21 +229,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncSince, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.since called on value that's not a Instant"_s);
 
-    // Step 2: ToTemporalInstant(other).
-    TemporalInstant* other = TemporalInstant::toInstant(globalObject, callFrame->argument(0));
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Steps 3-7: DifferenceTemporalInstant(since, instant, other, ...) = other.until(instant).
-    JSValue options = callFrame->argument(1);
-    ISO8601::Duration result = other->difference(globalObject, instant, options);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    return JSValue::encode(TemporalDuration::create(vm, globalObject->durationStructure(), WTF::move(result)));
+    // Step 3: Return ? DifferenceTemporalInstant(SINCE, instant, other, options).
+    RELEASE_AND_RETURN(scope, JSValue::encode(differenceTemporalInstant<DifferenceOperation::Since>(globalObject, instant, callFrame->argument(0), callFrame->argument(1))));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round
@@ -212,22 +244,69 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncRound, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.round called on value that's not a Instant"_s);
 
-    // Step 2: If roundTo is undefined, throw TypeError.
-    JSValue options = callFrame->argument(0);
-    if (options.isUndefined()) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.round requires an options argument"_s);
+    // Step 3: If roundTo is undefined, throw a TypeError exception.
+    JSValue roundToValue = callFrame->argument(0);
+    if (roundToValue.isUndefined()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.round requires a roundTo option"_s);
 
-    // Steps 3-8: GetOptionsObject + settings + RoundTemporalInstant (delegated to round()).
-    ISO8601::ExactTime newExactTime = instant->round(globalObject, options);
+    JSObject* roundTo = nullptr;
+    std::optional<TemporalUnit> smallest;
+
+    if (roundToValue.isString()) {
+        // Step 4: If roundTo is a String, let paramString be roundTo, set roundTo to OrdinaryObjectCreate(null),
+        //         and CreateDataPropertyOrThrow(roundTo, "smallestUnit", paramString).
+        // NOTE: We skip the object wrapper and parse the unit directly as an optimisation.
+        auto string = roundToValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        smallest = temporalUnitType(string);
+        if (!smallest) [[unlikely]]
+            return throwVMRangeError(globalObject, scope, "smallestUnit is an invalid Temporal unit"_s);
+    } else {
+        // Step 5: Else, set roundTo to ? GetOptionsObject(roundTo).
+        roundTo = intlGetOptionsObject(globalObject, roundToValue);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Step 6: NOTE: The following steps read options in alphabetical order.
+    // Step 7: Let roundingIncrement be ? GetRoundingIncrementOption(roundTo).
+    double roundingIncrement = temporalRoundingIncrement(globalObject, roundTo);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 9: CreateTemporalInstant(result).
-    return JSValue::encode(TemporalInstant::create(vm, globalObject->instantStructure(), newExactTime));
+    // Step 8: Let roundingMode be ? GetRoundingModeOption(roundTo, HALF-EXPAND).
+    RoundingMode roundingMode = temporalRoundingMode(globalObject, roundTo, RoundingMode::HalfExpand);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (!smallest) {
+        // Step 9: Let smallestUnit be ? GetTemporalUnitValuedOption(roundTo, "smallestUnit", REQUIRED).
+        auto smallestUnitMaybeAuto = temporalUnitValued(globalObject, roundTo, vm.propertyNames->smallestUnit, TemporalUnitDefault::Required);
+        RETURN_IF_EXCEPTION(scope, { });
+        // Step 10: Perform ? ValidateTemporalUnitValue(smallestUnit, time).
+        validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
+        RETURN_IF_EXCEPTION(scope, { });
+        smallest = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
+    } else {
+        // Step 10 (string path): Perform ? ValidateTemporalUnitValue(smallestUnit, time).
+        validateTemporalUnitValue(globalObject, smallest.value(), UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+    TemporalUnit smallestUnit = smallest.value();
+
+    // Steps 11-16: Let maximum be the per-unit maximum rounding increment.
+    // Step 17: Perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, true).
+    validateTemporalRoundingIncrement(globalObject, roundingIncrement, TemporalCore::maximumInstantIncrement(smallestUnit), Inclusivity::Inclusive);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 18: Let roundedNs be RoundTemporalInstant(instant.[[EpochNanoseconds]], roundingIncrement, smallestUnit, roundingMode).
+    ISO8601::ExactTime roundedNs = instant->exactTime().round(globalObject, roundingIncrement, smallestUnit, roundingMode);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 19: Return ! CreateTemporalInstant(roundedNs). Range bounded by spec maximum.
+    return JSValue::encode(TemporalInstant::create(vm, globalObject->instantStructure(), roundedNs));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals
@@ -236,16 +315,16 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncEquals, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.equals called on value that's not a Instant"_s);
 
-    // Step 2: ToTemporalInstant(other).
+    // Step 3: Set other to ? ToTemporalInstant(other).
     TemporalInstant* other = TemporalInstant::toInstant(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 3: Return instant.[[EpochNanoseconds]] = other.[[EpochNanoseconds]].
+    // Steps 4-5: If instant.[[EpochNanoseconds]] ≠ other.[[EpochNanoseconds]], return false; else return true.
     return JSValue::encode(jsBoolean(instant->exactTime() == other->exactTime()));
 }
 
@@ -255,11 +334,76 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToString, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.toString called on value that's not a Instant"_s);
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, instant->toString(globalObject, callFrame->argument(0)))));
+    // Step 3: Let resolvedOptions be ? GetOptionsObject(options).
+    JSObject* resolvedOptions = intlGetOptionsObject(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Fast path: undefined options → default precision (Auto, no rounding, no timezone).
+    if (!resolvedOptions)
+        return JSValue::encode(jsString(vm, instant->toString()));
+
+    // Step 4: NOTE: The following steps read options and perform independent validation in alphabetical order.
+    // Step 5: Let digits be ? GetTemporalFractionalSecondDigitsOption(resolvedOptions).
+    auto digits = temporalFractionalSecondDigits(globalObject, resolvedOptions);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 6: Let roundingMode be ? GetRoundingModeOption(resolvedOptions, TRUNC).
+    RoundingMode roundingMode = temporalRoundingMode(globalObject, resolvedOptions, RoundingMode::Trunc);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 7: Let smallestUnit be ? GetTemporalUnitValuedOption(resolvedOptions, "smallestUnit", UNSET).
+    auto smallestUnitResult = temporalUnitValued(globalObject, resolvedOptions, vm.propertyNames->smallestUnit);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 8: Let timeZone be ? Get(resolvedOptions, "timeZone").
+    JSValue timeZoneValue = resolvedOptions->get(globalObject, vm.propertyNames->timeZone);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 9: Perform ? ValidateTemporalUnitValue(smallestUnit, time).
+    validateTemporalUnitValue(globalObject, smallestUnitResult, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
+    RETURN_IF_EXCEPTION(scope, { });
+    auto smallestUnit = std::get<std::optional<TemporalUnit>>(smallestUnitResult);
+
+    // Step 10: If smallestUnit is HOUR, throw a RangeError exception.
+    if (smallestUnit == TemporalUnit::Hour) [[unlikely]]
+        return throwVMRangeError(globalObject, scope, "smallestUnit cannot be \"hour\" for Instant.toString"_s);
+
+    // Step 11: If timeZone is not undefined, set timeZone to ? ToTemporalTimeZoneIdentifier(timeZone).
+    std::optional<TimeZone> timeZone;
+    if (!timeZoneValue.isUndefined()) {
+        timeZone = toTemporalTimeZoneIdentifier(globalObject, timeZoneValue);
+        RETURN_IF_EXCEPTION(scope, { });
+        ASSERT(timeZone);
+    }
+
+    // Step 12: Let precision be ToSecondsStringPrecisionRecord(smallestUnit, digits).
+    auto data = toSecondsStringPrecisionRecord(smallestUnit, digits);
+
+    // Step 13: Let roundedNs be RoundTemporalInstant(...).
+    // Step 14: Let roundedInstant be ! CreateTemporalInstant(roundedNs).
+    // Auto precision means increment=1 ns — a no-op for any rounding mode; skip steps 13-14.
+    ISO8601::ExactTime roundedExactTime = instant->exactTime();
+    if (std::get<0>(data.precision) != Precision::Auto) {
+        roundedExactTime = instant->exactTime().round(globalObject, data.increment, data.unit, roundingMode);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Step 15: Return TemporalInstantToString(roundedInstant, timeZone, precision.[[Precision]]).
+    std::optional<int64_t> offsetNs;
+    if (timeZone) {
+        auto offsetResult = TemporalCore::getOffsetNanosecondsFor(*timeZone, roundedExactTime);
+        if (!offsetResult) [[unlikely]] {
+            throwRangeError(globalObject, scope, offsetResult.error().message);
+            return { };
+        }
+        offsetNs = *offsetResult;
+    }
+    return JSValue::encode(jsString(vm, TemporalCore::instantToString(roundedExactTime, offsetNs, data)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson
@@ -268,32 +412,33 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToJSON, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.toJSON called on value that's not a Instant"_s);
 
-    // Step 2: Return TemporalInstantToString(instant, undefined, "auto").
+    // Step 3: Return TemporalInstantToString(instant, undefined, AUTO). Default-args toString uses
+    //         timeZone = std::nullopt (UTC, "Z" suffix) and precision = Auto.
     RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, instant->toString())));
 }
 
 // https://tc39.es/proposal-temporal/#sup-temporal.instant.prototype.tolocalestring
-// FIXME: Is this better as a JSBuiltin?
 JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToLocaleString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.toLocaleString called on value that's not a Instant"_s);
 
+    // Step 3: Let dateFormat be ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, ANY, ALL).
     IntlDateTimeFormat* formatter = IntlDateTimeFormat::create(vm, globalObject->dateTimeFormatStructure());
-    RETURN_IF_EXCEPTION(scope, { });
-
     formatter->initializeDateTimeFormat(globalObject, callFrame->argument(0), callFrame->argument(1), IntlDateTimeFormat::RequiredComponent::Any, IntlDateTimeFormat::Defaults::All);
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 4: Return ? FormatDateTime(dateFormat, instant).
     RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
@@ -303,7 +448,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncValueOf, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: Throw TypeError — Instant has no primitive value.
+    // Step 1: Throw a TypeError exception. Instant has no primitive value.
     return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.valueOf must not be called. To compare Instant values, use Temporal.Instant.compare"_s);
 }
 
@@ -313,6 +458,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToZonedDateTimeISO, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(callFrame->thisValue());
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.toZonedDateTimeISO called on value that's not an Instant"_s);
@@ -321,36 +467,38 @@ JSC_DEFINE_HOST_FUNCTION(temporalInstantPrototypeFuncToZonedDateTimeISO, (JSGlob
     auto timeZone = toTemporalTimeZoneIdentifier(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     ASSERT(timeZone);
+
+    // Step 4: Return ! CreateTemporalZonedDateTime(instant.[[EpochNanoseconds]], timeZone, "iso8601").
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalZonedDateTime::create(vm, globalObject->zonedDateTimeStructure(), instant->exactTime(), *timeZone, iso8601CalendarID())));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.epochmilliseconds
+// https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochmilliseconds
 JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochMilliseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(JSValue::decode(thisValue));
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.epochMilliseconds called on value that's not a Instant"_s);
 
-    // Step 2: Return 𝔽(⌊instant.[[EpochNanoseconds]] / 10^6⌋).
+    // Steps 3-4: Let ns be instant.[[EpochNanoseconds]]; return 𝔽(floor(ℝ(ns) / 10^6)).
     return JSValue::encode(jsNumber(instant->exactTime().floorEpochMilliseconds()));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.epochnanoseconds
+// https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochnanoseconds
 JSC_DEFINE_CUSTOM_GETTER(temporalInstantPrototypeGetterEpochNanoseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: this value + ? RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
     TemporalInstant* instant = dynamicDowncast<TemporalInstant>(JSValue::decode(thisValue));
     if (!instant) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Instant.prototype.epochNanoseconds called on value that's not a Instant"_s);
 
-    // Step 2: Return ! CreateBigInt(instant.[[EpochNanoseconds]]).
+    // Step 3: Return ℤ(instant.[[EpochNanoseconds]]).
     RELEASE_AND_RETURN(scope, JSValue::encode(JSBigInt::createFrom(globalObject, instant->exactTime().epochNanoseconds())));
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalNow.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalNow.cpp
@@ -95,7 +95,7 @@ void TemporalNow::finishCreation(VM& vm)
 // https://tc39.es/proposal-temporal/#sec-temporal.now.instant
 JSC_DEFINE_HOST_FUNCTION(temporalNowFuncInstant, (JSGlobalObject* globalObject, CallFrame*))
 {
-    return JSValue::encode(TemporalInstant::tryCreateIfValid(globalObject, ISO8601::ExactTime::now()));
+    return JSValue::encode(TemporalInstant::create(globalObject->vm(), globalObject->instantStructure(), ISO8601::ExactTime::now()));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.now.timezoneid


### PR DESCRIPTION
#### 897d634c31e79c891729c5b3bfe1e108ade8cbd9
<pre>
[JSC][Temporal] Align Temporal.Instant with spec abstract operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=317224">https://bugs.webkit.org/show_bug.cgi?id=317224</a>
<a href="https://rdar.apple.com/179844859">rdar://179844859</a>

Reviewed by Yusuke Suzuki.

Refactor Temporal.Instant for 1:1 alignment with the Stage 4 spec
abstract operations. Each constructor static, prototype method, and
helper maps step-by-step to its spec citation. Removed:
TemporalInstant::from / parse / fromObject / tryCreateIfValid / member
toString(JSGlobalObject*, JSValue) / member difference / member round,
plus ISO8601::parseInstant — each inlined at the single call site that
owns the spec algorithm.

- TemporalInstant::toInstant implements ToTemporalInstant directly. The
  slot path now returns a NEW instance via CreateTemporalInstant (spec
  contract; previously returned same identity). Grammar restriction for
  TemporalInstantString (Time-required, Offset/Z-required) is layered on
  top of parseCalendarDateTime since JSC lacks a unified ParseISODateTime.

- In ToTemporalInstant, BalanceISODateTime + GetUTCEpochNanoseconds
  collapse into ExactTime::fromISOPartsAndOffset, and CheckISODaysRange
  + IsValidEpochNanoseconds collapse into ExactTime::isValid(). Both are
  observably equivalent.

- Prototype methods extract two abstract operations as templates:
  addDurationToInstant&lt;AddInstantOperation&gt; drives add/subtract, and
  differenceTemporalInstant&lt;DifferenceOperation&gt; drives until/since with
  NegateRoundingMode applied at extractDifferenceOptions for SINCE.

- FIXME notes the parser-architecture gap: JSC has four parser entry
  points covering subsets of the spec&apos;s single ParseISODateTime, forcing
  consumers to re-implement production guards. Future work should
  introduce ParseISODateTime(string, ProductionMask) for 1:1 spec parity.

Test: JSTests/stress/temporal-instant-totemporalinstant.js
Canonical link: <a href="https://commits.webkit.org/315377@main">https://commits.webkit.org/315377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e70bc8dae450b20a5be91706061edb614e10111

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126407 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/336ce3a4-90dc-4ce1-861e-44981fece009) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131342 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92396 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b574701a-d30e-4735-a4bb-4832c3b09d4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111846 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f82f460-207a-4a3f-a200-870d9fe07b52) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32778 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31492 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26726 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/26 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180632 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29951 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139783 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42271 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139632 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42960 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27980 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106687 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25721 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34913 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114727 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201379 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41463 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6068 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54067 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40860 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41114 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41005 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->