### PR TITLE
IIRProcessor normalization coefficient is narrowed to float

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-normalization-precision-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-normalization-precision-expected.txt
@@ -1,0 +1,3 @@
+
+PASS IIR coefficient normalization stays precise when feedback[0] is not exactly representable as a float
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-normalization-precision.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-normalization-precision.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Test IIRFilter coefficient normalization precision
+    </title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="../../resources/audit-util.js"></script>
+  </head>
+  <body>
+    <script>
+      test(t => {
+        const context = new OfflineAudioContext(1, 1, 48000);
+
+        const feedforward = [1, 0, -1];
+        const feedback = [1, -2 * 0.9995 * Math.cos(Math.PI / 4), 0.9995 ** 2];
+        const reference = context.createIIRFilter(feedforward, feedback);
+
+        const scaled = context.createIIRFilter(
+            feedforward.map(v => v / 10), feedback.map(v => v / 10));
+
+        const frequencies = new Float32Array(21);
+        for (let k = 0; k < frequencies.length; ++k)
+          frequencies[k] = 5980 + 2 * k;
+        const referenceMag = new Float32Array(frequencies.length);
+        const scaledMag = new Float32Array(frequencies.length);
+        const phase = new Float32Array(frequencies.length);
+
+        reference.getFrequencyResponse(frequencies, referenceMag, phase);
+        scaled.getFrequencyResponse(frequencies, scaledMag, phase);
+
+        assert_array_equal_within_eps(
+            scaledMag, referenceMag, {absoluteThreshold: 1e-3},
+            'Magnitude response normalized by feedback[0]=0.1 should match the ' +
+                'response of the equivalent feedback[0]=1 filter');
+      }, 'IIR coefficient normalization stays precise when feedback[0] is not ' +
+          'exactly representable as a float');
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
@@ -60,7 +60,7 @@ IIRProcessor::IIRProcessor(float sampleRate, unsigned numberOfChannels, const Ve
         //   y(n) + a[1]/a[0]*y(n-1) + ... = b[0]/a[0]*x(n) + b[1]/a[0]*x(n-1) + ...
         //
         // Thus, the feedback and feedforward coefficients need to be scaled by 1/a[0].
-        float scale = feedback[0];
+        double scale = feedback[0];
         for (unsigned k = 1; k < feedbackLength; ++k)
             m_feedback[k] /= scale;
 


### PR DESCRIPTION
#### b69cb1f238e9f05b9a3e60ac88a710a7bc62383a
<pre>
IIRProcessor normalization coefficient is narrowed to float
<a href="https://bugs.webkit.org/show_bug.cgi?id=317225">https://bugs.webkit.org/show_bug.cgi?id=317225</a>
<a href="https://rdar.apple.com/179847280">rdar://179847280</a>

Reviewed by Chris Dumez.

&quot;float scale = feedback[0]&quot; narrows the double coefficient to single precision before it divides the
double-precision feedforward/feedback coefficients, reducing filter precision for any coefficient
set whose a[0] is not exactly representable as a float. Use a double.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-normalization-precision.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-normalization-precision-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-iirfilternode-interface/iirfilter-normalization-precision.html: Added.
* Source/WebCore/Modules/webaudio/IIRProcessor.cpp:
(WebCore::IIRProcessor::IIRProcessor):

Canonical link: <a href="https://commits.webkit.org/315400@main">https://commits.webkit.org/315400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e02eab7dad2edfadedf8148d9aa0885dbf8d97a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126495 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3890741e-2796-49ee-9b54-036d59925759) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131425 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac626c17-d356-4004-a411-5afde76da26c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111929 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63a62e8f-7e3d-4313-9cd1-e6c344676afc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32865 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31580 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26814 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180720 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139872 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139716 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43048 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28069 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106795 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25734 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34997 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114815 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41551 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40948 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41202 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41093 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->