### PR TITLE
StabilityTracer: com.apple.WebKit.WebContent at com.apple.WebCore:  WebCore::Style::ContainerQueryEvaluator::selectContainer

### DIFF
--- a/Source/WebCore/dom/ComposedTreeAncestorIterator.h
+++ b/Source/WebCore/dom/ComposedTreeAncestorIterator.h
@@ -106,10 +106,20 @@ public:
 
     iterator begin()
     {
-        if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(m_node.get()))
-            return iterator(*shadowRoot->host());
-        if (auto* pseudoElement = dynamicDowncast<PseudoElement>(m_node.get()))
-            return iterator(*pseudoElement->hostElement());
+        if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(m_node.get())) {
+            auto* shadowHost = shadowRoot->host();
+            ASSERT(shadowHost);
+            if (!shadowHost)
+                return end();
+            return iterator(*shadowHost);
+        }
+        if (auto* pseudoElement = dynamicDowncast<PseudoElement>(m_node.get())) {
+            auto* hostElement = pseudoElement->hostElement();
+            ASSERT(hostElement);
+            if (!hostElement)
+                return end();
+            return iterator(*hostElement);
+        }
         return iterator(m_node);
     }
     iterator end()


### PR DESCRIPTION
#### 85a4c32b837c1bbaf3620d0e47ede7c3127f75e1
<pre>
StabilityTracer: com.apple.WebKit.WebContent at com.apple.WebCore:  WebCore::Style::ContainerQueryEvaluator::selectContainer
<a href="https://bugs.webkit.org/show_bug.cgi?id=317210">https://bugs.webkit.org/show_bug.cgi?id=317210</a>
<a href="https://rdar.apple.com/179144334">rdar://179144334</a>

Reviewed by Kiet Ho and Antti Koivisto.

The crash happens trying to get the hostElement() from the pseudo-element in ComposedTreeIterator.

* Source/WebCore/dom/ComposedTreeAncestorIterator.h:
(WebCore::ComposedTreeAncestorAdapter::begin):

Canonical link: <a href="https://commits.webkit.org/315485@main">https://commits.webkit.org/315485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df691f702f5872cc84bd0d110a0b8aa820cabc3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169161 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/43083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178515 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126873 "Failed to checkout and rebase branch from PR 67278") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c16b2d0f-45b8-4f6f-ba7d-2b92173f5f19) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42708 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/126873 "Failed to checkout and rebase branch from PR 67278") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2c14d53-fb4e-419b-aac1-69354a89345f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34202 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112249 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e25b5d20-b907-4bbc-ad01-7c27c77ab451) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27217 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181117 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36065 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42739 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140040 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37684 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43428 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28409 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107347 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35318 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41937 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6498 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41331 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41474 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->