### PR TITLE
Change WTF, libpas exception codes to 0xbb08

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -276,7 +276,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 #if ASAN_ENABLED
 #define WTF_FATAL_CRASH_CODE 0x0
 #else
-#define WTF_FATAL_CRASH_CODE 0xc471
+#define WTF_FATAL_CRASH_CODE 0xbb08
 #endif
 #endif
 
@@ -284,7 +284,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 #if ASAN_ENABLED
 #define WTF_FATAL_CRASH_INST "brk #0x0"
 #else
-#define WTF_FATAL_CRASH_INST "brk #0xc471"
+#define WTF_FATAL_CRASH_INST "brk #0xbb08"
 #endif
 #endif
 

--- a/Source/bmalloc/bmalloc/BAssert.h
+++ b/Source/bmalloc/bmalloc/BAssert.h
@@ -41,7 +41,7 @@
 #elif BCPU(ARM_THUMB2)
 #define BBreakpointTrap()  __asm__ volatile ("bkpt #0")
 #elif BCPU(ARM64)
-#define BBreakpointTrap()  __asm__ volatile ("brk #0xc471")
+#define BBreakpointTrap()  __asm__ volatile ("brk #0xbb08")
 #else
 #error "Unsupported CPU".
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -55,7 +55,7 @@
 #if BASAN_ENABLED
 #define PAS_FATAL_CRASH_INST "brk #0x0"
 #else
-#define PAS_FATAL_CRASH_INST "brk #0xc471"
+#define PAS_FATAL_CRASH_INST "brk #0xbb08"
 #endif
 #endif
 


### PR DESCRIPTION
#### 06dae2e5c388bf287834ada245d5d6c2ef760488
<pre>
Change WTF, libpas exception codes to 0xbb08
<a href="https://bugs.webkit.org/show_bug.cgi?id=317228">https://bugs.webkit.org/show_bug.cgi?id=317228</a>
<a href="https://rdar.apple.com/179850955">rdar://179850955</a>

Reviewed by Keith Miller.

The code 0xc471 has been used because it renders the resulting
exception unrecoverable, preventing any actor from catching it with
a signal handler. This however shows up as a &quot;PAC_EXCEPTION&quot; in the
crashlog, which causes a good deal of confusion.

This patch changes it to 0xbb08, which falls in the range
0xb000-0xbfff for which the kernel will enforce the same
unrecoverability guarantees but with a more generic syndrome
description.

Canonical link: <a href="https://commits.webkit.org/315408@main">https://commits.webkit.org/315408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a11713eae8ceae50bbfd82486ef9af6a5db9dac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178278 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112042 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26981 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/239 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180880 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30180 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33591 "Found 615 new failures in plugins/DOMPluginArray.cpp, bytecode/ExpressionInfo.cpp, dfg/DFGBasicBlock.cpp, runtime/IndexingType.cpp, rendering/NinePieceImagePainter.cpp, jit/GdbJIT.cpp, dom/TreeScope.cpp, accessibility/AccessibilityScrollView.cpp, Modules/webaudio/ChannelMergerNode.cpp, WebProcess/WebPage/Cocoa/WebPageCocoa.mm ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139986 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42503 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37643 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43192 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107012 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35123 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114957 "Found 618 new failures in plugins/DOMPluginArray.cpp, bytecode/ExpressionInfo.cpp, dfg/DFGBasicBlock.cpp, runtime/IndexingType.cpp, rendering/NinePieceImagePainter.cpp, jit/GdbJIT.cpp, accessibility/AccessibilityScrollView.cpp, dom/TreeScope.cpp, Modules/webaudio/ChannelMergerNode.cpp, WebProcess/WebPage/Cocoa/WebPageCocoa.mm ...") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201604 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41701 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6281 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54111 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41095 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41350 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41238 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->