### PR TITLE
[Site Isolation] Show cross-origin frames in the inspector frame model (Page live events)

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-expected.txt
@@ -1,0 +1,12 @@
+Test that a cross-origin child frame appears in the frontend frame model under Site Isolation.
+
+
+== Running test suite: SiteIsolation.NetworkManager.CrossOriginFrame
+-- Running test case: SiteIsolation.NetworkManager.CrossOriginFrame.AppearsInFrameModel
+PASS: There should be a main frame.
+PASS: Cross-origin child frame should appear in WI.networkManager.frames.
+PASS: Cross-origin child's parent should be the main frame.
+PASS: Cross-origin child's name attribute should be reported.
+PASS: Cross-origin child's url should point at the iframe document.
+PASS: Cross-origin child should have a different security origin from the main frame.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-rename-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-rename-expected.txt
@@ -1,0 +1,9 @@
+Test that a cross-origin child's window.name change propagates to the frontend frame model under Site Isolation.
+
+
+== Running test suite: SiteIsolation.NetworkManager.CrossOriginFrameRename
+-- Running test case: SiteIsolation.NetworkManager.CrossOriginFrameRename.NamePropagates
+PASS: Cross-origin child frame should appear in WI.networkManager.frames after navigating.
+PASS: Cross-origin child's parent should be the main frame.
+PASS: Cross-origin child's updated window.name should propagate to the frame model on the subsequent navigation.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-rename.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-rename.html
@@ -1,0 +1,56 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/rename-then-navigate-frame.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.NetworkManager.CrossOriginFrameRename");
+
+    suite.addTestCase({
+        name: "SiteIsolation.NetworkManager.CrossOriginFrameRename.NamePropagates",
+        description: "When a cross-origin child changes its window.name and then navigates, the updated name should be reflected in WI.networkManager.frames. The live Page.frameNavigated resolves the empty cross-origin name from the authoritative UIProcess WebFrameProxy tree, which tracks the rename under Site Isolation.",
+        async test() {
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+            let frameTarget = (await targetAddedPromise).data.target;
+
+            // The child commits rename-then-navigate-frame.html (first appearing as "child-frame"),
+            // sets window.name = "renamed-child" (frameNameChanged -> WebFrameProxy under Site
+            // Isolation), then navigates to resource-tree-frame.html, whose Page.frameNavigated
+            // resolves the now-updated name. Poll until the frame settles on that final url.
+            let child;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                if (!frameTarget.executionContext) {
+                    await Promise.race([
+                        frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                        new Promise((resolve) => setTimeout(resolve, 100)),
+                    ]);
+                }
+                child = WI.networkManager.frames.find((frame) => frame.url && frame.url.endsWith("/resource-tree-frame.html"));
+                if (child)
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 20));
+            }
+
+            InspectorTest.expectThat(!!child, "Cross-origin child frame should appear in WI.networkManager.frames after navigating.");
+            if (!child)
+                return;
+
+            InspectorTest.expectThat(child.parentFrame === WI.networkManager.mainFrame, "Cross-origin child's parent should be the main frame.");
+            InspectorTest.expectEqual(child.name, "renamed-child", "Cross-origin child's updated window.name should propagate to the frame model on the subsequent navigation.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that a cross-origin child's window.name change propagates to the frontend frame model under Site Isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame.html
@@ -1,0 +1,58 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.NetworkManager.CrossOriginFrame");
+
+    suite.addTestCase({
+        name: "SiteIsolation.NetworkManager.CrossOriginFrame.AppearsInFrameModel",
+        description: "A cross-origin child frame should appear in WI.networkManager.frames under Site Isolation, driven by the live Page.frameNavigated event from the cross-origin process, and must not be removed by the spurious frameDetached fired when it swaps out of its original process.",
+        async test() {
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+            let frameTarget = (await targetAddedPromise).data.target;
+
+            // The cross-origin child commits in its own process (CommitTiming::WaitForLoad); its
+            // Page.frameNavigated arrives shortly after. Drive/await the child's execution context
+            // (created right after commit) and poll the frame model until it appears.
+            let child;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                if (!frameTarget.executionContext) {
+                    await Promise.race([
+                        frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                        new Promise((resolve) => setTimeout(resolve, 100)),
+                    ]);
+                }
+                child = WI.networkManager.frames.find((frame) => frame.url && frame.url.endsWith("/resource-tree-frame.html"));
+                if (child)
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 20));
+            }
+
+            InspectorTest.expectThat(!!WI.networkManager.mainFrame, "There should be a main frame.");
+            InspectorTest.expectThat(!!child, "Cross-origin child frame should appear in WI.networkManager.frames.");
+            if (!child)
+                return;
+
+            InspectorTest.expectThat(child.parentFrame === WI.networkManager.mainFrame, "Cross-origin child's parent should be the main frame.");
+            InspectorTest.expectEqual(child.name, "child-frame", "Cross-origin child's name attribute should be reported.");
+            InspectorTest.expectThat(child.url.endsWith("/resource-tree-frame.html"), "Cross-origin child's url should point at the iframe document.");
+            InspectorTest.expectThat(child.securityOrigin !== WI.networkManager.mainFrame.securityOrigin, "Cross-origin child should have a different security origin from the main frame.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that a cross-origin child frame appears in the frontend frame model under Site Isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/rename-then-navigate-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/rename-then-navigate-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Cross-origin frame that renames itself</title>
+<script>
+// Change the browsing context name, then navigate. Setting window.name calls
+// LocalFrameLoaderClient::frameNameChanged, which under Site Isolation reports the new name to
+// the UIProcess WebFrameProxy tree. The subsequent navigation emits a fresh Page.frameNavigated
+// whose (empty, cross-origin) name is resolved from that tree -- so the updated name should reach
+// the frontend frame model. See webkit.org/b/316666.
+window.name = "renamed-child";
+location.href = "resource-tree-frame.html";
+</script>
+<p>Cross-origin frame that renames itself, then navigates.</p>

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -106,8 +106,17 @@ void ProxyingPageAgent::frameNavigated(FrameIdentifier frameID, const URL& url, 
 
     if (parentFrameID)
         frameObject->setParentId(protocolFrameIdForFrameID(*parentFrameID));
-    if (!name.isEmpty())
-        frameObject->setName(name);
+
+    // The event's name is empty for a cross-origin child: it fires in the child's own
+    // process where the owning <iframe> element is remote (frame.ownerElement() is null).
+    // Resolve it from the authoritative UIProcess WebFrameProxy tree, matching buildFrameTree().
+    String effectiveName = name;
+    if (effectiveName.isEmpty()) {
+        if (RefPtr webFrame = WebFrameProxy::webFrame(frameID))
+            effectiveName = webFrame->frameName();
+    }
+    if (!effectiveName.isEmpty())
+        frameObject->setName(effectiveName);
 
     m_frontendDispatcher->frameNavigated(WTF::move(frameObject));
 }
@@ -124,6 +133,14 @@ void ProxyingPageAgent::loadEventFired(double timestamp)
 
 void ProxyingPageAgent::frameDetached(FrameIdentifier frameID)
 {
+    // A cross-origin process swap tears down the frame's LocalFrame in its old process,
+    // firing frameDetached there -- but the frame still exists, now hosted by another
+    // process (the authoritative WebFrameProxy tree still contains it). Forwarding that to
+    // the frontend would remove a live frame. Only report frames that are genuinely gone
+    // from the tree. See webkit.org/b/308896.
+    if (WebFrameProxy::webFrame(frameID))
+        return;
+
     m_cachedFrameDocumentInfo.remove(frameID);
     m_frontendDispatcher->frameDetached(protocolFrameIdForFrameID(frameID));
 }


### PR DESCRIPTION
#### ff1dba6c2cbb523a62640d2a0ac94fefdd3ab366
<pre>
[Site Isolation] Show cross-origin frames in the inspector frame model (Page live events)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316666">https://bugs.webkit.org/show_bug.cgi?id=316666</a>
<a href="https://rdar.apple.com/179117404">rdar://179117404</a>

Reviewed by BJ Burg.

With live Page.frameNavigated/frameDetached now flowing from cross-origin processes to
the UIProcess ProxyingPageAgent and on to the frontend, the frontend&apos;s existing
NetworkManager.frameDidNavigate/frameDidDetach handlers already integrate cross-origin
frames into WI.networkManager.frames -- no frontend changes are needed. Two UIProcess-side
bugs prevented the frame from showing up correctly, both fixed in ProxyingPageAgent:

1. The frame name was empty for a cross-origin child. Its live frameNavigated fires in the
   child&apos;s own process, where the owning &lt;iframe&gt; element is remote (frame.ownerElement()
   is null), so PageAgentProxy can&apos;t read the name attribute. Resolve it from the
   authoritative UIProcess WebFrameProxy tree (frameName()) when the event&apos;s name is empty,
   matching buildFrameTree(). Because the resolution reads the WebFrameProxy tree -- which
   tracks dynamic window.name changes under Site Isolation (via frameNameChanged) -- a
   renamed cross-origin child reports its updated name on its next frameNavigated.

2. A spurious frameDetached fired during a cross-origin process swap removed the live frame
   from the frontend. When the child swaps from its original process to a new one, the
   old process tears down its LocalFrame and fires frameDetached; by the time
   ProxyingPageAgent handles it, the frame&apos;s hosting process has already updated, so
   protocolFrameIdForFrameID() resolves it to the new (current) protocol id -- exactly the
   id the frontend just added via frameNavigated -- and frameDidDetach removed it. This was
   timing-dependent (only when the detach raced after the navigate). Suppress frameDetached
   when the frame is still present in the authoritative WebFrameProxy tree: that means it
   swapped processes rather than being removed. A genuine removal (frame gone from the tree)
   is still reported.

* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp:
(Inspector::ProxyingPageAgent::frameNavigated):
Fill in the frame name from the WebFrameProxy tree when the event&apos;s name is empty.
(Inspector::ProxyingPageAgent::frameDetached):
Suppress the event when the frame is still in the WebFrameProxy tree (process-swap
artifact); only forward genuine removals.

* LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-expected.txt: Added.
Assert a cross-origin child frame appears in WI.networkManager.frames with the correct
name/url/parent/origin under Site Isolation, and is not removed by the process-swap
frameDetached.

* LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-rename.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/network-manager-cross-origin-frame-rename-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/resources/rename-then-navigate-frame.html: Added.
Assert a cross-origin child that changes its window.name and then navigates reports the
updated name in WI.networkManager.frames -- the live frameNavigated resolves the name from
the WebFrameProxy tree, which tracks the rename under Site Isolation.

Canonical link: <a href="https://commits.webkit.org/315360@main">https://commits.webkit.org/315360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11ca5014bad57d0c4b32aa3ef0f3e31f7c920f0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126477 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71a75334-da54-4967-bbb9-f94b497baf31) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131407 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ef55e1a-5fa2-4d35-a131-51e9dbd95520) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111911 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54ff21bb-b903-45d5-ab74-a163e7e39ec3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32847 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31561 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26796 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180702 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139855 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139699 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37618 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43030 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28053 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106776 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34977 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114797 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41533 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6141 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40930 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->