### PR TITLE
[Skia] canvas.toDataURL('image/webp', 1.0) should produce a lossless image

### DIFF
--- a/Source/WebCore/platform/graphics/skia/ImageUtilitiesSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageUtilitiesSkia.cpp
@@ -66,6 +66,19 @@ private:
     Vector<uint8_t>& m_vector;
 };
 
+static SkWebpEncoder::Options webpEncoderOptions(std::optional<double> quality)
+{
+    SkWebpEncoder::Options options;
+    if (quality && *quality == 1.0) {
+        // A quality of 1.0 selects lossless compression. For lossless encoding
+        // fQuality is the compression effort rather than the visual quality.
+        options.fCompression = SkWebpEncoder::Compression::kLossless;
+        options.fQuality = 75;
+    } else if (quality && *quality >= 0.0 && *quality < 1.0)
+        options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);
+    return options;
+}
+
 static sk_sp<SkData> encodeAcceleratedImage(const NativeImage& nativeImage, const String& mimeType, std::optional<double> quality)
 {
     if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
@@ -81,12 +94,8 @@ static sk_sp<SkData> encodeAcceleratedImage(const NativeImage& nativeImage, cons
         return SkJpegEncoder::Encode(grContext, image, options);
     }
 
-    if (equalLettersIgnoringASCIICase(mimeType, "image/webp"_s)) {
-        SkWebpEncoder::Options options;
-        if (quality && *quality >= 0.0 && *quality <= 1.0)
-            options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);
-        return SkWebpEncoder::Encode(grContext, image, options);
-    }
+    if (equalLettersIgnoringASCIICase(mimeType, "image/webp"_s))
+        return SkWebpEncoder::Encode(grContext, image, webpEncoderOptions(quality));
 
     if (equalLettersIgnoringASCIICase(mimeType, "image/png"_s))
         return SkPngEncoder::Encode(grContext, image, { });
@@ -106,10 +115,7 @@ static Vector<uint8_t> encodeUnacceleratedImage(const SkPixmap& pixmap, const St
         if (!SkJpegEncoder::Encode(&stream, pixmap, options))
             return { };
     } else if (equalLettersIgnoringASCIICase(mimeType, "image/webp"_s)) {
-        SkWebpEncoder::Options options;
-        if (quality && *quality >= 0.0 && *quality <= 1.0)
-            options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);
-        if (!SkWebpEncoder::Encode(&stream, pixmap, options))
+        if (!SkWebpEncoder::Encode(&stream, pixmap, webpEncoderOptions(quality)))
             return { };
     } else if (equalLettersIgnoringASCIICase(mimeType, "image/png"_s)) {
         if (!SkPngEncoder::Encode(&stream, pixmap, { }))


### PR DESCRIPTION
#### d1dcbd555ec8bc188a7127bd793f7795cc91cfbf
<pre>
[Skia] canvas.toDataURL(&apos;image/webp&apos;, 1.0) should produce a lossless image
<a href="https://bugs.webkit.org/show_bug.cgi?id=317234">https://bugs.webkit.org/show_bug.cgi?id=317234</a>

Reviewed by Carlos Garcia Campos and Devin Rousso.

Encode WebP losslessly when the requested quality is 1.0, matching Firefox
and Chromium.

* Source/WebCore/platform/graphics/skia/ImageUtilitiesSkia.cpp:
(WebCore::webpEncoderOptions):
(WebCore::encodeAcceleratedImage):
(WebCore::encodeUnacceleratedImage):

Canonical link: <a href="https://commits.webkit.org/315533@main">https://commits.webkit.org/315533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/345154d3404a8f27c4170c18a7bb0a6d3877adc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42900 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172309 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112419 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27406 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181306 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34016 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140373 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42928 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37723 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43617 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107627 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35475 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115382 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42127 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6673 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41520 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->