### PR TITLE
Fix callers of GCActivityCallback's didAllocate() to update allocated and abandoned bytes first.

### DIFF
--- a/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,15 +52,7 @@ double EdenGCActivityCallback::deathRate(JSC::Heap& heap)
 {
     size_t sizeBefore = heap.sizeBeforeLastEdenCollection();
     size_t sizeAfter = heap.sizeAfterLastEdenCollection();
-    if (!sizeBefore)
-        return 1.0;
-    if (sizeAfter > sizeBefore) {
-        // GC caused the heap to grow(!)
-        // This could happen if the we visited more extra memory than was reported allocated.
-        // We don't return a negative death rate, since that would schedule the next GC in the past.
-        return 0;
-    }
-    return static_cast<double>(sizeBefore - sizeAfter) / static_cast<double>(sizeBefore);
+    return GCActivityCallback::deathRate(sizeBefore, sizeAfter);
 }
 
 double EdenGCActivityCallback::gcTimeSlice(size_t bytes)

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,15 +64,7 @@ double FullGCActivityCallback::deathRate(JSC::Heap& heap)
 {
     size_t sizeBefore = heap.sizeBeforeLastFullCollection();
     size_t sizeAfter = heap.sizeAfterLastFullCollection();
-    if (!sizeBefore)
-        return 1.0;
-    if (sizeAfter > sizeBefore) {
-        // GC caused the heap to grow(!)
-        // This could happen if the we visited more extra memory than was reported allocated.
-        // We don't return a negative death rate, since that would schedule the next GC in the past.
-        return 0;
-    }
-    return static_cast<double>(sizeBefore - sizeAfter) / static_cast<double>(sizeBefore);
+    return GCActivityCallback::deathRate(sizeBefore, sizeAfter);
 }
 
 double FullGCActivityCallback::gcTimeSlice(size_t bytes)

--- a/Source/JavaScriptCore/heap/GCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/GCActivityCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,6 +76,20 @@ void GCActivityCallback::scheduleTimer(Seconds newDelay)
         newDelay = *timeUntilFire - delta;
     setTimeUntilFire(newDelay);
 }
+
+double GCActivityCallback::deathRate(size_t sizeBefore, size_t sizeAfter)
+{
+    if (!sizeBefore)
+        return 1.0;
+    if (sizeAfter > sizeBefore) {
+        // GC caused the heap to grow(!)
+        // This could happen if the we visited more extra memory than was reported allocated.
+        // We don't return a negative death rate, since that would schedule the next GC in the past.
+        return 0;
+    }
+    return static_cast<double>(sizeBefore - sizeAfter) / static_cast<double>(sizeBefore);
+}
+
 
 void GCActivityCallback::didAllocate(JSC::Heap& heap, size_t bytes)
 {

--- a/Source/JavaScriptCore/heap/GCActivityCallback.h
+++ b/Source/JavaScriptCore/heap/GCActivityCallback.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,6 +65,7 @@ protected:
     JS_EXPORT_PRIVATE void scheduleTimer(Seconds);
 
     GCActivityCallback(VM&, Synchronousness);
+    static double deathRate(size_t sizeBefore, size_t sizeAfter);
 
     Synchronousness m_synchronousness { Synchronousness::Async };
     bool m_enabled { true };

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -730,15 +730,16 @@ void Heap::reportAbandonedObjectGraph()
     // are abandoning so we just guess for them.
     size_t abandonedBytes = static_cast<size_t>(0.1 * capacity());
 
-    // We want to accelerate the next collection. Because memory has just 
-    // been abandoned, the next collection has the potential to 
+    m_bytesAbandonedSinceLastFullCollect += abandonedBytes;
+
+    // We want to accelerate the next collection. Because memory has just
+    // been abandoned, the next collection has the potential to
     // be more profitable. Since allocation is the trigger for collection, 
     // we hasten the next collection by pretending that we've allocated more memory. 
     if (m_fullActivityCallback) {
         m_fullActivityCallback->didAllocate(*this,
             m_sizeAfterLastCollect - m_sizeAfterLastFullCollect + totalBytesAllocatedThisCycle() + m_bytesAbandonedSinceLastFullCollect);
     }
-    m_bytesAbandonedSinceLastFullCollect += abandonedBytes;
 }
 
 void Heap::protect(JSValue k)
@@ -2669,13 +2670,17 @@ void Heap::setGarbageCollectionTimerEnabled(bool enable)
 constexpr size_t oversizedAllocationThreshold = 64 * KB;
 void Heap::didAllocate(size_t bytes)
 {
-    if (m_edenActivityCallback)
-        m_edenActivityCallback->didAllocate(*this, totalBytesAllocatedThisCycle() + m_bytesAbandonedSinceLastFullCollect);
     if (bytes >= oversizedAllocationThreshold) {
         m_oversizedBytesAllocatedThisCycle += bytes;
         m_lastOversidedAllocationThisCycle = bytes;
     } else
         m_nonOversizedBytesAllocatedThisCycle += bytes;
+
+    // totalBytesAllocatedThisCycle() depends on values updated above.
+    // So, only do this m_edenActivityCallback after updating those values.
+    if (m_edenActivityCallback)
+        m_edenActivityCallback->didAllocate(*this, totalBytesAllocatedThisCycle() + m_bytesAbandonedSinceLastFullCollect);
+
     performIncrement(bytes);
 }
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -408,7 +408,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Double, percentCPUPerMBForFullTimer, 0.0003125, Normal, nullptr) \
     v(Double, percentCPUPerMBForEdenTimer, 0.0025, Normal, nullptr) \
-    v(Double, collectionTimerMaxPercentCPU, 0.05, Normal, nullptr) \
+    v(Double, collectionTimerMaxPercentCPU, 0.10, Normal, nullptr) \
     \
     v(Bool, forceWeakRandomSeed, false, Normal, nullptr) \
     v(Unsigned, forcedWeakRandomSeed, 0, Normal, nullptr) \


### PR DESCRIPTION
#### d08c15c73b5124b56db6f1123bbb23cb55ad9535
<pre>
Fix callers of GCActivityCallback&apos;s didAllocate() to update allocated and abandoned bytes first.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317232">https://bugs.webkit.org/show_bug.cgi?id=317232</a>
<a href="https://rdar.apple.com/179854263">rdar://179854263</a>

Reviewed by Yusuke Suzuki.

Current code is updating the number of allocated and abandoned bytes after it calls
GCActivityCallback&apos;s didAllocate().  didAllocate() uses the number of allocated and
abandoned bytes to decide when GC needs to run next.  This means didAllocate() is being
fed the wrong / stale number of bytes.  Hence, its ability to decide when to run GC next
is impaired.

After fixing this, GC heuristics also need to be re-tuned to keep performance neutral on
benchmarks.  At this point, this simply means changing Options::collectionTimerMaxPercentCPU()
from 0.05 to 0.10.  With that, benchmark results are neutral.

Also refactored GCActivityCallback subclasses to call a common GCActivityCallback::deathRate
instead of duplicating code.  These functions are not in any critical hot path.

No new tests because this only changes performance characteristics.  It does not change
anything in terms of correctness.  The effects of this change will be monitored by
existing performance test bots.

* Source/JavaScriptCore/heap/EdenGCActivityCallback.cpp:
(JSC::EdenGCActivityCallback::deathRate):
* Source/JavaScriptCore/heap/FullGCActivityCallback.cpp:
(JSC::FullGCActivityCallback::deathRate):
* Source/JavaScriptCore/heap/GCActivityCallback.cpp:
(JSC::GCActivityCallback::deathRate):
* Source/JavaScriptCore/heap/GCActivityCallback.h:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::reportAbandonedObjectGraph):
(JSC::Heap::clearConcurrentRetainedDataIfPossible):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/315348@main">https://commits.webkit.org/315348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a1bc24e491f1cd93552f4388d72ce5ea6f80cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126431 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb97a3bb-8afe-4a59-8e09-316f4778674d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131365 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/272def52-2038-462d-955e-058cde0b1841) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111869 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e65c51cb-25b0-4938-aff7-d4a9bc7cea30) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32811 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31518 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26750 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/56 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180656 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29975 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139807 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42295 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139656 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42984 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106730 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25703 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34939 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114751 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201403 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41487 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6098 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54074 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41029 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->