### PR TITLE
[macOS] 2x media/media-source/media-source-real-webm-currenttime-progression.html are a flaky text diff

### DIFF
--- a/LayoutTests/media/media-source/media-source-real-currenttime-progression.html
+++ b/LayoutTests/media/media-source/media-source-real-currenttime-progression.html
@@ -50,6 +50,8 @@
         source.endOfStream();
 
         run('video.currentTime = 0');
+        await waitFor(video, 'seeking', true);
+        await waitFor(video, 'seeked', true);
         run('video.play()');
         await waitFor(video, 'playing');
 

--- a/LayoutTests/media/media-source/media-source-real-webm-currenttime-progression.html
+++ b/LayoutTests/media/media-source/media-source-real-webm-currenttime-progression.html
@@ -53,6 +53,8 @@
         source.endOfStream();
 
         run('video.currentTime = 0');
+        await waitFor(video, 'seeking', true);
+        await waitFor(video, 'seeked', true);
         run('video.play()');
         await waitFor(video, 'playing');
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2271,10 +2271,6 @@ webkit.org/b/308326 [ Debug ] imported/w3c/web-platform-tests/fetch/api/basic/er
 
 webkit.org/b/308586 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-pseudo-class.html [ Pass Failure ]
 
-# REGRESSION(314534@main): [macOS] 2x media/media-source/media-source-real-webm-currenttime-progression.html are a flaky text diff 
-webkit.org/b/316578 media/media-source/media-source-real-webm-currenttime-progression.html [ Pass Failure ]
-webkit.org/b/316578 media/media-source/media-source-real-currenttime-progression.html [ Pass Failure ]
-
 webkit.org/b/308594 imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html [ Pass Failure ]
 
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html [ Skip ]


### PR DESCRIPTION
#### 9f215d2782a8a74a9fd60e006a2421ae0ae73caf
<pre>
[macOS] 2x media/media-source/media-source-real-webm-currenttime-progression.html are a flaky text diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=317241">https://bugs.webkit.org/show_bug.cgi?id=317241</a>
<a href="https://rdar.apple.com/179039564">rdar://179039564</a>

Reviewed by Jer Noble.

After setting video.currentTime, these tests should wait for the seeking and seeked
events before calling video.play().

* LayoutTests/media/media-source/media-source-real-currenttime-progression.html:
* LayoutTests/media/media-source/media-source-real-webm-currenttime-progression.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/315489@main">https://commits.webkit.org/315489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d372f2790a7578c8af7ec1ddbbd4cdd04c60c38e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126686 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a8964c7-92ad-4605-afe3-f521a6cc89b2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131584 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92573 "1 flakes 11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cef322a3-7d11-4bbe-a5a4-7e4f9579de32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112087 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14f95600-8e7b-4b33-8e9f-8afed6aa15ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33024 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31735 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27031 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180930 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140033 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139875 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43242 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107068 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35159 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41751 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6325 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41145 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41400 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41288 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->