### PR TITLE
Web Inspector: Elements: Show ::picker-icon pseudo-element in DOM tree outline

### DIFF
--- a/LayoutTests/inspector/dom/pseudo-element-static.html
+++ b/LayoutTests/inspector/dom/pseudo-element-static.html
@@ -50,8 +50,22 @@ function test() {
             InspectorTest.expectThat(domNode.afterPseudoElement(), "DOMNode has an after pseudo element");
             InspectorTest.expectThat(domNode.beforePseudoElement().pseudoType() === WI.DOMNode.PseudoElementType.Before, "DOMNode for before pseudo element has the right type");
             InspectorTest.expectThat(domNode.afterPseudoElement().pseudoType() === WI.DOMNode.PseudoElementType.After, "DOMNode for after pseudo element has the right type");
-            InspectorTest.completeTest();
         });
+
+        documentNode.querySelector("select", function(nodeId) {
+            let domNode = WI.domManager.nodeForId(nodeId);
+            InspectorTest.log("");
+            InspectorTest.expectThat(domNode, "Got DOMNode for select element");
+            InspectorTest.assert(!domNode.pseudoType());
+            InspectorTest.expectThat(domNode.hasPseudoElements(), "DOMNode has pseudo elements");
+            InspectorTest.expectThat(domNode.pseudoElements().size === 1, "DOMNode has 1 pseudo element");
+
+            let pickerIconPseudo = domNode.pseudoElements().get(WI.DOMNode.PseudoElementType.PickerIcon);
+            InspectorTest.expectThat(pickerIconPseudo, "DOMNode has ::picker-icon pseudo element");
+            InspectorTest.expectEqual(pickerIconPseudo.pseudoType(), WI.DOMNode.PseudoElementType.PickerIcon, "DOMNode for ::picker-icon pseudo element has the right type");
+        });
+
+        InspectorTest.completeTest();
     });
 }
 </script>
@@ -62,12 +76,20 @@ function test() {
     <style>
     #x:before, #b:before { content: "before"; }
     #x:after, #a:after { content: "after"; }
+    select {
+       appearance: base-select;
+    }
+    select::picker-icon {
+        color: green;
+    }
     </style>
 
     <div id="none">TEST ELEMENT: No Pseudo Elements</div>
     <div id="b">TEST ELEMENT: Has Before Pseudo Element</div>
     <div id="a">TEST ELEMENT: Has After Pseudo Element</div>
     <div id="x">TEST ELEMENT: Has Before and After Pseudo Elements</div>
-
+    <select id="target">
+        <option>Option</option>
+    </select>
 </body>
 </html>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -17,7 +17,7 @@
         {
             "id": "PseudoType",
             "type": "string",
-            "enum": ["before", "after"],
+            "enum": ["before", "after", "picker-icon"],
             "description": "Pseudo element type."
         },
         {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -321,8 +321,7 @@ Element::Element(ClangVTableWorkaroundTag, const QualifiedName& tagName, Documen
 
 Element::~Element()
 {
-    ASSERT(!beforePseudoElement());
-    ASSERT(!afterPseudoElement());
+    ASSERT(!hasRareData() || elementRareData()->pseudoElements().isEmpty());
 
     ASSERT(!is<HTMLImageElement>(*this) || !intersectionObserverDataIfExists());
     disconnectFromIntersectionObservers();
@@ -3219,8 +3218,8 @@ void Element::removingSteps(RemovalType removalType, ContainerNode& oldParentOfR
 
         setSavedLayerScrollPosition({ });
 
-        clearBeforePseudoElement();
-        clearAfterPseudoElement();
+        for (auto type : elementBackedPseudoElementTypes)
+            clearPseudoElement(type);
 
 #if ENABLE(FULLSCREEN_API)
         if (hasFullscreenFlag()) [[unlikely]]
@@ -4710,9 +4709,8 @@ static PseudoElement* NODELETE beforeOrAfterPseudoElement(const Element& host, P
 {
     switch (pseudoElementSpecifier) {
     case PseudoElementType::Before:
-        return host.beforePseudoElement();
     case PseudoElementType::After:
-        return host.afterPseudoElement();
+        return host.pseudoElement(pseudoElementSpecifier);
     default:
         return nullptr;
     }
@@ -4992,35 +4990,32 @@ void Element::normalizeAttributes()
 
 PseudoElement& Element::ensurePseudoElement(PseudoElementType type)
 {
-    if (type == PseudoElementType::Before) {
-        if (!beforePseudoElement())
-            ensureElementRareData().setBeforePseudoElement(PseudoElement::create(*this, type));
-        return *beforePseudoElement();
-    }
+    ASSERT(isElementBackedPseudoElementType(type));
+    auto& rareData = ensureElementRareData();
+    if (auto* existing = rareData.pseudoElement(type))
+        return *existing;
+    rareData.setPseudoElement(type, PseudoElement::create(*this, type));
+    return *rareData.pseudoElement(type);
+}
 
-    ASSERT(type == PseudoElementType::After);
-    if (!afterPseudoElement())
-        ensureElementRareData().setAfterPseudoElement(PseudoElement::create(*this, type));
-    return *afterPseudoElement();
+PseudoElement* Element::pseudoElement(PseudoElementType type) const
+{
+    return hasRareData() ? elementRareData()->pseudoElement(type) : nullptr;
 }
 
 PseudoElement* Element::beforePseudoElement() const
 {
-    return hasRareData() ? elementRareData()->beforePseudoElement() : nullptr;
+    return hasRareData() ? elementRareData()->pseudoElement(PseudoElementType::Before) : nullptr;
 }
 
 PseudoElement* Element::afterPseudoElement() const
 {
-    return hasRareData() ? elementRareData()->afterPseudoElement() : nullptr;
+    return hasRareData() ? elementRareData()->pseudoElement(PseudoElementType::After) : nullptr;
 }
 
 RefPtr<PseudoElement> Element::pseudoElementIfExists(Style::PseudoElementIdentifier pseudoElementIdentifier)
 {
-    if (pseudoElementIdentifier.type == PseudoElementType::Before)
-        return beforePseudoElement();
-    if (pseudoElementIdentifier.type == PseudoElementType::After)
-        return afterPseudoElement();
-    return nullptr;
+    return hasRareData() ? RefPtr { elementRareData()->pseudoElement(pseudoElementIdentifier.type) } : nullptr;
 }
 
 RefPtr<const PseudoElement> Element::pseudoElementIfExists(Style::PseudoElementIdentifier pseudoElementIdentifier) const
@@ -5037,18 +5032,21 @@ static void disconnectPseudoElement(PseudoElement* pseudoElement)
     pseudoElement->clearHostElement();
 }
 
-void Element::clearBeforePseudoElementSlow()
+void Element::clearPseudoElementSlow(PseudoElementType type)
 {
     ASSERT(hasRareData());
-    disconnectPseudoElement(elementRareData()->beforePseudoElement());
-    elementRareData()->setBeforePseudoElement(nullptr);
+    disconnectPseudoElement(elementRareData()->pseudoElement(type));
+    elementRareData()->setPseudoElement(type, nullptr);
 }
 
-void Element::clearAfterPseudoElementSlow()
+void Element::clearBeforePseudoElement()
 {
-    ASSERT(hasRareData());
-    disconnectPseudoElement(elementRareData()->afterPseudoElement());
-    elementRareData()->setAfterPseudoElement(nullptr);
+    clearPseudoElement(PseudoElementType::Before);
+}
+
+void Element::clearAfterPseudoElement()
+{
+    clearPseudoElement(PseudoElementType::After);
 }
 
 bool Element::matchesValidPseudoClass() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -635,9 +635,10 @@ public:
     virtual void finishParsingChildren();
 
     PseudoElement& ensurePseudoElement(PseudoElementType);
+    PseudoElement* NODELETE pseudoElement(PseudoElementType) const;
     WEBCORE_EXPORT PseudoElement* NODELETE beforePseudoElement() const;
     WEBCORE_EXPORT PseudoElement* NODELETE afterPseudoElement() const;
-    RefPtr<PseudoElement> pseudoElementIfExists(Style::PseudoElementIdentifier);
+    WEBCORE_EXPORT RefPtr<PseudoElement> pseudoElementIfExists(Style::PseudoElementIdentifier);
     RefPtr<const PseudoElement> pseudoElementIfExists(Style::PseudoElementIdentifier) const;
 
     bool childNeedsShadowWalker() const;
@@ -807,6 +808,7 @@ public:
 
     void clearBeforePseudoElement();
     void clearAfterPseudoElement();
+    void clearPseudoElement(PseudoElementType);
     void resetComputedStyle();
     void NODELETE resetStyleRelations();
     void resetChildStyleRelations();
@@ -1006,8 +1008,7 @@ private:
     void removeAttributeInternal(unsigned index, InSynchronizationOfLazyAttribute);
 
     void setSavedLayerScrollPositionSlow(const ScrollPosition&);
-    void clearBeforePseudoElementSlow();
-    void clearAfterPseudoElementSlow();
+    void clearPseudoElementSlow(PseudoElementType);
 
     LayoutRect absoluteEventBounds(bool& boundsIncludeAllDescendantElements, bool& includesFixedPositionElements);
     LayoutRect absoluteEventBoundsOfElementAndDescendants(bool& includesFixedPositionElements);
@@ -1084,6 +1085,12 @@ private:
 };
 
 inline bool isInTopLayerOrBackdrop(const Style::ComputedStyle&, const Element*);
+
+inline void Element::clearPseudoElement(PseudoElementType type)
+{
+    if (hasRareData())
+        clearPseudoElementSlow(type);
+}
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ContentRelevancy);
 

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -40,7 +40,8 @@ struct SameSizeAsElementRareData : NodeRareData {
     IntPoint savedLayerScrollPosition;
     HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> animationRareData;
     HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> viewTransitionCapture;
-    void* pointers[17];
+    HashMap<PseudoElementType, Ref<PseudoElement>, IntHash<PseudoElementType>, WTF::StrongEnumHashTraits<PseudoElementType>> pseudoElements;
+    void* pointers[15];
     void* intersectionObserverData;
     void* resizeObserverData;
     void* largestContentfulPaintData;

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -55,11 +55,9 @@ public:
     explicit ElementRareData();
     ~ElementRareData();
 
-    void setBeforePseudoElement(RefPtr<PseudoElement>&&);
-    void setAfterPseudoElement(RefPtr<PseudoElement>&&);
-
-    PseudoElement* beforePseudoElement() const { return m_beforePseudoElement.get(); }
-    PseudoElement* afterPseudoElement() const { return m_afterPseudoElement.get(); }
+    void setPseudoElement(PseudoElementType, RefPtr<PseudoElement>&&);
+    PseudoElement* pseudoElement(PseudoElementType) const;
+    const auto& pseudoElements() const LIFETIME_BOUND { return m_pseudoElements; }
 
     void resetComputedStyle();
 
@@ -193,7 +191,7 @@ public:
             result.add(UseType::ResizeObserver);
         if (!m_animationRareData.isEmpty())
             result.add(UseType::Animations);
-        if (m_beforePseudoElement || m_afterPseudoElement)
+        if (!m_pseudoElements.isEmpty())
             result.add(UseType::PseudoElements);
         if (m_attributeStyleMap)
             result.add(UseType::AttributeStyleMap);
@@ -252,8 +250,7 @@ private:
 
     HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> m_viewTransitionCapturedName;
 
-    RefPtr<PseudoElement> m_beforePseudoElement;
-    RefPtr<PseudoElement> m_afterPseudoElement;
+    HashMap<PseudoElementType, Ref<PseudoElement>, IntHash<PseudoElementType>, WTF::StrongEnumHashTraits<PseudoElementType>> m_pseudoElements;
 
     RefPtr<StylePropertyMap> m_attributeStyleMap;
     RefPtr<StylePropertyMapReadOnly> m_computedStyleMap;
@@ -283,20 +280,25 @@ inline ElementRareData::ElementRareData()
 
 inline ElementRareData::~ElementRareData()
 {
-    ASSERT(!m_beforePseudoElement);
-    ASSERT(!m_afterPseudoElement);
+    ASSERT(m_pseudoElements.isEmpty());
 }
 
-inline void ElementRareData::setBeforePseudoElement(RefPtr<PseudoElement>&& pseudoElement)
+inline void ElementRareData::setPseudoElement(PseudoElementType type, RefPtr<PseudoElement>&& pseudoElement)
 {
-    ASSERT(!m_beforePseudoElement || !pseudoElement);
-    m_beforePseudoElement = WTF::move(pseudoElement);
+    if (!pseudoElement) {
+        m_pseudoElements.remove(type);
+        return;
+    }
+    ASSERT(!m_pseudoElements.contains(type));
+    m_pseudoElements.set(type, pseudoElement.releaseNonNull());
 }
 
-inline void ElementRareData::setAfterPseudoElement(RefPtr<PseudoElement>&& pseudoElement)
+inline PseudoElement* ElementRareData::pseudoElement(PseudoElementType type) const
 {
-    ASSERT(!m_afterPseudoElement || !pseudoElement);
-    m_afterPseudoElement = WTF::move(pseudoElement);
+    auto it = m_pseudoElements.find(type);
+    if (it == m_pseudoElements.end())
+        return nullptr;
+    return it->value.ptr();
 }
 
 inline void ElementRareData::resetComputedStyle()

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -35,6 +35,8 @@
 #include "RenderElement.h"
 #include "RenderImage.h"
 #include "RenderQuote.h"
+#include "RenderStyle+GettersInlines.h"
+#include "RenderStyleConstants.h"
 #include "StyleableInlines.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleResolver.h"
@@ -56,7 +58,7 @@ PseudoElement::PseudoElement(Element& host, PseudoElementType pseudoElementType)
     , m_pseudoElementType(pseudoElementType)
 {
     setEventTargetFlag(EventTargetFlag::IsConnected);
-    ASSERT(pseudoElementType == PseudoElementType::Before || pseudoElementType == PseudoElementType::After);
+    ASSERT(isElementBackedPseudoElementType(pseudoElementType));
 }
 
 PseudoElement::~PseudoElement()

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -459,10 +459,10 @@ void InspectorDOMAgent::unbind(Node& node)
     if (RefPtr element = dynamicDowncast<Element>(node)) {
         if (RefPtr root = element->shadowRoot())
             unbind(*root);
-        if (RefPtr beforeElement = element->beforePseudoElement())
-            unbind(*beforeElement);
-        if (RefPtr afterElement = element->afterPseudoElement())
-            unbind(*afterElement);
+        for (auto type : elementBackedPseudoElementTypes) {
+            if (RefPtr pseudo = element->pseudoElementIfExists({ type }))
+                unbind(*pseudo);
+        }
     }
 
     if (CheckedPtr cssAgent = Ref { m_instrumentingAgents.get() }->enabledCSSAgent())
@@ -1923,6 +1923,9 @@ static bool NODELETE pseudoElementType(PseudoElementType pseudoElementType, Insp
     case PseudoElementType::After:
         *type = Inspector::Protocol::DOM::PseudoType::After;
         return true;
+    case PseudoElementType::PickerIcon:
+        *type = Inspector::Protocol::DOM::PseudoType::PickerIcon;
+        return true;
     default:
         return false;
     }
@@ -2111,16 +2114,15 @@ Ref<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> InspectorDOMAgent::buildArray
 
 RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> InspectorDOMAgent::buildArrayForPseudoElements(const Element& element)
 {
-    RefPtr beforeElement = element.beforePseudoElement();
-    RefPtr afterElement = element.afterPseudoElement();
-    if (!beforeElement && !afterElement)
-        return nullptr;
-
-    auto pseudoElements = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
-    if (beforeElement)
-        pseudoElements->addItem(buildObjectForNode(beforeElement.get(), 0));
-    if (afterElement)
-        pseudoElements->addItem(buildObjectForNode(afterElement.get(), 0));
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::DOM::Node>> pseudoElements;
+    for (auto type : elementBackedPseudoElementTypes) {
+        auto* pseudo = element.pseudoElement(type);
+        if (!pseudo)
+            continue;
+        if (!pseudoElements)
+            pseudoElements = JSON::ArrayOf<Inspector::Protocol::DOM::Node>::create();
+        pseudoElements->addItem(buildObjectForNode(pseudo, 0));
+    }
     return pseudoElements;
 }
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -122,6 +122,17 @@ constexpr auto allInternalPseudoElementTypes = EnumSet {
 
 constexpr auto allPseudoElementTypes = allPublicPseudoElementTypes | allInternalPseudoElementTypes;
 
+constexpr auto elementBackedPseudoElementTypes = EnumSet {
+    PseudoElementType::Before,
+    PseudoElementType::After,
+    PseudoElementType::PickerIcon,
+};
+
+inline bool isElementBackedPseudoElementType(PseudoElementType type)
+{
+    return elementBackedPseudoElementTypes.contains(type);
+}
+
 inline std::optional<PseudoElementType> parentPseudoElement(PseudoElementType pseudoElementType)
 {
     switch (pseudoElementType) {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -126,6 +126,10 @@ void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type
     if (!shouldHavePseudoElementRenderer()) {
         if (existingPseudoElement)
             m_builder.destroy(*existingPseudoElement);
+        if (isElementBackedPseudoElementType(type)) {
+            if (RefPtr host = renderer.element())
+                host->clearPseudoElement(type);
+        }
         return;
     }
 
@@ -146,13 +150,24 @@ void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type
     Ref document = renderer.document();
     auto pseudoElementStyle = Style::ComputedStyle::clone(*pseudoStyle);
 
-    RenderPtr<RenderBlockFlow> pseudoElement = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, WTF::move(pseudoElementStyle));
+    RefPtr<PseudoElement> pseudoElementNode;
+    if (isElementBackedPseudoElementType(type)) {
+        if (RefPtr host = renderer.element())
+            pseudoElementNode = host->ensurePseudoElement(type);
+    }
+
+    RenderPtr<RenderBlockFlow> pseudoElement = pseudoElementNode
+        ? createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, *pseudoElementNode, WTF::move(pseudoElementStyle))
+        : createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, WTF::move(pseudoElementStyle));
     pseudoElement->initializeStyle();
 
     if (pseudoElement->style().content().isData())
         RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, *pseudoElement, pseudoElement->style(), type);
 
     renderer.setPseudoElementRenderer(type, *pseudoElement.get());
+
+    if (pseudoElementNode)
+        pseudoElementNode->setRenderer(pseudoElement.get());
 
     m_builder.attach(renderer, WTF::move(pseudoElement), beforeChild);
 }

--- a/Source/WebCore/rendering/updating/RenderTreePosition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.cpp
@@ -95,7 +95,7 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
                     return composedDescendants.at(*host).traverseNext();
                 return composedDescendants.begin();
             }
-            ASSERT(node.isAfterPseudoElement());
+            ASSERT(node.isAfterPseudoElement() || isElementBackedPseudoElementType(pseudoElement->pseudoElementType()));
             elementStack.removeLast();
             if (host != parentElement)
                 return composedDescendants.at(*host).traverseNextSkippingChildren();

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -891,8 +891,8 @@ void RenderTreeUpdater::tearDownRenderersInternal(Element& root, TeardownType te
                 break;
             }
 
-            GeneratedContent::removeBeforePseudoElement(element.get(), builder);
-            GeneratedContent::removeAfterPseudoElement(element.get(), builder);
+            for (auto type : elementBackedPseudoElementTypes)
+                GeneratedContent::removePseudoElement(element.get(), type, builder);
 
             if (!is<PseudoElement>(element.get())) {
                 // ::before and ::after cannot have a ::marker pseudo-element addressable via

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -335,22 +335,23 @@ bool RenderTreeUpdater::GeneratedContent::needsPseudoElement(const Style::Comput
     return true;
 }
 
-void RenderTreeUpdater::GeneratedContent::removeBeforePseudoElement(Element& element, RenderTreeBuilder& builder)
+void RenderTreeUpdater::GeneratedContent::removePseudoElement(Element& element, PseudoElementType type, RenderTreeBuilder& builder)
 {
-    RefPtr pseudoElement = element.beforePseudoElement();
+    RefPtr pseudoElement = element.pseudoElementIfExists({ type });
     if (!pseudoElement)
         return;
     tearDownRenderers(*pseudoElement, TeardownType::Full, builder);
-    element.clearBeforePseudoElement();
+    element.clearPseudoElement(type);
+}
+
+void RenderTreeUpdater::GeneratedContent::removeBeforePseudoElement(Element& element, RenderTreeBuilder& builder)
+{
+    removePseudoElement(element, PseudoElementType::Before, builder);
 }
 
 void RenderTreeUpdater::GeneratedContent::removeAfterPseudoElement(Element& element, RenderTreeBuilder& builder)
 {
-    RefPtr pseudoElement = element.afterPseudoElement();
-    if (!pseudoElement)
-        return;
-    tearDownRenderers(*pseudoElement, TeardownType::Full, builder);
-    element.clearAfterPseudoElement();
+    removePseudoElement(element, PseudoElementType::After, builder);
 }
 
 void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(RenderElement& renderer, Style::DifferenceResult minimalStyleDifference)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
@@ -46,6 +46,7 @@ public:
     void updateCounters();
     void updateWritingSuggestionsRenderer(RenderElement&, Style::DifferenceResult minimalStyleDifference);
 
+    static void removePseudoElement(Element&, PseudoElementType, RenderTreeBuilder&);
     static void removeBeforePseudoElement(Element&, RenderTreeBuilder&);
     static void removeAfterPseudoElement(Element&, RenderTreeBuilder&);
 

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -1502,6 +1502,7 @@ WI.DOMNode.Event = {
 WI.DOMNode.PseudoElementType = {
     Before: "before",
     After: "after",
+    PickerIcon: "picker-icon",
 };
 
 WI.DOMNode.ShadowRootType = {

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -1782,6 +1782,13 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         if (afterPseudoElement)
             visibleChildren.push(afterPseudoElement);
 
+        for (let [type, pseudoElement] of node.pseudoElements()) {
+            if (type === WI.DOMNode.PseudoElementType.Before || type === WI.DOMNode.PseudoElementType.After)
+                continue;
+
+            visibleChildren.push(pseudoElement);
+        }
+
         return visibleChildren;
     }
 


### PR DESCRIPTION
#### ea3b8a643d7e91df8c7c557fc0a7a0731606194b
<pre>
Web Inspector: Elements: Show ::picker-icon pseudo-element in DOM tree outline
<a href="https://bugs.webkit.org/show_bug.cgi?id=317237">https://bugs.webkit.org/show_bug.cgi?id=317237</a>
<a href="https://rdar.apple.com/179858145">rdar://179858145</a>

Reviewed by NOBODY (OOPS!).

Styles for the `::picker-icon` pseudo-element show up when inspecting
the host `&lt;select&gt;` element, but they&apos;re often buried at the bottom of
the Styles sidebar, below authored and UA styles for the `&lt;select&gt;`.

This patch exposes the `::picker-icon` as a pseudo-element in the DOM
tree outline, similar to `::before` and `::after`, to make it easy to
select and inspect its styles.

The `::picker-icon`&apos;s renderer was created directly by
`RenderTreeBuilder::FormControls` and stored only in the host renderer&apos;s
`pseudoElementRenderer` map. The Inspector DOM agent had no way to surface
a renderer that isn&apos;t backed by a `Node`. `::before` and `::after`
have always had backing `PseudoElement` nodes.

This patch brings the `::picker-icon` in line with how `::before` and `::after`
are handled by having a backing `PseudoElement` to participate in the existing
Web Inspector instrumentation flow.

The work is structured as a generalization to enable exposing additional
element-backed pseudo-elements (as well as the existing `::before` and `::after`).

* LayoutTests/inspector/dom/pseudo-element-static.html:
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::~Element):
(WebCore::Element::removingSteps):
(WebCore::beforeOrAfterPseudoElement):
(WebCore::Element::ensurePseudoElement):
(WebCore::Element::pseudoElement const):
(WebCore::Element::beforePseudoElement const):
(WebCore::Element::afterPseudoElement const):
(WebCore::Element::pseudoElementIfExists):
(WebCore::Element::clearPseudoElementSlow):
(WebCore::Element::clearBeforePseudoElement):
(WebCore::Element::clearAfterPseudoElement):
(WebCore::Element::clearBeforePseudoElementSlow): Deleted.
(WebCore::Element::clearAfterPseudoElementSlow): Deleted.
* Source/WebCore/dom/Element.h:
(WebCore::Element::clearPseudoElement):
(WebCore::Element::clearBeforePseudoElement): Deleted.
(WebCore::Element::clearAfterPseudoElement): Deleted.
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::useTypes const):
(WebCore::ElementRareData::~ElementRareData):
(WebCore::ElementRareData::setPseudoElement):
(WebCore::ElementRareData::pseudoElement const):
(WebCore::ElementRareData::beforePseudoElement const): Deleted.
(WebCore::ElementRareData::afterPseudoElement const): Deleted.
(WebCore::ElementRareData::setBeforePseudoElement): Deleted.
(WebCore::ElementRareData::setAfterPseudoElement): Deleted.
* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::m_pseudoElementType):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::unbind):
(WebCore::pseudoElementType):
(WebCore::InspectorDOMAgent::buildArrayForPseudoElements):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
(WebCore::isElementBackedPseudoElementType):

* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
(WebCore::RenderTreeBuilder::FormControls::updatePseudoElement):
Tie the pseudo-element&apos;s renderer to its host&apos;s to ensure
the `LayoutFlag::Rendered` flag is returned via `InspectorCSSAgent::layoutFlagsForNode`
and display the pseudo-element as rendered in the DOM tree outline (not grayed-out).

* Source/WebCore/rendering/updating/RenderTreePosition.cpp:
(WebCore::RenderTreePosition::nextSiblingRenderer const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::tearDownRenderersInternal):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::removePseudoElement):
(WebCore::RenderTreeUpdater::GeneratedContent::removeBeforePseudoElement):
(WebCore::RenderTreeUpdater::GeneratedContent::removeAfterPseudoElement):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h:
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype._visibleChildren):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea3b8a643d7e91df8c7c557fc0a7a0731606194b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168759 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42318 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35913 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178090 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126466 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31fe69d5-1a44-46e5-b899-56b16da4fcf7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170625 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42695 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42278 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/178090 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/126466 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bcaf08b-fccf-4fc2-a186-c17a7fd15fb3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171718 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/42695 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/35913 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/178090 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbb21bc8-735f-4dae-b5da-bdd5ce587452) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/42695 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/42278 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26785 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/35913 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/42695 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/35913 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180691 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30010 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33421 "Failed to build and analyze WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/42278 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/180691 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42330 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/35913 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/180691 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43019 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/35913 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106765 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/43019 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114786 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201438 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41522 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/35913 "Hash ea3b8a64 for PR 67289 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54077 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40919 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41173 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41064 "Hash ea3b8a64 for PR 67289 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->