### PR TITLE
Rename FloatRoundedRect::isRounded() and LayoutRoundedRect::isRounded() to hasNonZeroRadii()

### DIFF
--- a/Source/WebCore/platform/graphics/FloatRoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.cpp
@@ -76,7 +76,7 @@ bool FloatRoundedRect::xInterceptsAtY(float y, float& minXIntercept, float& maxX
     if (y < rect().y() || y >  rect().maxY())
         return false;
 
-    if (!isRounded()) {
+    if (!hasNonZeroRadii()) {
         minXIntercept = rect().x();
         maxXIntercept = rect().maxX();
         return true;
@@ -169,7 +169,7 @@ Region approximateAsRegion(const FloatRoundedRect& roundedRect, unsigned stepLen
     auto rect = LayoutRect(roundedRect.rect());
     region.unite(enclosingIntRect(rect));
 
-    if (!roundedRect.isRounded())
+    if (!roundedRect.hasNonZeroRadii())
         return region;
 
     auto& radii = roundedRect.radii();

--- a/Source/WebCore/platform/graphics/FloatRoundedRect.h
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.h
@@ -55,7 +55,7 @@ public:
 
     const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
     const CornerRadii& radii() const LIFETIME_BOUND { return m_radii; }
-    bool isRounded() const { return !m_radii.isZero(); }
+    bool hasNonZeroRadii() const { return !m_radii.isZero(); }
     bool isEmpty() const { return m_rect.isEmpty(); }
 
     void setRect(const FloatRect& rect) { m_rect = rect; }

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -463,7 +463,7 @@ void GraphicsContext::clipRoundedRect(const FloatRoundedRect& rect)
 
 void GraphicsContext::clipOutRoundedRect(const FloatRoundedRect& rect)
 {
-    if (!rect.isRounded()) {
+    if (!rect.hasNonZeroRadii()) {
         clipOut(rect.rect());
         return;
     }
@@ -494,7 +494,7 @@ void GraphicsContext::fillRect(const FloatRect& rect, const Color& color, Compos
 
 void GraphicsContext::fillRoundedRect(const FloatRoundedRect& rect, const Color& color, BlendMode blendMode)
 {
-    if (rect.isRounded()) {
+    if (rect.hasNonZeroRadii()) {
         setCompositeOperation(compositeOperation(), blendMode);
         fillRoundedRectImpl(rect, color);
         setCompositeOperation(compositeOperation());

--- a/Source/WebCore/platform/graphics/LayoutRoundedRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRoundedRect.h
@@ -33,6 +33,10 @@ namespace WebCore {
 class FloatQuad;
 class FloatRoundedRect;
 
+// Rect with per-corner radii and geometry operations. The radii define the corner extent (where
+// straight edges end and corners begin) and are used by all corner-shape values, not just round.
+// The actual rendered corner shape (round, bevel, notch, superellipse, etc.) is determined by
+// the corner-shape property and is not encoded here.
 class LayoutRoundedRectRadii {
 public:
     LayoutRoundedRectRadii() = default;
@@ -89,7 +93,7 @@ public:
 
     const LayoutRect& rect() const LIFETIME_BOUND { return m_rect; }
     const Radii& radii() const LIFETIME_BOUND { return m_radii; }
-    bool isRounded() const { return !m_radii.isZero(); }
+    bool hasNonZeroRadii() const { return !m_radii.isZero(); }
     bool isEmpty() const { return m_rect.isEmpty(); }
 
     void setRect(const LayoutRect& rect) { m_rect = rect; }

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -178,7 +178,7 @@ void Path::addRoundedRect(const FloatRoundedRect& roundedRect, PathRoundedRect::
         // after constraint scaling), adjust them to fit rather than dropping them.
         auto adjustedRect = roundedRect;
         adjustedRect.adjustRadii();
-        if (!adjustedRect.isRounded()) {
+        if (!adjustedRect.hasNonZeroRadii()) {
             addRect(adjustedRect.rect());
             return;
         }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3268,7 +3268,7 @@ void GraphicsLayerCA::updateContentsRects()
     auto contentBounds = FloatRect { { }, m_contentsRect.size() };
     
     bool gainedOrLostClippingLayer = false;
-    if (m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect)) {
+    if (m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect)) {
         if (!m_contentsClippingLayer) {
             Ref contentsClippingLayer = createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, this);
             m_contentsClippingLayer = contentsClippingLayer.copyRef();

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -353,7 +353,7 @@ void OperationRecorder::fillRoundedRect(const FloatRoundedRect& roundedRect, con
             Cairo::State::setCompositeOperation(platformContext, arg<2>(), arg<3>());
 
             auto& rect = arg<0>();
-            if (rect.isRounded())
+            if (rect.hasNonZeroRadii())
                 Cairo::fillRoundedRect(platformContext, rect, arg<1>(), arg<4>());
             else
                 Cairo::fillRect(platformContext, rect.rect(), arg<1>(), arg<4>());

--- a/Source/WebCore/platform/graphics/skia/FloatRoundedRectSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FloatRoundedRectSkia.cpp
@@ -49,7 +49,7 @@ FloatRoundedRect::FloatRoundedRect(const SkRRect& skRect)
 
 FloatRoundedRect::operator SkRRect() const
 {
-    if (!isRounded())
+    if (!hasNonZeroRadii())
         return SkRRect::MakeRect(rect());
 
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib/Win port

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -455,7 +455,7 @@ bool SkiaCompositingLayer::paint(SkCanvas& canvas, std::optional<Damage>& damage
 void SkiaCompositingLayer::clipRect(SkCanvas& canvas, const FloatRoundedRect& rect, const TransformationMatrix& transform)
 {
     if (transform.isIdentity()) {
-        if (rect.isRounded())
+        if (rect.hasNonZeroRadii())
             canvas.clipRRect(SkRRect(rect), true);
         else
             canvas.clipRect(SkRect(rect.rect()));
@@ -463,7 +463,7 @@ void SkiaCompositingLayer::clipRect(SkCanvas& canvas, const FloatRoundedRect& re
     }
 
     auto matrix = SkM44(transform).asM33();
-    if (rect.isRounded())
+    if (rect.hasNonZeroRadii())
         canvas.clipPath(SkPath::RRect(SkRRect(rect)).makeTransform(matrix), true);
     else if (matrix.rectStaysRect())
         canvas.clipRect(matrix.mapRect(SkRect(rect.rect())));
@@ -517,7 +517,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
         canvas.drawRect(m_contentsRect, paint);
     } else if (m_contentsBuffer || m_imageBackingStore) {
         bool shouldPaintNow = [&] {
-            if (m_contentsClippingRect.isRounded())
+            if (m_contentsClippingRect.hasNonZeroRadii())
                 return true;
 
             if (!m_contentsBuffer && !m_contentsTiling.size.isEmpty())
@@ -537,7 +537,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
         if (shouldPaintNow) {
             canvas.concat(SkM44(transform));
 
-            if (m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect))
+            if (m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect))
                 clipRect(canvas, m_contentsClippingRect);
         }
 
@@ -691,7 +691,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         return;
 
     auto canSkipClip = [&](const FloatRoundedRect& rect, const TransformationMatrix& transform) {
-        if (rect.isRounded())
+        if (rect.hasNonZeroRadii())
             return false;
 
         // We can only skip clipping for layers having one child that is a leaf.
@@ -724,7 +724,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
         return matrix.mapRect(SkRect(rect.rect())).contains(childMatrix.mapRect(SkRect(childBounds)));
     };
 
-    const bool contentsRectClipsDescendants = !m_preserves3D && m_contentsRectClipsDescendants && (m_contentsClippingRect.isRounded() || !m_contentsClippingRect.rect().contains(m_contentsRect));
+    const bool contentsRectClipsDescendants = !m_preserves3D && m_contentsRectClipsDescendants && (m_contentsClippingRect.hasNonZeroRadii() || !m_contentsClippingRect.rect().contains(m_contentsRect));
     const bool masksToBounds = !m_preserves3D && m_masksToBounds;
     TransformationMatrix clipTransform;
     FloatRoundedRect clippingRect;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -1379,7 +1379,7 @@ bool TextureMapper::beginRoundedRectClip(const TransformationMatrix& modelViewMa
     // arrays must have a predefined size. The limit is defined inside ClipStack, and that's why we need to call
     // clipStack().isRoundedRectClipAllowed() before trying to add a new clip.
 
-    if (!targetRect.isRounded() || !targetRect.isRenderable() || targetRect.isEmpty() || !modelViewMatrix.isInvertible() || !clipStack().isRoundedRectClipAllowed())
+    if (!targetRect.hasNonZeroRadii() || !targetRect.isRenderable() || targetRect.isEmpty() || !modelViewMatrix.isInvertible() || !clipStack().isRoundedRectClipAllowed())
         return false;
 
     FloatQuad quad = modelViewMatrix.projectQuad(targetRect.rect());

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -626,7 +626,7 @@ void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
         options.textureMapper.setPatternTransform(patternTransform);
     }
 
-    bool shouldClip = m_state.contentsClippingRect.isRounded() || !m_state.contentsClippingRect.rect().contains(m_state.contentsRect);
+    bool shouldClip = m_state.contentsClippingRect.hasNonZeroRadii() || !m_state.contentsClippingRect.rect().contains(m_state.contentsRect);
     if (shouldClip) {
         options.textureMapper.beginClip(transform, m_state.contentsClippingRect);
     }

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -271,7 +271,7 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const Style::ComputedSty
     }();
 
     bool haveAllSolidEdges = decorationHasAllSolidEdges(edges);
-    bool outerEdgeIsRectangular = !shape.isRounded() || (haveAllSolidEdges && shape.allCornersClippedOut(m_paintInfo.rect));
+    bool outerEdgeIsRectangular = !shape.hasNonZeroRadii() || (haveAllSolidEdges && shape.allCornersClippedOut(m_paintInfo.rect));
     bool innerEdgeIsRectangular = shape.innerShapeIsRectangular();
 
     paintSides(shape, {

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -184,7 +184,7 @@ bool BorderShape::outerShapeContains(const LayoutRect& rect) const
 
 bool BorderShape::allCornersClippedOut(const LayoutRect& rect) const
 {
-    if (!isRounded())
+    if (!hasNonZeroRadii())
         return true;
 
     auto borderRect = m_borderRect.rect();
@@ -218,12 +218,12 @@ bool BorderShape::allCornersClippedOut(const LayoutRect& rect) const
 
 bool BorderShape::outerShapeIsRectangular() const
 {
-    return !m_borderRect.isRounded();
+    return !m_borderRect.hasNonZeroRadii();
 }
 
 bool BorderShape::innerShapeIsRectangular() const
 {
-    return !m_innerEdgeRect.isRounded();
+    return !m_innerEdgeRect.hasNonZeroRadii();
 }
 
 void BorderShape::move(LayoutSize offset)
@@ -240,7 +240,7 @@ void BorderShape::inflate(LayoutUnit amount)
 
 static void addRoundedRectToPath(const FloatRoundedRect& roundedRect, Path& path)
 {
-    if (roundedRect.isRounded())
+    if (roundedRect.hasNonZeroRadii())
         path.addRoundedRect(roundedRect);
     else
         path.addRect(roundedRect.rect());
@@ -293,7 +293,7 @@ Path BorderShape::pathForBorderArea(float deviceScaleFactor) const
 void BorderShape::clipToOuterShape(GraphicsContext& context, float deviceScaleFactor) const
 {
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    if (pixelSnappedRect.isRounded())
+    if (pixelSnappedRect.hasNonZeroRadii())
         context.clipRoundedRect(pixelSnappedRect);
     else
         context.clip(pixelSnappedRect.rect());
@@ -303,7 +303,7 @@ void BorderShape::clipToInnerShape(GraphicsContext& context, float deviceScaleFa
 {
     auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(pixelSnappedRect.isRenderable());
-    if (pixelSnappedRect.isRounded())
+    if (pixelSnappedRect.hasNonZeroRadii())
         context.clipRoundedRect(pixelSnappedRect);
     else
         context.clip(pixelSnappedRect.rect());
@@ -315,7 +315,7 @@ void BorderShape::clipOutOuterShape(GraphicsContext& context, float deviceScaleF
     if (pixelSnappedRect.isEmpty())
         return;
 
-    if (pixelSnappedRect.isRounded())
+    if (pixelSnappedRect.hasNonZeroRadii())
         context.clipOutRoundedRect(pixelSnappedRect);
     else
         context.clipOut(pixelSnappedRect.rect());
@@ -327,7 +327,7 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
     if (pixelSnappedRect.isEmpty())
         return;
 
-    if (pixelSnappedRect.isRounded())
+    if (pixelSnappedRect.hasNonZeroRadii())
         context.clipOutRoundedRect(pixelSnappedRect);
     else
         context.clipOut(pixelSnappedRect.rect());
@@ -336,7 +336,7 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
 void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, float deviceScaleFactor) const
 {
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    if (pixelSnappedRect.isRounded())
+    if (pixelSnappedRect.hasNonZeroRadii())
         context.fillRoundedRect(pixelSnappedRect, color);
     else
         context.fillRect(pixelSnappedRect.rect(), color);
@@ -346,7 +346,7 @@ void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, f
 {
     auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(pixelSnappedRect.isRenderable());
-    if (pixelSnappedRect.isRounded())
+    if (pixelSnappedRect.hasNonZeroRadii())
         context.fillRoundedRect(pixelSnappedRect, color);
     else
         context.fillRect(pixelSnappedRect.rect(), color);
@@ -373,7 +373,7 @@ LayoutRoundedRect BorderShape::computeInnerEdgeRoundedRect(const LayoutRoundedRe
     };
 
     auto innerEdgeRect = LayoutRoundedRect { innerRect };
-    if (borderRoundedRect.isRounded()) {
+    if (borderRoundedRect.hasNonZeroRadii()) {
         auto innerRadii = borderRoundedRect.radii();
         innerRadii.shrink(borderWidths.top(), borderWidths.bottom(), borderWidths.left(), borderWidths.right());
         innerEdgeRect.setRadii(innerRadii);

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -94,7 +94,7 @@ public:
     FloatRect snappedOuterRect(float deviceScaleFactor) const;
     FloatRect snappedInnerRect(float deviceScaleFactor) const;
 
-    bool isRounded() const { return m_borderRect.isRounded(); }
+    bool hasNonZeroRadii() const { return m_borderRect.hasNonZeroRadii(); }
 
     bool NODELETE outerShapeIsRectangular() const;
     bool NODELETE innerShapeIsRectangular() const;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1221,7 +1221,7 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
         auto& renderBox = downcast<RenderBox>(renderer());
         auto borderShape = BorderShape::shapeForBorderRect(renderBox.style(), renderBox.borderBoxRect());
         FloatRoundedRect contentsClippingRect = borderShape.deprecatedPixelSnappedInnerRoundedRect(deviceScaleFactor());
-        needsDescendantsClippingLayer = contentsClippingRect.isRounded();
+        needsDescendantsClippingLayer = contentsClippingRect.hasNonZeroRadii();
     } else
         needsDescendantsClippingLayer = RenderLayerCompositor::clipsCompositingDescendants(m_owningLayer);
 

--- a/Source/WebCore/rendering/shapes/BoxLayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/BoxLayoutShape.cpp
@@ -129,7 +129,7 @@ LineSegment BoxLayoutShape::getExcludedInterval(LayoutUnit logicalTop, LayoutUni
     float y2 = logicalTop + logicalHeight;
     const FloatRect& rect = marginBounds.rect();
 
-    if (!marginBounds.isRounded())
+    if (!marginBounds.hasNonZeroRadii())
         return LineSegment(rect.x(), rect.maxX());
 
     float topCornerMaxY = std::max<float>(marginBounds.topLeftCorner().maxY(), marginBounds.topRightCorner().maxY());


### PR DESCRIPTION
#### 59db0b326f9b7609bd4b9f6fb40bad648b16b733
<pre>
Rename FloatRoundedRect::isRounded() and LayoutRoundedRect::isRounded() to hasNonZeroRadii()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317243">https://bugs.webkit.org/show_bug.cgi?id=317243</a>
<a href="https://rdar.apple.com/179862975">rdar://179862975</a>

Reviewed by Simon Fraser.

Changed for corner-shape implementation where a rect can have non-zero radii but a non-round shape

Changes pass existing tests

* Source/WebCore/platform/graphics/FloatRoundedRect.cpp:
(WebCore::FloatRoundedRect::xInterceptsAtY const):
(WebCore::approximateAsRegion):
* Source/WebCore/platform/graphics/FloatRoundedRect.h:
(WebCore::FloatRoundedRect::hasNonZeroRadii const):
(WebCore::FloatRoundedRect::isRounded const): Deleted.
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::clipOutRoundedRect):
(WebCore::GraphicsContext::fillRoundedRect):
* Source/WebCore/platform/graphics/LayoutRoundedRect.h:
(WebCore::LayoutRoundedRect::hasNonZeroRadii const):
(WebCore::LayoutRoundedRect::isRounded const): Deleted.
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::addRoundedRect):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp:
(WebCore::Cairo::OperationRecorder::fillRoundedRect):
* Source/WebCore/platform/graphics/skia/FloatRoundedRectSkia.cpp:
(WebCore::FloatRoundedRect::operator SkRRect const):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::clipRect):
(WebCore::SkiaCompositingLayer::paintContents):
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::beginRoundedRectClip):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintSelf):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintBorder const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::allCornersClippedOut const):
(WebCore::BorderShape::outerShapeIsRectangular const):
(WebCore::BorderShape::innerShapeIsRectangular const):
(WebCore::addRoundedRectToPath):
(WebCore::BorderShape::clipToOuterShape const):
(WebCore::BorderShape::clipToInnerShape const):
(WebCore::BorderShape::clipOutOuterShape const):
(WebCore::BorderShape::clipOutInnerShape const):
(WebCore::BorderShape::fillOuterShape const):
(WebCore::BorderShape::fillInnerShape const):
(WebCore::BorderShape::computeInnerEdgeRoundedRect):
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::hasNonZeroRadii const):
(WebCore::BorderShape::isRounded const): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
* Source/WebCore/rendering/shapes/BoxLayoutShape.cpp:
(WebCore::BoxLayoutShape::getExcludedInterval const):

Canonical link: <a href="https://commits.webkit.org/315380@main">https://commits.webkit.org/315380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4940f6123ac88abe284caada461fcca7d4f7c207

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131389 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92428 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32829 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31541 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26774 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180680 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139836 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42319 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139680 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37632 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28034 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106754 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34962 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114775 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41511 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6122 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40908 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->