### PR TITLE
Treat invalid Expires headers as already expired

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any-expected.txt
@@ -4,7 +4,7 @@ PASS HTTP cache does not reuse a response with a past Expires
 PASS HTTP cache does not reuse a response with a present Expires
 PASS HTTP cache does not reuse a response with an invalid Expires
 PASS HTTP cache does not reuse a response with an invalid Expires with Last-Modified now
-FAIL HTTP cache does not reuse a response with an invalid Expires with past Last-Modified assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache does not reuse a response with an invalid Expires with past Last-Modified
 PASS HTTP cache reuses a response with positive Cache-Control: max-age
 PASS HTTP cache does not reuse a response with Cache-Control: max-age=0
 PASS HTTP cache reuses a response with positive Cache-Control: max-age and a past Expires

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.serviceworker-expected.txt
@@ -4,7 +4,7 @@ PASS HTTP cache does not reuse a response with a past Expires
 PASS HTTP cache does not reuse a response with a present Expires
 PASS HTTP cache does not reuse a response with an invalid Expires
 PASS HTTP cache does not reuse a response with an invalid Expires with Last-Modified now
-FAIL HTTP cache does not reuse a response with an invalid Expires with past Last-Modified assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache does not reuse a response with an invalid Expires with past Last-Modified
 PASS HTTP cache reuses a response with positive Cache-Control: max-age
 PASS HTTP cache does not reuse a response with Cache-Control: max-age=0
 PASS HTTP cache reuses a response with positive Cache-Control: max-age and a past Expires

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.sharedworker-expected.txt
@@ -4,7 +4,7 @@ PASS HTTP cache does not reuse a response with a past Expires
 PASS HTTP cache does not reuse a response with a present Expires
 PASS HTTP cache does not reuse a response with an invalid Expires
 PASS HTTP cache does not reuse a response with an invalid Expires with Last-Modified now
-FAIL HTTP cache does not reuse a response with an invalid Expires with past Last-Modified assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache does not reuse a response with an invalid Expires with past Last-Modified
 PASS HTTP cache reuses a response with positive Cache-Control: max-age
 PASS HTTP cache does not reuse a response with Cache-Control: max-age=0
 PASS HTTP cache reuses a response with positive Cache-Control: max-age and a past Expires

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.worker-expected.txt
@@ -4,7 +4,7 @@ PASS HTTP cache does not reuse a response with a past Expires
 PASS HTTP cache does not reuse a response with a present Expires
 PASS HTTP cache does not reuse a response with an invalid Expires
 PASS HTTP cache does not reuse a response with an invalid Expires with Last-Modified now
-FAIL HTTP cache does not reuse a response with an invalid Expires with past Last-Modified assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache does not reuse a response with an invalid Expires with past Last-Modified
 PASS HTTP cache reuses a response with positive Cache-Control: max-age
 PASS HTTP cache does not reuse a response with Cache-Control: max-age=0
 PASS HTTP cache reuses a response with positive Cache-Control: max-age and a past Expires

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -133,6 +133,10 @@ Seconds computeFreshnessLifetimeForHTTPFamily(const ResourceResponse& response, 
     if (auto expires = response.expires())
         return *expires - effectiveDate;
 
+    // Check if the expires header is present but invalid.
+    if (response.httpHeaderFields().contains(HTTPHeaderName::Expires))
+        return 0_us;
+
     // Implicit lifetime.
     switch (response.httpStatusCode()) {
     case 301: // Moved Permanently


### PR DESCRIPTION
#### a408554a02a77dd23b5f3ca1680c7c21c9593a10
<pre>
Treat invalid Expires headers as already expired
<a href="https://bugs.webkit.org/show_bug.cgi?id=317246">https://bugs.webkit.org/show_bug.cgi?id=317246</a>

Reviewed by Chris Dumez.

computeFreshnessLifetimeForHTTPFamily() only consulted Expires when it parsed as a valid HTTP-date;
a present-but-invalid value made ResourceResponse::expires() return nullopt, so the function fell
through to Last-Modified heuristic freshness and could wrongly treat the response as fresh. Return
a zero freshness lifetime when an Expires header is present but did not parse, instead of falling
through to the heuristic.

A cache recipient MUST interpret invalid date formats, especially the value &quot;0&quot;, as representing a
time in the past (i.e., &quot;already expired&quot;)
 - <a href="https://www.rfc-editor.org/info/rfc9111/#section-5.3-7">https://www.rfc-editor.org/info/rfc9111/#section-5.3-7</a>

* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/freshness.any.worker-expected.txt:
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::computeFreshnessLifetimeForHTTPFamily):

Canonical link: <a href="https://commits.webkit.org/315448@main">https://commits.webkit.org/315448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcdf559f4df7acda204865cb81fb06cd1bc2d4c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42629 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36227 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178412 "Failed to checkout and rebase branch from PR 67293") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42605 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/178412 "Failed to checkout and rebase branch from PR 67293") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172017 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/178412 "Failed to checkout and rebase branch from PR 67293") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/27114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181013 "Failed to checkout and rebase branch from PR 67293") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33724 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/181013 "Failed to checkout and rebase branch from PR 67293") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42636 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/181013 "Failed to checkout and rebase branch from PR 67293") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43325 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107197 "Failed to checkout and rebase branch from PR 67293") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25762 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/35229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/41834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/41228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41483 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/41371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->