### PR TITLE
Update arbitrary Content-* headers from 304 responses

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any-expected.txt
@@ -3,5 +3,5 @@ PASS HTTP cache updates returned headers from a Last-Modified 304
 PASS HTTP cache updates stored headers from a Last-Modified 304
 PASS HTTP cache updates returned headers from a ETag 304
 PASS HTTP cache updates stored headers from a ETag 304
-FAIL Content-* header assert_equals: Response 2 header Content-Test-Header is "A", not "B" expected "B" but got "A"
+PASS Content-* header
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.serviceworker-expected.txt
@@ -3,5 +3,5 @@ PASS HTTP cache updates returned headers from a Last-Modified 304
 PASS HTTP cache updates stored headers from a Last-Modified 304
 PASS HTTP cache updates returned headers from a ETag 304
 PASS HTTP cache updates stored headers from a ETag 304
-FAIL Content-* header assert_equals: Response 2 header Content-Test-Header is "A", not "B" expected "B" but got "A"
+PASS Content-* header
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.sharedworker-expected.txt
@@ -3,5 +3,5 @@ PASS HTTP cache updates returned headers from a Last-Modified 304
 PASS HTTP cache updates stored headers from a Last-Modified 304
 PASS HTTP cache updates returned headers from a ETag 304
 PASS HTTP cache updates stored headers from a ETag 304
-FAIL Content-* header assert_equals: Response 2 header Content-Test-Header is "A", not "B" expected "B" but got "A"
+PASS Content-* header
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.worker-expected.txt
@@ -3,5 +3,5 @@ PASS HTTP cache updates returned headers from a Last-Modified 304
 PASS HTTP cache updates stored headers from a Last-Modified 304
 PASS HTTP cache updates returned headers from a ETag 304
 PASS HTTP cache updates stored headers from a ETag 304
-FAIL Content-* header assert_equals: Response 2 header Content-Test-Header is "A", not "B" expected "B" but got "A"
+PASS Content-* header
 

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -45,6 +45,13 @@ namespace WebCore {
 static constexpr std::array headersToIgnoreAfterRevalidation {
     "allow"_s,
     "connection"_s,
+    "content-disposition"_s,
+    "content-encoding"_s,
+    "content-language"_s,
+    "content-length"_s,
+    "content-location"_s,
+    "content-range"_s,
+    "content-type"_s,
     "etag"_s,
     "keep-alive"_s,
     "last-modified"_s,
@@ -62,7 +69,6 @@ static constexpr std::array headersToIgnoreAfterRevalidation {
 // Rather than listing all the relevant headers, we can consolidate them into
 // this list, also grabbed from Chromium's net/http/http_response_headers.cc.
 static constexpr std::array headerPrefixesToIgnoreAfterRevalidation {
-    "content-"_s,
     "x-content-"_s,
     "x-webkit-"_s
 };


### PR DESCRIPTION
#### 6235f1672706204ca4172bae3bf98be8893bb299
<pre>
Update arbitrary Content-* headers from 304 responses
<a href="https://bugs.webkit.org/show_bug.cgi?id=317250">https://bugs.webkit.org/show_bug.cgi?id=317250</a>
<a href="https://rdar.apple.com/179864251">rdar://179864251</a>

Reviewed by Chris Dumez.

RFC 9111 §4.3.4 requires caches to update stored response headers from a 304 using the rules in
RFC 9111 §3.2:

<a href="https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.4">https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.4</a>
<a href="https://www.rfc-editor.org/rfc/rfc9111.html#section-3.2">https://www.rfc-editor.org/rfc/rfc9111.html#section-3.2</a>

Section 3.2 lists specific exceptions, but explicitly says the Content-* prefix is not a signal that
a field is omitted from update. RFC 9110 §15.4.5 also defines 304 as a header-only metadata response:
<a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5">https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5</a>

Stop ignoring all Content-* headers after revalidation. Preserve only the specific
representation/body-related fields WebCore needs to keep consistent with the stored body, so
arbitrary extension headers such as Content-Test-Header update normally.

* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/304-update.any.worker-expected.txt:
* Source/WebCore/platform/network/CacheValidation.cpp:

Canonical link: <a href="https://commits.webkit.org/315449@main">https://commits.webkit.org/315449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58fc34b9043ecc927268022db2f59b7d4781c177

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126452 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54a07939-379c-4d98-a0ab-882e500453b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131384 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92423 "2 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4dcf372-27ba-469f-a9e7-4b18159477c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111888 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb55b7a3-d21b-4eb7-8626-5efc50b30964) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32819 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31537 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26771 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180677 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139831 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42316 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139675 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43005 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106751 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34953 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114772 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41508 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6110 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40905 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->