### PR TITLE
Honor Cache-Control request max-age, min-fresh and no-store

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.serviceworker-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.sharedworker-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.worker-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached promise_test: Unhandled rejection with value: object "TypeError: Load failed"
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached assert_equals: Response 1 status is 200, not 504 expected 504 but got 200
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached assert_equals: Response 1 status is 200, not 504 expected 504 but got 200
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.serviceworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.serviceworker-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached assert_equals: Response 1 status is 200, not 504 expected 504 but got 200
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.sharedworker-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached assert_equals: Response 1 status is 200, not 504 expected 504 but got 200
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.worker-expected.txt
@@ -1,14 +1,14 @@
 
 PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=0
-FAIL HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1 assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't use aged but fresh response when request contains Cache-Control: max-age=1
+PASS HTTP cache doesn't use fresh response with Age header when request contains Cache-Control: max-age that is greater than remaining freshness
 PASS HTTP cache does use aged stale response when request contains Cache-Control: max-stale that permits its use
 PASS HTTP cache does reuse stale response with Age header when request contains Cache-Control: max-stale that permits its use
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
-FAIL HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: min-fresh that wants it fresher
+PASS HTTP cache doesn't reuse fresh response with Age header when request contains Cache-Control: min-fresh that wants it fresher
 PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with Last-Modified when request contains Cache-Control: no-cache
 PASS HTTP cache validates fresh response with ETag when request contains Cache-Control: no-cache
-FAIL HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store assert_equals: Response 2 comes from cache expected 2 but got 1
+PASS HTTP cache doesn't reuse fresh response when request contains Cache-Control: no-store
 FAIL HTTP cache generates 504 status code when nothing is in cache and request contains Cache-Control: only-if-cached assert_equals: Response 1 status is 200, not 504 expected 504 but got 200
 

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -324,6 +324,13 @@ CacheControlDirectives parseCacheControlDirectives(const HTTPHeaderMap& headers)
                 double maxStale = directives[i].second.toDouble(ok);
                 if (ok)
                     result.maxStale = Seconds { maxStale };
+            } else if (equalLettersIgnoringASCIICase(directives[i].first, "min-fresh"_s)) {
+                if (result.minFresh)
+                    continue;
+                bool ok;
+                double minFresh = directives[i].second.toDouble(ok);
+                if (ok)
+                    result.minFresh = Seconds { minFresh };
             } else if (equalLettersIgnoringASCIICase(directives[i].first, "immutable"_s)) {
                 result.immutable = true;
             } else if (equalLettersIgnoringASCIICase(directives[i].first, "stale-while-revalidate"_s)) {

--- a/Source/WebCore/platform/network/CacheValidation.h
+++ b/Source/WebCore/platform/network/CacheValidation.h
@@ -71,6 +71,7 @@ struct CacheControlDirectives {
 
     Markable<Seconds> maxAge;
     Markable<Seconds> maxStale;
+    Markable<Seconds> minFresh;
     Markable<Seconds> staleWhileRevalidate;
     bool noCache : 1;
     bool noStore : 1;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -187,7 +187,7 @@ static bool NODELETE cachePolicyAllowsExpired(WebCore::ResourceRequestCachePolic
     return false;
 }
 
-static UseDecision responseNeedsRevalidation(NetworkSession& networkSession, const WebCore::ResourceResponse& response, WallTime timestamp, std::optional<Seconds> maxStale)
+static UseDecision responseNeedsRevalidation(NetworkSession& networkSession, const WebCore::ResourceResponse& response, WallTime timestamp, const WebCore::CacheControlDirectives& requestDirectives)
 {
     if (response.cacheControlContainsNoCache())
         return UseDecision::Validate;
@@ -195,6 +195,19 @@ static UseDecision responseNeedsRevalidation(NetworkSession& networkSession, con
     auto age = WebCore::computeCurrentAge(response, timestamp);
     auto lifetime = WebCore::computeFreshnessLifetimeForHTTPFamily(response, timestamp);
 
+    // Request max-age=0 (like no-cache) always forces revalidation.
+    if (requestDirectives.maxAge && requestDirectives.maxAge.value() == 0_ms)
+        return UseDecision::Validate;
+
+    if (age <= lifetime) {
+        if (requestDirectives.maxAge && age > requestDirectives.maxAge.value())
+            return UseDecision::Validate;
+
+        if (requestDirectives.minFresh && age + requestDirectives.minFresh.value() > lifetime)
+            return UseDecision::Validate;
+    }
+
+    auto maxStale = requestDirectives.maxStale;
     auto maximumStaleness = maxStale ? maxStale.value() : 0_ms;
     bool hasExpired = age - lifetime > maximumStaleness;
     if (hasExpired && !maxStale && networkSession.isStaleWhileRevalidateEnabled()) {
@@ -220,11 +233,11 @@ static UseDecision responseNeedsRevalidation(NetworkSession& networkSession, con
     auto requestDirectives = WebCore::parseCacheControlDirectives(request.httpHeaderFields());
     if (requestDirectives.noCache)
         return UseDecision::Validate;
-    // For requests we ignore max-age values other than zero.
-    if (requestDirectives.maxAge && requestDirectives.maxAge.value() == 0_ms)
+    // A request carrying no-store must not be satisfied from cache.
+    if (requestDirectives.noStore)
         return UseDecision::Validate;
 
-    return responseNeedsRevalidation(networkSession, response, timestamp, requestDirectives.maxStale);
+    return responseNeedsRevalidation(networkSession, response, timestamp, requestDirectives);
 }
 
 static UseDecision makeUseDecision(NetworkProcess& networkProcess, PAL::SessionID sessionID, const Entry& entry, const WebCore::ResourceRequest& request)


### PR DESCRIPTION
#### 7565d27f767470962d70ffa30b5a22e01c55df6a
<pre>
Honor Cache-Control request max-age, min-fresh and no-store
<a href="https://bugs.webkit.org/show_bug.cgi?id=317251">https://bugs.webkit.org/show_bug.cgi?id=317251</a>
<a href="https://rdar.apple.com/179865576">rdar://179865576</a>

Reviewed by Chris Dumez.

Apply request Cache-Control directives when deciding whether NetworkCache can reuse a stored
response.

RFC 9111 defines request max-age as preferring a response whose age is no greater than the supplied
delta, and min-fresh as preferring a response that remains fresh for at least the supplied delta:
<a href="https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.1">https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.1</a>
<a href="https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.3">https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.3</a>

Parse min-fresh and require validation when the stored response is too old for request max-age or
not fresh enough for request min-fresh. Also require validation for request no-store for web
compatibility, aligning with Fetch’s no-store cache mode:
<a href="https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.5">https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.5</a>
<a href="https://fetch.spec.whatwg.org/#request-cache-mode">https://fetch.spec.whatwg.org/#request-cache-mode</a>

* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.serviceworker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.sharedworker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/http-cache/cc-request.any.worker-expected.txt:
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::parseCacheControlDirectives):
* Source/WebCore/platform/network/CacheValidation.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::responseNeedsRevalidation):

Canonical link: <a href="https://commits.webkit.org/315447@main">https://commits.webkit.org/315447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef039e2932fdcbdd464adf13c3e68c5baaa3f65e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126485 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/226c5955-c593-4767-9d76-4c15e3d91b66) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131418 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92448 "1 flakes 6 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dd4962b-5c35-4be9-82a5-32a86d0b21d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111922 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a45952ec-fb47-4eb9-a56c-68e143162d72) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32858 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31573 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26804 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180710 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139864 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42349 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139708 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43038 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106784 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25761 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34993 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114805 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41541 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6160 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40938 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41083 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->