### PR TITLE
WebExtensionContext::tabsRemove may call the completion handler multiple times if passed multiple invalid tab IDs

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -576,24 +576,21 @@ void WebExtensionContext::tabsSetZoom(WebPageProxyIdentifier webPageProxyIdentif
 
 void WebExtensionContext::tabsRemove(Vector<WebExtensionTabIdentifier> tabIdentifiers, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    auto tabs = tabIdentifiers.map([&](auto& tabIdentifier) -> RefPtr<WebExtensionTab> {
-        RefPtr tab = getTab(tabIdentifier);
-        if (!tab) {
+    Vector<Ref<WebExtensionTab>> tabs;
+    tabs.reserveInitialCapacity(tabIdentifiers.size());
+
+    for (auto& tabIdentifier : tabIdentifiers) {
+        if (RefPtr tab = getTab(tabIdentifier))
+            tabs.append(tab.releaseNonNull());
+        else {
             completionHandler(toWebExtensionError(@"tabs.remove()", nullString(), makeString("tab '"_s, tabIdentifier.toUInt64(), "' was not found"_s)));
-            return nullptr;
+            return;
         }
-
-        return tab;
-    });
-
-    if (tabs.contains(nullptr)) {
-        // The completionHandler was called with an error in map() when returning nullptr.
-        return;
     }
 
     Ref callbackAggregator = EagerCallbackAggregator<void(Expected<void, WebExtensionError>)>::create(WTF::move(completionHandler), { });
 
-    for (RefPtr tab : tabs) {
+    for (Ref tab : tabs) {
         tab->close([callbackAggregator](Expected<void, WebExtensionError>&& result) mutable {
             if (!result)
                 callbackAggregator.get()(makeUnexpected(result.error()));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
@@ -1172,6 +1172,37 @@ TEST(WKWebExtensionAPITabs, RemoveMultipleTabs)
     [manager run];
 }
 
+TEST(WKWebExtensionAPITabs, RemoveMultipleInvalidTabs)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const allWindows = await browser.windows.getAll({ populate: true })",
+        @"const tabs = allWindows[0].tabs",
+
+        @"const validTabId = tabs[1].id",
+
+        @"await browser.test.assertRejects(browser.tabs.remove([9999, 9998]), /tab '9999' was not found/i, 'Removing multiple invalid tabs should reject once with the first invalid id')",
+
+        // A valid id batched with an invalid id should also reject without removing anything
+        @"await browser.test.assertRejects(browser.tabs.remove([validTabId, 9999]), /tab '9999' was not found/i, 'A trailing invalid id should reject and remove nothing')",
+        @"await browser.test.assertRejects(browser.tabs.remove([9999, validTabId]), /tab '9999' was not found/i, 'A leading invalid id should reject and remove nothing')",
+
+        @"const remainingTabs = (await browser.windows.getAll({ populate: true }))[0].tabs.map(tab => tab.id)",
+        @"browser.test.assertEq(remainingTabs.length, tabs.length, 'No tabs should be removed when an invalid id is provided')",
+        @"browser.test.assertTrue(remainingTabs.includes(validTabId), 'The valid tab should not have been removed')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().defaultWindow openNewTab];
+    [manager.get().defaultWindow openNewTab];
+
+    EXPECT_EQ(manager.get().defaultWindow.tabs.count, 3lu);
+
+    [manager run];
+}
+
 TEST(WKWebExtensionAPITabs, CreatedEvent)
 {
     auto *backgroundScript = Util::constructScript(@[


### PR DESCRIPTION
#### c07f39302a15e19b3b83576056450bb0178512f5
<pre>
WebExtensionContext::tabsRemove may call the completion handler multiple times if passed multiple invalid tab IDs
<a href="https://rdar.apple.com/179273354">rdar://179273354</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317230">https://bugs.webkit.org/show_bug.cgi?id=317230</a>

Reviewed by Kiara Rose and Timothy Hatcher.

`WebExtensionContext::tabsRemove` built its list of tabs with `Vector::map`, which visits every
identifier in the array. If any id was invalid (i.e., `getTab` returned `nullptr` for it), then the
`map` lambda would immediately call the completion handler. If there were multiple invalid tab
identifiers, then this would result in the completion handler being called multiple times, crashing
the browser.

To fix this, just use a for loop instead of map. If any invalid identifiers are found, call the
completion handler once and bail out of `tabsRemove`.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsRemove):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, RemoveMultipleInvalidTabs)):

Canonical link: <a href="https://commits.webkit.org/315353@main">https://commits.webkit.org/315353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ebd251e7aca54b52b6fb772040b7ecce48f16ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126456 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32b6594b-d6f0-4423-bedf-12a66a20d706) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131387 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7cae80fd-1c62-4aae-8d0b-b6265a23ca7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111891 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd2226b7-0d3d-43e4-b258-338b4d56bd6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32835 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31542 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26775 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180681 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139833 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42320 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139677 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37616 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43009 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28032 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/106755 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34958 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114776 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41512 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6120 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40909 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41054 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->