### PR TITLE
Add an API test to ensure WebContent is managed by RunningBoard

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1010,6 +1010,7 @@
 				WebKit/WKWebView/mac/PageVisibilityStateWithWindowChanges.mm,
 				WebKit/WKWebView/mac/RenderedImageFromDOMNode.mm,
 				WebKit/WKWebView/mac/RenderedImageFromDOMRange.mm,
+				WebKit/WKWebView/mac/RunningBoardManagement.mm,
 				WebKit/WKWebView/mac/ScrollbarTests.mm,
 				WebKit/WKWebView/mac/ScrollingCoordinatorTests.mm,
 				WebKit/WKWebView/mac/SetAndUpdateCacheModel.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/RunningBoardManagement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/RunningBoardManagement.mm
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+// Only runs on Mac because RunningBoard management is on by default on all other platforms. Only
+// runs with internal SDK since that enables WK_USE_RESTRICTED_ENTITLEMENTS, which provides
+// WebContent with the necessary entitlements to interface with RunningBoard.
+#if PLATFORM(MAC) && USE(APPLE_INTERNAL_SDK)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <sys/resource.h>
+#import <sys/resource_private.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+TEST(RunningBoardManagement, NonVisibleWebContentGoesIntoBackground)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 300) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get() addToWindow:NO]);
+    EXPECT_FALSE([[webView window] isVisible]);
+
+    [webView synchronouslyLoadHTMLString:@"<body>hello world</body>"];
+
+    pid_t pid = [webView _webProcessIdentifier];
+    ASSERT_NE(pid, 0);
+
+    bool success = Util::waitFor([pid] {
+        int role = getpriority(PRIO_DARWIN_ROLE, pid);
+        return role == PRIO_DARWIN_ROLE_DARWIN_BG;
+    });
+    EXPECT_TRUE(success) << "WebContent pid " << pid << " never got the PRIO_DARWIN_BG role even though it's non-visible. Check to make sure WebContent is properly managed by RunningBoard.";
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC) && USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### 131b0de0121a3ce5b3b4eebd2efad63e8a775ea5
<pre>
Add an API test to ensure WebContent is managed by RunningBoard
<a href="https://bugs.webkit.org/show_bug.cgi?id=317252">https://bugs.webkit.org/show_bug.cgi?id=317252</a>
<a href="https://rdar.apple.com/179866816">rdar://179866816</a>

Reviewed by Aditya Keerthi.

314749@main caused RunningBoard to no longer be able to manage WebContent. This adds a regression
test that tests this.

The test works by checking that a non-visible WebContent process is assigned the background
role. This only happens if the process is managed by RunningBoard.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/RunningBoardManagement.mm: Added.
(TestWebKitAPI::TEST(RunningBoardManagement, NonVisibleWebContentGoesIntoBackground)):

Canonical link: <a href="https://commits.webkit.org/315382@main">https://commits.webkit.org/315382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cfceb3e6b98a06731480a8e876a031f14d10f1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126490 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd625c94-993d-47b5-b849-794ab68539c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131421 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/334dfe3e-22b1-4c15-92d1-a754573fa52f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111925 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a3e4c2a-d83b-4205-b743-c6309dda6f4b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32861 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31575 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26809 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180715 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139868 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42354 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139712 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37634 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43043 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106789 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34988 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41546 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6152 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40943 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41197 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41088 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->