### PR TITLE
[Writing Tools] Hovering over the different options for AOP causes both suggestions to get inserted.

### DIFF
--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -192,6 +192,8 @@ private:
     std::optional<std::tuple<Node&, DocumentMarker&>> findTextSuggestionMarkerContainingRange(const SimpleRange&) const;
     std::optional<std::tuple<Node&, DocumentMarker&>> findTextSuggestionMarkerByID(const SimpleRange& outerRange, const WritingTools::TextSuggestion::ID&) const;
 
+    std::optional<SimpleRange> validatedRangeForSuggestionMarker(const SimpleRange& sessionRange, Node&, const DocumentMarker&, const String& expectedCurrentText) const;
+
     void replaceContentsOfRangeInSession(ProofreadingState&, const SimpleRange&, const String&);
     void replaceContentsOfRangeInSession(CompositionState&, const SimpleRange&, const AttributedString&, WritingToolsCompositionCommand::State);
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -452,13 +452,25 @@ void WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion(cons
 
     auto& [node, marker] = *nodeAndMarker;
 
+    auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
+
     auto rangeToReplace = makeSimpleRange(node, marker);
 
-    auto replaceMarkerWithType = [&](const String& replacementText, DocumentMarker::WritingToolsTextSuggestionData::State newState) {
-        auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
+    auto expectedCurrentText = data.state == DocumentMarker::WritingToolsTextSuggestionData::State::Accepted
+        ? textSuggestion.replacement
+        : data.originalText;
 
-        auto offsetRange = OffsetRange { marker.startOffset(), marker.endOffset() };
-        document->markers().removeMarkers(node, offsetRange, { DocumentMarkerType::WritingToolsTextSuggestion });
+    auto validatedRange = validatedRangeForSuggestionMarker(sessionRange, node, marker, expectedCurrentText);
+
+    auto removeSuggestionMarker = [&] {
+        document->markers().filterMarkers(sessionRange, [&](const DocumentMarker& candidate) {
+            auto candidateData = std::get<DocumentMarker::WritingToolsTextSuggestionData>(candidate.data());
+            return candidateData.suggestionID == textSuggestion.identifier ? FilterMarkerResult::Remove : FilterMarkerResult::Keep;
+        }, { DocumentMarkerType::WritingToolsTextSuggestion });
+    };
+
+    auto replaceMarkerWithType = [&](const String& replacementText, DocumentMarker::WritingToolsTextSuggestionData::State newState) {
+        removeSuggestionMarker();
 
         auto resolvedCharacterRange = characterRange(sessionRange, rangeToReplace);
 
@@ -501,10 +513,11 @@ void WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion(cons
         // When a given suggestion is "reverted" / rejected, remove the marker and replace the suggested text
         // with the original text.
 
-        auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
+        if (!validatedRange)
+            return;
+        rangeToReplace = *validatedRange;
 
-        auto offsetRange = OffsetRange { marker.startOffset(), marker.endOffset() };
-        document->markers().removeMarkers(node, offsetRange, { DocumentMarkerType::WritingToolsTextSuggestion });
+        removeSuggestionMarker();
 
         replaceContentsOfRangeInSession(*state, rangeToReplace, data.originalText);
 
@@ -516,7 +529,10 @@ void WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion(cons
             // In the proofreading review case, return to the default state which has the original text.
             // Need to replace the marker as well, so that further updates can continue to be applied.
 
-            auto data = std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data());
+            if (!validatedRange)
+                return;
+            rangeToReplace = *validatedRange;
+
             replaceMarkerWithType(data.originalText, DocumentMarker::WritingToolsTextSuggestionData::State::Rejected);
         }
         return;
@@ -527,6 +543,10 @@ void WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion(cons
             // In the proofreading review case, when a given suggestion is accepted, remove the marker
             // and replace the original text with the replacement text. Need to replace the marker
             // as well, so that further updates can continue to be applied.
+
+            if (!validatedRange)
+                return;
+            rangeToReplace = *validatedRange;
 
             replaceMarkerWithType(textSuggestion.replacement, DocumentMarker::WritingToolsTextSuggestionData::State::Accepted);
         }
@@ -1300,6 +1320,42 @@ std::optional<std::tuple<Node&, DocumentMarker&>> WritingToolsController::findTe
         return { { *targetNode, *targetMarker } };
 
     return std::nullopt;
+}
+
+std::optional<SimpleRange> WritingToolsController::validatedRangeForSuggestionMarker(const SimpleRange& sessionRange, Node& node, const DocumentMarker& marker, const String& expectedCurrentText) const
+{
+    auto rangeToReplace = makeSimpleRange(node, marker);
+    auto currentText = plainText(rangeToReplace);
+    if (currentText == expectedCurrentText)
+        return rangeToReplace;
+
+    if (expectedCurrentText.isEmpty())
+        return std::nullopt;
+
+    auto sessionPlainText = plainText(sessionRange);
+    auto staleOffset = characterRange(sessionRange, rangeToReplace).location;
+
+    size_t bestMatch = notFound;
+    uint64_t bestDistance = std::numeric_limits<uint64_t>::max();
+    unsigned searchStart = 0;
+    while (true) {
+        auto matchIndex = sessionPlainText.find(expectedCurrentText, searchStart);
+        if (matchIndex == notFound)
+            break;
+        uint64_t distance = matchIndex > staleOffset ? matchIndex - staleOffset : staleOffset - matchIndex;
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            bestMatch = matchIndex;
+        }
+        searchStart = static_cast<unsigned>(matchIndex + 1);
+    }
+
+    if (bestMatch == notFound) {
+        RELEASE_LOG(WritingTools, "WritingToolsController::validatedRangeForSuggestionMarker bailing - expected text of length %u not found in session range", expectedCurrentText.length());
+        return std::nullopt;
+    }
+
+    return resolveCharacterRange(sessionRange, { bestMatch, expectedCurrentText.length() });
 }
 
 std::optional<std::tuple<Node&, DocumentMarker&>> WritingToolsController::findTextSuggestionMarkerContainingRange(const SimpleRange& range) const

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm
@@ -1007,6 +1007,57 @@ TEST(WritingTools, ProofreadingReview)
     TestWebKitAPI::Util::run(&finished);
 }
 
+TEST(WritingTools, ProofreadingReviewDoesNotWriteIntoDriftedMarker)
+{
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeProofreading textViewDelegate:nil]);
+
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable><p id='first'>This is a test of system.</p></body>"]);
+    [webView focusDocumentBodyAndSelectAll];
+
+    NSString *originalText = @"This is a test of system.";
+    NSString *mutatedText = @"This is a test of syZZZstem.";
+
+    __block bool finished = false;
+
+    [(id)[webView writingToolsDelegate] willBeginWritingToolsSession:session.get() forProofreadingReview:YES requestContexts:^(NSArray<WTContext *> *contexts) {
+        EXPECT_EQ(1UL, contexts.count);
+        EXPECT_WK_STREQ(originalText, contexts.firstObject.attributedText.string);
+
+        [[webView writingToolsDelegate] didBeginWritingToolsSession:session.get() contexts:contexts];
+
+        RetainPtr suggestion = adoptNS([[WTTextSuggestion alloc] initWithOriginalRange:NSMakeRange(18, 6) replacement:@"the system"]);
+
+        [[webView writingToolsDelegate] proofreadingSession:session.get() didReceiveSuggestions:@[ suggestion.get() ] processedRange:NSMakeRange(0, originalText.length) inContext:contexts.firstObject finished:YES];
+        [webView waitForProofreadingSuggestionsToBeReplaced];
+
+        EXPECT_WK_STREQ(originalText, [webView contentsAsString]);
+
+        // Simulate a JS rich-text editor (Lexical / ProseMirror / Slate) reconciling the DOM by
+        // inserting characters inside the marked word "system" [18, 24]. The suggestion marker's
+        // offsets are not shifted by an edit that starts within its range, so they now cover drifted
+        // text ("syZZZs") and the original "system" no longer appears anywhere in the session range.
+        [webView stringByEvaluatingJavaScript:@"document.getElementById('first').firstChild.insertData(20, 'ZZZ')"];
+        [webView waitForNextPresentationUpdate];
+
+        EXPECT_WK_STREQ(mutatedText, [webView contentsAsString]);
+
+        // Accepting the suggestion must not write "the system" into the stale range. Because the
+        // expected text cannot be re-anchored, the controller bails and leaves the content untouched
+        // rather than corrupting it.
+        [[webView writingToolsDelegate] proofreadingSession:session.get() didUpdateState:WTTextSuggestionStateAccepted forSuggestionWithUUID:[suggestion uuid] inContext:contexts.firstObject];
+        [webView waitForProofreadingSuggestionsToBeReplaced];
+
+        EXPECT_WK_STREQ(mutatedText, [webView contentsAsString]);
+
+        [[webView writingToolsDelegate] didEndWritingToolsSession:session.get() accepted:YES];
+        [webView waitForProofreadingSuggestionsToBeReplaced];
+
+        finished = true;
+    }];
+
+    TestWebKitAPI::Util::run(&finished);
+}
+
 TEST(WritingTools, CompositionWithAttemptedEditing)
 {
     RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);


### PR DESCRIPTION
#### d7c42ec32b31f263bccc11a2625e30d60ea54c29
<pre>
[Writing Tools] Hovering over the different options for AOP causes both suggestions to get inserted.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317253">https://bugs.webkit.org/show_bug.cgi?id=317253</a>
<a href="https://rdar.apple.com/175304947">rdar://175304947</a>

Reviewed by Abrar Rahman Protyasha.

On sites whose rich-text editor maintains its own document model and reconciles the DOM after every WebKit-driven
mutation (Lexical on Reddit, ProseMirror, Slate, CKEditor 5), suggestion marker offsets cached in
WritingToolsController go stale across state-update events, and subsequent Pending/Accepted writes land at the wrong
location. Validate the marker&apos;s current target text against the expected text on each update; if the offsets have
drifted, re-anchor by searching the session range for the expected text and picking the closest match. Bail out
cleanly if it can&apos;t be found rather than writing into a stale range. Also remove suggestion markers by suggestion ID
across the whole session range instead of by cached node + offset, since the cached node can itself be stale after a
reconcile.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm

* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion):
(WebCore::WritingToolsController::validatedRangeForSuggestionMarker const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm:
(TEST(WritingTools, ProofreadingReviewDoesNotWriteIntoDriftedMarker)):

Canonical link: <a href="https://commits.webkit.org/316320@main">https://commits.webkit.org/316320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/034f4026d7619fad59a540d7ff2326c93c646022

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128237 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/262bda72-fa8e-490d-8d47-a21f7862ff13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132979 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93769 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b14b99d-930b-4ac9-a3ac-3e28e7751aca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113476 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a846a507-1f9b-41c0-9e3a-a604206f9076) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33123 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28582 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145497 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182485 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141433 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44105 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141250 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38424 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44794 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29795 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109305 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36515 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116683 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43304 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7897 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42709 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42950 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42840 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->