### PR TITLE
Short circuit same-realm MessagePort message delivery

### DIFF
--- a/LayoutTests/fast/events/message-port-transfer-preserves-pending-message-expected.txt
+++ b/LayoutTests/fast/events/message-port-transfer-preserves-pending-message-expected.txt
@@ -1,0 +1,4 @@
+Test that a message already posted to a same-context MessagePort is not lost when that port is transferred from within another port's message handler. The message should be delivered either to the port in this context (before it is neutered) or to the re-entangled port in the destination, but it must not be silently dropped.
+
+PASS: 'toB' was delivered.
+

--- a/LayoutTests/fast/events/message-port-transfer-preserves-pending-message.html
+++ b/LayoutTests/fast/events/message-port-transfer-preserves-pending-message.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test that a message already posted to a same-context MessagePort is not lost when
+that port is transferred from within another port's message handler. The message
+should be delivered either to the port in this context (before it is neutered) or
+to the re-entangled port in the destination, but it must not be silently dropped.</p>
+<pre id="log"></pre>
+<script>
+"use strict";
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function log(message)
+{
+    document.getElementById("log").textContent += message + "\n";
+}
+
+let toBDelivered = false;
+
+function finish()
+{
+    if (toBDelivered)
+        log("PASS: 'toB' was delivered.");
+    else
+        log("FAIL: 'toB' was silently lost.");
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+// Channel whose port we will transfer mid-flight.
+const channel1 = new MessageChannel();
+const a = channel1.port1;
+const b = channel1.port2;
+
+// Channel used purely to transfer "b" to a new entangled port in this same context.
+const channel2 = new MessageChannel();
+const sender = channel2.port1;
+const receiver = channel2.port2;
+
+// The spec allows B to get its message before A. However, since we're not transferring
+// anything across contexts, we will assume delivery will happen in the order the
+// messages were sent.
+b.onmessage = (event) => {
+    log("FAIL: out-of-order delivery");
+    if (event.data === "toB")
+        toBDelivered = true;
+};
+
+// "a" receives "toA" first. Its handler runs *after* the message-dispatch tasks for
+// both ports have already drained their queues, which is exactly the window in which
+// the bug drops the in-flight "toB".
+a.onmessage = () => {
+    sender.postMessage("transfer", [b]);
+};
+
+// If "toB" instead travels with the transferred port, the re-entangled port receives it.
+receiver.onmessage = (event) => {
+    const transferredPort = event.ports[0];
+    transferredPort.onmessage = (ev) => {
+        if (ev.data === "toB")
+            toBDelivered = true;
+    };
+    transferredPort.start();
+};
+
+// Post both messages synchronously so their dispatch tasks land in the same batch:
+// "toA" -> a (triggers the transfer), "toB" -> b (the in-flight message under test).
+setTimeout( () => {
+    b.postMessage("toA");
+    a.postMessage("toB");
+}, 10);
+
+// Give every queued task ample time to run, then report the outcome deterministically
+// (rather than relying on a delivery that may never happen).
+setTimeout(finish, 100);
+</script>
+</body>
+</html>

--- a/PerformanceTests/DOM/MessagePort/throughput-same-context-batch.html
+++ b/PerformanceTests/DOM/MessagePort/throughput-same-context-batch.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/runner.js"></script>
+<script>
+"use strict";
+
+const totalMessages = 10000;
+
+const channel = new MessageChannel();
+const sender = channel.port1;
+const receiver = channel.port2;
+
+let pendingDeliveries = 0;
+let iterationStart = 0;
+
+function onMessage()
+{
+    if (--pendingDeliveries !== 0)
+        return;
+
+    const elapsed = PerfTestRunner.now() - iterationStart;
+    if (!PerfTestRunner.measureValueAsync(elapsed))
+        return;
+
+    setTimeout(runIteration, 0);
+}
+
+receiver.onmessage = onMessage;
+
+function runIteration()
+{
+    pendingDeliveries = totalMessages;
+    iterationStart = PerfTestRunner.now();
+    for (let i = 0; i < totalMessages; ++i)
+        sender.postMessage(0);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+    description: 'Time to deliver a batch of ' + totalMessages + ' messages, '
+    + 'in a never-shipped, same-context MessagePort pair.',
+    unit: 'ms',
+});
+
+setTimeout(runIteration, 0);
+</script>
+</body>
+</html>

--- a/PerformanceTests/DOM/MessagePort/throughput-same-context-new-ports.html
+++ b/PerformanceTests/DOM/MessagePort/throughput-same-context-new-ports.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/runner.js"></script>
+<script>
+"use strict";
+
+const targetBounces = 1000;
+
+let currentSender = null;
+let currentReceiver = null;
+let bouncesRemaining = 0;
+let iterationStart = 0;
+
+function onReceive()
+{
+    if (--bouncesRemaining === 0) {
+        const elapsed = PerfTestRunner.now() - iterationStart;
+        if (!PerfTestRunner.measureValueAsync(elapsed))
+            return;
+        setTimeout(runIteration, 0);
+        return;
+    }
+    bounce();
+}
+
+function bounce()
+{
+    const channel = new MessageChannel();
+    currentSender = channel.port1;
+    currentReceiver = channel.port2;
+    currentReceiver.onmessage = onReceive;
+    currentSender.postMessage(0);
+}
+
+function runIteration()
+{
+    bouncesRemaining = targetBounces;
+    iterationStart = PerfTestRunner.now();
+    bounce();
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+    description: 'Time to deliver ' + targetBounces + ' messages, each on a freshly '
+        + 'constructed same-context MessageChannel. Measures combined channel-construction '
+        + 'plus single-message-delivery cost. This kind of logic is representative of a '
+        + 'requestIdleCallback() polyfill found on the web',
+    unit: 'ms',
+});
+
+setTimeout(runIteration, 0);
+</script>
+</body>
+</html>

--- a/PerformanceTests/DOM/MessagePort/throughput-same-context.html
+++ b/PerformanceTests/DOM/MessagePort/throughput-same-context.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/runner.js"></script>
+<script>
+"use strict";
+
+const targetBounces = 10000;
+
+const channel = new MessageChannel();
+const portA = channel.port1;
+const portB = channel.port2;
+
+let bouncesRemaining = 0;
+let iterationStart = 0;
+
+function onBounce(event)
+{
+    if (--bouncesRemaining === 0) {
+        const elapsed = PerfTestRunner.now() - iterationStart;
+        if (!PerfTestRunner.measureValueAsync(elapsed))
+            return;
+        setTimeout(runIteration, 0);
+        return;
+    }
+    event.target.postMessage(0);
+}
+
+portA.onmessage = onBounce;
+portB.onmessage = onBounce;
+
+function runIteration()
+{
+    bouncesRemaining = targetBounces;
+    iterationStart = PerfTestRunner.now();
+    portA.postMessage(0);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+    description: 'Time to deliver ' + targetBounces + ' messages by ping-ponging between '
+        + 'a single same-context MessagePort pair.',
+    unit: 'ms',
+});
+
+setTimeout(runIteration, 0);
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/MessageChannel.cpp
+++ b/Source/WebCore/dom/MessageChannel.cpp
@@ -52,6 +52,7 @@ MessageChannel::MessageChannel(ScriptExecutionContext& context)
     if (!context.activeDOMObjectsAreStopped()) {
         ASSERT(!port1().isDetached());
         ASSERT(!port2().isDetached());
+        MessagePort::entangleLocally(port1(), port2());
         protect(MessagePortChannelProvider::fromContext(context))->createNewMessagePortChannel(port1().identifier(), port2().identifier());
     } else {
         ASSERT(port1().isDetached());

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -205,6 +205,17 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JS
 
     LOG(MessagePorts, "Actually posting message to port %s (to be received by port %s)", m_identifier.logString().utf8().data(), m_remoteIdentifier.logString().utf8().data());
 
+    if (RefPtr partner = m_localPartner) {
+        partner->m_localQueue.append(WTF::move(message));
+        ++partner->m_newLocalMessages;
+        if (partner->started()) {
+            queueTaskKeepingObjectAlive(*partner, TaskSource::PostedMessageQueue, [](auto& port) mutable {
+                port.dispatchMessages();
+            });
+        }
+        return { };
+    }
+
     protect(MessagePortChannelProvider::fromContext(*protect(scriptExecutionContext())))->postMessageToRemote(WTF::move(message), m_remoteIdentifier);
     return { };
 }
@@ -220,6 +231,17 @@ TransferredMessagePort MessagePort::disentangle()
     m_entangled = false;
 
     Ref context = *scriptExecutionContext();
+    if (RefPtr localSibling = m_localPartner) {
+        localSibling->m_localPartner = nullptr;
+        m_localPartner = nullptr;
+    }
+
+    // Drain messages before disentanglement:
+    auto localMessagesToQueue = std::exchange(m_localQueue, { });
+    m_newLocalMessages = 0;
+    for (auto& message : localMessagesToQueue)
+        protect(MessagePortChannelProvider::fromContext(context))->postMessageToRemote(WTF::move(message), m_identifier);
+
     protect(MessagePortChannelProvider::fromContext(context))->messagePortDisentangled(m_identifier);
 
     // We can't receive any messages or generate any events after this, so remove ourselves from the list of active ports.
@@ -256,6 +278,10 @@ void MessagePort::start()
         return;
 
     m_started = true;
+
+    if (m_localPartner.get() && m_localQueue.isEmpty())
+        return;
+
     protect(scriptExecutionContext())->processMessageForPortSoon(m_identifier, [pendingActivity = makePendingActivity(*this)] { });
 }
 
@@ -264,6 +290,12 @@ void MessagePort::close()
     if (m_isDetached)
         return;
     m_isDetached = true;
+
+    m_localQueue.clear();
+    m_newLocalMessages = 0;
+    if (RefPtr partner = m_localPartner)
+        partner->m_localPartner = nullptr;
+    m_localPartner = nullptr;
 
     ensureOnMainThread([identifier = m_identifier] {
         MessagePortChannelProvider::singleton().messagePortClosed(identifier);
@@ -291,6 +323,20 @@ void MessagePort::dispatchMessages()
     if (!context || context->activeDOMObjectsAreSuspended() || !isEntangled())
         return;
 
+    LOG(MessagePorts, "Dispatching messages on MessagePort %s (%p)", m_identifier.logString().utf8().data(), this);
+    while (m_newLocalMessages) {
+        --m_newLocalMessages;
+        queueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [](auto& port) {
+            LOG(MessagePorts, "Draining one local message on MessagePort %s (%p)", port.m_identifier.logString().utf8().data(), &port);
+            port.drainOneLocalMessage();
+        });
+    }
+
+    // Scheduling message handling on a locally entangled port can cause races if
+    // the port is later disentangled:
+    if (m_localPartner.get())
+        return;
+
     auto messagesTakenHandler = [pendingActivity = makePendingActivity(*this)](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& completionCallback) mutable {
         auto scopeExit = makeScopeExit(WTF::move(completionCallback));
 
@@ -313,7 +359,7 @@ void MessagePort::dispatchMessages()
 
             if (pendingActivity->object().m_messageHandler) {
                 ASSERT(message.transferredPorts.isEmpty());
-                pendingActivity->object().m_messageHandler(*downcast<JSDOMGlobalObject>(globalObject), message.message.releaseNonNull().get());
+                pendingActivity->object().m_messageHandler(*downcast<JSDOMGlobalObject>(globalObject), message.message.releaseNonNull());
                 continue;
             }
 
@@ -335,9 +381,43 @@ void MessagePort::dispatchMessages()
     protect(MessagePortChannelProvider::fromContext(*context))->takeAllMessagesForPort(m_identifier, WTF::move(messagesTakenHandler));
 }
 
+void MessagePort::drainOneLocalMessage()
+{
+    RefPtr context = scriptExecutionContext();
+    if (!context || !context->globalObject() || context->activeDOMObjectsAreSuspended() || !isEntangled())
+        return;
+
+    ASSERT(context->isContextThread());
+    if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(*context)) {
+        if (workerGlobalScope->isClosing())
+            return;
+    }
+
+    auto* globalObject = context->globalObject();
+    Ref vm = globalObject->vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+    auto message = m_localQueue.takeFirst();
+
+    if (m_messageHandler) {
+        ASSERT(message.transferredPorts.isEmpty());
+        m_messageHandler(*downcast<JSDOMGlobalObject>(globalObject), message.message.releaseNonNull());
+        return;
+    }
+
+    auto ports = MessagePort::entanglePorts(*context, WTF::move(message.transferredPorts));
+    auto event = MessageEvent::create(*globalObject, message.message.releaseNonNull(), { }, { }, { }, WTF::move(ports));
+    if (scope.exception()) [[unlikely]] {
+        // Currently, we assume that the only way we can get here is if we have a termination.
+        RELEASE_ASSERT(vm->hasPendingTerminationException());
+        return;
+    }
+    dispatchEvent(event.event);
+}
+
 void MessagePort::dispatchEvent(Event& event)
 {
-    if (m_isDetached)
+    if (!isEntangled())
         return;
 
     if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext())) {
@@ -404,6 +484,19 @@ Ref<MessagePort> MessagePort::entangle(ScriptExecutionContext& context, Transfer
     Ref port = MessagePort::create(context, transferredPort.first, transferredPort.second);
     port->entangle();
     return port;
+}
+
+// FIXME: avoid SUPRESS_NODELETE with lazyInitialize() - ThreadSafeWeakPtr still unsupported
+SUPPRESS_NODELETE void MessagePort::entangleLocally(MessagePort& port1, MessagePort& port2)
+{
+    ASSERT(port1.scriptExecutionContext() == port2.scriptExecutionContext());
+    ASSERT(port2.identifier() == port1.m_remoteIdentifier);
+    ASSERT(port1.identifier() == port2.m_remoteIdentifier);
+    // Assertions ensure the assignment doesn't violate NODELETE.
+    ASSERT(!port1.m_localPartner.get());
+    ASSERT(!port2.m_localPartner.get());
+    port1.m_localPartner = port2;
+    port2.m_localPartner = port1;
 }
 
 bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -32,6 +32,7 @@
 #include <WebCore/MessagePortChannel.h>
 #include <WebCore/MessagePortIdentifier.h>
 #include <WebCore/MessageWithMessagePorts.h>
+#include <wtf/Deque.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -108,12 +109,17 @@ public:
     TransferredMessagePort disentangle();
     static Ref<MessagePort> entangle(ScriptExecutionContext&, TransferredMessagePort&&);
 
+    // Short-circuits message delivery for same-context ports. Should only be used for
+    // ports that have never been shippped, to avoid potential message reordering.
+    static void NODELETE entangleLocally(MessagePort&, MessagePort&);
+
 private:
     MessagePort(ScriptExecutionContext&, const MessagePortIdentifier& local, const MessagePortIdentifier& remote);
 
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
     using EventTarget::addEventListener;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
+    void drainOneLocalMessage();
 
     // ActiveDOMObject.
     void contextDestroyed() final;
@@ -132,6 +138,9 @@ private:
     MessagePortIdentifier m_remoteIdentifier;
 
     MessageHandler m_messageHandler;
+    Deque<MessageWithMessagePorts> m_localQueue;
+    ThreadSafeWeakPtr<MessagePort> m_localPartner;
+    unsigned m_newLocalMessages { 0 };
 };
 
 WebCoreOpaqueRoot NODELETE root(MessagePort*);


### PR DESCRIPTION
#### f7a7c2332942260c44489ff33acecbd87a1152e4
<pre>
Short circuit same-realm MessagePort message delivery
<a href="https://bugs.webkit.org/show_bug.cgi?id=317242">https://bugs.webkit.org/show_bug.cgi?id=317242</a>
<a href="https://rdar.apple.com/168247413">rdar://168247413</a>

Reviewed by Chris Dumez.

A path that does not involve IPC nor thread-hopping was added to
MessagePort::postMessage(). It is only used when both the sending and
receiving ends have never been shipped. This use case is not uncommon
because using a port pair simply for scheduling reasons is a known
workaround for nested setTimeout() timing restrictions.

When any of the ends is disentangled, all unhandled messages are
drained to the MessagePortChannelProvider, and the local path is
never used again.

One new test verifying the correctness of port transfer, for an
already started local port:
* LayoutTests/fast/events/message-port-transfer-preserves-pending-message.html

Three microbenchmarks were added:
* PerformanceTests/DOM/MessagePort/throughput-same-context-batch.html
* PerformanceTests/DOM/MessagePort/throughput-same-context-new-ports.html
* PerformanceTests/DOM/MessagePort/throughput-same-context.html

throughput-same-context-new-ports.html is of extra relevance because
it is analogous to a real requestIdleCallback() polyfill.

Canonical link: <a href="https://commits.webkit.org/315709@main">https://commits.webkit.org/315709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/315a9aa60617b8d56538b5e15b67cdbca494b1af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127392 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d76e32c6-c4b5-4400-8b23-3f2fc137730a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132226 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93141 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c17c524-6e3b-4f74-bbad-95018079a056) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172639 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112729 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3bd55c3-e77d-4739-9965-16971d68d4fe) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32365 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27736 "Built successfully") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/JSC-Tests-x86-64-EWS "Waiting to run tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181638 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140673 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140508 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37868 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43947 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108193 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35776 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115712 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42457 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7077 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41850 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41993 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->