### PR TITLE
[GTK] canvas.toDataURL() does not support image/webp

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -209,9 +209,6 @@ webkit.org/b/224924 fast/forms/datetimelocal/datetimelocal-show-picker.html [ Sk
 
 fast/forms/time/time-editable-components/time-editable-components-focus-and-blur-events.html [ Failure ]
 
-# Requires WebP support.
-webkit.org/b/98939 fast/canvas/canvas-toDataURL-webp.html [ Skip ]
-
 # DataTransferItems is not yet implemented.
 webkit.org/b/98940 editing/pasteboard/data-transfer-items.html [ Skip ]
 webkit.org/b/98940 editing/pasteboard/data-transfer-items-image-png.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -2592,8 +2592,6 @@ fast/css3-text/font-synthesis.html [ ImageOnlyFailure ]
 
 fast/css3-text/css3-text-decoration/text-underline-position/underline-visual-overflow-with-subpixel-position.html [ Failure ]
 
-fast/canvas/toDataURL-alpha-permutation.html [ ImageOnlyFailure ]
-
 fast/dynamic/float-from-empty-line.html [ Failure ]
 
 imported/w3c/web-platform-tests/resource-timing/cross-origin-redirects.html [ Pass Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -834,8 +834,6 @@ webkit.org/b/244476 fast/canvas/webgl/webgl-compressed-texture-size-limit.html [
 webkit.org/b/244489 fast/canvas/webgl/bufferData-offset-length.html [ Failure ]
 webkit.org/b/244491 fast/canvas/webgl/webgl2-texture-upload-enums.html [ Failure ]
 
-fast/canvas/toDataURL-alpha-permutation.html [ ImageOnlyFailure ]
-
 webgl/1.0.x/conformance/extensions/oes-texture-float-with-video.html [ Timeout ]
 webgl/1.0.x/conformance/extensions/oes-texture-half-float-with-video.html [ Timeout ]
 webgl/2.0.y/conformance2/textures/video [ Skip ]
@@ -881,8 +879,6 @@ http/tests/misc/ftp-eplf-directory.py [ Skip ] # Timeout.
 media/video-audio-session-mode.html [ Skip ] # Timeout.
 webgl/2.0.y/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html [ Skip ] # Timeout.
 webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html [ Skip ] # Timeout.
-
-imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/toDataURL.jpg.html [ Failure ]
 
 # Flaky tests Aug2023
 webkit.org/b/261024 fast/events/remove-child-onscroll.html [ Pass Timeout ]

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -492,18 +492,11 @@ std::unique_ptr<MIMETypeRegistryThreadGlobalData> MIMETypeRegistry::createMIMETy
         "image/png"_s,
         "image/jpeg"_s,
         "image/gif"_s,
-#elif PLATFORM(GTK)
-        "image/png"_s,
-        "image/jpeg"_s,
-        "image/tiff"_s,
-        "image/bmp"_s,
-        "image/ico"_s,
 #elif USE(CAIRO)
         "image/png"_s,
 #elif USE(SKIA)
         "image/png"_s,
         "image/jpeg"_s,
-        "image/jpg"_s,
         "image/webp"_s,
 #endif
     };


### PR DESCRIPTION
#### 932397288bfe883a25b12c440430fd10df2bbf47
<pre>
[GTK] canvas.toDataURL() does not support image/webp
<a href="https://bugs.webkit.org/show_bug.cgi?id=317254">https://bugs.webkit.org/show_bug.cgi?id=317254</a>

Reviewed by Carlos Garcia Campos and Devin Rousso.

The set of MIME types canvas.toDataURL() can encode to had a PLATFORM(GTK)
branch (image/png, image/jpeg, image/tiff, image/bmp, image/ico) left over
from the Cairo/gdk-pixbuf era. It precedes the USE(SKIA) branch in the #elif
chain, so the now-Skia-based GTK port took the stale list: it omitted
image/webp, which the Skia encoder supports, and advertised image/tiff,
image/bmp and image/ico, which it cannot encode. Those produced an empty
&quot;data:,&quot; URL instead of the spec-mandated image/png fallback.

Remove the dead PLATFORM(GTK) branch so the GTK port uses the USE(SKIA) list
(image/png, image/jpeg, image/webp), matching the WPE port and the formats
ImageUtilitiesSkia actually produces.

Also drop image/jpg from the USE(SKIA) list. image/jpg is not a valid MIME
type, so canvas.toDataURL(&apos;image/jpg&apos;) must fall back to image/png per the
spec (as the toDataURL.jpg WPT asserts).
Listing it made every Skia port (GTK, WPE, Windows) encode JPEG instead.
Dropping it restores the PNG fallback and makes two tests pass that
previously only passed when the type was unsupported:
fast/canvas/toDataURL-alpha-permutation.html, a reftest that renders
toDataURL(&apos;image/jpg&apos;) and matches the reference only when it falls back to
PNG (JPEG has no alpha channel), and the toDataURL.jpg WPT.

* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::createMIMETypeRegistryThreadGlobalData):

This commit include:

Canonical link: <a href="https://commits.webkit.org/315446@main">https://commits.webkit.org/315446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/169e535e9fcf6f4304cb1953be8b606d7ac63545

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131515 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92532 "1 flakes 11 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32960 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31669 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26955 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/207 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180854 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139964 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42477 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139807 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37665 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28161 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106983 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35093 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114931 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41675 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6249 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41069 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->