### PR TITLE
Honor Cache-Control: public on unknown statuses

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL HTTP cache reuses an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is present assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache reuses an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is present
 PASS HTTP cache does not reuse an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is not present
 PASS HTTP cache does not reuse a redirected response with no max-age and no Last-Modified header
 PASS HTTP cache reuses a 200 OK response with Last-Modified based upon heuristic freshness

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.serviceworker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL HTTP cache reuses an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is present assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache reuses an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is present
 PASS HTTP cache does not reuse an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is not present
 PASS HTTP cache does not reuse a redirected response with no max-age and no Last-Modified header
 PASS HTTP cache reuses a 200 OK response with Last-Modified based upon heuristic freshness

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.sharedworker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL HTTP cache reuses an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is present assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache reuses an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is present
 PASS HTTP cache does not reuse an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is not present
 PASS HTTP cache does not reuse a redirected response with no max-age and no Last-Modified header
 PASS HTTP cache reuses a 200 OK response with Last-Modified based upon heuristic freshness

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL HTTP cache reuses an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is present assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache reuses an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is present
 PASS HTTP cache does not reuse an unknown response with Last-Modified based upon heuristic freshness when Cache-Control: public is not present
 PASS HTTP cache does not reuse a redirected response with no max-age and no Last-Modified header
 PASS HTTP cache reuses a 200 OK response with Last-Modified based upon heuristic freshness

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -296,6 +296,8 @@ CacheControlDirectives parseCacheControlDirectives(const HTTPHeaderMap& headers)
                 result.noCache = true;
             else if (equalLettersIgnoringASCIICase(directives[i].first, "no-store"_s))
                 result.noStore = true;
+            else if (equalLettersIgnoringASCIICase(directives[i].first, "public"_s))
+                result.isPublic = true;
             else if (equalLettersIgnoringASCIICase(directives[i].first, "must-revalidate"_s))
                 result.mustRevalidate = true;
             else if (equalLettersIgnoringASCIICase(directives[i].first, "max-age"_s)) {

--- a/Source/WebCore/platform/network/CacheValidation.h
+++ b/Source/WebCore/platform/network/CacheValidation.h
@@ -66,6 +66,7 @@ struct CacheControlDirectives {
         , noStore(false)
         , mustRevalidate(false)
         , immutable(false)
+        , isPublic(false)
         { }
 
     Markable<Seconds> maxAge;
@@ -75,6 +76,7 @@ struct CacheControlDirectives {
     bool noStore : 1;
     bool mustRevalidate : 1;
     bool immutable : 1;
+    bool isPublic : 1;
 };
 WEBCORE_EXPORT CacheControlDirectives parseCacheControlDirectives(const HTTPHeaderMap&);
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -701,6 +701,13 @@ bool ResourceResponseBase::cacheControlContainsNoStore() const
     return m_cacheControlDirectives.noStore;
 }
 
+bool ResourceResponseBase::cacheControlContainsPublic() const
+{
+    if (!m_haveParsedCacheControlHeader)
+        parseCacheControlDirectives();
+    return m_cacheControlDirectives.isPublic;
+}
+
 bool ResourceResponseBase::cacheControlContainsMustRevalidate() const
 {
     if (!m_haveParsedCacheControlHeader)

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -159,6 +159,7 @@ public:
     // These functions return parsed values of the corresponding response headers.
     WEBCORE_EXPORT bool cacheControlContainsNoCache() const;
     WEBCORE_EXPORT bool cacheControlContainsNoStore() const;
+    WEBCORE_EXPORT bool cacheControlContainsPublic() const;
     WEBCORE_EXPORT bool cacheControlContainsMustRevalidate() const;
     WEBCORE_EXPORT bool cacheControlContainsImmutable() const;
     WEBCORE_EXPORT bool hasCacheValidatorFields() const;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -293,7 +293,7 @@ static StoreDecision makeStoreDecision(const WebCore::ResourceRequest& originalR
         // http://tools.ietf.org/html/rfc7234#section-4.3.2
         bool hasExpirationHeaders = response.expires() || response.cacheControlMaxAge();
         bool expirationHeadersAllowCaching = WebCore::isStatusCodePotentiallyCacheable(response.httpStatusCode()) && hasExpirationHeaders;
-        if (!expirationHeadersAllowCaching)
+        if (!expirationHeadersAllowCaching && !response.cacheControlContainsPublic())
             return StoreDecision::NoDueToHTTPStatusCode;
     }
 


### PR DESCRIPTION
#### e138469d1ad983d02a4a230bbb340011101c179c
<pre>
Honor Cache-Control: public on unknown statuses
<a href="https://bugs.webkit.org/show_bug.cgi?id=317256">https://bugs.webkit.org/show_bug.cgi?id=317256</a>
<a href="https://rdar.apple.com/179870099">rdar://179870099</a>

Reviewed by Chris Dumez.

Parse the Cache-Control: public response directive and allow it to make responses storable even when
their status code is not cacheable by default. This lets such responses be reused using heuristic
freshness (e.g. when they include Last-Modified).

RFC 9111 §3 defines public as an explicit storage condition:
<a href="https://www.rfc-editor.org/rfc/rfc9111.html#section-3">https://www.rfc-editor.org/rfc/rfc9111.html#section-3</a>

* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/heuristic.any.worker-expected.txt:
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::parseCacheControlDirectives):
* Source/WebCore/platform/network/CacheValidation.h:
(WebCore::CacheControlDirectives::CacheControlDirectives):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::cacheControlContainsPublic const):
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::makeStoreDecision):

Canonical link: <a href="https://commits.webkit.org/315445@main">https://commits.webkit.org/315445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/441ca41081adb73e792020f4952dfbc4e2c8ed22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126469 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/936e9f63-4130-4f79-adf4-416dfd71c70d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131404 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92436 "2 flakes 5 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a43ec08-2b01-4d17-9d60-3f1604a3c256) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111908 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc3272d4-a8dd-4422-a21e-1b4a3589b265) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32845 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31555 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26788 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180694 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139847 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42333 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139691 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43022 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28051 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106768 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25760 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34975 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114789 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41525 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6139 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40922 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->