### PR TITLE
GLib: Add magnification get/set APIs and notify property changes

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -79,6 +79,8 @@
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <WebCore/CertificateInfo.h>
+#include <WebCore/FloatPoint.h>
+#include <WebCore/FloatSize.h>
 #include <WebCore/JSDOMExceptionHandling.h>
 #include <WebCore/RunJavaScriptParameters.h>
 #include <WebCore/SharedBuffer.h>
@@ -238,6 +240,7 @@ enum {
 
     PROP_URI,
     PROP_ZOOM_LEVEL,
+    PROP_MAGNIFICATION,
     PROP_IS_LOADING,
     PROP_IS_PLAYING_AUDIO,
 #if !ENABLE(2022_GLIB_API)
@@ -590,6 +593,11 @@ WebKitWebResourceLoadManager* WebKitWebViewClient::webResourceLoadManager()
 void WebKitWebViewClient::themeColorDidChange()
 {
     webkitWebViewEmitThemeColorChanged(m_webView);
+}
+
+void WebKitWebViewClient::pageScaleFactorDidChange(WKWPE::View&)
+{
+    webkitWebViewDidChangePageScale(m_webView);
 }
 
 #if ENABLE(FULLSCREEN_API)
@@ -1104,6 +1112,9 @@ static void webkitWebViewSetProperty(GObject* object, guint propId, const GValue
     case PROP_ZOOM_LEVEL:
         webkit_web_view_set_zoom_level(webView, g_value_get_double(value));
         break;
+    case PROP_MAGNIFICATION:
+        webkit_web_view_set_magnification(webView, g_value_get_double(value));
+        break;
 #if !ENABLE(2022_GLIB_API)
     case PROP_IS_EPHEMERAL:
         webView->priv->isEphemeral = g_value_get_boolean(value);
@@ -1195,6 +1206,9 @@ static void webkitWebViewGetProperty(GObject* object, guint propId, GValue* valu
         break;
     case PROP_ZOOM_LEVEL:
         g_value_set_double(value, webkit_web_view_get_zoom_level(webView));
+        break;
+    case PROP_MAGNIFICATION:
+        g_value_set_double(value, webkit_web_view_get_magnification(webView));
         break;
     case PROP_IS_LOADING:
         g_value_set_boolean(value, webkit_web_view_is_loading(webView));
@@ -1523,6 +1537,25 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
             "zoom-level",
             nullptr, nullptr,
             0, G_MAXDOUBLE, 1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WebKitWebView:magnification:
+     *
+     * The magnification factor of the #WebKitWebView content.
+     *
+     * The magnification factor represents the visual scaling of the page (similar
+     * to pinch-to-zoom). This is independent of the layout zoom level. Setting
+     * the magnification factor scales the rendered page visually without affecting
+     * page layout or text wrapping.
+     *
+     * Since: 2.54
+     */
+    sObjProperties[PROP_MAGNIFICATION] =
+        g_param_spec_double(
+            "magnification",
+            nullptr, nullptr,
+            G_MINDOUBLE, G_MAXDOUBLE, 1,
             WEBKIT_PARAM_READWRITE);
 
     /**
@@ -3211,6 +3244,11 @@ void webkitWebViewSelectionDidChange(WebKitWebView* webView)
     webkitEditorStateChanged(webView->priv->editorState.get(), getPage(webView).editorState());
 }
 
+void webkitWebViewDidChangePageScale(WebKitWebView* webView)
+{
+    g_object_notify_by_pspec(G_OBJECT(webView), sObjProperties[PROP_MAGNIFICATION]);
+}
+
 WebKitWebsiteDataManager* webkitWebViewGetWebsiteDataManager(WebKitWebView* webView)
 {
 #if ENABLE(2022_GLIB_API)
@@ -4231,6 +4269,57 @@ gdouble webkit_web_view_get_zoom_level(WebKitWebView* webView)
     Ref page = getPage(webView);
     gboolean zoomTextOnly = webkit_settings_get_zoom_text_only(webView->priv->settings.get());
     return zoomTextOnly ? page->textZoomFactor() : page->pageZoomFactor() / pageScale;
+}
+
+/**
+ * webkit_web_view_set_magnification:
+ * @web_view: a #WebKitWebView
+ * @magnification: the magnification factor
+ *
+ * Set the magnification factor of @web_view.
+ *
+ * The magnification factor represents the visual scaling of the page (similar
+ * to pinch-to-zoom). This is independent of the layout zoom level (which is
+ * set with webkit_web_view_set_zoom_level()). Setting the magnification factor
+ * scales the rendered page visually around the center of the view without
+ * affecting page layout or text wrapping.
+ *
+ * Since: 2.54
+ */
+void webkit_web_view_set_magnification(WebKitWebView* webView, gdouble magnification)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+    g_return_if_fail(magnification > 0);
+
+    Ref page = getPage(webView);
+    if (page->pageScaleFactor() == magnification)
+        return;
+
+    // Dividing by 2 gives the midpoint of the view. This scales the page around
+    // the visual center of the WebKitWebView.
+    WebCore::FloatPoint center(WebCore::FloatSize(page->viewSize()) / 2);
+    page->scalePageInViewCoordinates(magnification, WebCore::roundedIntPoint(center));
+}
+
+/**
+ * webkit_web_view_get_magnification:
+ * @web_view: a #WebKitWebView
+ *
+ * Get the magnification factor of @web_view.
+ *
+ * The magnification factor represents the visual scaling of the page (similar
+ * to pinch-to-zoom). This is independent of the layout zoom level (which is
+ * obtained with webkit_web_view_get_zoom_level()).
+ *
+ * Returns: the current magnification factor of @web_view
+ *
+ * Since: 2.54
+ */
+gdouble webkit_web_view_get_magnification(WebKitWebView* webView)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), 1.0);
+
+    return getPage(webView).pageScaleFactor();
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -636,6 +636,12 @@ WEBKIT_API gdouble
 webkit_web_view_get_zoom_level                       (WebKitWebView             *web_view);
 
 WEBKIT_API void
+webkit_web_view_set_magnification                    (WebKitWebView             *web_view,
+                                                      gdouble                    magnification);
+WEBKIT_API gdouble
+webkit_web_view_get_magnification                    (WebKitWebView             *web_view);
+
+WEBKIT_API void
 webkit_web_view_can_execute_editing_command          (WebKitWebView             *web_view,
                                                       const gchar               *command,
                                                       GCancellable              *cancellable,

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -100,6 +100,7 @@ void webkitWebViewWebProcessTerminated(WebKitWebView*, WebKitWebProcessTerminati
 void webkitWebViewIsPlayingAudioChanged(WebKitWebView*);
 void webkitWebViewMediaCaptureStateDidChange(WebKitWebView*, WebCore::MediaProducer::MediaStateFlags);
 void webkitWebViewSelectionDidChange(WebKitWebView*);
+void webkitWebViewDidChangePageScale(WebKitWebView*);
 WebKitWebsiteDataManager* webkitWebViewGetWebsiteDataManager(WebKitWebView*);
 void webkitWebViewPermissionStateQuery(WebKitWebView*, WebKitPermissionStateQuery*);
 

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -540,6 +540,12 @@ void PageClientImpl::didRestoreScrollPosition()
     webkitWebViewBaseDidRestoreScrollPosition(WEBKIT_WEB_VIEW_BASE(m_viewWidget));
 }
 
+void PageClientImpl::pageScaleFactorDidChange()
+{
+    if (WEBKIT_IS_WEB_VIEW(m_viewWidget))
+        webkitWebViewDidChangePageScale(WEBKIT_WEB_VIEW(m_viewWidget));
+}
+
 void PageClientImpl::didChangeBackgroundColor()
 {
 }

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -160,6 +160,7 @@ private:
     void derefView() override;
 
     void didRestoreScrollPosition() override;
+    void pageScaleFactorDidChange() override;
     void isPlayingAudioWillChange() final { }
     void isPlayingAudioDidChange() final { }
 

--- a/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
@@ -55,6 +55,7 @@ public:
     virtual void didReceiveUserMessage(WKWPE::View&, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&& completionHandler) { completionHandler(WebKit::UserMessage()); }
     virtual WebKit::WebKitWebResourceLoadManager* webResourceLoadManager() { return nullptr; }
     virtual void themeColorDidChange() { }
+    virtual void pageScaleFactorDidChange(WKWPE::View&) { }
 
 #if ENABLE(FULLSCREEN_API)
     virtual bool enterFullScreen(WKWPE::View&) { return false; };

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -436,6 +436,11 @@ void PageClientImpl::didRestoreScrollPosition()
 {
 }
 
+void PageClientImpl::pageScaleFactorDidChange()
+{
+    m_view.pageScaleFactorDidChange();
+}
+
 WebCore::UserInterfaceLayoutDirection PageClientImpl::userInterfaceLayoutDirection()
 {
     return WebCore::UserInterfaceLayoutDirection::LTR;

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -167,6 +167,7 @@ private:
     void derefView() override;
 
     void didRestoreScrollPosition() override;
+    void pageScaleFactorDidChange() override;
 
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManagerProxyClient& NODELETE fullScreenManagerProxyClient() final;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -131,6 +131,11 @@ void View::themeColorDidChange()
     m_client->themeColorDidChange();
 }
 
+void View::pageScaleFactorDidChange()
+{
+    m_client->pageScaleFactorDidChange(*this);
+}
+
 void View::setSize(const WebCore::IntSize& size)
 {
     m_size = size;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -76,6 +76,7 @@ public:
     void setInputMethodState(std::optional<WebKit::InputMethodState>&&);
 
     void themeColorDidChange();
+    void pageScaleFactorDidChange();
 
 #if ENABLE(FULLSCREEN_API)
     bool isFullScreen() const;

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
@@ -56,6 +56,7 @@ private:
     void didReceiveUserMessage(WKWPE::View&, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&&) override;
     WebKit::WebKitWebResourceLoadManager* webResourceLoadManager() override;
     void themeColorDidChange() override;
+    void pageScaleFactorDidChange(WKWPE::View&) override;
 
 #if ENABLE(FULLSCREEN_API)
     bool enterFullScreen(WKWPE::View&) override;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -748,6 +748,7 @@ public:
     virtual void didEndSyntheticMomentumScrolling() { }
 
     virtual void didRestoreScrollPosition() = 0;
+    virtual void pageScaleFactorDidChange() { }
 
     virtual bool windowIsFrontWindowUnderMouse(const NativeWebMouseEvent&) { return false; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6652,6 +6652,7 @@ void WebPageProxy::scalePage(double scale, const IntPoint& origin, CompletionHan
     ASSERT(scale > 0);
 
     m_pageScaleFactor = scale;
+    pageScaleFactorDidChange();
 
     if (!hasRunningProcess()) {
         completionHandler();
@@ -6672,6 +6673,7 @@ void WebPageProxy::scalePageInViewCoordinates(double scale, const IntPoint& cent
     ASSERT(scale > 0);
 
     m_pageScaleFactor = scale;
+    pageScaleFactorDidChange();
 
     if (!hasRunningProcess())
         return;
@@ -6689,6 +6691,7 @@ void WebPageProxy::scalePageRelativeToScrollPosition(double scale, const IntPoin
     ASSERT(scale > 0);
 
     m_pageScaleFactor = scale;
+    pageScaleFactorDidChange();
 
     if (!hasRunningProcess())
         return;
@@ -7149,7 +7152,7 @@ static bool NODELETE scaleFactorIsValid(double scaleFactor)
     return scaleFactor > 0 && scaleFactor <= 100;
 }
 
-void WebPageProxy::pageScaleFactorDidChange(IPC::Connection& connection, double scaleFactor)
+void WebPageProxy::didSetPageScaleFactor(IPC::Connection& connection, double scaleFactor)
 {
     MESSAGE_CHECK_BASE(scaleFactorIsValid(scaleFactor), connection);
     if (!legacyMainFrameProcess().hasConnection(connection))
@@ -7166,6 +7169,14 @@ void WebPageProxy::pageScaleFactorDidChange(IPC::Connection& connection, double 
     // If the page's scale factor changes, the UI process needs to send an updated AffineTransform to each frame.
     updateAccessibilityFrameGeometry();
 #endif
+
+    pageScaleFactorDidChange();
+}
+
+void WebPageProxy::pageScaleFactorDidChange()
+{
+    if (RefPtr protectedPageClient = this->pageClient())
+        protectedPageClient->pageScaleFactorDidChange();
 }
 
 void WebPageProxy::viewScaleFactorDidChange(IPC::Connection& connection, double scaleFactor)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1571,6 +1571,7 @@ public:
     void scalePageInViewCoordinates(double scale, const WebCore::IntPoint& centerInViewCoordinates);
     void scalePageRelativeToScrollPosition(double scale, const WebCore::IntPoint& origin);
     double NODELETE pageScaleFactor() const;
+    void pageScaleFactorDidChange();
     double viewScaleFactor() const { return m_viewScaleFactor; }
     void scaleView(double scale);
     void setShouldScaleViewToFitDocument(bool);
@@ -1706,7 +1707,7 @@ public:
 #endif
 #endif
 
-    void pageScaleFactorDidChange(IPC::Connection&, double);
+    void didSetPageScaleFactor(IPC::Connection&, double);
     void viewScaleFactorDidChange(IPC::Connection&, double);
     void pluginScaleFactorDidChange(IPC::Connection&, double);
     void pluginZoomFactorDidChange(IPC::Connection&, double);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -223,7 +223,7 @@ messages -> WebPageProxy {
     HandleClickForDataDetectionResult(struct WebCore::DataDetectorElementInfo info, WebCore::IntPoint location)
 #endif
 
-    PageScaleFactorDidChange(double scaleFactor)
+    DidSetPageScaleFactor(double scaleFactor)
     ViewScaleFactorDidChange(double scaleFactor)
     PluginScaleFactorDidChange(double zoomFactor)
     PluginZoomFactorDidChange(double zoomFactor)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1595,7 +1595,7 @@ void WebLocalFrameLoaderClient::restoreViewState()
     // A scale factor of 0 means the history item has the default scale factor, thus we do not need to update it.
     RefPtr page = m_frame->page();
     if (page && scaleFactor)
-        page->send(Messages::WebPageProxy::PageScaleFactorDidChange(scaleFactor));
+        page->send(Messages::WebPageProxy::DidSetPageScaleFactor(scaleFactor));
 
     // FIXME: This should not be necessary. WebCore should be correctly invalidating
     // the view on restores from the back/forward cache.

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2972,7 +2972,7 @@ void WebPage::platformDidScalePage()
 void WebPage::scalePage(double scale, const IntPoint& origin)
 {
     didScalePage(scale, origin);
-    send(Messages::WebPageProxy::PageScaleFactorDidChange(scale));
+    send(Messages::WebPageProxy::DidSetPageScaleFactor(scale));
 }
 
 double WebPage::totalScaleFactor() const

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3686,7 +3686,7 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
                 setCorePageScaleFactor(scaleFromUIProcess.value(), scrollPosition, m_isInStableState);
 
             hasSetPageScale = true;
-            send(Messages::WebPageProxy::PageScaleFactorDidChange(scaleFromUIProcess.value()));
+            send(Messages::WebPageProxy::DidSetPageScaleFactor(scaleFromUIProcess.value()));
         }
 
         if (!hasSetPageScale && m_isInStableState && shouldSetCorePageScale)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp
@@ -358,6 +358,37 @@ static void testWebViewZoomLevel(WebViewTest* test, gconstpointer)
     g_assert_cmpfloat(webkit_web_view_get_zoom_level(test->webView()), ==, 2.5);
 }
 
+static void magnificationChangedCallback(WebKitWebView*, GParamSpec*, bool* magnificationChanged)
+{
+    *magnificationChanged = true;
+}
+
+static void testWebViewMagnification(WebViewTest* test, gconstpointer)
+{
+    g_assert_cmpfloat(webkit_web_view_get_magnification(test->webView()), ==, 1.0);
+
+    bool magnificationChanged = false;
+    gulong handlerId = g_signal_connect(test->webView(), "notify::magnification", G_CALLBACK(magnificationChangedCallback), &magnificationChanged);
+
+    webkit_web_view_set_magnification(test->webView(), 2.5);
+    g_assert_true(magnificationChanged);
+    g_assert_cmpfloat(webkit_web_view_get_magnification(test->webView()), ==, 2.5);
+    g_signal_handler_disconnect(test->webView(), handlerId);
+
+    // Magnification change should be independent of zoom level.
+    g_assert_cmpfloat(webkit_web_view_get_zoom_level(test->webView()), ==, 1.0);
+
+    // Zoom level change should be independent of magnification level.
+    webkit_web_view_set_zoom_level(test->webView(), 1.5);
+    g_assert_cmpfloat(webkit_web_view_get_zoom_level(test->webView()), ==, 1.5);
+    g_assert_cmpfloat(webkit_web_view_get_magnification(test->webView()), ==, 2.5);
+
+    // Revert magnification back to 1.0, zoom level should remain 1.5.
+    webkit_web_view_set_magnification(test->webView(), 1.0);
+    g_assert_cmpfloat(webkit_web_view_get_magnification(test->webView()), ==, 1.0);
+    g_assert_cmpfloat(webkit_web_view_get_zoom_level(test->webView()), ==, 1.5);
+}
+
 static void testWebViewRunAsyncFunctions(WebViewTest* test, gconstpointer)
 {
     GUniqueOutPtr<GError> error;
@@ -2289,6 +2320,7 @@ void beforeAll()
     WebViewTest::add("WebKitWebView", "custom-charset", testWebViewCustomCharset);
     WebViewTest::add("WebKitWebView", "settings", testWebViewSettings);
     WebViewTest::add("WebKitWebView", "zoom-level", testWebViewZoomLevel);
+    WebViewTest::add("WebKitWebView", "magnification", testWebViewMagnification);
     WebViewTest::add("WebKitWebView", "run-javascript", testWebViewRunJavaScript);
     WebViewTest::add("WebKitWebView", "run-async-js-functions", testWebViewRunAsyncFunctions);
 #if ENABLE(FULLSCREEN_API)


### PR DESCRIPTION
#### 3bac3385d0b910a1f461dfd78508871f84bd8243
<pre>
GLib: Add magnification get/set APIs and notify property changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=317322">https://bugs.webkit.org/show_bug.cgi?id=317322</a>

Reviewed by Michael Catanzaro and Carlos Garcia Campos.

To resolve GNOME Epiphany issue #1544, expose magnification get/set APIs
in WebKit&apos;s GLib API layer (WebKitWebView). Also, add support for notifying
property changes via a new &quot;magnification&quot; GObject property when pinch-zoom occurs.
Add API documentation and test coverage for the magnification APIs.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::pageScaleFactorDidChange): Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::pageScaleFactorDidChange): Forward scale changes to m_pageClient.
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::pageScaleFactorDidChange): Trigger webkitWebViewDidChangePageScale.
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::pageScaleFactorDidChange): Forward to WPE View.
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::pageScaleFactorDidChange): Notify WPE API view client.
* Source/WebKit/UIProcess/API/wpe/APIViewClient.h:
(API::ViewClient::pageScaleFactorDidChange): Added virtual method.
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
Add declarations for webkit_web_view_set_magnification and webkit_web_view_get_magnification.
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
Declare webkitWebViewDidChangePageScale private helper.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init): Document PROP_MAGNIFICATION.
(WebKitWebViewClient::pageScaleFactorDidChange): Call webkitWebViewDidChangePageScale.
(webkitWebViewDidChangePageScale): Notify magnification property change.
(webkit_web_view_set_magnification): Scale page in view coordinates around the center point, and notify PROP_MAGNIFICATION change.
(webkit_web_view_get_magnification): Retrieve pageScaleFactor.
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp:
(magnificationChangedCallback): Added.
(testWebViewMagnification): Added.
(beforeAll): Register the magnification test.

Canonical link: <a href="https://commits.webkit.org/317531@main">https://commits.webkit.org/317531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fb08f0d7c656f55bea4ddb3238833681fcd2ca0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131907 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135346 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95451 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35787 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186039 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144249 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47639 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144108 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39190 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48318 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32248 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/113741 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39017 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120203 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46824 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10592 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46227 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->