### PR TITLE
[iOS] Implement an alternative data source for MediaDeviceRoute

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -28,21 +28,21 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
+#import <AVKit/AVKit.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
-#define FOR_EACH_READONLY_KEY_PATH(Macro) \
+#define FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
     Macro(timeRange, TimeRange, MediaTimeRange) \
     Macro(ready, Ready, bool) \
     Macro(buffering, Buffering, bool) \
-    Macro(playbackError, PlaybackError, std::optional<MediaPlaybackSourceError>) \
     Macro(hasAudio, HasAudio, bool) \
 \
 
-#define FOR_EACH_READWRITE_KEY_PATH(Macro) \
+#define FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
     Macro(playing, Playing, bool) \
     Macro(playbackSpeed, PlaybackSpeed, float) \
     Macro(scanSpeed, ScanSpeed, float) \
@@ -50,17 +50,44 @@
     Macro(volume, Volume, float) \
 \
 
-#define FOR_EACH_KEY_PATH(Macro) \
-    FOR_EACH_READONLY_KEY_PATH(Macro) \
-    FOR_EACH_READWRITE_KEY_PATH(Macro) \
+#define FOR_EACH_COMMON_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
 \
 
-#define ADD_OBSERVER(KeyPath, SetterSuffix, Type) \
+#define FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
+    Macro(playbackError, PlaybackError, std::optional<MediaPlaybackSourceError>) \
+\
+
+#define FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
+    Macro(currentPlaybackPosition, CurrentPlaybackPosition, MediaTime) \
+\
+
+#define FOR_EACH_MEDIA_SOURCE_KEY_PATH(Macro) \
+    FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH(Macro) \
+\
+
+#define FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_KEY_PATH(Macro) \
+\
+
+#define ADD_MEDIA_SOURCE_OBSERVER(KeyPath, SetterSuffix, Type) \
     [_mediaSource addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebMediaSourceObserverContext]; \
 \
 
-#define REMOVE_OBSERVER(KeyPath, SetterSuffix, Type) \
+#define REMOVE_MEDIA_SOURCE_OBSERVER(KeyPath, SetterSuffix, Type) \
     [_mediaSource removeObserver:self forKeyPath:@#KeyPath context:WebMediaSourceObserverContext]; \
+\
+
+#define ADD_PLAYBACK_CONTROL_OBSERVER(KeyPath, SetterSuffix, Type) \
+    [_playbackControl addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebPlaybackControlObserverContext]; \
+\
+
+#define REMOVE_PLAYBACK_CONTROL_OBSERVER(KeyPath, SetterSuffix, Type) \
+    [_playbackControl removeObserver:self forKeyPath:@#KeyPath context:WebPlaybackControlObserverContext]; \
 \
 
 #define NOTIFY_CLIENT(KeyPath, SetterSuffix, Type) \
@@ -80,6 +107,8 @@
 #define DEFINE_GETTER(KeyPath, SetterSuffix, Type) \
     Type MediaDeviceRoute::KeyPath() const \
     { \
+        if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) \
+            return convert(playbackControl.get().KeyPath); \
         return convert([m_mediaSourceObserver mediaSource].KeyPath); \
     } \
 \
@@ -87,29 +116,29 @@
 #define DEFINE_SETTER(KeyPath, SetterSuffix, Type) \
     void MediaDeviceRoute::set##SetterSuffix(Type KeyPath) \
     { \
+        if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) \
+            return [playbackControl set##SetterSuffix:convert(WTF::move(KeyPath))]; \
         [[m_mediaSourceObserver mediaSource] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
     } \
 \
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSObject (Staging_169033633)
-@property (nonatomic) CMTime currentPlaybackPosition;
-@property (nonatomic) CMTime currentValue;
-@end
-
 static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
+static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverContext;
 
 @interface WebMediaSourceObserver : NSObject
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route NS_DESIGNATED_INITIALIZER;
 @property (nonatomic, nullable, strong) AVMediaSource *mediaSource;
+@property (nonatomic, nullable, strong) AVPlaybackControl *playbackControl;
 @end
 
 @implementation WebMediaSourceObserver {
     WeakPtr<WebCore::MediaDeviceRoute> _route;
     RetainPtr<AVMediaSource> _mediaSource;
+    RetainPtr<AVPlaybackControl> _playbackControl;
 }
 
 - (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route
@@ -128,26 +157,59 @@ static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
 
 - (void)setMediaSource:(AVMediaSource * _Nullable)mediaSource
 {
-    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
-    REMOVE_OBSERVER(currentPlaybackPosition, CurrentPlaybackPosition, CMTime)
-    REMOVE_OBSERVER(currentValue, CurrentValue, CMTime)
+    if (mediaSource)
+        self.playbackControl = nil;
+
+    FOR_EACH_MEDIA_SOURCE_KEY_PATH(REMOVE_MEDIA_SOURCE_OBSERVER)
 
     _mediaSource = mediaSource;
 
-    FOR_EACH_KEY_PATH(ADD_OBSERVER)
-    ADD_OBSERVER(currentPlaybackPosition, CurrentPlaybackPosition, CMTime)
-    ADD_OBSERVER(currentValue, CurrentValue, CMTime)
+    FOR_EACH_MEDIA_SOURCE_KEY_PATH(ADD_MEDIA_SOURCE_OBSERVER)
+}
+
+- (AVPlaybackControl * _Nullable)playbackControl
+{
+    return _playbackControl.get();
+}
+
+- (void)setPlaybackControl:(AVPlaybackControl * _Nullable)playbackControl
+{
+    if (playbackControl)
+        self.mediaSource = nil;
+
+    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(REMOVE_PLAYBACK_CONTROL_OBSERVER)
+    REMOVE_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
+    REMOVE_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
+
+    _playbackControl = playbackControl;
+
+    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(ADD_PLAYBACK_CONTROL_OBSERVER)
+    ADD_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
+    ADD_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
 }
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary *)change context:(nullable void*)context
 {
-    if (context != WebMediaSourceObserverContext) {
+    if (context != WebMediaSourceObserverContext && context != WebPlaybackControlObserverContext) {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
         return;
     }
 
     dispatch_async(mainDispatchQueueSingleton(), ^{
-        if ([keyPath isEqualToString:@"currentValue"] || [keyPath isEqualToString:@"currentPlaybackPosition"]) {
+        if (context == WebMediaSourceObserverContext) {
+            FOR_EACH_MEDIA_SOURCE_KEY_PATH(OBSERVE_VALUE)
+            ASSERT_NOT_REACHED();
+            return;
+        }
+
+        if ([keyPath isEqualToString:@"error"]) {
+            if (RefPtr route = _route.get()) {
+                if (RefPtr client = route->client())
+                    client->playbackErrorDidChange(*route);
+            }
+            return;
+        }
+        if ([keyPath isEqualToString:@"playbackPosition"]) {
             if (RefPtr route = _route.get()) {
                 if (RefPtr client = route->client())
                     client->currentPlaybackPositionDidChange(*route);
@@ -155,14 +217,17 @@ static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
             return;
         }
 
-        FOR_EACH_KEY_PATH(OBSERVE_VALUE)
+        FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(OBSERVE_VALUE)
         ASSERT_NOT_REACHED();
     });
 }
 
 - (void)dealloc
 {
-    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
+    FOR_EACH_MEDIA_SOURCE_KEY_PATH(REMOVE_MEDIA_SOURCE_OBSERVER)
+    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(REMOVE_PLAYBACK_CONTROL_OBSERVER)
+    REMOVE_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
+    REMOVE_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
     [super dealloc];
 }
 
@@ -236,26 +301,29 @@ WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
     return m_platformRoute.get();
 }
 
+std::optional<MediaPlaybackSourceError> MediaDeviceRoute::playbackError() const
+{
+    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl])
+        return convert(playbackControl.get().error);
+    return convert([m_mediaSourceObserver mediaSource].playbackError);
+}
+
 MediaTime MediaDeviceRoute::currentPlaybackPosition() const
 {
-    if ([[m_mediaSourceObserver mediaSource] respondsToSelector:@selector(currentPlaybackPosition)])
-        return convert([[m_mediaSourceObserver mediaSource] currentPlaybackPosition]);
-
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return convert([m_mediaSourceObserver mediaSource].currentValue);
-ALLOW_DEPRECATED_DECLARATIONS_END
+    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl])
+        return convert(playbackControl.get().playbackPosition.position);
+    return convert([m_mediaSourceObserver mediaSource].currentPlaybackPosition);
 }
 
 void MediaDeviceRoute::setCurrentPlaybackPosition(MediaTime currentPlaybackPosition)
 {
-    if ([[m_mediaSourceObserver mediaSource] respondsToSelector:@selector(setCurrentPlaybackPosition:)]) {
-        [[m_mediaSourceObserver mediaSource] setCurrentPlaybackPosition:convert(WTF::move(currentPlaybackPosition))];
+    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) {
+        // FIXME: We should introduce a proper seek-with-tolerance function on MediaDeviceRoute rather than assuming a zero tolerance here.
+        [playbackControl seekToPosition:convert(WTF::move(currentPlaybackPosition)) tolerance:PAL::kCMTimeZero];
         return;
     }
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[m_mediaSourceObserver mediaSource] setCurrentValue:convert(WTF::move(currentPlaybackPosition))];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    [m_mediaSourceObserver mediaSource].currentPlaybackPosition = convert(WTF::move(currentPlaybackPosition));
 }
 
 MediaDeviceRoute::~MediaDeviceRoute()
@@ -265,15 +333,22 @@ MediaDeviceRoute::~MediaDeviceRoute()
 #endif
 }
 
-FOR_EACH_KEY_PATH(DEFINE_GETTER)
-FOR_EACH_READWRITE_KEY_PATH(DEFINE_SETTER)
+FOR_EACH_COMMON_KEY_PATH(DEFINE_GETTER)
+FOR_EACH_COMMON_READWRITE_KEY_PATH(DEFINE_SETTER)
 
 } // namespace WebCore
 
-#undef FOR_EACH_READONLY_KEY_PATH
-#undef FOR_EACH_READWRITE_KEY_PATH
-#undef FOR_EACH_KEY_PATH
-#undef ADD_OBSERVER
+#undef FOR_EACH_COMMON_READONLY_KEY_PATH
+#undef FOR_EACH_COMMON_READWRITE_KEY_PATH
+#undef FOR_EACH_COMMON_KEY_PATH
+#undef FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH
+#undef FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH
+#undef FOR_EACH_MEDIA_SOURCE_KEY_PATH
+#undef FOR_EACH_PLAYBACK_CONTROL_KEY_PATH
+#undef ADD_MEDIA_SOURCE_OBSERVER
+#undef REMOVE_MEDIA_SOURCE_OBSERVER
+#undef ADD_PLAYBACK_CONTROL_OBSERVER
+#undef REMOVE_PLAYBACK_CONTROL_OBSERVER
 #undef OBSERVE_VALUE
 #undef DEFINE_GETTER
 #undef DEFINE_SETTER


### PR DESCRIPTION
#### 953542b2c76daf6335ccb9521b578c62cf2fd220
<pre>
[iOS] Implement an alternative data source for MediaDeviceRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=317255">https://bugs.webkit.org/show_bug.cgi?id=317255</a>
<a href="https://rdar.apple.com/175647939">rdar://175647939</a>

Reviewed by Jer Noble.

MediaDeviceRouteController can now vend one of two types as a data source for MediaDeviceRoute: an
AVMediaSource or an AVPlaybackControl. Eventually we will only use an AVPlaybackControl, but during
the migration we need to tolerate either type. To accomplish this, introduced a separate
AVPlaybackControl property on WebMediaSourceObserver that is mutually exclusive with the
AVMediaSource property (i.e., if one is set, the other becomes nil). Observers are registered on
the non-null object.

Since both types share many properties in common, refactored the observation macros so that there
is a list of common properties as well as lists of unique properties on each type. Some properties
have different names for the same conceptual property (e.g., playbackError and error). In those
cases the observation is hand-coded to call the appropriate MediaDeviceRouteClient callback.

No new tests. For layout tests we currently vend an AVMediaSource-conforming object, but in a
follow-on change it will become an AVPlaybackControl-conforming object.

* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(-[WebMediaSourceObserver setMediaSource:]):
(-[WebMediaSourceObserver playbackControl]):
(-[WebMediaSourceObserver setPlaybackControl:]):
(-[WebMediaSourceObserver observeValueForKeyPath:ofObject:change:context:]):
(-[WebMediaSourceObserver dealloc]):
(WebCore::MediaDeviceRoute::playbackError const):
(WebCore::MediaDeviceRoute::currentPlaybackPosition const):
(WebCore::MediaDeviceRoute::setCurrentPlaybackPosition):

Canonical link: <a href="https://commits.webkit.org/315421@main">https://commits.webkit.org/315421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dee9de56b7196a770db2cc4246ad23df9ec40232

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126473 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f53faca2-879a-48b4-a6aa-fe3df5e9b7e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131402 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92439 "1 flakes 4 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fce5baa5-15a0-402a-bdfb-afdb20ff6a94) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111906 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1d7b269-f98b-47db-afa8-9f8058fff441) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32841 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26792 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180698 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139849 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42337 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139693 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37649 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43026 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106772 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34972 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114793 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41529 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6136 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40926 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->