### PR TITLE
HTTP cache should store responses with explicit freshness regardless of status code

### DIFF
--- a/LayoutTests/http/tests/app-privacy-report/app-attribution-speculative-revalidation-expected.txt
+++ b/LayoutTests/http/tests/app-privacy-report/app-attribution-speculative-revalidation-expected.txt
@@ -1,5 +1,4 @@
 127.0.0.1:8000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Responding with testUsername:testPassword
-127.0.0.1:8000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 Tests speculative revalidation of authenticated resources.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/app-privacy-report/user-attribution-speculative-revalidation-expected.txt
+++ b/LayoutTests/http/tests/app-privacy-report/user-attribution-speculative-revalidation-expected.txt
@@ -1,5 +1,4 @@
 127.0.0.1:8000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Responding with testUsername:testPassword
-127.0.0.1:8000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 Tests speculative revalidation of authenticated resources.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/cache/disk-cache/disk-cache-range-expected.txt
+++ b/LayoutTests/http/tests/cache/disk-cache/disk-cache-range-expected.txt
@@ -21,7 +21,7 @@ response source: Network
 response status: 206
 
 response headers: {"Cache-control":"max-age=100","Range":"bytes=5-7"}
-response source: Network
+response source: Disk cache
 response status: 416
 
 response headers: {"Cache-control":"max-age=0","Range":"bytes=5-7"}

--- a/LayoutTests/http/tests/cache/disk-cache/speculative-validation/http-auth-expected.txt
+++ b/LayoutTests/http/tests/cache/disk-cache/speculative-validation/http-auth-expected.txt
@@ -1,5 +1,4 @@
 127.0.0.1:8000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Responding with testUsername:testPassword
-127.0.0.1:8000 - didReceiveAuthenticationChallenge - ProtectionSpaceAuthenticationSchemeHTTPBasic - Simulating cancelled authentication sheet
 Tests speculative revalidation of authenticated resources.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any-expected.txt
@@ -6,23 +6,23 @@ PASS HTTP cache avoids going to the network if it has a fresh 203 response
 PASS HTTP cache goes to the network if it has a stale 204 response
 PASS HTTP cache avoids going to the network if it has a fresh 204 response
 PASS HTTP cache goes to the network if it has a stale 299 response
-FAIL HTTP cache avoids going to the network if it has a fresh 299 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 299 response
 PASS HTTP cache goes to the network if it has a stale 400 response
-FAIL HTTP cache avoids going to the network if it has a fresh 400 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 400 response
 PASS HTTP cache goes to the network if it has a stale 404 response
 PASS HTTP cache avoids going to the network if it has a fresh 404 response
 PASS HTTP cache goes to the network if it has a stale 410 response
 PASS HTTP cache avoids going to the network if it has a fresh 410 response
 PASS HTTP cache goes to the network if it has a stale 499 response
-FAIL HTTP cache avoids going to the network if it has a fresh 499 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 499 response
 PASS HTTP cache goes to the network if it has a stale 500 response
-FAIL HTTP cache avoids going to the network if it has a fresh 500 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 500 response
 PASS HTTP cache goes to the network if it has a stale 502 response
-FAIL HTTP cache avoids going to the network if it has a fresh 502 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 502 response
 PASS HTTP cache goes to the network if it has a stale 503 response
-FAIL HTTP cache avoids going to the network if it has a fresh 503 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 503 response
 PASS HTTP cache goes to the network if it has a stale 504 response
-FAIL HTTP cache avoids going to the network if it has a fresh 504 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 504 response
 PASS HTTP cache goes to the network if it has a stale 599 response
-FAIL HTTP cache avoids going to the network if it has a fresh 599 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 599 response
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.serviceworker-expected.txt
@@ -6,23 +6,23 @@ PASS HTTP cache avoids going to the network if it has a fresh 203 response
 PASS HTTP cache goes to the network if it has a stale 204 response
 PASS HTTP cache avoids going to the network if it has a fresh 204 response
 PASS HTTP cache goes to the network if it has a stale 299 response
-FAIL HTTP cache avoids going to the network if it has a fresh 299 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 299 response
 PASS HTTP cache goes to the network if it has a stale 400 response
-FAIL HTTP cache avoids going to the network if it has a fresh 400 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 400 response
 PASS HTTP cache goes to the network if it has a stale 404 response
 PASS HTTP cache avoids going to the network if it has a fresh 404 response
 PASS HTTP cache goes to the network if it has a stale 410 response
 PASS HTTP cache avoids going to the network if it has a fresh 410 response
 PASS HTTP cache goes to the network if it has a stale 499 response
-FAIL HTTP cache avoids going to the network if it has a fresh 499 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 499 response
 PASS HTTP cache goes to the network if it has a stale 500 response
-FAIL HTTP cache avoids going to the network if it has a fresh 500 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 500 response
 PASS HTTP cache goes to the network if it has a stale 502 response
-FAIL HTTP cache avoids going to the network if it has a fresh 502 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 502 response
 PASS HTTP cache goes to the network if it has a stale 503 response
-FAIL HTTP cache avoids going to the network if it has a fresh 503 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 503 response
 PASS HTTP cache goes to the network if it has a stale 504 response
-FAIL HTTP cache avoids going to the network if it has a fresh 504 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 504 response
 PASS HTTP cache goes to the network if it has a stale 599 response
-FAIL HTTP cache avoids going to the network if it has a fresh 599 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 599 response
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.sharedworker-expected.txt
@@ -6,23 +6,23 @@ PASS HTTP cache avoids going to the network if it has a fresh 203 response
 PASS HTTP cache goes to the network if it has a stale 204 response
 PASS HTTP cache avoids going to the network if it has a fresh 204 response
 PASS HTTP cache goes to the network if it has a stale 299 response
-FAIL HTTP cache avoids going to the network if it has a fresh 299 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 299 response
 PASS HTTP cache goes to the network if it has a stale 400 response
-FAIL HTTP cache avoids going to the network if it has a fresh 400 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 400 response
 PASS HTTP cache goes to the network if it has a stale 404 response
 PASS HTTP cache avoids going to the network if it has a fresh 404 response
 PASS HTTP cache goes to the network if it has a stale 410 response
 PASS HTTP cache avoids going to the network if it has a fresh 410 response
 PASS HTTP cache goes to the network if it has a stale 499 response
-FAIL HTTP cache avoids going to the network if it has a fresh 499 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 499 response
 PASS HTTP cache goes to the network if it has a stale 500 response
-FAIL HTTP cache avoids going to the network if it has a fresh 500 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 500 response
 PASS HTTP cache goes to the network if it has a stale 502 response
-FAIL HTTP cache avoids going to the network if it has a fresh 502 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 502 response
 PASS HTTP cache goes to the network if it has a stale 503 response
-FAIL HTTP cache avoids going to the network if it has a fresh 503 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 503 response
 PASS HTTP cache goes to the network if it has a stale 504 response
-FAIL HTTP cache avoids going to the network if it has a fresh 504 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 504 response
 PASS HTTP cache goes to the network if it has a stale 599 response
-FAIL HTTP cache avoids going to the network if it has a fresh 599 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 599 response
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.worker-expected.txt
@@ -6,23 +6,23 @@ PASS HTTP cache avoids going to the network if it has a fresh 203 response
 PASS HTTP cache goes to the network if it has a stale 204 response
 PASS HTTP cache avoids going to the network if it has a fresh 204 response
 PASS HTTP cache goes to the network if it has a stale 299 response
-FAIL HTTP cache avoids going to the network if it has a fresh 299 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 299 response
 PASS HTTP cache goes to the network if it has a stale 400 response
-FAIL HTTP cache avoids going to the network if it has a fresh 400 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 400 response
 PASS HTTP cache goes to the network if it has a stale 404 response
 PASS HTTP cache avoids going to the network if it has a fresh 404 response
 PASS HTTP cache goes to the network if it has a stale 410 response
 PASS HTTP cache avoids going to the network if it has a fresh 410 response
 PASS HTTP cache goes to the network if it has a stale 499 response
-FAIL HTTP cache avoids going to the network if it has a fresh 499 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 499 response
 PASS HTTP cache goes to the network if it has a stale 500 response
-FAIL HTTP cache avoids going to the network if it has a fresh 500 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 500 response
 PASS HTTP cache goes to the network if it has a stale 502 response
-FAIL HTTP cache avoids going to the network if it has a fresh 502 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 502 response
 PASS HTTP cache goes to the network if it has a stale 503 response
-FAIL HTTP cache avoids going to the network if it has a fresh 503 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 503 response
 PASS HTTP cache goes to the network if it has a stale 504 response
-FAIL HTTP cache avoids going to the network if it has a fresh 504 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 504 response
 PASS HTTP cache goes to the network if it has a stale 599 response
-FAIL HTTP cache avoids going to the network if it has a fresh 599 response assert_less_than: Response 2 does not come from cache expected a number less than 2 but got 2
+PASS HTTP cache avoids going to the network if it has a fresh 599 response
 

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -477,22 +477,4 @@ bool isStatusCodeCacheableByDefault(int statusCode)
     }
 }
 
-bool isStatusCodePotentiallyCacheable(int statusCode)
-{
-    switch (statusCode) {
-    case 201: // Created
-    case 202: // Accepted
-    case 205: // Reset Content
-    case 302: // Found
-    case 303: // See Other
-    case 307: // Temporary redirect
-    case 403: // Forbidden
-    case 406: // Not Acceptable
-    case 415: // Unsupported Media Type
-        return true;
-    default:
-        return false;
-    }
-}
-
 }

--- a/Source/WebCore/platform/network/CacheValidation.h
+++ b/Source/WebCore/platform/network/CacheValidation.h
@@ -87,6 +87,5 @@ WEBCORE_EXPORT bool verifyVaryingRequestHeaders(NetworkStorageSession*, const Ve
 WEBCORE_EXPORT bool verifyVaryingRequestHeaders(const CookieJar*, const Vector<std::pair<String, String>>& varyingRequestHeaders, const ResourceRequest&);
 
 WEBCORE_EXPORT bool NODELETE isStatusCodeCacheableByDefault(int statusCode);
-WEBCORE_EXPORT bool NODELETE isStatusCodePotentiallyCacheable(int statusCode);
 
 }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -305,9 +305,8 @@ static StoreDecision makeStoreDecision(const WebCore::ResourceRequest& originalR
     if (!WebCore::isStatusCodeCacheableByDefault(response.httpStatusCode())) {
         // http://tools.ietf.org/html/rfc7234#section-4.3.2
         bool hasExpirationHeaders = response.expires() || response.cacheControlMaxAge();
-        bool expirationHeadersAllowCaching = WebCore::isStatusCodePotentiallyCacheable(response.httpStatusCode()) && hasExpirationHeaders;
-        if (!expirationHeadersAllowCaching && !response.cacheControlContainsPublic())
-            return StoreDecision::NoDueToHTTPStatusCode;
+        if (!hasExpirationHeaders && !response.cacheControlContainsPublic())
+            return StoreDecision::NoDueToMissingExpirationHeaders;
     }
 
     // FIXME: We are not correctly computing the redirected request URL in case original request

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -129,7 +129,7 @@ enum class StoreDecision {
     NoDueToProtocol,
     NoDueToHTTPMethod,
     NoDueToNoStoreResponse,
-    NoDueToHTTPStatusCode,
+    NoDueToMissingExpirationHeaders,
     NoDueToNoStoreRequest,
     NoDueToUnlikelyToReuse,
     NoDueToStreamingMedia,


### PR DESCRIPTION
#### 2b388e3d9c5a65bb3aa7a0df8ab84c501d1fe998
<pre>
HTTP cache should store responses with explicit freshness regardless of status code
<a href="https://bugs.webkit.org/show_bug.cgi?id=317258">https://bugs.webkit.org/show_bug.cgi?id=317258</a>
<a href="https://rdar.apple.com/179871690">rdar://179871690</a>

Reviewed by Chris Dumez.

NetworkCache::makeStoreDecision() refused to store any response whose status code was neither
cacheable-by-default nor in the isStatusCodePotentiallyCacheable() allowlist, even when the response
carried explicit expiration headers.

RFC 9111 §3 allows caches to store responses with explicit freshness information, and RFC 9110
§16.2.2 clarifies that this applies to any final status code.

<a href="https://www.rfc-editor.org/rfc/rfc9111.html#section-3">https://www.rfc-editor.org/rfc/rfc9111.html#section-3</a>
<a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-16.2.2">https://www.rfc-editor.org/rfc/rfc9110.html#section-16.2.2</a>

* LayoutTests/http/tests/cache/disk-cache/disk-cache-range-expected.txt:
Rebaselined: a 416 (Range Not Satisfiable) response carrying Cache-Control: max-age=100 now has
explicit freshness, so it is stored and served from the disk cache on the second load instead of
going to the network.

* LayoutTests/http/tests/app-privacy-report/app-attribution-speculative-revalidation-expected.txt:
* LayoutTests/http/tests/app-privacy-report/user-attribution-speculative-revalidation-expected.txt:
* LayoutTests/http/tests/cache/disk-cache/speculative-validation/http-auth-expected.txt:
Rebaselined: the authenticated resource&apos;s 401 response carries Cache-Control: max-age=0, so it is
now stored in the disk cache. This removes one network-issued (and cancelled) authentication
challenge from the speculative-revalidation path; the test&apos;s assertions are otherwise unchanged.

* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/http-cache/status.any.worker-expected.txt:
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::isStatusCodePotentiallyCacheable): Deleted.
* Source/WebCore/platform/network/CacheValidation.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::makeStoreDecision):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:

Canonical link: <a href="https://commits.webkit.org/315450@main">https://commits.webkit.org/315450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7b61de300fe0bb886e83a19c3b8d1c260089821

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126771 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7be6fe1c-a58e-4699-b641-737a7e1fb3ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42606 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00ee9b68-49db-4512-9d25-584c210bb8de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172018 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112164 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2cd49a0-6e22-4940-9993-73c2caf1b80f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27115 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143097 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181014 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33725 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42637 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139952 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43326 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107198 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25764 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35231 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41835 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6401 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41229 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41484 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->