### PR TITLE
AX: Isolated tree left permanently rootless when the root's ID is applied before its node, causing VoiceOver to report "empty web content"

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -6188,9 +6188,14 @@ AXTreeData AXObjectCache::treeData(std::optional<OptionSet<AXStreamOptions>> add
 
             // There's no root — maybe there's a pending ID that can't be hydrated into an actual root object?
             if (std::optional pendingRootID = tree->pendingRootNodeID())
-                stream << "Has pending root ID " << *pendingRootID << ". Object exists for that ID in the isolated tree: " << tree->unsafeHasObjectForID(*pendingRootID);
+                stream << "Has pending root ID " << *pendingRootID << ". Object exists for that ID in the isolated tree: " << tree->unsafeHasObjectForID(*pendingRootID) << ". ";
             else
-                stream << "No pending root ID.";
+                stream << "No pending root ID. ";
+
+            if (std::optional rootID = tree->unsafeRootNodeID())
+                stream << "Has root ID " << *rootID << ". Object exists for that ID in the isolated tree: " << tree->unsafeHasObjectForID(*rootID) << ".";
+            else
+                stream << "No root ID.";
         } else
             stream << "No isolated tree!";
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1458,7 +1458,6 @@ void AXIsolatedTree::clearTreeContentsLocked()
     // Because each AXIsolatedObject holds a RefPtr to this tree, clear out any member variable
     // that holds an AXIsolatedObject so the ref-cycle is broken and this tree can be destroyed.
     m_readerThreadNodeMap.clear();
-    m_rootNode = nullptr;
     m_pendingChanges.appends.clear();
     // We don't need to bother clearing out any other non-cycle-causing member variables as they
     // will be cleaned up automatically when the tree is destroyed.
@@ -1595,10 +1594,14 @@ AXIsolatedTree::PendingChanges AXIsolatedTree::takePendingChangesLocked()
     AX_ASSERT(m_changeLogLock.isLocked());
 
     auto snapshot = std::exchange(m_pendingChanges, { });
-    // focusedNodeID represents persistent state (not a queue), so preserve it
-    // across snapshots. Otherwise it gets reset to empty and incorrectly clears
-    // the focused node on the next apply cycle.
+
+    // focusedNodeID and rootNodeID represent persistent state (not a queue), so preserve them
+    // across snapshots. Otherwise they get reset to empty and incorrectly clear the focused / root
+    // node on the next apply cycle. Re-sending the root every snapshot also lets the accessibility
+    // thread re-affirm (and, if it ever drifted, repair) the root on every apply.
     m_pendingChanges.focusedNodeID = snapshot.focusedNodeID;
+    m_pendingChanges.rootNodeID = snapshot.rootNodeID;
+
     m_hasPendingChanges.store(false);
 #if ENABLE(ACCESSIBILITY_THREAD_DISPATCHING)
     m_appliedOrApplyingMainThreadSnapshot.store(true, std::memory_order_relaxed);
@@ -1736,25 +1739,27 @@ void AXIsolatedTree::applyPendingChangesFromSnapshot(PendingChanges&& snapshot)
         m_frameViewOriginScrollPosition = *snapshot.frameViewOriginScrollPosition;
 #endif
 
-    // Do this at the end because it requires looking up the root node by ID, so doing it at the end
-    // ensures all additions to m_readerThreadNodeMap have been made by now.
-    if (snapshot.rootNodeID) {
-        if (RefPtr root = objectForID(snapshot.rootNodeID)) {
-            m_rootNode = WTF::move(root);
+    if (snapshot.rootNodeID != m_rootNodeID) {
+        m_rootNodeID = snapshot.rootNodeID;
 
 #if ASSERT_ENABLED
+        // Check that the applied tree is fully reachable from the root. For performance, only do this
+        // when the root changes. Do this last so all additions to m_readerThreadNodeMap have been made by now.
+        if (RefPtr root = objectForID(m_rootNodeID)) {
             auto markReachableNodes = [](AXCoreObject* object, HashSet<AXID>& reachableNodes, auto& self) -> void {
                 reachableNodes.add(object->objectID());
                 for (auto& child : object->children())
                     self(&child.get(), reachableNodes, self);
             };
             HashSet<AXID> reachableNodes;
-            if (m_rootNode) {
-                markReachableNodes(m_rootNode.get(), reachableNodes, markReachableNodes);
-                ASSERT_WITH_MESSAGE(reachableNodes.size() == m_readerThreadNodeMap.size(), "AX: After applying pending root node, %u reachable nodes but %u are in the node map", reachableNodes.size(), m_readerThreadNodeMap.size());
-            }
-#endif
+            markReachableNodes(root.get(), reachableNodes, markReachableNodes);
+            // FIXME: This can spuriously fire when the tree has unconnected nodes (relation origins /
+            // targets added via addUnconnectedNode), which live in m_readerThreadNodeMap but aren't
+            // reachable from the root. We can't subtract them here because m_unconnectedNodes is only
+            // safe to read on the main thread.
+            ASSERT_WITH_MESSAGE(reachableNodes.size() == m_readerThreadNodeMap.size(), "AX: After applying pending root node, %u reachable nodes but %u are in the node map", reachableNodes.size(), m_readerThreadNodeMap.size());
         }
+#endif // ASSERT_ENABLED
     }
 
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -453,7 +453,7 @@ public:
     void updateFrameGeometryAndScrollPositionIfNeeded(AXObjectCache&);
 #endif
 
-    AXIsolatedObject* rootNode() { AX_ASSERT(!isMainThread()); return m_rootNode.get(); }
+    AXIsolatedObject* rootNode() { AX_ASSERT(!isMainThread()); return objectForID(m_rootNodeID); }
     std::optional<AXID> pendingRootNodeID();
     RefPtr<AXIsolatedObject> rootWebArea();
     std::optional<AXID> focusedNodeID();
@@ -462,6 +462,8 @@ public:
     bool unsafeHasObjectForID(AXID axID) const;
     // Not threadsafe, only for debug snapshot use.
     std::optional<AXID> unsafeFocusedNodeID() const { return m_focusedNodeID; }
+    std::optional<AXID> unsafeRootNodeID() const { return m_rootNodeID; }
+
     inline AXIsolatedObject* objectForID(AXID axID) const
     {
         AX_ASSERT(!isMainThread());
@@ -749,7 +751,7 @@ private:
 
     // Only accessed on AX thread.
     HashMap<AXID, Ref<AXIsolatedObject>> m_readerThreadNodeMap;
-    RefPtr<AXIsolatedObject> m_rootNode;
+    Markable<AXID> m_rootNodeID;
 
     // Written to by main thread under lock, accessed and applied by AX thread.
     PendingChanges m_pendingChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);


### PR DESCRIPTION
#### 96e5bdf065e0cd05046e9e2c5bcb41f99812edfe
<pre>
AX: Isolated tree left permanently rootless when the root&apos;s ID is applied before its node, causing VoiceOver to report &quot;empty web content&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=317261">https://bugs.webkit.org/show_bug.cgi?id=317261</a>
<a href="https://rdar.apple.com/179873618">rdar://179873618</a>

Reviewed by Dominic Mazzoni and Andres Gonzalez.

setPendingRootNodeIDLocked() and the root object&apos;s append are queued under
separate acquisitions of m_changeLogLock (see createEmptyContent() and
nodeChangeForObject()), so a pending-changes snapshot can carry the root ID
before the snapshot that carries the root&apos;s append. Since 312765@main, the
apply path consumed rootNodeID from a single snapshot and, if the root object
wasn&apos;t in m_readerThreadNodeMap yet, dropped it. m_rootNode then stayed null
forever and VoiceOver reported &quot;empty web content&quot;.

To fix this, store only the root ID (m_rootNodeID) and resolve rootNode() on
demand from m_readerThreadNodeMap, mirroring m_focusedNodeID / focusedNode().

In the future, we should apply tree updates entirely atomically. This is
tracked by <a href="https://bugs.webkit.org/show_bug.cgi?id=316148.">https://bugs.webkit.org/show_bug.cgi?id=316148.</a>

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::treeData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::clearTreeContentsLocked):
(WebCore::AXIsolatedTree::applyPendingChangesFromSnapshot):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::rootNode):
(WebCore::AXIsolatedTree::unsafeRootNodeID const):

Canonical link: <a href="https://commits.webkit.org/315648@main">https://commits.webkit.org/315648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1154ac77f44aae15fcce2dbd56b0b5e254836281

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127298 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171452 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132137 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93066 "9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172545 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112640 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32272 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27642 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181544 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34252 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36438 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 3 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140585 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43164 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140421 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37805 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43853 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108073 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35687 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115618 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42363 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6993 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41899 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->