### PR TITLE
Revert 312468@main, which blocked required read access in sandbox

### DIFF
--- a/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
@@ -192,7 +192,11 @@
 
 (define-once (device-access)
     (allow file-read* file-write-data file-ioctl
-           (literal "/dev/dtracehelper")))
+           (literal "/dev/dtracehelper"))
+
+    (allow file-read* (with telemetry)
+           (literal "/dev/random")
+           (literal "/dev/urandom")))
 
 (define required-etc-files
   (literal "/private/etc/passwd"))

--- a/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb
@@ -164,7 +164,11 @@
             (literal "/dev/dtracehelper"))
         (allow file-write-data (with report) (with telemetry)
             (literal "/dev/dtracehelper"))
-        (allow nvram-get (nvram-variable "emu")))) ;; <rdar://problem/78363040>
+        (allow nvram-get (nvram-variable "emu"))) ;; <rdar://problem/78363040>
+
+    (allow file-read*
+           (literal "/dev/random")
+           (literal "/dev/urandom")))
 
 (define required-etc-files
   (literal "/private/etc/fstab"


### PR DESCRIPTION
#### ffef0e720f40297463a11ab6a1c0107da28ff900
<pre>
Revert 312468@main, which blocked required read access in sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=317263">https://bugs.webkit.org/show_bug.cgi?id=317263</a>
<a href="https://rdar.apple.com/179875292">rdar://179875292</a>

Unreviewed revert.

The commit in <a href="https://commits.webkit.org/312468@main">https://commits.webkit.org/312468@main</a> blocked required file access. This patch reverts that commit.

* Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb:
* Source/WebKit/Shared/Sandbox/iOS/webcontent-defines.sb:

Canonical link: <a href="https://commits.webkit.org/315383@main">https://commits.webkit.org/315383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67c2890992c32b131ac8ad966d633894bab042a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126487 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d424984a-5098-4890-a55c-83a31850fb9a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abd2ceb1-4eda-44d2-a80e-504137cce2e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111920 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c62facf-4c7d-4b5e-bdab-7182b7cc7d11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31570 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26806 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180712 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139866 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42351 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139710 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43040 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106786 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34987 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114807 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41543 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6148 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40940 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41194 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->