### PR TITLE
[GFC] Implement GridLayoutUtils::preferredSizeBehavesAsAuto

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-minimum-contribution-fixed-size-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-minimum-contribution-fixed-size-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-content">
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<meta name="assert" content="Resolving the minimum contribution of a grid item with a fixed inline-size in a fixed-size track does not crash.">
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: 100px;
+}
+.item {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+    width: 10px;
+}
+</style>
+<div class="grid"><div class="item"></div></div>
+<script>
+document.body.offsetHeight;
+</script>

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -467,22 +467,21 @@ GridItemSizingFunctions blockAxisGridItemSizingFunctions(const GridFormattingCon
     };
 }
 
+// https://www.w3.org/TR/css-sizing-3/#behave-as-auto
+// To have a common term for both when width/height computes to auto and
+// when it is defined to behave as if auto were specified.
+// (as in the case of block percentage heights resolving against an indefinite size, see CSS2§10.5),
+// the property is said to behave as auto in both of these cases.
 bool preferredSizeBehavesAsAuto(const Style::PreferredSize& preferredSize)
 {
-    return WTF::switchOn(preferredSize,
-        [](const CSS::Keyword::Auto&) {
-            return true;
-        },
-        [](const auto&) {
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return false;
-    });
+    // FIXME: Handle cases where preferred size is not auto but behaves as auto,
+    // such as percentage height resolving against indefinite size.
+    return preferredSize.isAuto();
 }
 
-bool preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize&)
+bool preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize& preferredSize)
 {
-    ASSERT_NOT_IMPLEMENTED_YET();
-    return false;
+    return preferredSize.isStretch() || preferredSize.isFitContent() || preferredSize.isPercentOrCalculated();
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -212,6 +212,7 @@ static Vector<LayoutUnit> maxContentContributions(const TrackSizingItemList& tra
     });
 }
 
+// https://www.w3.org/TR/css-grid-2/#algo-single-span-items
 static Vector<LayoutUnit> minimumContributions(const TrackSizingItemList& trackSizingItems, const ComputedSizesList& gridItemComputedSizesList, const UsedBorderAndPaddingList& borderAndPaddingList,
     const GridItemIndexes& gridItemIndexes, const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions& gridItemSizingFunctions, const TrackSizingFunctionsList& trackSizingFunctions)
 {


### PR DESCRIPTION
#### fd0d854eb31cc2124c1338675fa02c2b9e76e297
<pre>
[GFC] Implement GridLayoutUtils::preferredSizeBehavesAsAuto
<a href="https://bugs.webkit.org/show_bug.cgi?id=317235">https://bugs.webkit.org/show_bug.cgi?id=317235</a>
&lt;<a href="https://rdar.apple.com/179857225">rdar://179857225</a>&gt;

Reviewed by Sammy Gill.

This PR ports over RenderGrid&apos;s implementation of preferredSizeBehavesAsAuto()
and preferredSizeDependsOnContainingBlockSize() to GFC.

RenderGrid implements this part of the spec:

        &quot;if the item’s computed preferred size behaves as auto or depends on the size of its containing block in the relevant axis&quot;

with the check

        if (!gridItemSize.isAuto() &amp;&amp; !gridItemSize.isPercentOrCalculated())

This behavior is inline with GridTrackSizingAlgorithmStrategy::minContributionForGridItem()
in the legacy RenderGrid, but does not yet handle stretch/fit content
in preferredSizeDependsOnContainingBlockSize(). preferredSizeBehavesAsAuto()
also only checks for auto preferred size, matching the RenderGrid implementation but
not yet implement the full spec.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-minimum-contribution-fixed-size-crash.html: Added.
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::preferredSizeBehavesAsAuto):
(WebCore::Layout::GridLayoutUtils::preferredSizeDependsOnContainingBlockSize):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:

Canonical link: <a href="https://commits.webkit.org/315911@main">https://commits.webkit.org/315911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74539c0dc7f330b3092fc205be57153aedbe7865

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179713 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128051 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dafc776e-826c-441e-a2a5-3fe353ca12ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132817 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96c32f10-79e7-413b-891f-fab107e32f68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113317 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9306ec09-771f-412b-820d-d6b70febbd34) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28397 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182298 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141265 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141085 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44608 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29629 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109045 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25980 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36359 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116490 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43118 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7732 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42524 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42764 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42653 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->