### PR TITLE
[AppKit Gestures] Scrolling, then interrupting, sometimes follows the link below the mouse

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -745,6 +745,8 @@ public:
 
     virtual void pageDidScroll(const WebCore::IntPoint& scrollOffset) { }
 
+    virtual void didEndSyntheticMomentumScrolling() { }
+
     virtual void didRestoreScrollPosition() = 0;
 
     virtual bool windowIsFrontWindowUnderMouse(const NativeWebMouseEvent&) { return false; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -170,6 +170,7 @@ private:
     void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
     void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID);
     void stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID);
+    void didEndSyntheticMomentumScrolling();
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     void flushMomentumEventLoggingSoon();
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -849,6 +849,14 @@ void RemoteLayerTreeEventDispatcher::stopDisplayDidRefreshCallbacks(PlatformDisp
         startOrStopDisplayLink();
 }
 
+void RemoteLayerTreeEventDispatcher::didEndSyntheticMomentumScrolling()
+{
+    RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }] {
+        if (CheckedPtr scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
+            protect(scrollingCoordinator->webPageProxy())->didEndSyntheticMomentumScrolling();
+    });
+}
+
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
 void RemoteLayerTreeEventDispatcher::flushMomentumEventLoggingSoon()
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10845,6 +10845,12 @@ void WebPageProxy::pageDidScroll(const WebCore::IntPoint& scrollOffset)
 #endif
 }
 
+void WebPageProxy::didEndSyntheticMomentumScrolling()
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->didEndSyntheticMomentumScrolling();
+}
+
 void WebPageProxy::setHasActiveAnimatedScrolls(bool isRunning)
 {
     m_hasActiveAnimatedScroll = isRunning;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1447,6 +1447,7 @@ public:
     void interruptSyntheticMomentumScrolling();
     void continueWheelEventHandling(const WebWheelEvent&, const WebCore::WheelEventHandlingResult&, std::optional<bool> willStartSwipe);
     void wheelEventHandlingCompleted(bool wasHandled);
+    void didEndSyntheticMomentumScrolling();
 
     bool NODELETE isProcessingKeyboardEvents() const;
     void sendKeyEvent(const NativeWebKeyboardEvent&);

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -294,6 +294,7 @@ private:
     void derefView() override;
 
     void pageDidScroll(const WebCore::IntPoint&) override;
+    void didEndSyntheticMomentumScrolling() override;
     void didRestoreScrollPosition() override;
     bool windowIsFrontWindowUnderMouse(const NativeWebMouseEvent&) override;
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1079,6 +1079,11 @@ void PageClientImpl::pageDidScroll(const WebCore::IntPoint& scrollOffset)
     protect(m_impl)->pageDidScroll(scrollOffset);
 }
 
+void PageClientImpl::didEndSyntheticMomentumScrolling()
+{
+    protect(m_impl)->didEndSyntheticMomentumScrolling();
+}
+
 #if ENABLE(HORIZONTAL_BANNER_VIEW_OVERLAYS)
 void PageClientImpl::didUpdateTransientZoomStateForScrollPocket(std::optional<TransientZoomState> state)
 {

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -65,6 +65,7 @@ OBJC_CLASS NSPanGestureRecognizer;
 - (void)setTextSelectionDragGesture:(NSGestureRecognizer *)gesture completionHandler:(void (^)(NSDraggingSession *))completionHandler;
 - (void)positionInformationDidChange:(const WebKit::InteractionInformationAtPosition&)info;
 - (void)didCommitLoadForMainFrame;
+- (void)didEndSyntheticMomentumScrolling;
 - (void)reset;
 
 #if ENABLE(TWO_PHASE_CLICKS)

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -198,6 +198,8 @@ static NSString *gestureLogName(NSGestureRecognizer *gesture)
     RetainPtr<WKDeferringGestureRecognizer> _dragDeferringGestureRecognizer;
 
     bool _isMomentumActive;
+    bool _caughtDeceleratingScroll;
+    bool _suppressNextPanScrollDelta;
 
     bool _potentialClickInProgress;
     bool _isClickHighlightIDValid;
@@ -449,6 +451,16 @@ static NSString *gestureLogName(NSGestureRecognizer *gesture)
 
     [self sendWheelEventForGesture:_panGestureRecognizer];
     [self startMomentumIfNeededForGesture:_panGestureRecognizer];
+
+    switch (gesture.state) {
+    case NSGestureRecognizerStateEnded:
+    case NSGestureRecognizerStateCancelled:
+    case NSGestureRecognizerStateFailed:
+        [self _resetCaughtDeceleratingScroll];
+        break;
+    default:
+        break;
+    }
 }
 
 - (void)singleClickGestureRecognized:(NSGestureRecognizer *)gesture
@@ -468,6 +480,22 @@ static NSString *gestureLogName(NSGestureRecognizer *gesture)
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG_DEBUG(page->logIdentifier(), "%@ state=%ld", gestureLogName(gesture), static_cast<long>(gesture.state));
 
     RELEASE_ASSERT(_singleClickGestureRecognizer == gesture);
+
+    if (_caughtDeceleratingScroll) {
+        // This gesture is interrupting a decelerating scroll; it should stop the scroll (and may
+        // turn into a pan) but must never perform a click.
+        switch (gesture.state) {
+        case NSGestureRecognizerStateEnded:
+        case NSGestureRecognizerStateCancelled:
+        case NSGestureRecognizerStateFailed:
+            [self _resetCaughtDeceleratingScroll];
+            [self _handleClickCancelled];
+            break;
+        default:
+            break;
+        }
+        return;
+    }
 
     // Clicks aren't delivered to NSButton's built-in click gesture
     // recognizer when a parent view's GR recognizes first, so we
@@ -1181,6 +1209,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     WebCore::IntPoint position { [gesture locationInView:webView.get()] };
     auto globalPosition { WebCore::globalPoint([gesture locationInView:nil], [webView window]) };
     auto gestureDelta { translationInView(gesture, webView.get()) };
+
+    if (std::exchange(_suppressNextPanScrollDelta, false))
+        gestureDelta = { };
+
     auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
     auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
     bool directionInvertedFromDevice = false;
@@ -1298,8 +1330,22 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (!page)
         return;
 
+    _caughtDeceleratingScroll = true;
+    _suppressNextPanScrollDelta = true;
+
     page->interruptSyntheticMomentumScrolling();
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Interrupted momentum scrolling");
+}
+
+- (void)didEndSyntheticMomentumScrolling
+{
+    _isMomentumActive = false;
+}
+
+- (void)_resetCaughtDeceleratingScroll
+{
+    _caughtDeceleratingScroll = false;
+    _suppressNextPanScrollDelta = false;
 }
 
 #pragma mark - Drag Gesture State
@@ -1351,6 +1397,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     [self _handleClickCancelled];
     _mouseTrackingHasSentMouseDown = false;
     _isMomentumActive = false;
+    [self _resetCaughtDeceleratingScroll];
     _isSuppressingSingleClickGestureForTextSelection = false;
     _latestClickID.reset();
     _layerTreeTransactionIdAtLastInteractionStart.reset();
@@ -1477,6 +1524,16 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
         return NO;
 
     NSPoint locationInViewCoordinates = [gestureRecognizer locationInView:webView];
+
+    // While catching a decelerating scroll, only select gestures are allowed to begin:
+    // - single click, so it can reset the interruption state
+    // - pan, so it can continue with successive scrolls
+    if (_caughtDeceleratingScroll) {
+        if (gestureRecognizer == _singleClickGestureRecognizer)
+            return YES;
+        if (gestureRecognizer != _panGestureRecognizer)
+            return NO;
+    }
 
     if (gestureRecognizer == _doubleClickGestureRecognizer)
         return viewImpl->allowsMagnification();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -381,6 +381,7 @@ public:
     void activeSpaceDidChange();
 
     void pageDidScroll(const WebCore::IntPoint&);
+    void didEndSyntheticMomentumScrolling();
 
     NSRect scrollViewFrame();
     bool NODELETE hasScrolledContentsUnderTitlebar();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2539,6 +2539,13 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollOffset)
     }
 }
 
+void WebViewImpl::didEndSyntheticMomentumScrolling()
+{
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    [appKitGestureController() didEndSyntheticMomentumScrolling];
+#endif
+}
+
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 void WebViewImpl::updateScrollPocketVisibilityWhenScrolledToTop()

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -161,6 +161,8 @@ private:
     void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) override;
     void stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) override;
 
+    void didEndSyntheticMomentumScrolling() override { }
+
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     void flushMomentumEventLoggingSoon() override;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -242,6 +242,8 @@ void MomentumEventDispatcher::didEndMomentumPhase()
 
     dispatchSyntheticMomentumEvent(WebWheelEvent::Phase::Ended, { });
 
+    m_client->didEndSyntheticMomentumScrolling();
+
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
     RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher ending synthetic momentum phase with total offset %.1f %.1f, duration %f (event offset would have been %.1f %.1f) (tail index %d of %zu)", m_currentGesture.currentOffset.width(), m_currentGesture.currentOffset.height(), (MonotonicTime::now() - m_currentGesture.startTime).seconds(), m_currentGesture.accumulatedEventOffset.width(), m_currentGesture.accumulatedEventOffset.height(), m_currentGesture.currentTailDeltaIndex, m_currentGesture.tailDeltaTable.size());
     m_client->flushMomentumEventLoggingSoon();

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -67,6 +67,8 @@ public:
         virtual void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) = 0;
         virtual void stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) = 0;
 
+        virtual void didEndSyntheticMomentumScrolling() = 0;
+
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)
         virtual void flushMomentumEventLoggingSoon() = 0;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -24,6 +24,7 @@
 #if HAVE_APPKIT_GESTURES_SUPPORT
 
 import Foundation
+import struct Foundation.URL
 @_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
 import SwiftUI
 import struct Swift.String
@@ -475,6 +476,40 @@ struct AppKitGesturesTests {
         let finalScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
         #expect(finalScrollPosition.x == 0)
         #expect(finalScrollPosition.y > 0)
+    }
+
+    @Test
+    func interruptingDeceleratingScrollDoesNotFollowLink() async throws {
+        let html = """
+            <a id="link" href="about:blank"
+               style="display: block; width: 100%; height: 5000px;
+                      background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);">
+            </a>
+            """
+        let initialURL = try #require(URL(string: "http://webkit.org/"))
+        try await page.load(html: html, baseURL: initialURL).wait()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let center = convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: window.frame.center, window: window)
+        let scrollEnd = CGPoint(x: center.x, y: center.y - 200)
+
+        // Begin a momentum scroll, then catch it before it settles.
+        // The interruption should not follow the link beneath it.
+        await recap.play { composer in
+            composer._wk_scroll(withStart: center, end: scrollEnd, duration: .seconds(0.1))
+            composer.advanceTime(0.05)
+            composer._wk_click(at: center, for: .seconds(0.05))
+        }
+
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        #expect(page.url == initialURL)
     }
 
     // MARK: - Drag Press Disambiguation Tests


### PR DESCRIPTION
#### 78e487f91bd19e10527f2e89d693ee4588f27eb7
<pre>
[AppKit Gestures] Scrolling, then interrupting, sometimes follows the link below the mouse
<a href="https://bugs.webkit.org/show_bug.cgi?id=317265">https://bugs.webkit.org/show_bug.cgi?id=317265</a>
<a href="https://rdar.apple.com/174849278">rdar://174849278</a>

Reviewed by Abrar Rahman Protyasha.

Prevent a scroll-interrupting gesture from triggering any other gestures,
including link navigation... except another scroll, of course!

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::didEndSyntheticMomentumScrolling):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::didEndSyntheticMomentumScrolling):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didEndSyntheticMomentumScrolling):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didEndSyntheticMomentumScrolling):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::didEndSyntheticMomentumScrolling):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::didEndMomentumPhase):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:
Plumb the end of MomentumEventGenerator-driven scrolling out to clients (all the way to WKAppKitGestureController).

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController panGestureRecognized:]):

When a pan gesture completes successfully (possibly kicking off momentum),
reset the &quot;caught a momentum scroll&quot; bit, since it necessarily cannot be true at that point.

(-[WKAppKitGestureController singleClickGestureRecognized:]):
If this gesture is downstream of one that interrupted momentum, ignore it.

(-[WKAppKitGestureController sendWheelEventForGesture:]):
Zero the delta for the first pan event after an interruption, to avoid a hop.
Future events will have deltas starting from the interruption point.
This matches the behavior of the native scroller.

(-[WKAppKitGestureController interruptMomentumIfNeeded]):
Now that we keep better track of whether momentum is actually active, we can
set a bit (or two!) if it is active when we interrupt, and use that to drive
all the other parts of this patch.

(-[WKAppKitGestureController didEndSyntheticMomentumScrolling]):
(-[WKAppKitGestureController _resetCaughtDeceleratingScroll]):
(-[WKAppKitGestureController reset]):
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]):
Disallow all of our other gestures from starting if we interrupted scrolling.
We allow single click, which will fire and reset the interruption state,
and we let pan use its normal logic to determine whether or not to recognize.
All other gestures are blocked.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.interruptingDeceleratingScrollDoesNotFollowLink):
Add a test for this behavior!

Canonical link: <a href="https://commits.webkit.org/315351@main">https://commits.webkit.org/315351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cc5c102ff56f9da30b1550917fb2f28122371e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42377 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/35972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178149 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73e3daff-3025-4e4d-8d0d-cb9822d5d9e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131452 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a321175-5b7e-495c-891b-f36dc919c5fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33906 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111956 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/783f20d4-eae0-44af-a9d3-db0b0cd123a4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26844 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180750 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33480 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/139900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42389 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139744 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37614 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43078 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106839 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35026 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114845 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41581 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40978 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41232 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41123 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->