### PR TITLE
Clean up RenderImage::paintReplaced()

### DIFF
--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -505,23 +505,128 @@ void RenderImage::paintIncompleteImageOutline(PaintInfo& paintInfo, LayoutPoint 
     if (contentSize.width() <= 2 || contentSize.height() <= 2)
         return;
 
-    auto leftBorder = borderLeft();
-    auto topBorder = borderTop();
-    auto leftPadding = paddingLeft();
-    auto topPadding = paddingTop();
+    auto borderWidths = this->borderWidths();
+    auto padding = this->padding();
 
     // Draw an outline rect where the image should be.
     GraphicsContext& context = paintInfo.context();
     context.setStrokeStyle(StrokeStyle::SolidStroke);
     context.setStrokeColor(Color::lightGray);
     context.setFillColor(Color::transparentBlack);
-    context.drawRect(snapRectToDevicePixels(LayoutRect({ paintOffset.x() + leftBorder + leftPadding, paintOffset.y() + topBorder + topPadding }, contentSize), document().deviceScaleFactor()), borderWidth);
+    context.drawRect(snapRectToDevicePixels(LayoutRect({ paintOffset.x() + borderWidths.left() + padding.left(), paintOffset.y() + borderWidths.top() + padding.top() }, contentSize), document().deviceScaleFactor()), borderWidth);
 }
 
 static bool NODELETE isDeferredImage(Element* element)
 {
     auto* image = dynamicDowncast<HTMLImageElement>(element);
     return image && image->isDeferred();
+}
+
+void RenderImage::paintMissingImageState(PaintInfo& paintInfo, const LayoutPoint& paintOffset) const
+{
+    if (paintInfo.phase == PaintPhase::Selection)
+        return;
+
+    if (paintInfo.phase == PaintPhase::Foreground)
+        page().addRelevantUnpaintedObject(*this, visualOverflowRect());
+
+    float deviceScaleFactor = document().deviceScaleFactor();
+    LayoutUnit missingImageBorderWidth(1 / deviceScaleFactor);
+
+    paintIncompleteImageOutline(paintInfo, paintOffset, missingImageBorderWidth);
+
+    auto contentSize = this->contentBoxSize();
+    if (contentSize.width() <= 2 || contentSize.height() <= 2)
+        return;
+
+    auto borderWidths = this->borderWidths();
+    auto padding = this->padding();
+
+    bool errorPictureDrawn = false;
+    LayoutSize imageOffset;
+    // When calculating the usable dimensions, exclude the pixels of
+    // the outline rect so the error image/alt text doesn't draw on it.
+    LayoutSize usableSize = contentSize - LayoutSize(2 * missingImageBorderWidth, 2 * missingImageBorderWidth);
+
+    RefPtr image = imageResource().image();
+    auto& context = paintInfo.context();
+
+    if (shouldDisplayBrokenImageIcon() && !image->isNull() && usableSize.width() >= image->width() && usableSize.height() >= image->height()) {
+        // Call brokenImage() explicitly to ensure we get the broken image icon at the appropriate resolution.
+        auto brokenImageAndImageScaleFactor = cachedImage()->brokenImage(deviceScaleFactor);
+        image = brokenImageAndImageScaleFactor.first.get();
+        FloatSize imageSize = image->size();
+        imageSize.scale(1 / brokenImageAndImageScaleFactor.second);
+
+        // Center the error image, accounting for border and padding.
+        LayoutUnit centerX { (usableSize.width() - imageSize.width()) / 2 };
+        if (centerX < 0)
+            centerX = 0;
+        LayoutUnit centerY { (usableSize.height() - imageSize.height()) / 2 };
+        if (centerY < 0)
+            centerY = 0;
+        imageOffset = LayoutSize(borderWidths.left() + padding.left() + centerX + missingImageBorderWidth, borderWidths.top() + padding.top() + centerY + missingImageBorderWidth);
+
+        context.drawImage(*image, snapRectToDevicePixels(LayoutRect(paintOffset + imageOffset, imageSize), deviceScaleFactor), { imageOrientation() });
+        errorPictureDrawn = true;
+    }
+
+    if (m_altText.isEmpty())
+        return;
+
+    auto& style = this->style();
+    auto& fontCascade = style.fontCascade();
+    auto& fontMetrics = fontCascade.metricsOfPrimaryFont();
+    auto isHorizontal = writingMode().isHorizontal();
+    auto encodedDisplayString = document().displayStringModifiedByEncoding(m_altText);
+    auto textRun = RenderBlock::constructTextRun(encodedDisplayString, style, ExpansionBehavior::defaultBehavior(), RespectDirection | RespectDirectionOverride);
+    auto textWidth = LayoutUnit { fontCascade.width(textRun) };
+
+    auto hasRoomForAltText = [&] {
+        // Only draw the alt text if it fits within the content box (content width) and above the error image (content height).
+        // Error picture is always visually below the text regardless of writing direction.
+        auto availableLogicalWidth = isHorizontal ? usableSize.width() : (errorPictureDrawn ? imageOffset.height() : usableSize.height());
+        if (availableLogicalWidth < textWidth)
+            return false;
+        auto availableLogicalHeight = isHorizontal ? (errorPictureDrawn ? imageOffset.height() : usableSize.height()) : usableSize.width();
+        return availableLogicalHeight >= (settings().subpixelInlineLayoutEnabled() ? fontMetrics.height() : fontMetrics.intHeight());
+    };
+
+    if (!hasRoomForAltText())
+        return;
+
+    context.setFillColor(style.visitedDependentColorApplyingColorFilter());
+    if (isHorizontal) {
+        auto altTextLocation = [&]() -> LayoutPoint {
+            auto contentHorizontalOffset = LayoutUnit { borderWidths.left() + padding.left() + (paddingWidth / 2) - missingImageBorderWidth };
+            auto contentVerticalOffset = LayoutUnit { borderWidths.top() + padding.top() + (settings().subpixelInlineLayoutEnabled() ? fontMetrics.ascent() : fontMetrics.intAscent()) + (paddingHeight / 2) - missingImageBorderWidth };
+            if (!style.writingMode().isInlineLeftToRight())
+                contentHorizontalOffset += contentSize.width() - textWidth;
+            return paintOffset + LayoutPoint { contentHorizontalOffset, contentVerticalOffset };
+        };
+        auto textOrigin = altTextLocation();
+        textOrigin.setY(roundToDevicePixel(LayoutUnit { textOrigin.y() }, document().deviceScaleFactor()));
+        context.drawBidiText(fontCascade, textRun, textOrigin);
+    } else {
+        // FIXME: TextBoxPainter has this logic already, maybe we should transition to some painter class.
+        auto contentLogicalHeight = settings().subpixelInlineLayoutEnabled() ? fontMetrics.height() : fontMetrics.intHeight();
+        auto adjustedPaintOffset = LayoutPoint { paintOffset.x(), paintOffset.y() - contentLogicalHeight };
+
+        auto visualLeft = size().width() / 2 - contentLogicalHeight / 2;
+        auto visualRight = visualLeft + contentLogicalHeight;
+        if (writingMode().isBlockFlipped())
+            visualLeft = size().width() - visualRight;
+        visualLeft += adjustedPaintOffset.x();
+
+        visualLeft = roundToDevicePixel(visualLeft, document().deviceScaleFactor());
+        adjustedPaintOffset.setY(roundToDevicePixel(adjustedPaintOffset.y(), document().deviceScaleFactor()));
+
+        auto rotationRect = LayoutRect { visualLeft, adjustedPaintOffset.y(), textWidth, contentLogicalHeight };
+        context.concatCTM(rotation(rotationRect, RotationDirection::Clockwise));
+        auto textOrigin = LayoutPoint { visualLeft, adjustedPaintOffset.y() + (settings().subpixelInlineLayoutEnabled() ? fontCascade.metricsOfPrimaryFont().ascent() : fontCascade.metricsOfPrimaryFont().intAscent()) };
+        context.drawBidiText(fontCascade, textRun, roundPointToDevicePixels(textOrigin, document().deviceScaleFactor()));
+        context.concatCTM(rotation(rotationRect, RotationDirection::Counterclockwise));
+    }
 }
 
 void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
@@ -535,7 +640,7 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
         return;
     }
 
-    auto contentSize = this->contentBoxSize();
+    auto contentBoxRect = this->contentBoxRect();
     float deviceScaleFactor = document().deviceScaleFactor();
     LayoutUnit missingImageBorderWidth(1 / deviceScaleFactor);
 
@@ -543,118 +648,22 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
         return;
 
     if (context.detectingContentfulPaint()) {
-        if (!context.contentfulPaintDetected() && cachedImage() && cachedImage()->canRender(this, deviceScaleFactor) && !contentSize.isEmpty())
+        if (!context.contentfulPaintDetected() && cachedImage() && cachedImage()->canRender(this, deviceScaleFactor) && !contentBoxRect.isEmpty())
             context.setContentfulPaintDetected();
-
         return;
     }
 
     if (!imageResource().cachedImage() || shouldDisplayBrokenImageIcon()) {
-        if (paintInfo.phase == PaintPhase::Selection)
-            return;
-
-        if (paintInfo.phase == PaintPhase::Foreground)
-            page().addRelevantUnpaintedObject(*this, visualOverflowRect());
-
-        paintIncompleteImageOutline(paintInfo, paintOffset, missingImageBorderWidth);
-
-        if (contentSize.width() > 2 && contentSize.height() > 2) {
-            LayoutUnit leftBorder = borderLeft();
-            LayoutUnit topBorder = borderTop();
-            LayoutUnit leftPadding = paddingLeft();
-            LayoutUnit topPadding = paddingTop();
-
-            bool errorPictureDrawn = false;
-            LayoutSize imageOffset;
-            // When calculating the usable dimensions, exclude the pixels of
-            // the outline rect so the error image/alt text doesn't draw on it.
-            LayoutSize usableSize = contentSize - LayoutSize(2 * missingImageBorderWidth, 2 * missingImageBorderWidth);
-
-            RefPtr image = imageResource().image();
-
-            if (shouldDisplayBrokenImageIcon() && !image->isNull() && usableSize.width() >= image->width() && usableSize.height() >= image->height()) {
-                // Call brokenImage() explicitly to ensure we get the broken image icon at the appropriate resolution.
-                auto brokenImageAndImageScaleFactor = cachedImage()->brokenImage(deviceScaleFactor);
-                image = brokenImageAndImageScaleFactor.first.get();
-                FloatSize imageSize = image->size();
-                imageSize.scale(1 / brokenImageAndImageScaleFactor.second);
-
-                // Center the error image, accounting for border and padding.
-                LayoutUnit centerX { (usableSize.width() - imageSize.width()) / 2 };
-                if (centerX < 0)
-                    centerX = 0;
-                LayoutUnit centerY { (usableSize.height() - imageSize.height()) / 2 };
-                if (centerY < 0)
-                    centerY = 0;
-                imageOffset = LayoutSize(leftBorder + leftPadding + centerX + missingImageBorderWidth, topBorder + topPadding + centerY + missingImageBorderWidth);
-
-                context.drawImage(*image, snapRectToDevicePixels(LayoutRect(paintOffset + imageOffset, imageSize), deviceScaleFactor), { imageOrientation() });
-                errorPictureDrawn = true;
-            }
-
-            if (!m_altText.isEmpty()) {
-                auto& style = this->style();
-                auto& fontCascade = style.fontCascade();
-                auto& fontMetrics = fontCascade.metricsOfPrimaryFont();
-                auto isHorizontal = writingMode().isHorizontal();
-                auto encodedDisplayString = document().displayStringModifiedByEncoding(m_altText);
-                auto textRun = RenderBlock::constructTextRun(encodedDisplayString, style, ExpansionBehavior::defaultBehavior(), RespectDirection | RespectDirectionOverride);
-                auto textWidth = LayoutUnit { fontCascade.width(textRun) };
-
-                auto hasRoomForAltText = [&] {
-                    // Only draw the alt text if it fits within the content box (content width) and above the error image (content height).
-                    // Error picture is always visually below the text regardless of writing direction.
-                    auto availableLogicalWidth = isHorizontal ? usableSize.width() : (errorPictureDrawn ? imageOffset.height() : usableSize.height());
-                    if (availableLogicalWidth < textWidth)
-                        return false;
-                    auto availableLogicalHeight = isHorizontal ? (errorPictureDrawn ? imageOffset.height() : usableSize.height()) : usableSize.width();
-                    return availableLogicalHeight >= (settings().subpixelInlineLayoutEnabled() ? fontMetrics.height() : fontMetrics.intHeight());
-                };
-                if (hasRoomForAltText()) {
-                    context.setFillColor(style.visitedDependentColorApplyingColorFilter());
-                    if (isHorizontal) {
-                        auto altTextLocation = [&]() -> LayoutPoint {
-                            auto contentHorizontalOffset = LayoutUnit { leftBorder + leftPadding + (paddingWidth / 2) - missingImageBorderWidth };
-                            auto contentVerticalOffset = LayoutUnit { topBorder + topPadding + (settings().subpixelInlineLayoutEnabled() ? fontMetrics.ascent() : fontMetrics.intAscent()) + (paddingHeight / 2) - missingImageBorderWidth };
-                            if (!style.writingMode().isInlineLeftToRight())
-                                contentHorizontalOffset += contentSize.width() - textWidth;
-                            return paintOffset + LayoutPoint { contentHorizontalOffset, contentVerticalOffset };
-                        };
-                        auto textOrigin = altTextLocation();
-                        textOrigin.setY(roundToDevicePixel(LayoutUnit { textOrigin.y() }, document().deviceScaleFactor()));
-                        context.drawBidiText(fontCascade, textRun, textOrigin);
-                    } else {
-                        // FIXME: TextBoxPainter has this logic already, maybe we should transition to some painter class.
-                        auto contentLogicalHeight = settings().subpixelInlineLayoutEnabled() ? fontMetrics.height() : fontMetrics.intHeight();
-                        auto adjustedPaintOffset = LayoutPoint { paintOffset.x(), paintOffset.y() - contentLogicalHeight };
-
-                        auto visualLeft = size().width() / 2 - contentLogicalHeight / 2;
-                        auto visualRight = visualLeft + contentLogicalHeight;
-                        if (writingMode().isBlockFlipped())
-                            visualLeft = size().width() - visualRight;
-                        visualLeft += adjustedPaintOffset.x();
-
-                        visualLeft = roundToDevicePixel(visualLeft, document().deviceScaleFactor());
-                        adjustedPaintOffset.setY(roundToDevicePixel(adjustedPaintOffset.y(), document().deviceScaleFactor()));
-
-                        auto rotationRect = LayoutRect { visualLeft, adjustedPaintOffset.y(), textWidth, contentLogicalHeight };
-                        context.concatCTM(rotation(rotationRect, RotationDirection::Clockwise));
-                        auto textOrigin = LayoutPoint { visualLeft, adjustedPaintOffset.y() + (settings().subpixelInlineLayoutEnabled() ? fontCascade.metricsOfPrimaryFont().ascent() : fontCascade.metricsOfPrimaryFont().intAscent()) };
-                        context.drawBidiText(fontCascade, textRun, roundPointToDevicePixels(textOrigin, document().deviceScaleFactor()));
-                        context.concatCTM(rotation(rotationRect, RotationDirection::Counterclockwise));
-                    }
-                }
-            }
-        }
+        paintMissingImageState(paintInfo, paintOffset);
         return;
     }
     
-    if (contentSize.isEmpty())
+    if (contentBoxRect.isEmpty())
         return;
 
     bool showBorderForIncompleteImage = settings().incompleteImageBorderEnabled();
 
-    RefPtr<Image> img = imageResource().image(flooredIntSize(contentSize));
+    RefPtr<Image> img = imageResource().image(flooredIntSize(contentBoxRect.size()));
     if (!img || img->isNull()) {
         if (showBorderForIncompleteImage)
             paintIncompleteImageOutline(paintInfo, paintOffset, missingImageBorderWidth);
@@ -664,7 +673,6 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
         return;
     }
 
-    LayoutRect contentBoxRect = this->contentBoxRect();
     contentBoxRect.moveBy(paintOffset);
 
     // For SVGs without intrinsic dimensions (no width/height/viewBox), use

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -117,6 +117,7 @@ private:
 
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
     void paintIncompleteImageOutline(PaintInfo&, LayoutPoint, LayoutUnit) const;
+    void paintMissingImageState(PaintInfo&, const LayoutPoint&) const;
 
     bool computeBackgroundIsKnownToBeObscured(const LayoutPoint& paintOffset) final;
 


### PR DESCRIPTION
#### 5cce6db960ddc377d1f0a00df9d1e93cc2173e1a
<pre>
Clean up RenderImage::paintReplaced()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317268">https://bugs.webkit.org/show_bug.cgi?id=317268</a>
<a href="https://rdar.apple.com/179880055">rdar://179880055</a>

Reviewed by Dan Glastonbury.

Move the missing image painting code, which is the bulk of `RenderImage::paintReplaced()`,
into its own function. We can add early returns and outdent much of the code.

There&apos;s a minor optimization here, which is that we avoid calling `contentSize()`
followed by `contentRect()`, since the latter&apos;s size is the same.

* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintIncompleteImageOutline const):
(WebCore::RenderImage::paintMissingImageState const):
(WebCore::RenderImage::paintReplaced):
* Source/WebCore/rendering/RenderImage.h:

Canonical link: <a href="https://commits.webkit.org/315373@main">https://commits.webkit.org/315373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/911d1f127fbd915f3c70a0245ecf1a1a77cb23f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126498 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2712e1ca-1719-405e-9198-67d1b417ca62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131428 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bda4880d-424e-43f2-b7a3-6ea068a7e555) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111932 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66554fa1-6890-45a7-8a16-6a9d7b8fd1ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32868 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26817 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180723 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139875 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42362 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139719 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37629 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43051 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106798 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35000 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114818 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41554 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6161 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40951 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41205 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41096 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->