### PR TITLE
[BFCache] Clear-Site-Data: "cache" does not evict BFCache or MemoryCache entries due to HashSet hash mismatch

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -725,11 +725,20 @@ void BackForwardCache::prune(PruningReason pruningReason)
     }
 }
 
-void BackForwardCache::clearEntriesForOrigins(const HashSet<Ref<SecurityOrigin>>& origins)
+void BackForwardCache::clearEntriesForOrigins(const HashSet<Ref<SecurityOrigin>, SecurityOriginHash>& origins)
 {
     m_cachedPageMap.removeIf([&](auto& pair) -> bool {
         if (auto* cachedPage = std::get_if<UniqueRef<CachedPage>>(&pair.value)) {
-            if (origins.contains(SecurityOrigin::create((*cachedPage)->page().mainFrameURL()))) {
+            Ref cachedOrigin = SecurityOrigin::create((*cachedPage)->page().mainFrameURL());
+            bool found = origins.contains(cachedOrigin);
+#if ASSERT_ENABLED
+            // rdar://179387089
+            if (!found) {
+                for (auto& o : origins)
+                    ASSERT(!o->isSameSchemeHostPort(cachedOrigin));
+            }
+#endif
+            if (found) {
                 RELEASE_LOG(BackForwardCache, "BackForwardCache::clearEntriesForOrigins removing item: %s, size: %u / %u", pair.key.toString().utf8().data(), pageCount() - 1, maxSize());
                 notifyClientOfEviction(protect(cachedPage->get()));
                 m_items.remove(pair.key);

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -28,6 +28,7 @@
 #include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/HistoryItem.h>
+#include <WebCore/SecurityOriginHash.h>
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
@@ -68,7 +69,7 @@ public:
 
     WEBCORE_EXPORT void removeAllItemsForPage(Page&);
 
-    WEBCORE_EXPORT void clearEntriesForOrigins(const HashSet<Ref<SecurityOrigin>>&);
+    WEBCORE_EXPORT void clearEntriesForOrigins(const HashSet<Ref<SecurityOrigin>, SecurityOriginHash>&);
 
     unsigned pageCount() const { return m_items.size(); }
     WEBCORE_EXPORT unsigned frameCount() const;

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -570,7 +570,7 @@ void MemoryCache::removeResourcesWithOrigin(const ClientOrigin& origin)
     removeResourcesWithOrigin(origin.clientOrigin.securityOrigin(), cachePartition);
 }
 
-void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const HashSet<Ref<SecurityOrigin>>& origins)
+void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const SecurityOriginSet& origins)
 {
     RELEASE_ASSERT(isMainThread());
     auto* resourceMap = sessionResourceMap(sessionID);
@@ -615,11 +615,11 @@ void MemoryCache::getOriginsWithCache(SecurityOriginSet& origins)
     }
 }
 
-HashSet<Ref<SecurityOrigin>> MemoryCache::originsWithCache(PAL::SessionID sessionID) const
+MemoryCache::SecurityOriginSet MemoryCache::originsWithCache(PAL::SessionID sessionID) const
 {
     RELEASE_ASSERT(isMainThread());
 
-    HashSet<Ref<SecurityOrigin>> origins;
+    SecurityOriginSet origins;
 
     auto it = m_sessionResources.find(sessionID);
     if (it != m_sessionResources.end()) {

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -161,13 +161,13 @@ public:
     void resourceAccessed(CachedResource&);
     bool NODELETE inLiveDecodedResourcesList(CachedResource&) const;
 
-    using SecurityOriginSet = HashSet<Ref<SecurityOrigin>>;
+    using SecurityOriginSet = HashSet<Ref<SecurityOrigin>, SecurityOriginHash>;
     WEBCORE_EXPORT void removeResourcesWithOrigin(const SecurityOrigin&);
     void removeResourcesWithOrigin(const SecurityOrigin&, const String& cachePartition);
     WEBCORE_EXPORT void removeResourcesWithOrigin(const ClientOrigin&);
-    WEBCORE_EXPORT void removeResourcesWithOrigins(PAL::SessionID, const HashSet<Ref<SecurityOrigin>>&);
+    WEBCORE_EXPORT void removeResourcesWithOrigins(PAL::SessionID, const SecurityOriginSet&);
     WEBCORE_EXPORT void getOriginsWithCache(SecurityOriginSet& origins);
-    WEBCORE_EXPORT HashSet<Ref<SecurityOrigin>> originsWithCache(PAL::SessionID) const;
+    WEBCORE_EXPORT SecurityOriginSet originsWithCache(PAL::SessionID) const;
 
     // pruneDead*() - Flush decoded and encoded data from resources not referenced by Web pages.
     // pruneLive*() - Flush decoded data from resources still referenced by Web pages.

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1683,8 +1683,11 @@ void WebProcess::deleteWebsiteDataForOrigin(OptionSet<WebsiteDataType> websiteDa
     ASSERT(websiteDataTypes.contains(WebsiteDataType::MemoryCache)); // This would be useless IPC otherwise.
     if (websiteDataTypes.contains(WebsiteDataType::MemoryCache)) {
         MemoryCache::singleton().removeResourcesWithOrigin(origin);
-        if (origin.topOrigin == origin.clientOrigin)
-            BackForwardCache::singleton().clearEntriesForOrigins({ Ref { origin.clientOrigin.securityOrigin() } });
+        if (origin.topOrigin == origin.clientOrigin) {
+            HashSet<Ref<WebCore::SecurityOrigin>, WebCore::SecurityOriginHash> origins;
+            origins.add(origin.clientOrigin.securityOrigin());
+            BackForwardCache::singleton().clearEntriesForOrigins(origins);
+        }
     }
     completionHandler();
 }
@@ -1701,7 +1704,7 @@ void WebProcess::reloadExecutionContextsForOrigin(const ClientOrigin& origin, st
 void WebProcess::deleteWebsiteDataForOrigins(OptionSet<WebsiteDataType> websiteDataTypes, const Vector<WebCore::SecurityOriginData>& originDatas, CompletionHandler<void()>&& completionHandler)
 {
     if (websiteDataTypes.contains(WebsiteDataType::MemoryCache)) {
-        HashSet<Ref<SecurityOrigin>> origins;
+        HashSet<Ref<SecurityOrigin>, WebCore::SecurityOriginHash> origins;
         for (auto& originData : originDatas)
             origins.add(originData.securityOrigin());
 


### PR DESCRIPTION
#### 72367779fcf91bacae62f9bccecd9331fd323e3a
<pre>
[BFCache] Clear-Site-Data: &quot;cache&quot; does not evict BFCache or MemoryCache entries due to HashSet hash mismatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=317269">https://bugs.webkit.org/show_bug.cgi?id=317269</a>
<a href="https://rdar.apple.com/179387089">rdar://179387089</a>

Reviewed by NOBODY (OOPS!).

`BackForwardCache::clearEntriesForOrigins` and the parallel
`MemoryCache::removeResourcesWithOrigins` silently fail to remove
matching entries. `origins.contains(SecurityOrigin::create(...))` ends
up using pointer-based comparison and never matches a freshly-created
SecurityOrigin even when content (scheme/host/port) is equal. Net
effect: an HTTP `Clear-Site-Data: &quot;cache&quot;` response does not evict
either back/forward cache or memory cache entries for the calling site.

The HashSet is built and queried correctly in the WebProcess caller
(content-keyed via the visible `SecurityOriginHash` specialization),
but inside the WebCore eviction functions the lookup links to a
different instantiation of `HashSet&lt;Ref&lt;SecurityOrigin&gt;&gt;::contains`
and uses PtrHash semantics. Pinning the parameter type to
`HashSet&lt;Ref&lt;SecurityOrigin&gt;, SecurityOriginHash&gt;` makes the mangled
name unambiguous across TUs, so the same SecurityOriginHash-based
container is used everywhere.

This is what `http/tests/clear-site-data/bfcache.html` exercises; iOS
Debug shows it as a constant failure (slow cold WKTR process) and Mac
Debug reproduces it as a flaky failure.

A defensive ASSERT is added inside `clearEntriesForOrigins`: if
`contains()` returns false, no entry in `origins` may compare
`isSameSchemeHostPort`-equal to the cached origin. This crashes
deterministically in debug builds if the template-spec/ODR regression
recurs.

Covered by existing test `http/tests/clear-site-data/bfcache.html`
(iOS Debug constant fail before; 30/30 pass after on iOS Simulator
Debug).

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::clearEntriesForOrigins): Take HashSet pinned
to SecurityOriginHash. Add diagnostic ASSERT for content-vs-pointer
match divergence. <a href="https://rdar.apple.com/179387089">rdar://179387089</a>.
* Source/WebCore/history/BackForwardCache.h: Match new signature; pull
in SecurityOriginHash.h so callers see the explicit specialization at
the API boundary.
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::removeResourcesWithOrigins): Take SecurityOriginSet
(now SecurityOriginHash-pinned).
(WebCore::MemoryCache::originsWithCache): Return SecurityOriginSet.
* Source/WebCore/loader/cache/MemoryCache.h: Pin `SecurityOriginSet` and
the public APIs to `SecurityOriginHash`.
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::deleteWebsiteDataForOrigin): Build a
SecurityOriginHash-keyed HashSet for the BFCache call.
(WebKit::WebProcess::deleteWebsiteDataForOrigins): Use one
SecurityOriginHash-keyed HashSet for both MemoryCache and BFCache.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72367779fcf91bacae62f9bccecd9331fd323e3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126529 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68be87b2-f9b2-4a4f-a968-15697ad5727b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131453 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f358785-3856-4e6d-8eb1-e4f6d704ae72) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/876af03d-defb-4d60-9d2d-3eadd50669de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32897 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26848 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180754 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139902 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42393 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139746 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43082 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28099 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106847 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35027 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114849 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41585 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6187 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40982 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->