### PR TITLE
Make scrollToFocusedElementInternal use post-animation geometry for accelerated transform animations

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Focus into a panel mid-transform-animation does NOT page-scroll when target is visible at the panel's resting position (Spotify-class case, rdar://171019322)
+PASS Focus into a panel mid-transform-animation DOES scroll the panel's internal scroll container, immediately, when target requires scrolling at rest — and the scroll position is stable across the rest of the animation (no hop)
+

--- a/LayoutTests/fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html
+++ b/LayoutTests/fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+/*
+ * Test scenario A: focus target is visible at the panel's RESTING (post-animation) position.
+ * The panel slides in from off-screen via an accelerated transform; focus fires mid-animation.
+ * Expectation: NO page scroll (because the target IS visible at rest). Matches Chrome/Firefox.
+ */
+#panelA {
+    position: fixed;
+    top: 100px;
+    left: 0;
+    width: 300px;
+    height: 200px;
+    background: #eee;
+    transform: translateX(-500px);
+    will-change: transform;
+    transition: transform 0.5s linear;
+}
+#panelA.open { transform: translateX(0); }
+#targetA { position: absolute; top: 50px; left: 10px; }
+
+/*
+ * Test scenario B: focus target is NOT visible at rest — scrolling INTO the panel's overflow
+ * is required to reveal it. The panel ALSO has a transform animation in flight at the moment
+ * focus fires. Expectation: scroll-into-view fires immediately and lands on the RESTING geometry
+ * (no later "hop").
+ */
+#panelB {
+    position: fixed;
+    top: 350px;
+    left: 0;
+    width: 300px;
+    height: 200px;
+    overflow: auto;
+    background: #ddd;
+    transform: translateX(-500px);
+    will-change: transform;
+    transition: transform 0.5s linear;
+}
+#panelB.open { transform: translateX(0); }
+#panelB .spacer { height: 800px; }
+#targetB { position: absolute; top: 700px; left: 10px; }
+</style>
+
+<div id="panelA"><a id="targetA" href="#">target A</a></div>
+
+<div id="panelB"><div class="spacer"></div><a id="targetB" href="#">target B</a></div>
+
+<script>
+async function runScenario(panelId, targetId, mustScroll) {
+    const panel = document.getElementById(panelId);
+    const target = document.getElementById(targetId);
+
+    const transitionRun = new Promise(resolve =>
+        panel.addEventListener('transitionrun', resolve, { once: true }));
+    const transitionEnd = new Promise(resolve =>
+        panel.addEventListener('transitionend', resolve, { once: true }));
+
+    const initialPageScrollY = window.scrollY;
+    const initialPanelScrollTop = panel.scrollTop;
+
+    await new Promise(requestAnimationFrame);
+    panel.classList.add('open');
+    await transitionRun;
+
+    target.focus();
+
+    // scrollToFocusedElementInternal runs from a delayed timer (0 s); give it a chance to fire
+    // before sampling scroll positions. A single rAF + step_timeout(0) is enough in practice.
+    await new Promise(resolve => requestAnimationFrame(() => t.step_timeout(resolve, 0)));
+
+    // Mid-animation: scroll-into-view computed the focus target's rect against the panel's
+    // *resting* (post-animation) transform, not the in-flight interpolated value. So the
+    // observable result depends only on whether the target would be visible at rest:
+    //   scenario A: visible at rest → no scroll
+    //   scenario B: not visible at rest → panel.scrollTop is non-zero (immediately, not deferred)
+    if (!mustScroll) {
+        assert_equals(window.scrollY, initialPageScrollY,
+            `${panelId}: page must not scroll when target is visible at panel's resting position (got window.scrollY=${window.scrollY})`);
+        assert_equals(panel.scrollTop, initialPanelScrollTop,
+            `${panelId}: panel must not internal-scroll either (target visible at rest; got panel.scrollTop=${panel.scrollTop})`);
+    } else {
+        assert_greater_than(panel.scrollTop, 100,
+            `${panelId}: panel must scroll to bring focus target into view, immediately, using resting geometry (got panel.scrollTop=${panel.scrollTop})`);
+    }
+
+    // After the animation ends, geometry must remain stable — no hop. The post-animation
+    // scroll position should match what we observed mid-animation.
+    const midAnimationPanelScroll = panel.scrollTop;
+    const midAnimationPageScroll = window.scrollY;
+    await transitionEnd;
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+    assert_equals(panel.scrollTop, midAnimationPanelScroll,
+        `${panelId}: panel scroll must not change after animation completes (no hop)`);
+    assert_equals(window.scrollY, midAnimationPageScroll,
+        `${panelId}: page scroll must not change after animation completes (no hop)`);
+}
+
+promise_test(t => runScenario('panelA', 'targetA', /* mustScroll */ false),
+    "Focus into a panel mid-transform-animation does NOT page-scroll when target is visible at the panel's resting position (Spotify-class case, rdar://171019322)");
+
+promise_test(t => runScenario('panelB', 'targetB', /* mustScroll */ true),
+    "Focus into a panel mid-transform-animation DOES scroll the panel's internal scroll container, immediately, when target requires scrolling at rest — and the scroll position is stable across the rest of the animation (no hop)");
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3,7 +3,7 @@
  *                     1999 Lars Knoll <knoll@kde.org>
  *                     1999 Antti Koivisto <koivisto@kde.org>
  *                     2000 Dirk Mueller <mueller@kde.org>
- * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  *           (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2009 Google Inc. All rights reserved.
@@ -3461,15 +3461,13 @@ void LocalFrameView::scrollToFocusedElementInternal()
     if (!m_shouldScrollToFocusedElement || m_delayedScrollToFocusedElementTimer.isActive())
         return; // Updating the layout may have ran scripts.
 
-    m_shouldScrollToFocusedElement = false;
-
     RefPtr focusedElement = document->focusedElement();
     if (!focusedElement)
         return;
     auto updateTarget = focusedElement->focusAppearanceUpdateTarget();
     if (!updateTarget)
         return;
-    
+
     // Get the scroll-margin of the shadow host when we're inside a user agent shadow root.
     if (updateTarget->containingShadowRoot() && updateTarget->containingShadowRoot()->mode() == ShadowRootMode::UserAgent)
         updateTarget = updateTarget->shadowHost();
@@ -3478,8 +3476,18 @@ void LocalFrameView::scrollToFocusedElementInternal()
     if (!renderer || renderer->isRenderWidget())
         return;
 
+    m_shouldScrollToFocusedElement = false;
+
+    // Compute the focus target's anchor rect using *resting* (post-animation) transforms for any
+    // ancestor running an accelerated transform-family animation. This matches what Chrome and
+    // Firefox observably do: when focus moves into an element whose parent is sliding/scaling/rotating
+    // into view, we scroll based on where the element will be at rest, not where it is mid-animation.
+    // See rdar://171019322 (spotify.com queue panel "hop") for the motivating bug. With the resting
+    // rect, scrollRectToVisible naturally short-circuits when the target would already be visible at
+    // rest (the Spotify case) and otherwise scrolls to the right (resting) position rather than to a
+    // transient mid-animation snapshot that the animation would later invalidate.
     bool insideFixed;
-    auto absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed);
+    auto absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed, { MapCoordinatesMode::UseTransforms, MapCoordinatesMode::IgnoreAcceleratedTransforms });
     auto anchorRectWithScrollMargin = absoluteBounds.marginRect;
     auto anchorRect = absoluteBounds.anchorRect;
     LocalFrameView::scrollRectToVisible(anchorRectWithScrollMargin, *renderer, insideFixed, { m_selectionRevealModeForFocusedElement, ScrollAlignment::alignCenterIfNeeded, ScrollAlignment::alignCenterIfNeeded, ShouldAllowCrossOriginScrolling::No, ScrollBehavior::Auto, OnlyAllowForwardScrolling::No, AllowScrollingOverflowHidden::Yes, anchorRect });

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2069,15 +2069,15 @@ const Style::ComputedStyle* RenderElement::targetTextPseudoStyle() const
     return textSegmentPseudoStyle(PseudoElementType::TargetText);
 }
 
-bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
+bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed, OptionSet<MapCoordinatesMode> mode) const
 {
     if (isSVGRenderer()) {
-        point = localToAbsoluteQuad(strokeBoundingBox(), MapCoordinatesMode::UseTransforms).boundingBox().minXMinYCorner();
+        point = localToAbsoluteQuad(strokeBoundingBox(), mode).boundingBox().minXMinYCorner();
         return true;
     }
 
     if (!isInline() || isBlockLevelReplacedOrAtomicInline()) {
-        point = localToAbsolute(FloatPoint(), MapCoordinatesMode::UseTransforms, &insideFixed);
+        point = localToAbsolute(FloatPoint(), mode, &insideFixed);
         return true;
     }
 
@@ -2103,7 +2103,7 @@ bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
         ASSERT(o);
 
         if (!o->isInline() || o->isBlockLevelReplacedOrAtomicInline()) {
-            point = o->localToAbsolute(FloatPoint(), MapCoordinatesMode::UseTransforms, &insideFixed);
+            point = o->localToAbsolute(FloatPoint(), mode, &insideFixed);
             return true;
         }
 
@@ -2116,7 +2116,7 @@ bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
                     point.move(textRenderer->linesBoundingBox().x(), run->lineBox()->contentLogicalTop());
             } else if (auto* box = dynamicDowncast<RenderBox>(*o))
                 point.moveBy(box->location());
-            point = o->container()->localToAbsolute(point, MapCoordinatesMode::UseTransforms, &insideFixed);
+            point = o->container()->localToAbsolute(point, mode, &insideFixed);
             return true;
         }
     }
@@ -2130,15 +2130,15 @@ bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
     return false;
 }
 
-bool RenderElement::getTrailingCorner(FloatPoint& point, bool& insideFixed) const
+bool RenderElement::getTrailingCorner(FloatPoint& point, bool& insideFixed, OptionSet<MapCoordinatesMode> mode) const
 {
     if (isSVGRenderer()) {
-        point = localToAbsoluteQuad(strokeBoundingBox(), MapCoordinatesMode::UseTransforms).boundingBox().maxXMaxYCorner();
+        point = localToAbsoluteQuad(strokeBoundingBox(), mode).boundingBox().maxXMaxYCorner();
         return true;
     }
 
     if (!isInline() || isBlockLevelReplacedOrAtomicInline()) {
-        point = localToAbsolute(LayoutPoint(downcast<RenderBox>(*this).size()), MapCoordinatesMode::UseTransforms, &insideFixed);
+        point = localToAbsolute(LayoutPoint(downcast<RenderBox>(*this).size()), mode, &insideFixed);
         return true;
     }
 
@@ -2169,20 +2169,20 @@ bool RenderElement::getTrailingCorner(FloatPoint& point, bool& insideFixed) cons
                 point.moveBy(linesBox.maxXMaxYCorner());
             } else
                 point.moveBy(downcast<RenderBox>(*o).frameRect().maxXMaxYCorner());
-            point = o->container()->localToAbsolute(point, MapCoordinatesMode::UseTransforms, &insideFixed);
+            point = o->container()->localToAbsolute(point, mode, &insideFixed);
             return true;
         }
     }
     return true;
 }
 
-LayoutRect RenderElement::absoluteAnchorRect(bool* insideFixed) const
+LayoutRect RenderElement::absoluteAnchorRect(bool* insideFixed, OptionSet<MapCoordinatesMode> mode) const
 {
     FloatPoint leading, trailing;
     bool leadingInFixed = false;
     bool trailingInFixed = false;
-    getLeadingCorner(leading, leadingInFixed);
-    getTrailingCorner(trailing, trailingInFixed);
+    getLeadingCorner(leading, leadingInFixed, mode);
+    getTrailingCorner(trailing, trailingInFixed, mode);
 
     FloatPoint upperLeft = leading;
     FloatPoint lowerRight = trailing;
@@ -2201,9 +2201,9 @@ LayoutRect RenderElement::absoluteAnchorRect(bool* insideFixed) const
     return enclosingLayoutRect(FloatRect(upperLeft, lowerRight.expandedTo(upperLeft) - upperLeft));
 }
 
-MarginRect RenderElement::absoluteAnchorRectWithScrollMargin(bool* insideFixed) const
+MarginRect RenderElement::absoluteAnchorRectWithScrollMargin(bool* insideFixed, OptionSet<MapCoordinatesMode> mode) const
 {
-    auto anchorRect = absoluteAnchorRect(insideFixed);
+    auto anchorRect = absoluteAnchorRect(insideFixed, mode);
 
     auto& scrollMarginBox = style().scrollMarginBox();
     if (Style::isZero(scrollMarginBox))

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -213,11 +213,11 @@ public:
     // absoluteAnchorRect() is conceptually similar to absoluteBoundingBoxRect(), but is intended for scrolling to an
     // anchor. For inline renderers, this gets the logical top left of the first leaf child and the logical bottom
     // right of the last leaf child, converts them to absolute coordinates, and makes a box out of them.
-    LayoutRect absoluteAnchorRect(bool* insideFixed = nullptr) const;
+    LayoutRect absoluteAnchorRect(bool* insideFixed = nullptr, OptionSet<MapCoordinatesMode> = MapCoordinatesMode::UseTransforms) const;
 
     // absoluteAnchorRectWithScrollMargin() is similar to absoluteAnchorRect, but it also takes into account any
     // CSS scroll-margin that is set in the style of this RenderElement.
-    MarginRect absoluteAnchorRectWithScrollMargin(bool* insideFixed = nullptr) const;
+    MarginRect absoluteAnchorRectWithScrollMargin(bool* insideFixed = nullptr, OptionSet<MapCoordinatesMode> = MapCoordinatesMode::UseTransforms) const;
 
     inline bool hasFilter() const; // Defined in RenderElementStyleInlines.h.
     inline bool hasBackdropFilter() const; // Defined in RenderElementStyleInlines.h.
@@ -438,8 +438,8 @@ private:
     void imageContentChanged(CachedImage&) final;
     void scheduleRenderingUpdateForImage(CachedImage&) final;
 
-    bool getLeadingCorner(FloatPoint& output, bool& insideFixed) const;
-    bool getTrailingCorner(FloatPoint& output, bool& insideFixed) const;
+    bool getLeadingCorner(FloatPoint& output, bool& insideFixed, OptionSet<MapCoordinatesMode> = MapCoordinatesMode::UseTransforms) const;
+    bool getTrailingCorner(FloatPoint& output, bool& insideFixed, OptionSet<MapCoordinatesMode> = MapCoordinatesMode::UseTransforms) const;
 
     void NODELETE clearSubtreeLayoutRootIfNeeded() const;
     

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1806,6 +1806,29 @@ TransformationMatrix RenderLayer::currentTransform() const
     return currentTransform(Style::TransformResolver::allTransformOperations);
 }
 
+TransformationMatrix RenderLayer::currentRestingTransform(OptionSet<Style::TransformResolverOption> options) const
+{
+    if (!m_transform)
+        return { };
+
+    auto styleable = Styleable::fromRenderer(renderer());
+    if (styleable && styleable->isRunningAcceleratedTransformRelatedAnimation()) {
+        // Compute the transform from the style as it was *before* keyframe effects were applied this
+        // frame. lastStyleChangeEventStyle() is set by StyleTreeResolver right before
+        // applyKeyframeEffects mutates the resolved style with interpolated values, so it's the
+        // resting/at-rest transform we want.
+        if (CheckedPtr restingStyle = styleable->lastStyleChangeEventStyle()) {
+            TransformationMatrix transform;
+            updateTransformFromStyle(transform, *restingStyle, options);
+            return transform;
+        }
+    }
+
+    // No in-flight accelerated transform animation, or no resting style cached: the live
+    // currentTransform() result is also the resting result.
+    return currentTransform(options);
+}
+
 TransformationMatrix RenderLayer::renderableTransform(OptionSet<PaintBehavior> paintBehavior) const
 {
     if (!m_transform)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -841,6 +841,10 @@ public:
     // the layer does not have a transform, the identity matrix is returned.
     TransformationMatrix currentTransform(OptionSet<Style::TransformResolverOption>) const;
     TransformationMatrix currentTransform() const;
+    // Like currentTransform(), but computes the transform from the pre-animation (resting) style
+    // when an accelerated transform-related animation is in flight. Used by callers that want the
+    // post-animation/at-rest geometry rather than the live interpolated geometry.
+    TransformationMatrix currentRestingTransform(OptionSet<Style::TransformResolverOption>) const;
     TransformationMatrix renderableTransform(OptionSet<PaintBehavior>) const;
     
     // Get the children transform (to apply a perspective on children), which is applied to transformed sublayers, but not this layer.

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1535,14 +1535,17 @@ bool RenderObject::shouldUseTransformFromContainer(const RenderElement* containe
 }
 
 // FIXME: Now that it's no longer passed a container maybe this should be renamed?
-void RenderObject::getTransformFromContainer(const LayoutSize& offsetInContainer, TransformationMatrix& transform) const
+void RenderObject::getTransformFromContainer(const LayoutSize& offsetInContainer, TransformationMatrix& transform, OptionSet<MapCoordinatesMode> mode) const
 {
     transform.makeIdentity();
     transform.translate(offsetInContainer.width(), offsetInContainer.height());
     CheckedPtr<RenderLayer> layer;
-    if (hasLayer() && (layer = downcast<RenderLayerModelObject>(*this).layer()) && layer->transform())
-        transform.multiply(layer->currentTransform());
-    else if (document().settings().layerBasedSVGEngineEnabled() && isSVGLayerAwareRenderer()) {
+    if (hasLayer() && (layer = downcast<RenderLayerModelObject>(*this).layer()) && layer->transform()) {
+        if (mode.contains(MapCoordinatesMode::IgnoreAcceleratedTransforms))
+            transform.multiply(layer->currentRestingTransform(Style::TransformResolver::allTransformOperations));
+        else
+            transform.multiply(layer->currentTransform());
+    } else if (document().settings().layerBasedSVGEngineEnabled() && isSVGLayerAwareRenderer()) {
         // Non-layered SVG elements: use the cached local transform. localTransform() is virtual,
         // returning m_localTransform for RenderSVGModelObject and RenderSVGText, identity otherwise.
         if (auto svgTransform = localTransform(); !svgTransform.isIdentity())
@@ -1570,7 +1573,7 @@ void RenderObject::pushOntoTransformState(TransformState& transformState, Option
     bool preserve3D = mode.contains(MapCoordinatesMode::UseTransforms) && participatesInPreserve3D();
     if (mode.contains(MapCoordinatesMode::UseTransforms) && shouldUseTransformFromContainer(container)) {
         TransformationMatrix matrix;
-        getTransformFromContainer(offsetInContainer, matrix);
+        getTransformFromContainer(offsetInContainer, matrix, mode);
         transformState.applyTransform(matrix, preserve3D ? TransformState::AccumulateTransform : TransformState::FlattenTransform);
     } else
         transformState.move(offsetInContainer.width(), offsetInContainer.height(), preserve3D ? TransformState::AccumulateTransform : TransformState::FlattenTransform);

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1069,7 +1069,7 @@ public:
     virtual void mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode>, TransformState&) const;
 
     bool NODELETE shouldUseTransformFromContainer(const RenderElement* container) const;
-    void getTransformFromContainer(const LayoutSize& offsetInContainer, TransformationMatrix&) const;
+    void getTransformFromContainer(const LayoutSize& offsetInContainer, TransformationMatrix&, OptionSet<MapCoordinatesMode> = MapCoordinatesMode::UseTransforms) const;
     
     void pushOntoTransformState(TransformState&, OptionSet<MapCoordinatesMode>, const RenderLayerModelObject* repaintContainer, const RenderElement* container, const LayoutSize& offsetInContainer, bool containerSkipped) const;
 

--- a/Source/WebCore/rendering/RenderObjectEnums.h
+++ b/Source/WebCore/rendering/RenderObjectEnums.h
@@ -53,11 +53,12 @@ enum class MarkingBehavior : uint8_t {
 };
 
 enum class MapCoordinatesMode : uint8_t {
-    IsFixed             = 1 << 0,
-    UseTransforms       = 1 << 1,
-    ApplyContainerFlip  = 1 << 2,
-    IgnoreStickyOffsets = 1 << 3,
-    ClampOverscroll     = 1 << 4,
+    IsFixed                     = 1 << 0,
+    UseTransforms               = 1 << 1,
+    ApplyContainerFlip          = 1 << 2,
+    IgnoreStickyOffsets         = 1 << 3,
+    ClampOverscroll             = 1 << 4,
+    IgnoreAcceleratedTransforms = 1 << 5,
 };
 
 }


### PR DESCRIPTION
#### 69b05dfc35a466cb6719154023e1d02fbeb03e60
<pre>
Make scrollToFocusedElementInternal use post-animation geometry for accelerated transform animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=317690">https://bugs.webkit.org/show_bug.cgi?id=317690</a>
<a href="https://rdar.apple.com/180450213">rdar://180450213</a>

Reviewed by NOBODY (OOPS!).

LocalFrameView::scrollToFocusedElementInternal walks the focus target&apos;s renderer chain to
compute an absolute anchor rect, then asks scrollRectToVisible whether to scroll. During
an accelerated transform-family animation on an ancestor, the chain walk applies the
ancestor&apos;s *interpolated* (live) transform via RenderLayer::currentTransform, so the rect
reflects mid-animation geometry. The resulting scroll target is a transient position; when
the animation completes, layout reconciles and the visible position shifts.

This patch makes the focus-scroll path opt-in to a &quot;use the resting transform&quot; walk for
ancestors with running accelerated transform-family animations:

The flag covers the entire transform-family uniformly (transform, translate, rotate, scale,
perspective) because all of them flow through RenderLayer::updateTransformFromStyle, which
currentRestingTransform calls with the resting style.

Test: fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html

* LayoutTests/fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFocusedElementInternal):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::getLeadingCorner const):
(WebCore::RenderElement::getTrailingCorner const):
(WebCore::RenderElement::absoluteAnchorRect const):
(WebCore::RenderElement::absoluteAnchorRectWithScrollMargin const):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::currentRestingTransform const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::getTransformFromContainer const):
(WebCore::RenderObject::pushOntoTransformState const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderObjectEnums.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69b05dfc35a466cb6719154023e1d02fbeb03e60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179220 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127573 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bead515-afba-453a-83fd-1659af473835) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43413 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132388 "Found 1 new test failure: fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93273 "11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f88fccd-797c-4af1-9925-980ec8b37e8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172820 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35673 "Found 1 new test failure: fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112890 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2813a32f-f816-4bbc-a683-0a49d6e3ed7d) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34253 "4 new passes 2 flakes 2 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32530 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27918 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144747 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinProtocol2 (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32203 "Found 1 new test failure: fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181819 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34527 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36696 "Found 1 new test failure: fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140836 "Found 1 new test failure: fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43439 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152274 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140667 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44128 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29184 "Found 1 new test failure: fast/scrolling/scroll-to-focused-element-uses-resting-geometry-during-transform-animation.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108423 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35939 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115893 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42639 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7284 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42286 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42174 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->