### PR TITLE
[Text Extraction] Rearrange any single text child to be next to its enclosing button or link when retrieving as text tree

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -31,10 +31,12 @@ root
                 'Related Links' […]
                 list
                     link uid=… url=https://webkit.org/ 'Example Link' […]
+                        canvas uid=… […]
                     link uid=… url=https://apple.com/ 'Test Link' […]
             role=region
                 role=status 'Ready' […]
                 button uid=… 'Update Status' […]
+                    canvas uid=… […]
             label='Figure 1'
                 canvas uid=… […]
             textarea uid=… 'This is a text box' […]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -99,13 +99,13 @@ canvas {
         <aside role="complementary" aria-label="Related information">
             <h4>Related Links</h4>
             <ul>
-                <li><a href="https://webkit.org" onmouseover="this.style.color='red'">Example Link</a></li>
+                <li><a href="https://webkit.org" onmouseover="this.style.color='red'"><canvas></canvas>Example Link</a></li>
                 <li><a href="https://apple.com" onmouseout="this.style.color=''">Test Link</a></li>
             </ul>
         </aside>
         <div role="region">
             <div role="status" aria-live="polite" id="status-msg">Ready</div>
-            <button onclick="document.getElementById('status-msg').textContent = 'Updated!'">Update Status</button>
+            <button onclick="document.getElementById('status-msg').textContent = 'Updated!'"><canvas></canvas>Update Status</button>
         </div>
         <div class="canvas-container" aria-label="Figure 1">
             <canvas width="400" height="400"></canvas>

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -1941,7 +1941,41 @@ static void addTextRepresentationRecursive(const TextExtraction::Item& item, std
         }
     }
 
+    std::optional<size_t> inlinedTextChildIndex;
+    std::optional<size_t> elidedTextChildIndex;
+    if (aggregator.useTextTreeOutput() && item.children.size() > 1 && (containerType == TextExtraction::ContainerType::Button || item.hasData<TextExtraction::LinkItemData>())) {
+        size_t textChildCount = 0;
+        size_t firstTextChildIndex = 0;
+        for (size_t i = 0; i < item.children.size(); ++i) {
+            if (item.children[i].hasData<TextExtraction::TextItemData>()) {
+                if (!textChildCount)
+                    firstTextChildIndex = i;
+                ++textChildCount;
+            }
+        }
+
+        if (textChildCount == 1) {
+            auto& textChild = item.children[firstTextChildIndex];
+            if (auto textData = textChild.dataAs<TextExtraction::TextItemData>()) {
+                auto trimmed = textData->content.trim(isASCIIWhitespace);
+                aggregator.collectTextMapping(trimmed, item.frameIdentifier, identifier, item.nodeIdentifier ? ExtractedNodeInfo::IsInteractive::Yes : ExtractedNodeInfo::IsInteractive::No);
+                if (childTextNodeIsRedundant(aggregator, item, trimmed))
+                    elidedTextChildIndex = firstTextChildIndex;
+                else {
+                    inlinedTextChildIndex = firstTextChildIndex;
+                    addPartsForItem(textChild, std::optional { identifier }, line, aggregator, includeRectForParentItem);
+                }
+            }
+        }
+    }
+
     for (size_t i = 0; i < item.children.size(); ++i) {
+        if (inlinedTextChildIndex && i == *inlinedTextChildIndex)
+            continue;
+
+        if (elidedTextChildIndex && i == *elidedTextChildIndex)
+            continue;
+
         auto& child = item.children[i];
         bool childHasLinkAfter = i + 1 < item.children.size() && item.children[i + 1].hasData<TextExtraction::LinkItemData>();
         addTextRepresentationRecursive(child, std::optional { identifier }, depth + 1, aggregator, childHasLinkAfter ? HasAdjacentLinkAfter::Yes : HasAdjacentLinkAfter::No);


### PR DESCRIPTION
#### 11f71f89d0d3a53764a2e414e52ddea4c4cabebc
<pre>
[Text Extraction] Rearrange any single text child to be next to its enclosing button or link when retrieving as text tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=317273">https://bugs.webkit.org/show_bug.cgi?id=317273</a>
<a href="https://rdar.apple.com/179883896">rdar://179883896</a>

Reviewed by Abrar Rahman Protyasha.

For buttons and links with a single text child (but with other children), such as:

```
button uid=101
    image uid=102 src=pluscircle.svg alt=expand
    &apos;Password&apos;
link uid=103 url=/2fa
    image uid=104 src=pluscircle.svg alt=expand
    &apos;2-factor authentication (2FA)&apos;
```

When extracting as text tree, automatically reorder the child elements so that the single text
child is on the same line as the button/link:

```
button uid=101 &apos;Password&apos;
    image uid=102 src=pluscircle.svg alt=expand
link uid=103 url=/2fa &apos;2-factor authentication (2FA)&apos;
    image uid=104 src=pluscircle.svg alt=expand
```

In practice, this helps prevent the agent from (for instance) misreading the structure of the page,
and confuse `uid=103` as a button that expands a password update section (as opposed to 2FA).

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addTextRepresentationRecursive):

Canonical link: <a href="https://commits.webkit.org/315371@main">https://commits.webkit.org/315371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5097ab463c3d168469243b5462da0deb444e7d33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126507 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbdf7d4b-4fbc-472f-8881-8b9419c74a62) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131436 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/552af58b-9006-48e6-9157-f98708e0099f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111940 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11dcfe43-1569-49ea-893d-2c3586990270) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32876 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26826 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180732 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139884 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139728 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37628 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43060 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28084 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106813 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35009 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114827 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41563 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6172 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40960 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->