### PR TITLE
REGRESSION(311406@main): Dark band in non-sRGB gradients with transparent stops

### DIFF
--- a/LayoutTests/fast/gradients/alpha-premultiplied-sampled-expected.html
+++ b/LayoutTests/fast/gradients/alpha-premultiplied-sampled-expected.html
@@ -14,14 +14,9 @@
     #linear {
         background-image: linear-gradient(rgba(0, 0, 0, 0), rgb(0, 128, 0));
     }
-
-    #radial {
-        background-image: radial-gradient(rgba(0, 0, 0, 0), rgb(0, 128, 0));
-    }
 </style>
 </head>
 <body>
 <div id="linear"></div>
-<div id="radial"></div>
 </body>
 </html>

--- a/LayoutTests/fast/gradients/alpha-premultiplied-sampled.html
+++ b/LayoutTests/fast/gradients/alpha-premultiplied-sampled.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2000" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-19000" />
 <style>
     div {
         width: 200px;
@@ -21,14 +21,9 @@
     #linear {
         background-image: linear-gradient(in srgb, color(srgb none 0 0 / 0), rgb(0, 128, 0));
     }
-
-    #radial {
-        background-image: radial-gradient(in srgb, color(srgb none 0 0 / 0), rgb(0, 128, 0));
-    }
 </style>
 </head>
 <body>
 <div id="linear"></div>
-<div id="radial"></div>
 </body>
 </html>

--- a/LayoutTests/fast/gradients/oklab-transparent-keyword-stop-expected.html
+++ b/LayoutTests/fast/gradients/oklab-transparent-keyword-stop-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+    }
+
+    /* Reference: same OKLab interpolation path as the test, but with both
+       stops sharing the white hue (L=1). Component-wise lerp without premul
+       happens to produce the correct result here, so this case is unaffected
+       by the SampledGradientBuilder bug exercised by the test. */
+
+    #linear {
+        background-image: linear-gradient(in oklab to bottom, rgba(255, 255, 255, 0), #fff);
+        background-color: #f0a500;
+    }
+</style>
+</head>
+<body>
+<div id="linear"></div>
+</body>
+</html>

--- a/LayoutTests/fast/gradients/oklab-transparent-keyword-stop.html
+++ b/LayoutTests/fast/gradients/oklab-transparent-keyword-stop.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-13500" />
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+    }
+
+    /* The 'transparent' keyword resolves to rgba(0, 0, 0, 0). With OKLab
+       interpolation it goes through the SampledGradientBuilder path, where
+       evaluateLinearOS lerps the IS components directly (no premultiplied
+       alpha). The L channel of the transparent stop is 0, so midpoints carry
+       residual blackness through the gradient — visible as a dark band.
+       The reference uses rgba(255, 255, 255, 0) instead, so both endpoints
+       share L=1 and the bug doesn't manifest. */
+
+    #linear {
+        background-image: linear-gradient(in oklab to bottom, transparent, #fff);
+        background-color: #f0a500;
+    }
+</style>
+</head>
+<body>
+<div id="linear"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/SampledGradientBuilder.h
+++ b/Source/WebCore/platform/graphics/SampledGradientBuilder.h
@@ -156,14 +156,25 @@ static ColorComponents<float, 4> evaluateColorIS(const SamplingData& data, float
     return asColorComponents(interpolatedColor.unresolved());
 }
 
-// Linearly interpolate between stops in the interpolation color space (plain
-// component-wise lerp, no hue interpolation rules) and convert to the output
-// color space. Used by bisection after coarse sampling, where the hue
-// interpolation has already been baked into the coarse IS samples.
-template<typename OutputColorType, typename InterpolationSpace>
+// Interpolate between stops in the interpolation color space and convert to
+// the output color space. Used by bisection between adjacent coarse samples.
+//
+// For rectangular orthogonal color spaces (sRGB, OKLab, etc.) the IS lerp
+// honors the CSS Color 4 §12.3 premultiplied-alpha rule via
+// interpolateColorComponents. For hue color spaces (HSL, LCH, OKLCH, …) the
+// per-bisection step uses a plain component-wise lerp: the global hue rotation
+// has already been baked into the coarse samples by coarseSampleStops, and
+// re-running the hueInterpolationMethod (Longer in particular) on adjacent
+// coarse samples would re-expand small angle deltas back to ≥180° and scramble
+// the gradient.
+template<typename OutputColorType, typename InterpolationSpace, AlphaPremultiplication alphaPremultiplication>
 static ColorComponents<float, 4> evaluateLinearOS(const SamplingData& data, float offset)
 {
     using InterpolationSpaceColorType = typename InterpolationSpace::ColorType;
+    constexpr auto componentInfo = InterpolationSpaceColorType::Model::componentInfo;
+    constexpr bool isHueColorSpace = componentInfo[0].type == ColorComponentType::Angle
+        || componentInfo[1].type == ColorComponentType::Angle
+        || componentInfo[2].type == ColorComponentType::Angle;
 
     // 1. Find stops that bound the requested offset.
     auto [stop0, stop1] = [&] {
@@ -177,18 +188,33 @@ static ColorComponents<float, 4> evaluateLinearOS(const SamplingData& data, floa
     // 2. Compute percentage offset between the two stops.
     float t = (stop1.offset == stop0.offset) ? 0.0f : (offset - stop0.offset) / (stop1.offset - stop0.offset);
 
-    // 3. Plain linear interpolation of IS components (hue already resolved).
-    // Handle NaN ('none') components: replace with the other stop's value per CSS spec.
-    auto lerped = mapColorComponents([t](float c0, float c1) {
-        if (std::isnan(c0))
-            return c1;
-        if (std::isnan(c1))
-            return c0;
-        return c0 + t * (c1 - c0);
-    }, stop0.color, stop1.color);
+    // 3. Interpolate IS components.
+    auto interpolated = [&] {
+        if constexpr (isHueColorSpace) {
+            // Plain component-wise lerp: the hue rotation rule has already
+            // been applied by coarseSampleStops. NaN ('none') is replaced
+            // with the other stop's value per CSS spec.
+            auto lerped = mapColorComponents([t](float c0, float c1) {
+                if (std::isnan(c0))
+                    return c1;
+                if (std::isnan(c1))
+                    return c0;
+                return c0 + t * (c1 - c0);
+            }, stop0.color, stop1.color);
+            return makeFromComponents<InterpolationSpaceColorType>(lerped);
+        } else {
+            // interpolateColorComponents premultiplies, lerps, and unpremultiplies
+            // internally per §12.3, leaving the result in non-premultiplied IS form
+            // ready for color-space conversion.
+            return interpolateColorComponents<alphaPremultiplication>(
+                std::get<InterpolationSpace>(data.colorInterpolationMethod.colorSpace),
+                makeFromComponents<InterpolationSpaceColorType>(stop0.color), 1.0f - t,
+                makeFromComponents<InterpolationSpaceColorType>(stop1.color), t);
+        }
+    }();
 
     // 4. Convert to the output color space.
-    return asColorComponents(convertColor<OutputColorType>(makeFromComponents<InterpolationSpaceColorType>(lerped)).resolved());
+    return asColorComponents(convertColor<OutputColorType>(interpolated).resolved());
 }
 
 static void bisectAndCollectStops(
@@ -304,7 +330,12 @@ SampledGradientStops sampleGradientStops(ColorInterpolationMethod colorInterpola
 
     auto evaluateOS = WTF::switchOn(colorInterpolationMethod.colorSpace,
         [&]<typename MethodColorSpace>(const MethodColorSpace&) -> EvaluateCallback {
-            return &evaluateLinearOS<OutputColorType, MethodColorSpace>;
+            switch (colorInterpolationMethod.alphaPremultiplication) {
+            case AlphaPremultiplication::Unpremultiplied:
+                return &evaluateLinearOS<OutputColorType, MethodColorSpace, AlphaPremultiplication::Unpremultiplied>;
+            case AlphaPremultiplication::Premultiplied:
+                return &evaluateLinearOS<OutputColorType, MethodColorSpace, AlphaPremultiplication::Premultiplied>;
+            }
         });
 
     Vector<float> locations;


### PR DESCRIPTION
#### 239811efa2af9defc9ca2ff59d710618f4cba2d6
<pre>
REGRESSION(311406@main): Dark band in non-sRGB gradients with transparent stops
<a href="https://bugs.webkit.org/show_bug.cgi?id=317277">https://bugs.webkit.org/show_bug.cgi?id=317277</a>
<a href="https://rdar.apple.com/179870903">rdar://179870903</a>

Reviewed by Simon Fraser.

When SampledGradientBuilder bisects a segment to densify samples for CGGradient,
evaluateLinearOS lerped the interpolation-space color components directly,
ignoring CSS Color 4 §12.3&apos;s requirement that rectangular orthogonal color
spaces premultiply by alpha before interpolating. With the `transparent`
keyword (which resolves to rgba(0, 0, 0, 0)) paired with an opaque color in
OKLab, the zero-alpha stop&apos;s black RGB bled into the L component at the
midpoint, producing a visible dark band rather than a clean alpha ramp. The
defensive author form `rgb(255 255 255 / 0)` masked the bug because both
endpoints share the same hue.

Route the IS-space lerp for rectangular orthogonal interpolation spaces through
interpolateColorComponents, which already applies the §12.3 premul/lerp/unpremul
algorithm and handles &apos;none&apos;, NaN, and α=0 edge cases. evaluateLinearOS now
takes alphaPremultiplication as a template parameter, and the dispatch site in
sampleGradientStops switches on the runtime flag, mirroring how evaluateColorIS
is dispatched immediately above. Hue color spaces stay on the original plain
component-wise lerp: coarseSampleStops has already baked the
hueInterpolationMethod (e.g. Longer) into the coarse samples, so the angle
deltas between adjacent coarse samples are small. Re-running the hue rule per
bisection — which is what interpolateColorComponents would do — would re-expand
those ~5° deltas back to ≥180° under Longer and scramble the gradient.
evaluateLinearOS detects a hue color space at compile time from
ColorComponentType::Angle in the IS color type&apos;s componentInfo and branches
between the two paths.

* LayoutTests/fast/gradients/alpha-premultiplied-sampled-expected.html:
* LayoutTests/fast/gradients/alpha-premultiplied-sampled.html:
* LayoutTests/fast/gradients/oklab-transparent-keyword-stop-expected.html: Added.
* LayoutTests/fast/gradients/oklab-transparent-keyword-stop.html: Added.
* Source/WebCore/platform/graphics/SampledGradientBuilder.h:
(WebCore::evaluateLinearOS): For rectangular orthogonal interpolation spaces,
use interpolateColorComponents to honor the premultiplied-alpha rule. For hue
spaces, keep the original plain component-wise lerp so per-bisection
interpolation does not re-apply the hue rotation already baked in by
coarseSampleStops.
(WebCore::sampleGradientStops): Switch on alphaPremultiplication when selecting
the evaluateLinearOS specialization.

Canonical link: <a href="https://commits.webkit.org/315551@main">https://commits.webkit.org/315551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29573bcf5c03ad6d3b0bc2c075145e509b485f59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127002 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5650a523-44dc-40a0-b7cd-73af0a08f0ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131858 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61e87000-3636-4b2c-9dea-6b946060d151) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112362 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f534213-2463-48a6-9cea-ce54c9ca4fe1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33322 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32001 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27346 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181246 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140315 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37730 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43557 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107493 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35422 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115322 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42067 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6609 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41460 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->