### PR TITLE
Debounce screen properties changed notifications

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -875,7 +875,7 @@ void WebProcessPool::registerNotificationObservers()
     }];
 
     m_accessibilityDisplayOptionsNotificationObserver = [retainPtr([NSWorkspace.sharedWorkspace notificationCenter]) addObserverForName:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        screenPropertiesChanged("NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification"_s);
+        screenPropertiesChanged();
     }];
 
     m_scrollerStyleNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSPreferredScrollerStyleDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -895,7 +895,7 @@ void WebProcessPool::registerNotificationObservers()
     }];
 
     m_didChangeScreenParametersNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationDidChangeScreenParametersNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        screenPropertiesChanged("NSApplicationDidChangeScreenParametersNotification"_s);
+        screenPropertiesChanged();
     }];
 #if HAVE(SUPPORT_HDR_DISPLAY_APIS)
     m_didBeginSuppressingHighDynamicRange = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification object:NSAppSingleton() queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
@@ -1297,86 +1297,10 @@ void WebProcessPool::notifyPreferencesChanged(const String& domain, const String
 }
 #endif // ENABLE(CFPREFS_DIRECT_MODE)
 
-void WebProcessPool::sendScreenPropertiesChangedToAllProcesses(const WebCore::ScreenProperties& screenProperties, ASCIILiteral reason)
-{
-    static constexpr Seconds excessiveUpdateWindow { 60_s };
-    static constexpr unsigned excessiveUpdateThreshold = 600;
-
-    auto now = ApproximateTime::now();
-    if (now - m_screenPropertiesUpdateReasonsTime > excessiveUpdateWindow) {
-        if (m_logScreenPropertiesUpdateReasonsTimer.isActive()) {
-            // Drain any pending log first so we don't drop counts that were about to be reported.
-            m_logScreenPropertiesUpdateReasonsTimer.stop();
-            logScreenPropertiesUpdateReasonsTimerFired();
-        } else {
-            m_screenPropertiesUpdateReasons.clear();
-            m_screenPropertiesUpdateCount = 0;
-            m_screenPropertiesUpdateReasonsTime = now;
-        }
-    }
-    m_screenPropertiesUpdateReasons.add(reason);
-    ++m_screenPropertiesUpdateCount;
-
-    if (m_screenPropertiesUpdateCount > excessiveUpdateThreshold && !m_logScreenPropertiesUpdateReasonsTimer.isActive())
-        m_logScreenPropertiesUpdateReasonsTimer.startOneShot(excessiveUpdateWindow - (now - m_screenPropertiesUpdateReasonsTime));
-
-    static constexpr Seconds debounceInterval { 1_s };
-
-    if (m_screenPropertiesUpdateTimer.isActive()) {
-        ASSERT(m_pendingScreenProperties);
-        *m_pendingScreenProperties = screenProperties;
-        return;
-    }
-
-    auto elapsed = now - m_lastScreenPropertiesSendTime;
-    if (elapsed >= debounceInterval) {
-        m_lastScreenPropertiesSendTime = now;
-        dispatchScreenPropertiesChangedToAllProcesses(screenProperties);
-        return;
-    }
-
-    m_pendingScreenProperties = makeUnique<WebCore::ScreenProperties>(screenProperties);
-    m_screenPropertiesUpdateTimer.startOneShot(debounceInterval - elapsed);
-}
-
-void WebProcessPool::logScreenPropertiesUpdateReasonsTimerFired()
-{
-    ASCIILiteral mostCommonReason;
-    unsigned mostCommonCount = 0;
-    for (const auto& entry : m_screenPropertiesUpdateReasons) {
-        if (entry.value > mostCommonCount) {
-            mostCommonCount = entry.value;
-            mostCommonReason = entry.key;
-        }
-    }
-    auto elapsed = ApproximateTime::now() - m_screenPropertiesUpdateReasonsTime;
-    WEBPROCESSPOOL_RELEASE_LOG(DisplayLink, "Excessive screen property updates: %u updates over %.1f seconds, most common reason: %" PUBLIC_LOG_STRING " (%u times)", m_screenPropertiesUpdateCount, elapsed.seconds(), mostCommonReason.characters(), mostCommonCount);
-
-    m_screenPropertiesUpdateReasons.clear();
-    m_screenPropertiesUpdateCount = 0;
-    m_screenPropertiesUpdateReasonsTime = ApproximateTime::now();
-}
-
 void WebProcessPool::screenPropertiesUpdateTimerFired()
 {
-    ASSERT(m_pendingScreenProperties);
-    auto pendingProperties = std::exchange(m_pendingScreenProperties, nullptr);
-    m_lastScreenPropertiesSendTime = ApproximateTime::now();
-    dispatchScreenPropertiesChangedToAllProcesses(*pendingProperties);
-}
+    m_lastScreenPropertiesUpdateTime = ApproximateTime::now();
 
-void WebProcessPool::dispatchScreenPropertiesChangedToAllProcesses(const WebCore::ScreenProperties& screenProperties)
-{
-    sendToAllProcesses(Messages::WebProcess::SetScreenProperties(screenProperties));
-
-#if PLATFORM(MAC) && ENABLE(GPU_PROCESS)
-    if (RefPtr gpuProcess = this->gpuProcess())
-        gpuProcess->setScreenProperties(screenProperties);
-#endif
-}
-
-void WebProcessPool::screenPropertiesChanged(ASCIILiteral reason)
-{
     auto screenProperties = WebCore::collectScreenProperties();
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (m_suppressEDR) {
@@ -1389,24 +1313,51 @@ void WebProcessPool::screenPropertiesChanged(ASCIILiteral reason)
     }
 #endif
 
-    sendScreenPropertiesChangedToAllProcesses(screenProperties, reason);
+    sendToAllProcesses(Messages::WebProcess::SetScreenProperties(screenProperties));
+
+#if PLATFORM(MAC) && ENABLE(GPU_PROCESS)
+    if (RefPtr gpuProcess = this->gpuProcess())
+        gpuProcess->setScreenProperties(screenProperties);
+#endif
+}
+
+void WebProcessPool::screenPropertiesChanged()
+{
+    static const Seconds debounceInterval = []() -> Seconds {
+        if (auto value = dynamic_cf_cast<CFNumberRef>(adoptCF(CFPreferencesCopyAppValue(CFSTR("WebKitDebugScreenPropertiesDebounceInterval"), kCFPreferencesCurrentApplication)))) {
+            float floatValue = 0;
+            if (CFNumberGetValue(value.get(), kCFNumberFloatType, &floatValue))
+                return Seconds(floatValue);
+        }
+        return 250_ms;
+    }();
+
+    if (m_screenPropertiesUpdateTimer.isActive())
+        return;
+
+    auto elapsed = ApproximateTime::now() - m_lastScreenPropertiesUpdateTime;
+    if (elapsed >= debounceInterval) {
+        screenPropertiesUpdateTimerFired();
+        return;
+    }
+
+    m_screenPropertiesUpdateTimer.startOneShot(debounceInterval - elapsed);
 }
 
 #if PLATFORM(MAC)
-void WebProcessPool::displayPropertiesChanged(const WebCore::ScreenProperties& screenProperties, WebCore::PlatformDisplayID displayID, CGDisplayChangeSummaryFlags flags)
+void WebProcessPool::displayPropertiesChanged(WebCore::PlatformDisplayID displayID, CGDisplayChangeSummaryFlags flags)
 {
     if (auto* displayLink = displayLinks().existingDisplayLinkForDisplay(displayID))
         displayLink->displayPropertiesChanged();
 
-    sendScreenPropertiesChangedToAllProcesses(screenProperties, "displayPropertiesChanged"_s);
+    screenPropertiesChanged();
 }
 
 static void displayReconfigurationCallBack(CGDirectDisplayID displayID, CGDisplayChangeSummaryFlags flags, void *userInfo)
 {
     RunLoop::mainSingleton().dispatch([displayID, flags]() {
-        auto screenProperties = WebCore::collectScreenProperties();
         for (auto& processPool : WebProcessPool::allProcessPools())
-            processPool->displayPropertiesChanged(screenProperties, displayID, flags);
+            processPool->displayPropertiesChanged(displayID, flags);
     });
 }
 
@@ -1423,9 +1374,8 @@ void WebProcessPool::registerDisplayConfigurationCallback()
 static void webProcessPoolHighDynamicRangeDidChangeCallback(CFNotificationCenterRef, void*, CFNotificationName, const void*, CFDictionaryRef)
 {
     RunLoop::mainSingleton().dispatch([] {
-        auto properties = WebCore::collectScreenProperties();
         for (auto& pool : WebProcessPool::allProcessPools())
-            pool->sendScreenPropertiesChangedToAllProcesses(properties, "ShouldPlayHDRVideoChanged"_s);
+            pool->screenPropertiesChanged();
     });
 }
 
@@ -1464,9 +1414,8 @@ void WebProcessPool::systemDidWake()
 void WebProcessPool::registerHighDynamicRangeChangeCallback()
 {
     static NeverDestroyed<LowPowerModeNotifier> notifier { [](bool) {
-        auto properties = WebCore::collectScreenProperties();
         for (auto& pool : WebProcessPool::allProcessPools())
-            pool->sendScreenPropertiesChangedToAllProcesses(properties, "LowPowerModeNotifier"_s);
+            pool->screenPropertiesChanged();
     } };
 }
 #endif // PLATFORM(IOS) || PLATFORM(VISION)
@@ -1479,7 +1428,7 @@ void WebProcessPool::didRefreshDisplay()
     float headroom = currentEDRHeadroomForDisplay(screen->primaryScreenDisplayID());
     if (m_currentEDRHeadroom != headroom) {
         m_currentEDRHeadroom = headroom;
-        screenPropertiesChanged("didRefreshDisplayEDRHeadroomChanged"_s);
+        screenPropertiesChanged();
     }
 #endif
 }
@@ -1492,7 +1441,7 @@ void WebProcessPool::suppressEDR(bool suppressEDR)
         return;
 
     m_suppressEDR = suppressEDR;
-    screenPropertiesChanged("suppressEDR"_s);
+    screenPropertiesChanged();
 #else
     UNUSED_PARAM(m_suppressEDR);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6529,7 +6529,7 @@ void WebPageProxy::accessibilitySettingsDidChange()
 
 #if PLATFORM(COCOA)
     // Also update screen properties which encodes invert colors.
-    protect(legacyMainFrameProcess().processPool())->screenPropertiesChanged("accessibilitySettingsDidChange"_s);
+    protect(legacyMainFrameProcess().processPool())->screenPropertiesChanged();
 #endif
     send(Messages::WebPage::AccessibilitySettingsDidChange());
 }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -109,7 +109,6 @@
 #include <WebCore/ProcessWarming.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
-#include <WebCore/ScreenProperties.h>
 #include <WebCore/SecurityPolicy.h>
 #include <WebCore/Site.h>
 #include <algorithm>
@@ -271,7 +270,6 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
 #endif
 #if PLATFORM(COCOA)
     , m_screenPropertiesUpdateTimer(RunLoop::mainSingleton(), "WebProcessPool::ScreenPropertiesUpdateTimer"_s, this, &WebProcessPool::screenPropertiesUpdateTimerFired)
-    , m_logScreenPropertiesUpdateReasonsTimer(RunLoop::mainSingleton(), "WebProcessPool::LogScreenPropertiesUpdateReasonsTimer"_s, this, &WebProcessPool::logScreenPropertiesUpdateReasonsTimerFired)
 #endif
 #if ENABLE(IPC_TESTING_API)
     , m_ipcTester(IPCTester::create())

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -45,7 +45,6 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
-#include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/MemoryPressureHandler.h>
@@ -107,7 +106,6 @@ enum class GamepadHapticEffectType : uint8_t;
 enum class ProcessSwapDisposition : uint8_t;
 struct GamepadEffectParameters;
 struct MockMediaDevice;
-struct ScreenProperties;
 #if PLATFORM(COCOA)
 class PowerSourceNotifier;
 #endif
@@ -258,12 +256,11 @@ public:
     void handleMemoryPressureWarning(Critical);
 
 #if PLATFORM(COCOA)
-    void sendScreenPropertiesChangedToAllProcesses(const WebCore::ScreenProperties&, ASCIILiteral reason);
-    void screenPropertiesChanged(ASCIILiteral reason);
+    void screenPropertiesChanged();
 #endif
 
 #if PLATFORM(MAC)
-    void displayPropertiesChanged(const WebCore::ScreenProperties&, WebCore::PlatformDisplayID, CGDisplayChangeSummaryFlags);
+    void displayPropertiesChanged(WebCore::PlatformDisplayID, CGDisplayChangeSummaryFlags);
 #endif
 
 #if HAVE(DISPLAY_LINK)
@@ -747,9 +744,7 @@ private:
     void clearAudibleActivity();
 
 #if PLATFORM(COCOA)
-    void dispatchScreenPropertiesChangedToAllProcesses(const WebCore::ScreenProperties&);
     void screenPropertiesUpdateTimerFired();
-    void logScreenPropertiesUpdateReasonsTimerFired();
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -1030,14 +1025,8 @@ private:
     std::optional<Vector<URL>> m_sandboxExtensionURLs;
     HashMap<String, bool> m_mediaSourceTypesSupported;
 
-    ApproximateTime m_lastScreenPropertiesSendTime;
+    ApproximateTime m_lastScreenPropertiesUpdateTime;
     RunLoop::Timer m_screenPropertiesUpdateTimer;
-    std::unique_ptr<WebCore::ScreenProperties> m_pendingScreenProperties;
-
-    ApproximateTime m_screenPropertiesUpdateReasonsTime;
-    HashCountedSet<ASCIILiteral> m_screenPropertiesUpdateReasons;
-    unsigned m_screenPropertiesUpdateCount { 0 };
-    RunLoop::Timer m_logScreenPropertiesUpdateReasonsTimer;
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2323,7 +2323,7 @@ void WebViewImpl::windowWillClose()
 
 void WebViewImpl::screenDidChangeColorSpace()
 {
-    protect(m_page->configuration().processPool())->screenPropertiesChanged("screenDidChangeColorSpace"_s);
+    protect(m_page->configuration().processPool())->screenPropertiesChanged();
 }
 
 void WebViewImpl::applicationShouldSuppressHDR(bool suppress)


### PR DESCRIPTION
#### 357ab70819c4a640f26f83a620ec2683fcccaade
<pre>
Debounce screen properties changed notifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=317278">https://bugs.webkit.org/show_bug.cgi?id=317278</a>
<a href="https://rdar.apple.com/177875932">rdar://177875932</a>

Reviewed by Mike Wyrzykowski.

314702@main debounced ScreenPropertiesDidChange IPC messages. However, we&apos;ve gotten more logs and it
now seems that not only are we sending excessive number of IPCs, but the time spent in the screen
properties changed notification handler is also excessive. For instance, some part of
`collectScreenProperties` involves sync IPCs to WindowServer, so calling that too often can affect
the responsiveness of the UIProcess&apos;s main thread.

Fix this by moving the debouncing up one level. Previously we were debouncing only IPC sends. Now we
are debouncing screen properties changed notification handler (which as a side effect, also
debounces IPC sends since that is downstream of the screen properties changed notification).

Other related in changes in the patch:

1. The debouncing interval is configurable via a pref and arbitrarily defaults to 250 ms.

2. I removed the excessive update logging introduced in 314702@main as it made the code more
   complicated to maintain.

3. Both `displayPropertiesChanged` and `screenPropertiesChanged` are debounced, and
   `displayPropertiesChanged` now updates the suppressEDR property on the screen properties
   object. Previously, only `screenPropertiesChanged` updated the suppressEDR property. In talking
   to others, this just seemed like an oversight.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::screenPropertiesUpdateTimerFired):
(WebKit::WebProcessPool::screenPropertiesChanged):
(WebKit::WebProcessPool::displayPropertiesChanged):
(WebKit::displayReconfigurationCallBack):
(WebKit::webProcessPoolHighDynamicRangeDidChangeCallback):
(WebKit::WebProcessPool::registerHighDynamicRangeChangeCallback):
(WebKit::WebProcessPool::didRefreshDisplay):
(WebKit::WebProcessPool::suppressEDR):
(WebKit::WebProcessPool::sendScreenPropertiesChangedToAllProcesses): Deleted.
(WebKit::WebProcessPool::logScreenPropertiesUpdateReasonsTimerFired): Deleted.
(WebKit::WebProcessPool::dispatchScreenPropertiesChangedToAllProcesses): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::accessibilitySettingsDidChange):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::screenDidChangeColorSpace):

Canonical link: <a href="https://commits.webkit.org/315381@main">https://commits.webkit.org/315381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b272139479e5409ca18b6ffe08fbba5f3173f1fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126516 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131443 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111947 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32884 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26835 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180741 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139891 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42380 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139735 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37633 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43069 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106823 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35016 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114836 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41572 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6177 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40969 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41223 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41114 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->