### PR TITLE
[Site Isolation] Joint session history popstate broken under useUIProcessForBackForwardItemLoading

### DIFF
--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -355,7 +355,7 @@ public:
     bool errorOccurredInLoading() const { return m_errorOccurredInLoading; }
 
     // HistoryController specific.
-    void loadItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, ShouldTreatAsContinuingLoad, ShouldRestoreFromBackForwardCache = ShouldRestoreFromBackForwardCache::Unspecified);
+    WEBCORE_EXPORT void loadItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, ShouldTreatAsContinuingLoad, ShouldRestoreFromBackForwardCache = ShouldRestoreFromBackForwardCache::Unspecified);
     HistoryItem* requestedHistoryItem() const { return m_requestedHistoryItem.get(); }
     WEBCORE_EXPORT void setRequestedHistoryItem(HistoryItem&);
     WEBCORE_EXPORT void loadRequestedHistoryItem(FrameLoadType, PolicyAlreadyDecided = PolicyAlreadyDecided::No);

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -49,6 +49,8 @@ public:
     Ref<FrameState> copyFrameState();
     Ref<FrameState> copyFrameStateWithChildren();
 
+    const Vector<Ref<WebBackForwardListFrameItem>>& children() const LIFETIME_BOUND { return m_children; }
+
     std::optional<WebCore::FrameIdentifier> NODELETE frameID() const;
     WebCore::BackForwardFrameItemIdentifier identifier() const { return m_identifier; }
     const String& NODELETE url() const LIFETIME_BOUND;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2850,6 +2850,11 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
     process->send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(frameItem), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, shouldRestoreFromBackForwardCache, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), webPageIDInProcess(process));
     process->startResponsivenessTimer();
 
+    if (preferences->useUIProcessForBackForwardItemLoading()) {
+        if (RefPtr currentItem = backForwardList().currentItem())
+            dispatchSameDocumentJointTraversals(protect(currentItem->mainFrameItem()), protect(item->mainFrameItem()), frameLoadType, frameItem.frameID());
+    }
+
     return RefPtr<API::Navigation> { WTF::move(navigation) };
 }
 
@@ -2972,6 +2977,49 @@ void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frame
     }
 
     goToBackForwardItem(frameItem, frameLoadType);
+}
+
+void WebPageProxy::dispatchSameDocumentJointTraversals(WebBackForwardListFrameItem& fromFrameItem, WebBackForwardListFrameItem& toFrameItem, FrameLoadType frameLoadType, std::optional<WebCore::FrameIdentifier> primaryFrameID)
+{
+    auto fromSeq = fromFrameItem.frameState().itemSequenceNumber;
+    auto toSeq = toFrameItem.frameState().itemSequenceNumber;
+
+    bool itemsMatch = fromSeq == toSeq;
+    if (!itemsMatch) {
+        bool sameDocument = fromFrameItem.frameState().documentSequenceNumber == toFrameItem.frameState().documentSequenceNumber;
+        auto frameID = toFrameItem.frameID();
+        bool isPrimary = primaryFrameID && frameID && *frameID == *primaryFrameID;
+        if (sameDocument && !isPrimary && frameID) {
+            if (RefPtr webFrame = WebFrameProxy::webFrame(*frameID); webFrame && webFrame->page() == this) {
+                if (webFrame->provisionalFrame())
+                    WEBPAGEPROXY_RELEASE_LOG(Loading, "dispatchSameDocumentJointTraversals: skipping frameID=%" PRIu64 " (provisional load in flight)", frameID->toUInt64());
+                else {
+                    Ref process = webFrame->process();
+                    process->send(Messages::WebPage::ApplyHistoryTraversalToFrame(toFrameItem.copyFrameState(), fromFrameItem.copyFrameState(), frameLoadType), webPageIDInProcess(process));
+                }
+            }
+        }
+    }
+
+    for (auto& toChild : toFrameItem.children()) {
+        auto childFrameID = toChild->frameID();
+        if (!childFrameID)
+            continue;
+        RefPtr fromChild = fromFrameItem.childItemForFrameID(*childFrameID);
+        if (!fromChild) {
+            WEBPAGEPROXY_RELEASE_LOG(Loading, "dispatchSameDocumentJointTraversals: target child frameID=%" PRIu64 " has no counterpart in current; skipping", childFrameID->toUInt64());
+            continue;
+        }
+        dispatchSameDocumentJointTraversals(*fromChild, toChild.get(), frameLoadType, primaryFrameID);
+    }
+
+    for (auto& fromChild : fromFrameItem.children()) {
+        auto childFrameID = fromChild->frameID();
+        if (!childFrameID)
+            continue;
+        if (!toFrameItem.childItemForFrameID(*childFrameID))
+            WEBPAGEPROXY_RELEASE_LOG(Loading, "dispatchSameDocumentJointTraversals: current child frameID=%" PRIu64 " has no counterpart in target; same-document step (if any) for this frame is dropped", childFrameID->toUInt64());
+    }
 }
 
 bool WebPageProxy::shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem& item)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3692,6 +3692,7 @@ private:
 
     WebProcessProxy& processForTheFrameItem(WebBackForwardListFrameItem&) const;
     Ref<FrameState> copyFrameStateForBackForwardNavigation(WebBackForwardListFrameItem&) const;
+    void dispatchSameDocumentJointTraversals(WebBackForwardListFrameItem& fromFrameItem, WebBackForwardListFrameItem& toFrameItem, WebCore::FrameLoadType, std::optional<WebCore::FrameIdentifier> primaryFrameID);
     WebProcessProxy* frameProcessForNonCachedBackForwardNavigation(WebBackForwardListFrameItem&) const;
 
     void setClientNavigationActivity(API::Navigation&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2692,6 +2692,52 @@ void WebPage::goToBackForwardItemWaitingForProcessLaunch(GoToBackForwardItemPara
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+void WebPage::applyHistoryTraversalToFrame(Ref<FrameState>&& toFrameState, Ref<FrameState>&& fromFrameState, FrameLoadType frameLoadType)
+{
+    RELEASE_ASSERT(corePage()->settings().useUIProcessForBackForwardItemLoading());
+
+    auto frameID = toFrameState->frameID;
+    if (!frameID) {
+        WEBPAGE_RELEASE_LOG_ERROR(Loading, "applyHistoryTraversalToFrame: missing frameID in toFrameState");
+        return;
+    }
+
+    RefPtr webFrame = WebProcess::singleton().webFrame(*frameID);
+    if (!webFrame || webFrame->page() != this) {
+        WEBPAGE_RELEASE_LOG_ERROR(Loading, "applyHistoryTraversalToFrame: no live local frame for frameID=%" PRIu64, frameID->toUInt64());
+        return;
+    }
+
+    RefPtr localFrame = webFrame->coreLocalFrame();
+    if (!localFrame) {
+        WEBPAGE_RELEASE_LOG_ERROR(Loading, "applyHistoryTraversalToFrame: frame is not local for frameID=%" PRIu64, frameID->toUInt64());
+        return;
+    }
+
+    RefPtr<HistoryItem> toItem;
+    RefPtr<HistoryItem> fromItem;
+    {
+        auto ignoreHistoryItemChangesForScope = m_historyItemClient->ignoreChangesForScope();
+        toItem = toHistoryItem(m_historyItemClient, toFrameState);
+        fromItem = toHistoryItem(m_historyItemClient, fromFrameState);
+    }
+
+    if (!toItem || !fromItem) {
+        WEBPAGE_RELEASE_LOG_ERROR(Loading, "applyHistoryTraversalToFrame: toHistoryItem returned null (frameID=%" PRIu64 ")", frameID->toUInt64());
+        return;
+    }
+
+    RefPtr currentItem = localFrame->loader().history().currentItem();
+    if (!currentItem || currentItem->documentSequenceNumber() != fromItem->documentSequenceNumber()) {
+        WEBPAGE_RELEASE_LOG_ERROR(Loading, "applyHistoryTraversalToFrame: frame currentItem documentSequenceNumber mismatch — bailing (frameID=%" PRIu64 ")", frameID->toUInt64());
+        return;
+    }
+
+    WEBPAGE_RELEASE_LOG(Loading, "applyHistoryTraversalToFrame: frameID=%" PRIu64 ", frameLoadType=%u, url=%" SENSITIVE_LOG_STRING, frameID->toUInt64(), static_cast<unsigned>(frameLoadType), toItem->url().string().utf8().data());
+
+    localFrame->loader().loadItem(*toItem, fromItem.get(), frameLoadType, ShouldTreatAsContinuingLoad::No, ShouldRestoreFromBackForwardCache::Unspecified);
+}
+
 void WebPage::tryRestoreScrollPosition()
 {
     if (RefPtr localMainFrame = this->localMainFrame())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2330,6 +2330,7 @@ private:
     void reload(WebCore::NavigationIdentifier, OptionSet<WebCore::ReloadOption> reloadOptions, SandboxExtensionHandle&&);
     void goToBackForwardItem(GoToBackForwardItemParameters&&);
     [[noreturn]] void NODELETE goToBackForwardItemWaitingForProcessLaunch(GoToBackForwardItemParameters&&, WebKit::WebPageProxyIdentifier);
+    void applyHistoryTraversalToFrame(Ref<FrameState>&& toFrameState, Ref<FrameState>&& fromFrameState, WebCore::FrameLoadType);
     void tryRestoreScrollPosition();
     void setInitialFocus(bool forward, bool isKeyboardEventValid, const std::optional<WebKeyboardEvent>&, CompletionHandler<void()>&&);
     void updateIsInWindow(bool isInitialState = false);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -204,6 +204,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     GoToBackForwardItem(struct WebKit::GoToBackForwardItemParameters parameters)
     GoToBackForwardItemWaitingForProcessLaunch(struct WebKit::GoToBackForwardItemParameters parameters, WebKit::WebPageProxyIdentifier pageID)
+    ApplyHistoryTraversalToFrame(Ref<WebKit::FrameState> toFrameState, Ref<WebKit::FrameState> fromFrameState, enum:uint8_t WebCore::FrameLoadType frameLoadType)
     TryRestoreScrollPosition()
 
     LoadURLInFrame(URL url, String referrer, WebCore::FrameIdentifier frameID)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2096,6 +2096,17 @@ WKURLRef TestController::createTestURL(std::span<const char> pathOrURL)
     return url.leakRef();
 }
 
+// FIXME: remove once test infrastructure auto-enables
+// UseUIProcessForBackForwardItemLoading under SiteIsolation
+// (https://bugs.webkit.org/show_bug.cgi?id=316588 / rdar://179043211 follow-up).
+static TestFeatures siteIsolationImpliedFeaturesForTest(const TestCommand& command)
+{
+    TestFeatures features;
+    if (command.pathOrURL.find("html/browsers/history/the-history-interface/001.html") != std::string::npos)
+        features.boolWebPreferenceFeatures.insert({ "UseUIProcessForBackForwardItemLoading", true });
+    return features;
+}
+
 TestOptions TestController::testOptionsForTest(const TestCommand& command) const
 {
     TestFeatures features = TestOptions::defaults();
@@ -2106,6 +2117,11 @@ TestOptions TestController::testOptionsForTest(const TestCommand& command) const
     merge(features, featureDefaultsFromTestHeaderForTest(command, TestOptions::keyTypeMapping()));
     merge(features, featureFromAdditionalHeaderOption(command, TestOptions::keyTypeMapping()));
     merge(features, platformSpecificFeatureOverridesDefaultsForTest(command));
+
+    auto siteIsolationIt = features.boolWebPreferenceFeatures.find("SiteIsolationEnabled");
+    if (siteIsolationIt != features.boolWebPreferenceFeatures.end() && siteIsolationIt->second)
+        merge(features, siteIsolationImpliedFeaturesForTest(command));
+
     return TestOptions { features };
 }
 


### PR DESCRIPTION
#### 0ac937442b6cf9477534ef948627c5da99fd9df1
<pre>
[Site Isolation] Joint session history popstate broken under useUIProcessForBackForwardItemLoading
<a href="https://bugs.webkit.org/show_bug.cgi?id=317090">https://bugs.webkit.org/show_bug.cgi?id=317090</a>
<a href="https://rdar.apple.com/179641336">rdar://179641336</a>

Reviewed by NOBODY (OOPS!).

Under useUIProcessForBackForwardItemLoading, the FrameState sent by the
UI process to a WebProcess for a back/forward navigation has its
children stripped (introduced by <a href="https://bugs.webkit.org/show_bug.cgi?id=309791">https://bugs.webkit.org/show_bug.cgi?id=309791</a>
to keep cross-origin children&apos;s URLs/state out of an untrusted WebProcess).
The original design relied on each child frame independently triggering
a BackForward dispatch through frameStateForBackForwardChildFrame. That
path only fires when a child frame independently initiates a BackForward
navigation; for joint session history same-document traversals (e.g. a
top-level history.go(-1) crossing an iframe pushState entry) no per-frame
navigation is initiated and the iframe never traverses, so popstate
never fires and ev.state / history.state stay empty.

Six subtests of html/browsers/history/the-history-interface/001.html
regress as a result:
  - popstate event should fire when navigation occurs
  - popstate event should pass the state data
  - state data should cope with circular object references
  - state data should be a clone of the original object, not a reference to it
  - history.state should also reference a clone of the original object (2)
  - history.state should be identical to the object passed to the event handler unless history.state is updated

Add a new IPC, WebPage::ApplyHistoryTraversalToFrame, that the UI
process sends per-frame for the joint same-document traversal cases
that the existing GoToBackForwardItem dispatch does not cover. The UI
process walks the current/target BackForward item trees pair-wise and
dispatches the new IPC to each frame whose itemSequenceNumber differs
and whose documentSequenceNumber matches (i.e. same-document step),
skipping the primary frame already dispatched to via GoToBackForwardItem.
Cross-document subtrees keep flowing through GoToBackForwardItem and
frameStateForBackForwardChildFrame as today.

The new IPC&apos;s payload is per-frame FrameState only (no children). Site
Isolation cross-origin protection is preserved — same-process frame
data the receiving WebProcess already has, cross-process frame data
never leaves UI. The receiver guards itself with a
RELEASE_ASSERT(useUIProcessForBackForwardItemLoading) so a stale or
malicious sender cannot drive this path under the legacy children-tree
contract.

The walker is gated on useUIProcessForBackForwardItemLoading and lives
inside WebPageProxy::goToBackForwardItem(WebBackForwardListFrameItem&amp;,
FrameLoadType) so it covers all entry points (history.go from script,
WKWebView.goBack, ProvisionalPage paths, etc.). The walker always
recurses into children: a clone item at one level does not preclude
same-document steps in deeper frames, since child identity is keyed on
frameID independently of the parent frame&apos;s itemSequenceNumber.
Skipping the per-frame dispatch at the diverging level alone avoids
double-traversal. The walker also RELEASE_LOGs when a current-tree
child has no counterpart in the target tree so iframe detach/reattach
interleaved with a BF traversal does not silently lose its popstate.

The receiver applyHistoryTraversalToFrame defensively null-checks the
HistoryItems built from the IPC payload, then verifies the iframe&apos;s
HistoryController currentItem against the from item&apos;s
documentSequenceNumber before calling FrameLoader::loadItem, bailing
cleanly on a mismatch (e.g. provisional load in flight, BFCache, fresh
attach) rather than tripping the loadSameDocumentItem ASSERT.

Regression coverage uses the imported WPT fixture
imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/001.html
directly, rather than an in-tree copy. The bug only reproduces when
both SiteIsolationEnabled and UseUIProcessForBackForwardItemLoading are
on; the imported WPT cannot pin those flags via a webkit-test-runner
header (its expected.txt is the upstream baseline, shared across
configurations). Production already auto-enables
UseUIProcessForBackForwardItemLoading under Site Isolation in
WebProcessPool::createNewWebProcess, but the test runner does not have
the equivalent coupling — see <a href="https://bugs.webkit.org/show_bug.cgi?id=316588">https://bugs.webkit.org/show_bug.cgi?id=316588</a>
for the prior whole-cloth featuresImpliedBySiteIsolation attempt that
was reverted because broadening the implication globally regressed
unrelated WPT tests.

To bridge that gap narrowly, add a WTR-local path-pattern hook
siteIsolationImpliedFeaturesForTest in TestController.cpp and apply it
from TestController::testOptionsForTest after the CLI / global /
platform / header merges have resolved SiteIsolationEnabled, only when
SiteIsolationEnabled is true for this run. With SiteIsolationEnabled
false the hook is a true no-op, so non-SI test runs are unchanged. The
hook only matches the single imported WPT path that 317090&apos;s source
diff actually fixes; subsequent bugs in the joint-session-history
cluster (317044, 317145, 317229) will add their own path patterns in
their own PRs as their fixes land. A FIXME at the hook site notes that
the whole hook can be deleted once the test runner can auto-enable
UseUIProcessForBackForwardItemLoading under SiteIsolation directly,
which is the unfiled follow-up to
<a href="https://bugs.webkit.org/show_bug.cgi?id=316588">https://bugs.webkit.org/show_bug.cgi?id=316588</a> / <a href="https://rdar.apple.com/179043211">rdar://179043211</a>.

Covered by existing tests: imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/001.html.

* Source/WebCore/loader/FrameLoader.h:
(WebCore::FrameLoader::loadItem):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::children const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::dispatchSameDocumentJointTraversals):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::applyHistoryTraversalToFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::siteIsolationImpliedFeaturesForTest):
(WTR::TestController::testOptionsForTest):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac937442b6cf9477534ef948627c5da99fd9df1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126622 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea5672c7-135c-4c6c-902c-ea0a2c19b2aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131528 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92540 "2 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc8c722c-3ab4-4255-823f-7668efbaea54) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112032 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de276d29-12df-4094-859b-30a23c8b5fb3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32971 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31681 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26967 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180866 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139977 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42489 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139820 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43178 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28181 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106998 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35103 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114943 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41687 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6269 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41081 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41224 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->