### PR TITLE
[visionOS] Add analytics call for model element interactions

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -35,6 +35,7 @@
 #include "DOMMatrixReadOnly.h"
 #include "DOMPointReadOnly.h"
 #include "DOMPromiseProxy.h"
+#include "DiagnosticLoggingClient.h"
 #include "DocumentEventLoop.h"
 #include "DocumentPage.h"
 #include "DocumentResourceLoader.h"
@@ -272,6 +273,7 @@ void HTMLModelElement::setSourceURL(const URL& url)
     m_dataMemoryCost.store(0, std::memory_order_relaxed);
     m_dataComplete = false;
     m_model = nullptr;
+    m_originalMIMEType = String();
 
     if (RefPtr resource = std::exchange(m_resource, nullptr))
         resource->removeClient(*this);
@@ -951,6 +953,8 @@ void HTMLModelElement::beginStageModeTransform(const TransformationMatrix& trans
 {
     if (m_modelPlayer)
         m_modelPlayer->beginStageModeTransform(transform);
+
+    logInteractionDiagnostic();
 }
 
 void HTMLModelElement::updateStageModeTransform(const TransformationMatrix& transform)
@@ -1158,6 +1162,28 @@ bool HTMLModelElement::isPointInSystemPreviewBadge(const FloatPoint& localPoint)
 }
 #endif
 
+void HTMLModelElement::logInteractionDiagnostic()
+{
+    RefPtr page = document().page();
+    if (!page)
+        return;
+
+    // Models may be converted at runtime so we classify analytics based on the original resource MIME type
+    // We log model type for analytics as:
+    // Unknown = 0
+    int64_t modelType = 0;
+    // USD = 1
+    if (MIMETypeRegistry::isUSDMIMEType(m_originalMIMEType))
+        modelType = 1;
+    // GLTF = 2
+    else if (MIMETypeRegistry::isGLTFMIMEType(m_originalMIMEType))
+        modelType = 2;
+
+    DiagnosticLoggingClient::ValueDictionary dictionary;
+    dictionary.set("type"_s, modelType);
+    protect(page->diagnosticLoggingClient())->logDiagnosticMessageWithValueDictionary("ModelElementInteraction"_s, "Safari"_s, dictionary, ShouldSample::No);
+}
+
 void HTMLModelElement::dragDidStart(WebCore::MouseRelatedEvent& event)
 {
     ASSERT(!m_isDragging);
@@ -1169,6 +1195,8 @@ void HTMLModelElement::dragDidStart(WebCore::MouseRelatedEvent& event)
     frame->eventHandler().setCapturingMouseEventsElement(this);
     event.setDefaultHandled();
     m_isDragging = true;
+
+    logInteractionDiagnostic();
 
     if (RefPtr modelPlayer = m_modelPlayer)
         modelPlayer->handleMouseDown(flippedLocationInElementForMouseEvent(event), event.timeStamp());
@@ -1526,6 +1554,7 @@ void HTMLModelElement::modelResourceFinished()
 
     m_dataComplete = true;
     m_dataMemoryCost.store(m_data.size(), std::memory_order_relaxed);
+    m_originalMIMEType = resource->mimeType();
     m_model = Model::create(m_data.takeBufferAsContiguous().get(), resource->mimeType(), resource->url());
 
     ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -275,6 +275,8 @@ private:
     void dragDidChange(WebCore::MouseRelatedEvent&);
     void dragDidEnd(WebCore::MouseRelatedEvent&);
 
+    void logInteractionDiagnostic();
+
     LayoutPoint flippedLocationInElementForMouseEvent(WebCore::MouseRelatedEvent&);
 #if USE(SYSTEM_PREVIEW)
     bool isPointInSystemPreviewBadge(const FloatPoint&) const;
@@ -327,6 +329,7 @@ private:
 
     URL m_sourceURL;
     CachedResourceHandle<CachedRawResource> m_resource;
+    String m_originalMIMEType;
     SharedBufferBuilder m_data;
     mutable std::atomic<size_t> m_dataMemoryCost { 0 };
     size_t m_reportedDataMemoryCost { 0 };


### PR DESCRIPTION
#### c37346f1a20a64303bb944b11d1793b7208ca958
<pre>
[visionOS] Add analytics call for model element interactions
<a href="https://rdar.apple.com/170126791">rdar://170126791</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317260">https://bugs.webkit.org/show_bug.cgi?id=317260</a>

Reviewed by Mike Wyrzykowski.

Add Safari analytics log event using `diagnosticLoggingClient` whenever a user interacts with a model element
Add tracking for original MIME type of model elements (the model itself may be converted at runtime to a different type)

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::setSourceURL):
(WebCore::HTMLModelElement::beginStageModeTransform):
(WebCore::HTMLModelElement::logInteractionDiagnostic):
(WebCore::HTMLModelElement::dragDidStart):
(WebCore::HTMLModelElement::modelResourceFinished):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:

Canonical link: <a href="https://commits.webkit.org/315491@main">https://commits.webkit.org/315491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd4d8db8399bdb41a0d6d46789668631bfcd4e25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131534 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92544 "1 flakes 11 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32981 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31687 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26975 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180874 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139982 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42497 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139825 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37688 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43186 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28183 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107006 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35110 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114951 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41695 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6271 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->