### PR TITLE
REGRESSION(315338@main): WebCore SPI audit fails on iOS 26.4 debug with unrecognized symbol "kCTFontDescriptorLanguageAttribute"

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -95,6 +95,12 @@ selectors = [
 ]
 requires-sdk = ["iOS <= 26.*"]
 
+[[legacy]]
+symbols = [
+    "kCTFontDescriptorLanguageAttribute",
+]
+requires-sdk = ["iOS <= 26.4"]
+
 # ------------------------------------------------------------------------
 # Below are uncategorized and unconditionally used SPI introduced in older
 # releases.

--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -67,6 +67,14 @@ selectors = [
     { name = "_parentTypes", class = "UTType" },
 ]
 
+[[staging]]
+request = "rdar://161241270"
+cleanup = "rdar://161241477"
+symbols = [
+    "CTFontGetUIFontType",
+]
+requires-sdk = ["iOS <= 26.4"]
+
 [[temporary-usage]]
 request = "rdar://168834967"
 cleanup = "rdar://168834815"


### PR DESCRIPTION
#### 9d701ba2716ed7fa145da273c51d9c064281cc2c
<pre>
REGRESSION(315338@main): WebCore SPI audit fails on iOS 26.4 debug with unrecognized symbol &quot;kCTFontDescriptorLanguageAttribute&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=317284">https://bugs.webkit.org/show_bug.cgi?id=317284</a>
<a href="https://rdar.apple.com/179890896">rdar://179890896</a>

Reviewed by Jonathan Bedard.

In 315338@main, we removed two SPI symbol entries used in WebCore since
they were being pulled in from the CoreText SDKDB. However, these
entries are still necessary to build for iOS &lt;= 26.4, since the symbols
in question do not exist in the CoreText SDKDB corresponding to those
iOS SDKs.

* Source/WebCore/Configurations/AllowedSPI-legacy.toml:
* Source/WebCore/Configurations/AllowedSPI.toml:

Canonical link: <a href="https://commits.webkit.org/315364@main">https://commits.webkit.org/315364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f62e62236d7ceeeb5932e7629af374a0215787c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126542 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74b719e8-a8cd-481a-b4a4-3a733a0d151d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131466 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/166442a9-755d-4995-8a40-75e75035752e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33919 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111970 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e51a49a4-a8f5-4456-a691-bf23c6dbad85) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26861 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180767 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139915 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42406 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139759 "Found 1 new API test failure: WebKitGTK/TestNetworkProcessMemoryPressure:/webkit/WebKitWebsiteData/memory-pressure (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43095 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106867 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35043 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114862 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41598 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6201 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40995 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41249 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->