### PR TITLE
REGRESSION (307212@main Safari 26.x): flex column padding excluded from scrollHeight

### DIFF
--- a/LayoutTests/compositing/shared-backing/overflow-scroll/relative-in-clipping-in-scroller-in-relative-clipping-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/relative-in-clipping-in-scroller-in-relative-clipping-expected.txt
@@ -11,42 +11,61 @@ Relative
         (GraphicsLayer
           (position 28.00 20.00)
           (bounds 324.00 324.00)
-          (children 1
+          (drawsContent 1)
+          (children 2
             (GraphicsLayer
               (offsetFromRenderer width=2 height=2)
               (position 2.00 2.00)
-              (bounds 320.00 320.00)
+              (bounds 320.00 305.00)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 304.00 304.00)
-                  (drawsContent 1)
-                  (children 2
+                  (offsetFromRenderer width=2 height=2)
+                  (anchor 0.00 0.00)
+                  (bounds 324.00 309.00)
+                  (children 1
                     (GraphicsLayer
-                      (offsetFromRenderer width=2 height=2)
-                      (position 2.00 2.00)
-                      (bounds 285.00 300.00)
-                      (children 1
+                      (position 10.00 10.00)
+                      (bounds 304.00 289.00)
+                      (drawsContent 1)
+                      (children 2
                         (GraphicsLayer
                           (offsetFromRenderer width=2 height=2)
-                          (anchor 0.00 0.00)
-                          (bounds 285.00 426.00)
-                          (drawsContent 1)
+                          (position 2.00 2.00)
+                          (bounds 285.00 285.00)
+                          (children 1
+                            (GraphicsLayer
+                              (offsetFromRenderer width=2 height=2)
+                              (anchor 0.00 0.00)
+                              (bounds 285.00 426.00)
+                              (drawsContent 1)
+                            )
+                          )
                         )
-                      )
-                    )
-                    (GraphicsLayer
-                      (position 2.00 2.00)
-                      (bounds 300.00 300.00)
-                      (children 1
                         (GraphicsLayer
-                          (position 285.00 0.00)
-                          (bounds 15.00 300.00)
-                          (drawsContent 1)
+                          (position 2.00 2.00)
+                          (bounds 300.00 285.00)
+                          (children 1
+                            (GraphicsLayer
+                              (position 285.00 0.00)
+                              (bounds 15.00 285.00)
+                              (drawsContent 1)
+                            )
+                          )
                         )
                       )
                     )
                   )
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (bounds 320.00 320.00)
+              (children 1
+                (GraphicsLayer
+                  (position 0.00 305.00)
+                  (bounds 320.00 15.00)
+                  (drawsContent 1)
                 )
               )
             )

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-padding-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-padding-expected.txt
@@ -13,5 +13,5 @@ Inline block child gets block and inline padding.
 Padding applies to linebox, not linebox overflow.
 
 
-FAIL Container padding is applied approriately to block/inline children. assert_true: horizontal scrollbar 1 expected true got false
+PASS Container padding is applied approriately to block/inline children.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-child-border-within-padding.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-child-border-within-padding.tentative-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Container with overflow:x-only — child border crossing content edge extends scrollable area by inline/block padding
+PASS Container with overflow:y-only — child border crossing content edge extends scrollable area by inline/block padding
+PASS Container with overflow:both — child border crossing content edge extends scrollable area by inline/block padding
+PASS Container with overflow:clip-y — child border crossing content edge extends scrollable area by inline/block padding
+PASS Container with overflow:clip-x — child border crossing content edge extends scrollable area by inline/block padding
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-child-border-within-padding.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-child-border-within-padding.tentative.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>scrollWidth/scrollHeight: child border-box extending past content-box but within padding-box does not extend the scrollable area</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollheight">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/129">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/8660">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  .container {
+    box-sizing: content-box;
+    width: 300px;
+    height: 300px;
+    padding: 10px;
+    border: 2px solid black;
+    /* content-box 300x300, padding-box 320x320, border-box 324x324 */
+    /* scrollbar-width: none — keep clientWidth/scrollWidth math
+       independent of platform scrollbar size (classic vs overlay). */
+    scrollbar-width: none;
+  }
+  .child {
+    box-sizing: content-box;
+    width: 100%;
+    height: 100%;
+    border: 2px solid black;
+    /* in default content-box sizing, width:100% gives content-box 300,
+       so the child's rendered border-box is 304x304 — 4px past the
+       container's content edge on each side, but 16px inside the
+       padding edge on each side */
+  }
+  .x-only  { overflow-x: auto; overflow-y: visible; }
+  .y-only  { overflow-y: auto; overflow-x: visible; }
+  .both    { overflow: auto; }
+  .clip-y  { overflow-y: hidden; overflow-x: visible; /* computes to overflow-x: auto */ }
+  .clip-x  { overflow-x: hidden; overflow-y: visible; /* computes to overflow-y: auto */ }
+</style>
+
+<div class="container x-only" id="x-only"><div class="child"></div></div>
+<div class="container y-only" id="y-only"><div class="child"></div></div>
+<div class="container both"   id="both"><div class="child"></div></div>
+<div class="container clip-y" id="clip-y"><div class="child"></div></div>
+<div class="container clip-x" id="clip-x"><div class="child"></div></div>
+
+<script>
+// CSS Overflow 3 §3, read literally, defines the scrollable overflow
+// rectangle as the smallest rectangle containing the padding-box AND
+// every in-flow child's margin area. With that reading, the child's
+// margin-box (304×304) is fully contained in the padding-box (320×320)
+// and scrollWidth/scrollHeight should both be 320.
+//
+// In practice every engine implements the resolution from
+// csswg-drafts#129 / #8660 ("padding edge appended to outer margin
+// edge of overflowing block-level child"), and applies it as soon as
+// the child margin-box's edge crosses the content edge — even by 1px,
+// even when the child remains inside the padding-box. The child here
+// extends 4px past the content edge in both axes, so the right (and
+// bottom) padding edge is appended:
+//   union(padding-box X 2..322, child-X 12..316 + right-padding 10) = 2..326 → width 324
+//   union(padding-box Y 2..322, child-Y 12..316 + bottom-padding 10) = 2..326 → height 324
+// Cross-engine measurement (2026-06-23): Chrome 150, Firefox 152, and
+// WebKit (post-bug-316902 patch) all report scrollWidth = scrollHeight = 324.
+// Pre-patch WebKit reports 320 — the original spec-literal reading.
+//
+// This test is `tentative` because §3 prose still doesn't say "324",
+// but engine consensus says it does. It serves as a regression sentinel
+// against drift back to 320, and as a marker for the spec-prose gap.
+
+for (const id of ["x-only", "y-only", "both", "clip-y", "clip-x"]) {
+  test(() => {
+    const el = document.getElementById(id);
+    assert_equals(el.clientWidth, 320, "clientWidth (padding-box width)");
+    assert_equals(el.clientHeight, 320, "clientHeight (padding-box height)");
+    assert_equals(el.scrollWidth, 324,
+      "scrollWidth — inline-axis padding edge appended to overflowing child margin edge (csswg-drafts#8660)");
+    assert_equals(el.scrollHeight, 324,
+      "scrollHeight — block-axis padding edge appended to overflowing child margin edge (csswg-drafts#129)");
+  }, `Container with overflow:${id} — child border crossing content edge extends scrollable area by inline/block padding`);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-flex-column-padding-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-flex-column-padding-001-expected.txt
@@ -1,0 +1,4 @@
+
+PASS flex-direction:column scrollHeight includes block-axis padding around overflowing items
+PASS flex-direction:column-reverse scrollHeight includes block-axis padding around overflowing items
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-flex-column-padding-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-flex-column-padding-001.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>scrollHeight on a flex column scroll container includes block-axis padding when items overflow the content edge</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollheight">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/129">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/8660">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+.scroller {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  width: 100px;
+  height: 206px;
+  padding: 100px 0;
+}
+.scroller > .item {
+  flex-shrink: 0;
+  height: 38px;
+  background: blue;
+}
+</style>
+
+<div class="scroller" id="column">
+  <div class="item"></div>
+  <div class="item"></div>
+</div>
+
+<div class="scroller" id="column-reverse" style="flex-direction: column-reverse">
+  <div class="item"></div>
+  <div class="item"></div>
+</div>
+
+<script>
+// box-sizing:border-box + height:206 + padding:100px 0 => content-box height = 6.
+// Two 38px flex items (76px total) overflow the content edge. The scrollable
+// overflow area is the union of the items' margin boxes with the container's
+// content area, then extended by the container's block-axis padding.
+//   Expected scrollHeight: 100 (padding-top) + 38 + 38 + 100 (padding-bottom) = 276.
+//   Expected clientHeight: padding-box height = 206.
+for (const id of ["column", "column-reverse"]) {
+  test(() => {
+    const el = document.getElementById(id);
+    assert_equals(el.clientHeight, 206, "clientHeight");
+    assert_equals(el.scrollHeight, 276, "scrollHeight");
+  }, `flex-direction:${id} scrollHeight includes block-axis padding around overflowing items`);
+}
+</script>

--- a/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/relative-in-clipping-in-scroller-in-relative-clipping-expected.txt
+++ b/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/relative-in-clipping-in-scroller-in-relative-clipping-expected.txt
@@ -11,6 +11,7 @@ Relative
         (GraphicsLayer
           (position 28.00 20.00)
           (bounds 324.00 324.00)
+          (drawsContent 1)
           (children 1
             (GraphicsLayer
               (offsetFromRenderer width=2 height=2)
@@ -18,20 +19,27 @@ Relative
               (bounds 320.00 320.00)
               (children 1
                 (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 304.00 304.00)
-                  (drawsContent 1)
+                  (offsetFromRenderer width=2 height=2)
+                  (anchor 0.00 0.00)
+                  (bounds 324.00 324.00)
                   (children 1
                     (GraphicsLayer
-                      (offsetFromRenderer width=2 height=2)
-                      (position 2.00 2.00)
-                      (bounds 300.00 300.00)
+                      (position 10.00 10.00)
+                      (bounds 304.00 304.00)
+                      (drawsContent 1)
                       (children 1
                         (GraphicsLayer
                           (offsetFromRenderer width=2 height=2)
-                          (anchor 0.00 0.00)
-                          (bounds 300.00 428.00)
-                          (drawsContent 1)
+                          (position 2.00 2.00)
+                          (bounds 300.00 300.00)
+                          (children 1
+                            (GraphicsLayer
+                              (offsetFromRenderer width=2 height=2)
+                              (anchor 0.00 0.00)
+                              (bounds 300.00 428.00)
+                              (drawsContent 1)
+                            )
+                          )
                         )
                       )
                     )

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -191,7 +191,7 @@ inline LayoutRect RenderBox::marginBoxRect() const
 inline const LayoutRect RenderBox::scrollableContentAreaOverflowRect() const
 {
     if (!m_overflow)
-        return flippedClientBoxRect();
+        return flippedContentBoxRect();
 
     return m_overflow->contentArea();
 }


### PR DESCRIPTION
#### 5a62fb16bf60aa6bc6943270c7d3c4ebbf58f5c5
<pre>
REGRESSION (307212@main Safari 26.x): flex column padding excluded from scrollHeight
<a href="https://bugs.webkit.org/show_bug.cgi?id=316902">https://bugs.webkit.org/show_bug.cgi?id=316902</a>
<a href="https://rdar.apple.com/179376053">rdar://179376053</a>

Reviewed by Elika Etemad.

This fix an issue introduced in
<a href="https://webkit.org/b/286753">https://webkit.org/b/286753</a>
<a href="https://github.com/WebKit/WebKit/pull/57545">https://github.com/WebKit/WebKit/pull/57545</a>

A flex column with overflow:auto and top/bottom padding stopped including
that padding in scrollHeight when its items overflow the content edge.

307212@main introduced scrollableContentAreaOverflowRect() returning the
padding box instead of the content box when no overflow is recorded yet.

Return flippedContentBoxRect() instead, matching the pre-307212
behavior and the helper&apos;s name.

It also adds a WPT test to catch it next time.

Test: imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-flex-column-padding-001.html
      imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-child-border-within-padding.tentative.html

* LayoutTests/compositing/shared-backing/overflow-scroll/relative-in-clipping-in-scroller-in-relative-clipping-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-padding-expected.txt:
  fix this test
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-child-border-within-padding.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-child-border-within-padding.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-flex-column-padding-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-flex-column-padding-001.html: Added.
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::scrollableContentAreaOverflowRect const):

Canonical link: <a href="https://commits.webkit.org/315813@main">https://commits.webkit.org/315813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c66333dd5f3b5d151cf43cca8a529b214b9f463

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179294 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127645 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5141c24-6aae-484c-9ca3-3434c61a84c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132447 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93315 "1 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a6d5bce-495d-47ac-ba79-630e2496bb16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112949 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31d4ad2d-e723-48f2-ab89-ab563052d9d7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32587 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27990 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181891 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140899 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140730 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37945 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44200 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29249 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108511 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35998 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115965 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42711 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7349 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42103 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42358 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42246 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->