### PR TITLE
[GTK][WPE] Move per-buffer frame-damage bookkeeping into SwapChainDamageTracker

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -123,6 +123,9 @@ AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& fram
     , m_swapChain(*this)
     , m_isVisible(webPage.activityState().contains(ActivityState::IsVisible))
     , m_useExplicitSync(usesGL() && useExplicitSync())
+#if ENABLE(DAMAGE_TRACKING)
+    , m_damageTracker(m_swapChain)
+#endif
 {
 }
 
@@ -896,12 +899,20 @@ uint64_t AcceleratedSurface::SwapChain::window()
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
-void AcceleratedSurface::SwapChain::addDamage(const std::optional<Damage>& damage)
+Vector<IntRect, 1> AcceleratedSurface::SwapChainDamageTracker::takeFrameDamageRects()
 {
-    for (auto& renderTarget : m_freeTargets)
-        renderTarget->addDamage(damage);
-    for (auto& renderTarget : m_lockedTargets)
-        renderTarget->addDamage(damage);
+    if (!m_frameDamage)
+        return { };
+
+    return std::exchange(m_frameDamage, std::nullopt)->rects();
+}
+
+const std::optional<Damage>& AcceleratedSurface::SwapChainDamageTracker::damageForTarget(RenderTarget& target)
+{
+    m_swapChain.forEachTarget([&](RenderTarget& candidate) {
+        candidate.addDamage(m_frameDamage);
+    });
+    return target.damage();
 }
 #endif
 
@@ -1025,7 +1036,7 @@ void AcceleratedSurface::willRenderFrame(const IntSize& size)
     if (sizeDidChange || bufferFormatChanged) {
         m_pendingFrameNotifyTargets.clear();
 #if ENABLE(DAMAGE_TRACKING)
-        m_frameDamage = std::nullopt;
+        m_damageTracker.reset();
 #endif
     }
 
@@ -1089,11 +1100,8 @@ void AcceleratedSurface::didRenderFrame()
     // (CoordinatedBackingStore & ThreadedCompositor) only fetch bounds. Thus having damage with
     // better resolution is pointless as the bounds are the same in such case.
     // FIXME: If we start to consume fine-grained damage in the Skia compositor, we will need to relax the usesGL condition.
-    m_target->setDamage(Damage(m_swapChain.size(), usesGL() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, m_frameDamageRectangleThreshold));
-    if (m_frameDamage) {
-        damageRects = m_frameDamage->rects();
-        m_frameDamage = std::nullopt;
-    }
+    m_target->setDamage(Damage(m_swapChain.size(), usesGL() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, m_damageTracker.rectangleThreshold()));
+    damageRects = m_damageTracker.takeFrameDamageRects();
 #endif
 
     m_target->didRenderFrame();
@@ -1111,16 +1119,10 @@ void AcceleratedSurface::sendFrame()
 }
 
 #if ENABLE(DAMAGE_TRACKING)
-void AcceleratedSurface::setFrameDamage(Damage&& damage)
-{
-    m_frameDamage = WTF::move(damage);
-}
-
 const std::optional<Damage>& AcceleratedSurface::renderTargetDamage()
 {
-    m_swapChain.addDamage(m_frameDamage);
     static std::optional<Damage> nulloptDamage;
-    return m_target ? m_target->damage() : nulloptDamage;
+    return m_target ? m_damageTracker.damageForTarget(*m_target) : nulloptDamage;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -132,9 +132,9 @@ public:
     void clear(const OptionSet<WebCore::CompositionReason>&);
 
 #if ENABLE(DAMAGE_TRACKING)
-    void setFrameDamage(WebCore::Damage&&);
-    void setFrameDamageRectangleThreshold(unsigned threshold) { m_frameDamageRectangleThreshold = threshold; }
-    const std::optional<WebCore::Damage>& frameDamage() const LIFETIME_BOUND { return m_frameDamage; }
+    void setFrameDamage(WebCore::Damage&& damage) { m_damageTracker.recordFrameDamage(WTF::move(damage)); }
+    void setFrameDamageRectangleThreshold(unsigned threshold) { m_damageTracker.setRectangleThreshold(threshold); }
+    const std::optional<WebCore::Damage>& frameDamage() const LIFETIME_BOUND { return m_damageTracker.frameDamage(); }
     const std::optional<WebCore::Damage>& renderTargetDamage();
 #endif
 
@@ -366,7 +366,13 @@ private:
         void releaseUnusedBuffers();
 
 #if ENABLE(DAMAGE_TRACKING)
-        void addDamage(const std::optional<WebCore::Damage>&);
+        template<typename Functor> void forEachTarget(Functor&& functor)
+        {
+            for (auto& target : m_freeTargets)
+                functor(*target);
+            for (auto& target : m_lockedTargets)
+                functor(*target);
+        }
 #endif
 
 #if (PLATFORM(GTK) || ENABLE(WPE_PLATFORM)) && (USE(GBM) || OS(ANDROID))
@@ -401,6 +407,36 @@ private:
 #endif
     };
 
+#if ENABLE(DAMAGE_TRACKING)
+    class SwapChainDamageTracker {
+        WTF_MAKE_NONCOPYABLE(SwapChainDamageTracker);
+    public:
+        explicit SwapChainDamageTracker(SwapChain& swapChain)
+            : m_swapChain(swapChain)
+        {
+        }
+
+        void setRectangleThreshold(unsigned threshold) { m_rectangleThreshold = threshold; }
+        unsigned rectangleThreshold() const { return m_rectangleThreshold; }
+
+        // This frame's content change vs the last presented frame - propagated to the platform.
+        void recordFrameDamage(WebCore::Damage&& damage) { m_frameDamage = WTF::move(damage); }
+        const std::optional<WebCore::Damage>& frameDamage() const LIFETIME_BOUND { return m_frameDamage; }
+        Vector<WebCore::IntRect, 1> takeFrameDamageRects();
+
+        // Propagates this frame's damage into every buffer and returns the given buffer's accumulated damage.
+        const std::optional<WebCore::Damage>& damageForTarget(RenderTarget&);
+
+        // Discards the pending frame damage, e.g. when the swap chain is resized.
+        void reset() { m_frameDamage = std::nullopt; }
+
+    private:
+        SwapChain& m_swapChain;
+        std::optional<WebCore::Damage> m_frameDamage;
+        unsigned m_rectangleThreshold { 4 };
+    };
+#endif
+
     const WeakRef<WebPage> m_webPage;
     Function<void()> m_frameCompleteHandler;
     bool m_useSkia { false };
@@ -418,8 +454,7 @@ private:
     bool m_useExplicitSync { false };
     std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
 #if ENABLE(DAMAGE_TRACKING)
-    std::optional<WebCore::Damage> m_frameDamage;
-    unsigned m_frameDamageRectangleThreshold { 4 };
+    SwapChainDamageTracker m_damageTracker;
 #endif
 };
 


### PR DESCRIPTION
#### 4267ab4b310334521a7943b7a370a41b5cd316d7
<pre>
[GTK][WPE] Move per-buffer frame-damage bookkeeping into SwapChainDamageTracker
<a href="https://bugs.webkit.org/show_bug.cgi?id=317290">https://bugs.webkit.org/show_bug.cgi?id=317290</a>

Reviewed by Carlos Garcia Campos.

Prepare for further enhancments when using the damage information to
restrict the area needed for composition in the Skia compositor: Extract
AcceleratedSurface&apos;s per-buffer frame-damage accounting - the frame
damage, its rectangle threshold, and the per-target accumulation done by
renderTargetDamage() - into a dedicated SwapChainDamageTracker, and replace
SwapChain::addDamage() with a forEachTarget() helper the tracker uses to
propagate damage across targets.

The public API was left untouched, the new SwapChainDamageTracker is
left as internal detail to AcceleratedSurface, for better encapsulation.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::AcceleratedSurface):
(WebKit::AcceleratedSurface::SwapChainDamageTracker::takeFrameDamageRects):
(WebKit::AcceleratedSurface::SwapChainDamageTracker::damageForTarget):
(WebKit::AcceleratedSurface::willRenderFrame):
(WebKit::AcceleratedSurface::didRenderFrame):
(WebKit::AcceleratedSurface::renderTargetDamage):
(WebKit::AcceleratedSurface::SwapChain::addDamage): Deleted.
(WebKit::AcceleratedSurface::setFrameDamage): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:

Canonical link: <a href="https://commits.webkit.org/315361@main">https://commits.webkit.org/315361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3d39d5068cda9ca526db13d301a48447eec893f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126550 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131475 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33929 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111979 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26869 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180775 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139923 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42414 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37619 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43103 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106886 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35049 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114870 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41606 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6210 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41003 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->