### PR TITLE
[model] <model> element is not captured in Tab Overview snapshots on macOS

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -131,16 +131,7 @@ void CompositorIntegrationImpl::withDisplayBufferAsNativeImage(uint32_t bufferIn
         if (!isIOSurfaceSupportedFormat)
             return completion(nullptr);
 
-        auto& renderBuffer = m_renderBuffers[bufferIndex];
-        std::optional<CGImageAlphaInfo> alphaInfo;
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-        if (renderBuffer->pixelFormat() == IOSurface::Format::RGBA16F)
-            alphaInfo = kCGImageAlphaNoneSkipLast;
-#endif
-        RetainPtr<CGContextRef> cgContext = renderBuffer->createPlatformContext(0, alphaInfo);
-
-        if (cgContext)
-            displayImage = NativeImage::create(renderBuffer->createImage(cgContext.get()));
+        displayImage = m_renderBuffers[bufferIndex]->createNativeImage();
     }
 
     if (!displayImage)

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -45,7 +45,9 @@
 #include "EventNames.h"
 #include "Exception.h"
 #include "FloatPoint3D.h"
+#include "FloatRect.h"
 #include "FrameDestructionObserverInlines.h"
+#include "GraphicsContext.h"
 #include "GraphicsLayer.h"
 #include "GraphicsLayerCA.h"
 #include "HTMLAnchorElement.h"
@@ -53,6 +55,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLSourceElement.h"
+#include "ImageBuffer.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMPromiseDeferred.h"
@@ -860,6 +863,19 @@ void HTMLModelElement::sizeMayHaveChanged()
         modelPlayer->sizeDidChange(contentSize());
     else
         createModelPlayer();
+}
+
+void HTMLModelElement::paintCurrentFrameInContext(GraphicsContext& context, const FloatRect& destinationRect)
+{
+    if (destinationRect.isEmpty() || context.paintingDisabled())
+        return;
+
+    RefPtr modelPlayer { m_modelPlayer };
+    if (!modelPlayer)
+        return;
+
+    if (RefPtr imageBuffer { modelPlayer->snapshotCurrentFrame(destinationRect.size().scaled(protect(document())->deviceScaleFactor()), context.colorSpace()) })
+        context.drawImageBuffer(*imageBuffer, destinationRect);
 }
 
 void HTMLModelElement::configureGraphicsLayer(GraphicsLayer& graphicsLayer, Color backgroundColor)

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -63,6 +63,8 @@ class DOMPointReadOnly;
 class Event;
 class Exception;
 class FloatPoint;
+class FloatRect;
+class GraphicsContext;
 class GraphicsLayer;
 class LayoutPoint;
 class LayoutSize;
@@ -187,6 +189,8 @@ public:
 #endif
 
     void sizeMayHaveChanged();
+
+    void paintCurrentFrameInContext(GraphicsContext&, const FloatRect&);
 
     size_t NODELETE memoryCost() const;
 #if ENABLE(RESOURCE_USAGE)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -28,6 +28,7 @@
 
 #include "Color.h"
 #include "FloatPoint3D.h"
+#include "ImageBuffer.h"
 #include "ModelPlayerAnimationState.h"
 #include "ModelPlayerTransformState.h"
 #include "TransformationMatrix.h"
@@ -65,6 +66,11 @@ void ModelPlayer::reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::un
 
 void ModelPlayer::visibilityStateDidChange()
 {
+}
+
+RefPtr<ImageBuffer> ModelPlayer::snapshotCurrentFrame(const FloatSize&, const DestinationColorSpace&)
+{
+    return nullptr;
 }
 
 #if ENABLE(MODEL_ELEMENT_BOUNDING_BOX)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -53,12 +53,15 @@ namespace WebCore {
 
 class FloatPoint3D;
 class GraphicsLayer;
+class ImageBuffer;
 class Model;
 class ModelPlayerAnimationState;
 class ModelPlayerTransformState;
 class SharedBuffer;
 class TransformationMatrix;
 
+class DestinationColorSpace;
+class FloatSize;
 struct ModelPlayerGraphicsLayerConfiguration;
 
 class WEBCORE_EXPORT ModelPlayer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ModelPlayer> {
@@ -75,6 +78,8 @@ public:
 
     // Graphics.
     virtual void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) = 0;
+
+    virtual RefPtr<ImageBuffer> snapshotCurrentFrame(const FloatSize& deviceSize, const DestinationColorSpace&);
 
     // State changes.
     virtual void NODELETE visibilityStateDidChange();

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -32,6 +32,7 @@
 #include <WebCore/IntSize.h>
 #include <WebCore/PixelFormat.h>
 #include <WebCore/ProcessIdentity.h>
+#include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
 
@@ -43,6 +44,7 @@ class TextStream;
 namespace WebCore {
 
 class IOSurfacePool;
+class NativeImage;
 
 enum class RenderingPurpose : uint8_t;
 enum class SetNonVolatileResult : uint8_t;
@@ -168,6 +170,7 @@ public:
     // the context, or an expensive GPU readback can result.
     // Passed in context is the context through which the contents was drawn.
     WEBCORE_EXPORT RetainPtr<CGImageRef> createImage(CGContextRef);
+    WEBCORE_EXPORT RefPtr<NativeImage> createNativeImage();
     // Passed in context is the context through which the contents was drawn.
     WEBCORE_EXPORT static RetainPtr<CGImageRef> sinkIntoImage(std::unique_ptr<IOSurface>, RetainPtr<CGContextRef> = nullptr);
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -32,6 +32,7 @@
 #import "IOSurfacePool.h"
 #import "ImageBufferBackend.h"
 #import "Logging.h"
+#import "NativeImage.h"
 #import "PlatformScreen.h"
 #import "ProcessCapabilities.h"
 #import "ProcessIdentity.h"
@@ -540,6 +541,20 @@ RetainPtr<CGImageRef> IOSurface::createImage(CGContextRef context)
 {
     ASSERT(CGIOSurfaceContextGetSurface(context) == m_surface);
     return adoptCF(CGIOSurfaceContextCreateImage(context));
+}
+
+RefPtr<NativeImage> IOSurface::createNativeImage()
+{
+    std::optional<CGImageAlphaInfo> alphaInfo;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (pixelFormat() == Format::RGBA16F)
+        alphaInfo = kCGImageAlphaNoneSkipLast;
+#endif
+    RetainPtr<CGContextRef> cgContext { createPlatformContext(0, alphaInfo) };
+    if (!cgContext)
+        return nullptr;
+
+    return NativeImage::create(createImage(cgContext.get()));
 }
 
 RetainPtr<CGImageRef> IOSurface::sinkIntoImage(std::unique_ptr<IOSurface> surface, RetainPtr<CGContextRef> context)

--- a/Source/WebCore/rendering/RenderModel.cpp
+++ b/Source/WebCore/rendering/RenderModel.cpp
@@ -88,7 +88,6 @@ void RenderModel::update()
     contentChanged(ContentChangeType::Model);
 }
 
-#if USE(SYSTEM_PREVIEW)
 void RenderModel::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
     if (paintInfo.phase != PaintPhase::Foreground)
@@ -97,6 +96,13 @@ void RenderModel::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
     if (paintInfo.context().paintingDisabled())
         return;
 
+    if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting)) {
+        LayoutRect snapshotRect { replacedContentRect() };
+        snapshotRect.moveBy(paintOffset);
+        protect(modelElement())->paintCurrentFrameInContext(paintInfo.context(), snapRectToDevicePixels(snapshotRect, protect(document())->deviceScaleFactor()));
+    }
+
+#if USE(SYSTEM_PREVIEW)
     if (!modelElement().document().settings().systemPreviewEnabled())
         return;
 
@@ -114,8 +120,8 @@ void RenderModel::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
     contentRect.moveBy(paintOffset);
     RefPtr document = modelElement().document();
     theme().paintSystemPreviewBadge(paintInfo, snapRectToDevicePixels(contentRect, document->deviceScaleFactor()));
-}
 #endif
+}
 
 }
 

--- a/Source/WebCore/rendering/RenderModel.h
+++ b/Source/WebCore/rendering/RenderModel.h
@@ -53,9 +53,7 @@ private:
     bool NODELETE requiresLayer() const final;
     void updateFromElement() final;
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) final;
-#if USE(SYSTEM_PREVIEW)
     void paintReplaced(PaintInfo&, const LayoutPoint&) final;
-#endif
 
     void update();
 };

--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
@@ -31,6 +31,8 @@
 #include "ModelTypes.h"
 #include "WebKitMesh.h"
 #include <WebCore/IOSurface.h>
+#include <WebCore/NativeImage.h>
+#include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -125,6 +127,19 @@ void MeshImpl::updateRenderBuffers(WebModel::ResizeMeshDescriptor&& descriptor)
 {
     m_backing->updateRenderBuffers(descriptor);
     m_renderBuffers = WTF::move(descriptor.renderBuffers);
+}
+
+RefPtr<WebCore::NativeImage> MeshImpl::getCurrentFrameAsNativeImage(uint32_t bufferIndex)
+{
+    if (bufferIndex >= m_renderBuffers.size())
+        return nullptr;
+
+    RefPtr nativeImage { m_renderBuffers[bufferIndex]->createNativeImage() };
+    if (!nativeImage)
+        return nullptr;
+
+    CGImageSetCachingFlags(nativeImage->platformImage().get(), kCGImageCachingTransient);
+    return nativeImage;
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
@@ -52,6 +52,7 @@ public:
 #if PLATFORM(COCOA)
     Vector<MachSendRight> ioSurfaceHandles() final;
     void updateRenderBuffers(WebModel::ResizeMeshDescriptor&&) final;
+    RefPtr<WebCore::NativeImage> getCurrentFrameAsNativeImage(uint32_t bufferIndex) final;
 #endif
 
 private:

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -161,6 +161,13 @@ void RemoteMesh::processRemovals(Vector<WebModel::TypedResourceId>&& meshRemoval
     m_backing->processRemovals(WTF::move(meshRemovals), WTF::move(materialRemovals), WTF::move(textureRemovals), WTF::move(completionHandler));
 }
 
+void RemoteMesh::paintCurrentFrameToImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, uint32_t bufferIndex, CompletionHandler<void()>&& completionHandler)
+{
+    if (RefPtr nativeImage { m_backing->getCurrentFrameAsNativeImage(bufferIndex) })
+        m_gpu->paintNativeImageToImageBuffer(*nativeImage, imageBufferIdentifier);
+    completionHandler();
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
@@ -101,6 +101,7 @@ private:
     void setEnvironmentMap(WebModel::UpdateTextureDescriptor&&);
     void updateContentsHeadroom(float);
     void updateRenderBuffers(unsigned, unsigned, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
+    void paintCurrentFrameToImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, uint32_t bufferIndex, CompletionHandler<void()>&&);
 
     void render(uint32_t textureIndex, CompletionHandler<void(bool)>&&);
     void processRemovals(Vector<WebModel::TypedResourceId>&& meshRemovals, Vector<WebModel::TypedResourceId>&& materialRemovals, Vector<WebModel::TypedResourceId>&& textureRemovals, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
@@ -43,5 +43,6 @@ messages -> RemoteMesh Stream {
     void SetEnvironmentMap(struct WebModel::UpdateTextureDescriptor imageAsset) NotStreamEncodable
     void UpdateContentsHeadroom(float headroom)
     void UpdateRenderBuffers(unsigned width, unsigned height) -> (Vector<MachSendRight> renderBuffers) NotStreamEncodableReply
+    void PaintCurrentFrameToImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, uint32_t bufferIndex) -> () Synchronous
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -278,6 +278,17 @@ void RemoteMeshProxy::sizeDidChange(unsigned width, unsigned height, CompletionH
 #endif
 }
 
+void RemoteMeshProxy::paintCurrentFrameToImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, uint32_t bufferIndex)
+{
+#if ENABLE(GPU_PROCESS_MODEL)
+    auto sendResult { sendSync(Messages::RemoteMesh::PaintCurrentFrameToImageBuffer(imageBufferIdentifier, bufferIndex)) };
+    UNUSED_VARIABLE(sendResult);
+#else
+    UNUSED_PARAM(imageBufferIdentifier);
+    UNUSED_PARAM(bufferIndex);
+#endif
+}
+
 std::optional<WebModel::Float4x4> RemoteMeshProxy::entityTransform() const
 {
     return m_computedTransform;

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -89,6 +89,11 @@ private:
     {
         return protect(root().streamClientConnection())->sendWithAsyncReply(WTF::move(message), WTF::move(completionHandler), backing());
     }
+    template<typename T>
+    [[nodiscard]] auto sendSync(T&& message)
+    {
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
+    }
 
     void update(Vector<WebModel::UpdateMeshDescriptor>&&) final;
     void updateTexture(Vector<WebModel::UpdateTextureDescriptor>&&) final;
@@ -96,6 +101,7 @@ private:
 #if PLATFORM(COCOA)
     std::pair<simd_float4, simd_float4> getCenterAndExtents() const final;
     void sizeDidChange(unsigned, unsigned, CompletionHandler<void(Vector<MachSendRight>&&)>&&) final;
+    void paintCurrentFrameToImageBuffer(WebCore::RenderingResourceIdentifier, uint32_t bufferIndex) final;
 #endif
     void play(bool) final;
 

--- a/Source/WebKit/WebProcess/Model/Mesh.h
+++ b/Source/WebKit/WebProcess/Model/Mesh.h
@@ -33,6 +33,7 @@
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
+#include <WebCore/RenderingResourceIdentifier.h>
 #include <simd/simd.h>
 #include <wtf/MachSendRight.h>
 #endif
@@ -42,6 +43,7 @@ struct ResizeMeshDescriptor;
 }
 
 namespace WebCore {
+class NativeImage;
 class TransformationMatrix;
 enum class StageModeOperation : bool;
 }
@@ -93,6 +95,8 @@ public:
 #if PLATFORM(COCOA)
     virtual std::optional<WebModel::Float4x4> entityTransform() const = 0;
     virtual Vector<MachSendRight> ioSurfaceHandles() { return { }; }
+    virtual void paintCurrentFrameToImageBuffer(WebCore::RenderingResourceIdentifier, uint32_t) { }
+    virtual RefPtr<WebCore::NativeImage> getCurrentFrameAsNativeImage(uint32_t) { return nullptr; }
     virtual void updateRenderBuffers(WebModel::ResizeMeshDescriptor&&) { }
     virtual void sizeDidChange(unsigned, unsigned, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback) { callback({ }); }
     virtual std::pair<simd_float4, simd_float4> getCenterAndExtents() const { return std::make_pair(simd_make_float4(0.f), simd_make_float4(0.f)); }

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -50,7 +50,10 @@ struct ImageAsset;
 }
 
 namespace WebCore {
+class DestinationColorSpace;
+class FloatSize;
 class GraphicsLayerContentsDisplayDelegate;
+class ImageBuffer;
 class ModelPlayerClient;
 class Page;
 }
@@ -80,6 +83,7 @@ private:
     void load(WebCore::Model&, WebCore::LayoutSize, bool) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
+    RefPtr<WebCore::ImageBuffer> snapshotCurrentFrame(const WebCore::FloatSize& deviceSize, const WebCore::DestinationColorSpace&) final;
     void enterFullscreen() final;
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseMove(const WebCore::LayoutPoint&, MonotonicTime) final;
@@ -154,6 +158,7 @@ private:
     WeakPtr<WebCore::GraphicsLayer> m_graphicsLayer;
     uint32_t m_renderTextureIndex { 0 };
     uint32_t m_displayTextureIndex { 0 };
+    bool m_hasRenderedFrame { false };
     WebCore::StageModeOperation m_stageMode { WebCore::StageModeOperation::None };
     std::optional<WebCore::Color> m_backgroundColor;
     WebCore::IntSize m_currentPixelSize;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -36,6 +36,7 @@
 #import "RemoteGPUProxy.h"
 #import "RemoteMeshProxy.h"
 #import "WKStageModeOrbitSimulator.h"
+#import <WebCore/Chrome.h>
 #import <WebCore/Document.h>
 #import <WebCore/DocumentEventLoop.h>
 #import <WebCore/FloatPoint3D.h>
@@ -43,6 +44,7 @@
 #import <WebCore/GraphicsLayer.h>
 #import <WebCore/GraphicsLayerContentsDisplayDelegate.h>
 #import <WebCore/HTMLModelElement.h>
+#import <WebCore/ImageBuffer.h>
 #import <WebCore/ModelPlayerAnimationState.h>
 #import <WebCore/ModelPlayerGraphicsLayerConfiguration.h>
 #import <WebCore/ModelPlayerTransformState.h>
@@ -206,6 +208,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size,
     m_didFinishLoading = false;
     m_renderTextureIndex = 0;
     m_displayTextureIndex = 0;
+    m_hasRenderedFrame = false;
     m_isUpdateLoopRunning = false;
     RefPtr document = corePage->localTopDocument();
     if (!document)
@@ -243,6 +246,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size,
             protectedThis->m_displayBuffers = WTF::move(surfaceHandles);
             protectedThis->m_renderTextureIndex = 0;
             protectedThis->m_displayTextureIndex = 0;
+            protectedThis->m_hasRenderedFrame = false;
             protectedThis->updateScreenHeadroomFromPage();
         }
     });
@@ -363,6 +367,7 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
         protectedThis->m_displayBuffers = WTF::move(newBuffers);
         protectedThis->m_renderTextureIndex = 0;
         protectedThis->m_displayTextureIndex = 0;
+        protectedThis->m_hasRenderedFrame = false;
         if (protectedThis->m_contentsDisplayDelegate)
             protect(protectedThis->m_contentsDisplayDelegate)->setDisplayBuffer(*protectedThis->displayBuffer());
         protectedThis->startUpdateLoopIfNeeded();
@@ -514,6 +519,25 @@ const MachSendRight* WebModelPlayer::displayBuffer() const
     return &m_displayBuffers[m_displayTextureIndex];
 }
 
+RefPtr<WebCore::ImageBuffer> WebModelPlayer::snapshotCurrentFrame(const WebCore::FloatSize& deviceSize, const WebCore::DestinationColorSpace& colorSpace)
+{
+    RefPtr currentModel { m_currentModel };
+    if (!currentModel || !m_hasRenderedFrame || m_displayTextureIndex >= m_displayBuffers.size())
+        return nullptr;
+
+    RefPtr corePage { m_page.get() };
+    if (!corePage)
+        return nullptr;
+
+    RefPtr imageBuffer { WebCore::ImageBuffer::create(deviceSize, WebCore::RenderingMode::Accelerated, WebCore::RenderingPurpose::Snapshot, 1, colorSpace, WebCore::PixelFormat::BGRA8, &corePage->chrome()) };
+    if (!imageBuffer)
+        return nullptr;
+
+    imageBuffer->flushDrawingContext();
+    currentModel->paintCurrentFrameToImageBuffer(imageBuffer->renderingResourceIdentifier(), m_displayTextureIndex);
+    return imageBuffer;
+}
+
 WebCore::GraphicsLayerContentsDisplayDelegate* WebModelPlayer::contentsDisplayDelegate()
 {
     if (auto buffer = displayBuffer(); !m_contentsDisplayDelegate && buffer) {
@@ -648,6 +672,7 @@ bool WebModelPlayer::render()
                 return;
 
             protectedThis->m_displayTextureIndex = textureIndex;
+            protectedThis->m_hasRenderedFrame = true;
             if (auto* machSendRight = protectedThis->displayBuffer(); machSendRight && protectedThis->contentsDisplayDelegate()) {
                 Ref delegate = *protectedThis->m_contentsDisplayDelegate;
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
@@ -845,6 +870,7 @@ void WebModelPlayer::visibilityStateDidChange()
         m_isUpdateScheduled = false;
         m_isUpdating = false;
         m_displayTextureIndex = 0;
+        m_hasRenderedFrame = false;
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
         m_cachedModelSource = nullptr;
 #endif


### PR DESCRIPTION
#### 1f64f6a35a3bb997fdb54b3690a88658406dc6ee
<pre>
[model] &lt;model&gt; element is not captured in Tab Overview snapshots on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=317291">https://bugs.webkit.org/show_bug.cgi?id=317291</a>
<a href="https://rdar.apple.com/178453822">rdar://178453822</a>

Reviewed by Mike Wyrzykowski.

The model&apos;s frame is composited out of the render tree (rendered in the GPU process and
presented through its own layer), so software-paint snapshots such as Tab Overview thumbnails
did not capture it, leaving the model area blank.

Two earlier strategies did not work. Mimicking iOS by asking the render server to photograph
the already-composited layers (CARenderServerSnapshot) regressed &lt;video&gt; to black on macOS:
the render server only includes another process&apos;s hosted content when snapshotting from the
owning layer group, and the only group reachable from the macOS thumbnail code is the
WebContent process&apos;s group, a different security domain, so the GPU-process video layer is
gated out. Painting the model&apos;s frame in the WebContent process by materializing its IOSurface
(createFromSendRight) also left the model blank, because the sandboxed WebContent process
cannot redeem the GPU process&apos;s IOSurface handle.

Instead, add a snapshot path to RenderModel::paintReplaced: under PaintBehavior::Snapshotting,
ask the model player for its current frame as an ImageBuffer and draw that into the snapshot
context, the same way &lt;canvas&gt; and &lt;video&gt; are captured. WebModelPlayer produces the frame by
having the GPU process draw its current render buffer into a GPU-process-backed ImageBuffer
(device-pixel sized) resolved by RenderingResourceIdentifier, so WebContent never materializes
the surface; this mirrors the WebGPU canvas snapshot readback. Players that cannot produce a
frame return nullptr so nothing is drawn (no wasted allocation).

The render buffers are allocated before the first frame is drawn, and an undrawn buffer would
composite as opaque black, so WebModelPlayer tracks m_hasRenderedFrame and only produces a
snapshot frame once a render has completed; it is reset whenever the display buffers are
(re)allocated or released so a stale value cannot expose an undrawn buffer.

Also extract the shared IOSurface-to-NativeImage conversion into IOSurface::createNativeImage().

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::withDisplayBufferAsNativeImage):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::paintCurrentFrameInContext):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::snapshotCurrentFrame):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::createNativeImage):
* Source/WebCore/rendering/RenderModel.cpp:
(WebCore::RenderModel::paintReplaced):
* Source/WebCore/rendering/RenderModel.h:
* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp:
(WebKit::MeshImpl::getCurrentFrameAsNativeImage):
* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::paintCurrentFrameToImageBuffer):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::paintCurrentFrameToImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
(WebKit::RemoteMeshProxy::sendSync):
* Source/WebKit/WebProcess/Model/Mesh.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::sizeDidChange):
(WebKit::WebModelPlayer::snapshotCurrentFrame):
(WebKit::WebModelPlayer::render):
(WebKit::WebModelPlayer::visibilityStateDidChange):

Canonical link: <a href="https://commits.webkit.org/315436@main">https://commits.webkit.org/315436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1100425f1d9263579b95c0ba2a4e690562b572bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126633 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131537 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112041 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32984 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31691 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26978 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180877 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139987 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42500 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37661 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43189 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107009 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35115 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114954 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41698 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6350 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41092 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41347 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41235 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->