### PR TITLE
Clear-Site-Data: "cache" does not evict BFCache or MemoryCache entries due to SecurityOriginHash visibility

### DIFF
--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -244,3 +245,15 @@ inline void add(Hasher& hasher, const SecurityOrigin& origin)
 }
 
 } // namespace WebCore
+
+namespace WTF {
+
+// The content-based DefaultHash specialization for Ref<SecurityOrigin> is
+// declared here but intentionally defined only in SecurityOriginHash.h. Using
+// Ref<SecurityOrigin> as a hash-table key without including SecurityOriginHash.h
+// is therefore a hard compile error (instantiating an incomplete DefaultHash)
+// rather than a silent fall back to pointer hashing.
+template<typename> struct DefaultHash;
+template<> struct DefaultHash<Ref<WebCore::SecurityOrigin>>; // Defined in SecurityOriginHash.h
+
+} // namespace WTF

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -50,6 +50,7 @@
 #import "ResourceResponse.h"
 #import "SampleMap.h"
 #import "SecurityOrigin.h"
+#import "SecurityOriginHash.h"
 #import "ShareableBitmap.h"
 #import "TrackBuffer.h"
 #import "VP9UtilitiesCocoa.h"


### PR DESCRIPTION
#### 20790ef5e0288815eef06cd31fb0ade3c0ef8982
<pre>
Clear-Site-Data: &quot;cache&quot; does not evict BFCache or MemoryCache entries due to SecurityOriginHash visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=317269">https://bugs.webkit.org/show_bug.cgi?id=317269</a>
<a href="https://rdar.apple.com/179387089">rdar://179387089</a>

Reviewed by Darin Adler and Basuke Suzuki.

BackForwardCache::clearEntriesForOrigins and MemoryCache::removeResourcesWithOrigins
silently failed to evict matching entries after an HTTP Clear-Site-Data: &quot;cache&quot;
response. The HashSet&lt;Ref&lt;SecurityOrigin&gt;&gt; built in WebProcess.cpp used the
pointer-based PtrHash, while WebCore queried it using the content-based
SecurityOriginHash, so contains(SecurityOrigin::create(...)) never matched a
freshly-created origin and neither the back/forward cache nor the memory cache
was cleared for the calling site.

The root cause was that the content-based DefaultHash&lt;Ref&lt;SecurityOrigin&gt;&gt;
specialization lived in SecurityOriginHash.h, so the meaning of
HashSet&lt;Ref&lt;SecurityOrigin&gt;&gt; depended on whether that header happened to be
included at the point of instantiation. Where it was not visible,
DefaultHash&lt;Ref&lt;SecurityOrigin&gt;&gt; fell back to the pointer-based PtrHash primary
template in HashFunctions.h. Because both spellings resolve to the identically
named HashSet&lt;Ref&lt;SecurityOrigin&gt;, DefaultHash&lt;Ref&lt;SecurityOrigin&gt;&gt;&gt; but with two
different definitions of DefaultHash, this is an ODR violation: the linker keeps
one definition of the inline add()/contains() arbitrarily. The mismatch became
active in 307882@main, which converted these containers from
RefPtr&lt;SecurityOrigin&gt; to Ref&lt;SecurityOrigin&gt; and thereby changed which
definition won the merge.

Forward-declare the explicit DefaultHash&lt;Ref&lt;SecurityOrigin&gt;&gt; specialization in
SecurityOrigin.h (the type&apos;s own header), leaving the definition in
SecurityOriginHash.h. The full specialization out-ranks the generic PtrHash
partial, so Ref&lt;SecurityOrigin&gt; can no longer silently resolve to pointer
hashing; and because the declared-but-undefined specialization is an incomplete
type, using Ref&lt;SecurityOrigin&gt; as a hash-table key without including
SecurityOriginHash.h is now a hard compile error rather than a silent
miscompile. This mirrors the existing DefaultHash&lt;RefPtr&lt;StringImpl&gt;&gt; idiom
(declared in StringImpl.h, defined in StringHash.h).

MediaPlayerPrivateWebM.mm is updated to include SecurityOriginHash.h, which the
new guard now requires at the point it uses a HashSet&lt;Ref&lt;SecurityOrigin&gt;&gt;.

Covered by existing test http/tests/clear-site-data/bfcache.html.

* Source/WebCore/page/SecurityOrigin.h: Forward-declare the
WTF::DefaultHash&lt;Ref&lt;SecurityOrigin&gt;&gt; specialization (defined in
SecurityOriginHash.h) so that using Ref&lt;SecurityOrigin&gt; as a hash key without
that header is a compile error instead of a silent fall back to PtrHash. Include
&lt;wtf/Ref.h&gt;.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm: Include
SecurityOriginHash.h, now required by the guard for the m_origins member.

Canonical link: <a href="https://commits.webkit.org/315432@main">https://commits.webkit.org/315432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3098caa76741b86fe8f7e4097774e9c3b822c07f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126701 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f5c46e4-1b9e-4d00-9363-b9d55bba9b12) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131597 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92584 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ddbeab6a-cb93-4065-9fa1-ad352d7415b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112100 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/665bf81d-6130-4d20-942c-3a17b98879fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33037 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31747 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27046 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180945 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140046 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42568 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37658 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43257 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107083 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35180 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115022 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41766 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6333 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41160 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41415 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41303 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->