### PR TITLE
Extend CSS::CustomIdent to support an unresolved ident() function alternative

### DIFF
--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -79,8 +79,13 @@ CSSCounterStyleDescriptors::Ranges rangeFromCSSValue(const CSSValue& value)
 
 CSSCounterStyleDescriptors::Symbol symbolFromCSSValue(const CSSValue* value)
 {
-    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value))
-        return { .isCustomIdent = true, .text = customIdentValue->customIdent().value };
+    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value)) {
+        // ident() is invalid in descriptors (https://github.com/w3c/csswg-drafts/issues/12219),
+        // so only plain identifiers apply.
+        if (auto* resolved = std::get_if<AtomString>(&customIdentValue->customIdent().value))
+            return { .isCustomIdent = true, .text = *resolved };
+        return { };
+    }
 
     if (RefPtr stringValue = dynamicDowncast<CSSStringValue>(value))
         return { .isCustomIdent = false, .text = stringValue->string().value };
@@ -122,7 +127,8 @@ CSSCounterStyleDescriptors::Pad padFromCSSValue(const CSSValue& value)
     ASSERT(list.size() == 2);
     auto length = Style::deprecatedToStyleFromCSSValue<Style::Integer<CSS::Nonnegative>>(protect(downcast<CSSPrimitiveValue>(list[0])))->value;
     ASSERT(length >= 0);
-    return { static_cast<unsigned>(std::max(0, length)), symbolFromCSSValue(&list[1]) };
+    Ref suffix = list[1];
+    return { static_cast<unsigned>(std::max(0, length)), symbolFromCSSValue(suffix.ptr()) };
 }
 
 static CSSCounterStyleDescriptors::NegativeSymbols negativeSymbolsFromStyleProperties(const StyleProperties& properties)
@@ -138,8 +144,10 @@ CSSCounterStyleDescriptors::NegativeSymbols negativeSymbolsFromCSSValue(const CS
     CSSCounterStyleDescriptors::NegativeSymbols result;
     if (auto* list = dynamicDowncast<CSSValueList>(value)) {
         ASSERT(list->size() == 2);
-        result.m_prefix = symbolFromCSSValue(list->item(0));
-        result.m_suffix = symbolFromCSSValue(list->item(1));
+        Ref prefix = *list->item(0);
+        Ref suffix = *list->item(1);
+        result.m_prefix = symbolFromCSSValue(prefix.ptr());
+        result.m_suffix = symbolFromCSSValue(suffix.ptr());
     } else
         result.m_prefix = symbolFromCSSValue(&value);
     return result;
@@ -174,8 +182,11 @@ static CSSCounterStyleDescriptors::Name fallbackNameFromStyleProperties(const St
 
 CSSCounterStyleDescriptors::Name fallbackNameFromCSSValue(const CSSValue& value)
 {
-    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value))
-        return customIdentValue->customIdent().value;
+    if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(value)) {
+        if (auto* resolved = std::get_if<AtomString>(&customIdentValue->customIdent().value))
+            return *resolved;
+        return nullAtom();
+    }
     if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value))
         return nameStringForSerialization(keywordValue->valueID());
     return { };
@@ -222,8 +233,10 @@ CSSCounterStyleDescriptors::SystemData extractSystemDataFromCSSValue(const CSSVa
             ASSERT(secondValue->isKeywordValue() || secondValue->isCustomIdentValue());
             if (RefPtr secondValueIdent = dynamicDowncast<CSSKeywordValue>(secondValue))
                 result.first = nameStringForSerialization(secondValueIdent->valueID());
+            else if (auto* resolved = std::get_if<AtomString>(&downcast<CSSCustomIdentValue>(secondValue)->customIdent().value))
+                result.first = *resolved;
             else
-                result.first = downcast<CSSCustomIdentValue>(secondValue)->customIdent().value;
+                result.first = nullAtom();
         } else if (system == CSSCounterStyleDescriptors::System::Fixed) {
             if (auto secondValueInteger = Style::deprecatedToStyleFromCSSValue<Style::Integer<>>(secondValue))
                 result.second = secondValueInteger->value;

--- a/Source/WebCore/css/CSSCustomIdentValue.cpp
+++ b/Source/WebCore/css/CSSCustomIdentValue.cpp
@@ -16,6 +16,7 @@
  * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
  * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
@@ -25,6 +26,10 @@
 #include "config.h"
 #include "CSSCustomIdentValue.h"
 
+#include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
+#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSSerializationContext.h"
 #include "CSSValuePool.h"
 #include "CSSValueTypes+DeprecatedCSSOMValueCreation.h"
 #include <wtf/Hasher.h>

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -322,6 +322,10 @@ void CSSValue::collectComputedStyleDependencies(ComputedStyleDependencies& depen
             listValue.collectComputedStyleDependencies(dependencies);
         return;
     }
+    if (auto* asCustomIdentValue = dynamicDowncast<CSSCustomIdentValue>(*this)) {
+        CSS::collectComputedStyleDependencies(dependencies, asCustomIdentValue->customIdent());
+        return;
+    }
     if (auto* asPrimitiveValue = dynamicDowncast<CSSPrimitiveValue>(*this))
         asPrimitiveValue->collectComputedStyleDependencies(dependencies);
 }

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1553,6 +1553,9 @@ infinity
 -infinity id=NegativeInfinity
 NaN
 
+// ident()
+ident
+
 from-image
 
 // overflow

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -61,8 +61,12 @@ StyleRuleViewTransition::StyleRuleViewTransition(Ref<StyleProperties>&& properti
         m_explicitlySetTypes = true;
 
         auto processSingleValue = [&](const CSSValue& currentValue) {
-            if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(currentValue))
-                m_types.append(customIdentValue->customIdent().value);
+            if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(currentValue)) {
+                // ident() is invalid in descriptors (https://github.com/w3c/csswg-drafts/issues/12219),
+                // so only plain identifiers apply.
+                if (auto* resolved = std::get_if<AtomString>(&customIdentValue->customIdent().value))
+                    m_types.append(*resolved);
+            }
         };
         if (auto* list = dynamicDowncast<CSSValueList>(*value)) {
             for (Ref currentValue : *list)

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -573,8 +573,11 @@ public:
 
     CSSValueID valueIDIncludingCustomIdent(unsigned index) const
     {
-        if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(m_values[index].get()))
-            return cssValueKeywordID(customIdentValue->customIdent().value);
+        if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(m_values[index].get())) {
+            if (auto* resolved = std::get_if<AtomString>(&customIdentValue->customIdent().value))
+                return cssValueKeywordID(*resolved);
+            return CSSValueInvalid;
+        }
         return valueID(index).value_or(CSSValueInvalid);
     }
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -406,7 +406,7 @@ void serializeMathFunctionArguments(StringBuilder& builder, const IndirectNode<R
                     // Noting to do.
                 },
                 [&](const CSS::CustomIdent& customIdent) {
-                    if (!customIdent.value.isNull()) {
+                    if (!customIdent.isNull()) {
                         CSS::serializationForCSS(builder, state.serializationContext, customIdent);
                         if (options.elementScoped)
                             builder.append(' ', nameLiteralForSerialization(CSSValueElementScoped), ", "_s);
@@ -524,7 +524,7 @@ template<typename Op> void serializeMathFunctionArguments(StringBuilder& builder
             }
         },
         [&](const CSS::CustomIdent& root) {
-            if (!root.value.isNull()) {
+            if (!root.isNull()) {
                 builder.append(std::exchange(separator, ", "_s));
                 CSS::serializationForCSS(builder, state.serializationContext, root);
             }

--- a/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/deprecated-cssom/DeprecatedCSSOMPrimitiveValue.cpp
@@ -336,7 +336,9 @@ ExceptionOr<String> DeprecatedCSSOMPrimitiveValue::getStringValue() const
 {
     return WTF::switchOn(m_data.get(),
         [](const CSS::CustomIdent& customIdent) -> ExceptionOr<String> {
-            return String { customIdent.value };
+            if (auto* resolved = std::get_if<AtomString>(&customIdent.value))
+                return String { resolved->string() };
+            return CSS::serializationForCSS(CSS::defaultSerializationContext(), customIdent);
         },
         [](const CSS::Keyword& keyword) -> ExceptionOr<String> {
             return String { nameStringForSerialization(keyword.value) };
@@ -361,27 +363,33 @@ ExceptionOr<String> DeprecatedCSSOMPrimitiveValue::getStringValue() const
 
 ExceptionOr<Ref<DeprecatedCSSOMCounter>> DeprecatedCSSOMPrimitiveValue::getCounterValue() const
 {
-    auto convertStyleToString = [](auto& style) -> String {
+    auto customIdentString = [](const CSS::CustomIdent& customIdent) -> String {
+        if (auto* resolved = std::get_if<AtomString>(&customIdent.value))
+            return resolved->string();
+        return CSS::serializationForCSS(CSS::defaultSerializationContext(), customIdent);
+    };
+
+    auto convertStyleToString = [&](auto& style) -> String {
         return WTF::switchOn(style.identifier,
             [](const CSS::Keyword& predefinedKeyword) -> String {
                 return nameLiteralForSerialization(predefinedKeyword.value);
             },
-            [](const CSS::CustomIdent& customIdent) -> String {
-                return customIdent.value.string();
+            [&](const CSS::CustomIdent& customIdent) -> String {
+                return customIdentString(customIdent);
             }
         );
     };
 
     if (auto* contentCounter = std::get_if<CSS::ContentCounterFunction>(&m_data->value)) {
         return DeprecatedCSSOMCounter::create(
-            contentCounter->parameters.identifier.value,
+            customIdentString(contentCounter->parameters.identifier),
             emptyString(),
             convertStyleToString(contentCounter->parameters.style)
         );
     }
     if (auto* contentCounters = std::get_if<CSS::ContentCountersFunction>(&m_data->value)) {
         return DeprecatedCSSOMCounter::create(
-            contentCounters->parameters.identifier.value,
+            customIdentString(contentCounters->parameters.identifier),
             contentCounters->parameters.separator.value,
             convertStyleToString(contentCounters->parameters.style)
         );

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp
@@ -98,6 +98,9 @@ StringView consumeEagerlyResolvableCustomIdentRawExcluding(CSSParserTokenRange& 
 
 std::optional<CSS::CustomIdent> consumeUnresolvedCustomIdent(CSSParserTokenRange& range, CSS::PropertyParserState&)
 {
+    // FIXME: When support for the ident() function is added, it must only be consumed within an
+    // element context (https://github.com/w3c/csswg-drafts/issues/12219), so descriptors and
+    // at-rule preludes continue to reject it.
     if (range.peek().type() != IdentToken || !isValidCustomIdentifier(range.peek().id()))
         return { };
     return CSS::CustomIdent { range.consumeIncludingWhitespace().value().toAtomString() };
@@ -105,6 +108,11 @@ std::optional<CSS::CustomIdent> consumeUnresolvedCustomIdent(CSSParserTokenRange
 
 std::optional<CSS::CustomIdent> consumeUnresolvedCustomIdentExcluding(CSSParserTokenRange& range, CSS::PropertyParserState&, std::initializer_list<CSSValueID> excluding)
 {
+    // FIXME: When support for the ident() function is added, here must be tested
+    // against the mock-evaluation from https://github.com/w3c/csswg-drafts/issues/12206, not against this
+    // single token's id.
+    // e.g. for excluding={none}, ident("no" "ne") -> "none" must be rejected
+    // while ident("none" 1) -> "none0" must be accepted.
     if (range.peek().type() != IdentToken || !isValidCustomIdentifier(range.peek().id()) || std::ranges::find(excluding, range.peek().id()) != excluding.end())
         return { };
     return CSS::CustomIdent { range.consumeIncludingWhitespace().value().toAtomString() };
@@ -138,6 +146,11 @@ StringView consumeEagerlyResolvableDashedIdentRaw(CSSParserTokenRange& range)
 
 std::optional<CSS::CustomIdent> consumeUnresolvedDashedIdent(CSSParserTokenRange& range, CSS::PropertyParserState&)
 {
+    // FIXME: When support for the ident() function is added, here must be tested with
+    // the mock-evaluation from https://github.com/w3c/csswg-drafts/issues/12206,
+    // not against this single token's value.
+    // e.g. ident("--" "foo") -> "--foo" must be accepted while
+    // ident("-" 1) -> "-0" must be rejected.
     if (range.peek().type() != IdentToken || !range.peek().value().startsWith("--"_s))
         return { };
     return CSS::CustomIdent { range.consumeIncludingWhitespace().value().toAtomString() };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp
@@ -48,8 +48,8 @@ RefPtr<CSSValue> consumeViewTransitionTypes(CSSParserTokenRange& range, CSS::Pro
     do {
         auto type = consumeUnresolvedCustomIdentExcluding(range, state, { CSSValueNone });
         if (!type)
-             return nullptr;
-        if (type->value.startsWith("-ua-"_s))
+            return nullptr;
+        if (type->startsWith("-ua-"_s))
             return nullptr;
         list.append(CSSCustomIdentValue::create(WTF::move(*type)));
     } while (!range.atEnd());

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -277,8 +277,10 @@ static ExceptionOr<Ref<CSSStyleValue>> reifyValue(CSS::SpecificKeyword auto cons
     return WebCore::reifyValue(keyword.value);
 }
 
-static ExceptionOr<Ref<CSSStyleValue>> reifyValue(const CSS::CustomIdent& customIdent)
+static ExceptionOr<Ref<CSSStyleValue>> reifyValue(const CSS::CustomIdent& customIdent, const CSSValue& cssValue, AssociatedProperty&& associatedProperty)
 {
+    if (!customIdent.isResolved())
+        return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), WTF::move(associatedProperty));
     return upcast<CSSStyleValue>(CSSOMKeywordValue::rectifyKeywordish(CSS::serializationForCSS(CSS::defaultSerializationContext(), customIdent)));
 }
 
@@ -289,7 +291,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
     else if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(cssValue))
         return WebCore::reifyValue(keywordValue->keyword());
     else if (auto* customIdentValue = dynamicDowncast<CSSCustomIdentValue>(cssValue))
-        return WebCore::reifyValue(customIdentValue->customIdent());
+        return WebCore::reifyValue(customIdentValue->customIdent(), cssValue, WTF::move(associatedProperty));
     else if (auto* imageValue = dynamicDowncast<CSSImageValue>(cssValue))
         return Ref<CSSStyleValue> { CSSStyleImageValue::create(const_cast<CSSImageValue&>(*imageValue), document) };
     else if (auto* referenceValue = dynamicDowncast<CSSSubstitutionValue>(cssValue))
@@ -383,7 +385,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
                 return WebCore::reifyValue(keyword);
             },
             [&](const CSS::CustomIdent& customIdent) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return WebCore::reifyValue(customIdent);
+                return WebCore::reifyValue(customIdent, cssValue, WTF::move(associatedProperty));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
                 return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), WTF::move(associatedProperty));

--- a/Source/WebCore/css/values/primitives/CSSCustomIdent.cpp
+++ b/Source/WebCore/css/values/primitives/CSSCustomIdent.cpp
@@ -29,6 +29,10 @@
 
 #include "CSSCustomIdentValue.h"
 #include "CSSMarkup.h"
+#include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
+#include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSSerializationContext.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include <wtf/Hasher.h>
 #include <wtf/text/TextStream.h>
@@ -36,9 +40,78 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<CustomIdent>::operator()(StringBuilder& builder, const SerializationContext&, const CustomIdent& value)
+bool CustomIdent::isNull() const
+{
+    auto* resolved = std::get_if<AtomString>(&value);
+    return resolved && resolved->isNull();
+}
+
+bool CustomIdent::startsWith(StringView prefix) const
+{
+    return WTF::switchOn(value,
+        [&](const AtomString& resolved) {
+            return resolved.startsWith(prefix);
+        },
+        [&](const IdentFunction& function) {
+            // Build the identifier with every <integer> argument treated as "0", then test the prefix.
+            // https://github.com/w3c/csswg-drafts/issues/12206#issuecomment-3998743769
+            StringBuilder builder;
+            for (auto& argument : function.parameters) {
+                WTF::switchOn(argument,
+                    [&](const IdentFunctionIdent& ident) { builder.append(ident.value); },
+                    [&](const String& string) { builder.append(string.value); },
+                    [&](const Integer<>&) { builder.append('0'); }
+                );
+            }
+            return StringView { builder }.startsWith(prefix);
+        }
+    );
+}
+
+// MARK: - Equality
+
+SUPPRESS_NODELETE bool CustomIdent::operator==(const CustomIdent& other) const
+{
+    return value == other.value;
+}
+
+void Serialize<IdentFunctionIdent>::operator()(StringBuilder& builder, const SerializationContext&, const IdentFunctionIdent& value)
 {
     WebCore::serializeIdentifier(builder, value.value);
+}
+
+void Serialize<CustomIdent>::operator()(StringBuilder& builder, const SerializationContext& context, const CustomIdent& value)
+{
+    WTF::switchOn(value.value,
+        [&](const AtomString& resolved) {
+            WebCore::serializeIdentifier(builder, resolved);
+        },
+        [&](const IdentFunction& function) {
+            serializationForCSS(builder, context, function);
+        }
+    );
+}
+
+void ComputedStyleDependenciesCollector<CustomIdent>::operator()(ComputedStyleDependencies& dependencies, const CustomIdent& value)
+{
+    WTF::switchOn(value.value,
+        [&](const AtomString&) { },
+        [&](const IdentFunction& function) {
+            collectComputedStyleDependencies(dependencies, function);
+        }
+    );
+}
+
+IterationStatus CSSValueChildrenVisitor<CustomIdent>::operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>& func, const CustomIdent& value)
+{
+    return WTF::switchOn(value.value,
+        [&](const AtomString&) {
+            return IterationStatus::Continue;
+        },
+        [&](const IdentFunction& function) {
+            return visitCSSValueChildren(func, function);
+        }
+    );
 }
 
 Ref<CSSValue> CSSValueCreation<CustomIdent>::operator()(CSSValuePool&, const CustomIdent& value)
@@ -55,14 +128,32 @@ Ref<DeprecatedCSSOMValue> DeprecatedCSSOMValueCreation<CustomIdent>::operator()(
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const CustomIdent& value)
 {
-    return ts << value.value;
+    WTF::switchOn(value.value,
+        [&](const AtomString& resolved) {
+            ts << resolved;
+        },
+        [&](const IdentFunction&) {
+            ts << serializationForCSS(defaultSerializationContext(), value);
+        }
+    );
+    return ts;
 }
 
 // MARK: - Hashing
 
-void add(Hasher& hasher, const CustomIdent& value)
+SUPPRESS_NODELETE void add(Hasher& hasher, const CustomIdent& value)
 {
-    add(hasher, value.value);
+    add(hasher, value.value.index());
+
+    WTF::switchOn(value.value,
+        [&](const AtomString& resolved) {
+            add(hasher, resolved);
+        },
+        [&](const IdentFunction& function) {
+            // Hash the serialization; an <integer> argument may be an unevaluated calc with no raw value.
+            add(hasher, serializationForCSS(defaultSerializationContext(), function));
+        }
+    );
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/primitives/CSSCustomIdent.h
+++ b/Source/WebCore/css/values/primitives/CSSCustomIdent.h
@@ -26,28 +26,49 @@
 
 #pragma once
 
+#include <WebCore/CSSPrimitiveNumericTypes.h>
+#include <WebCore/CSSString.h>
 #include <WebCore/CSSValueTypes.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
 namespace CSS {
 
-// https://drafts.csswg.org/css-values-4/#identifier-value
-struct CustomIdent {
+// Non-keyword <ident> argument to the ident() function, contributing its codepoints to the resulting identifier.
+struct IdentFunctionIdent {
     AtomString value;
 
-    std::optional<AtomString> tryResolved() const
-    {
-        // FIXME: When ident() function is added, only successfully resolve when there are no <integer> components.
-        return value;
-    }
+    bool operator==(const IdentFunctionIdent&) const = default;
+};
 
-    bool operator==(const CustomIdent&) const = default;
+template<> struct Serialize<IdentFunctionIdent> { void operator()(StringBuilder&, const SerializationContext&, const IdentFunctionIdent&); };
+template<> struct ComputedStyleDependenciesCollector<IdentFunctionIdent> { constexpr void operator()(ComputedStyleDependencies&, const IdentFunctionIdent&) { } };
+template<> struct CSSValueChildrenVisitor<IdentFunctionIdent> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const IdentFunctionIdent&) { return IterationStatus::Continue; } };
+
+// <ident-arg> = <string> | <integer> | <ident>
+using IdentFunctionArg = Variant<IdentFunctionIdent, String, Integer<>>;
+
+// <ident()> = ident( <ident-arg>+ )
+// https://drafts.csswg.org/css-values-5/#ident
+using IdentFunction = FunctionNotation<CSSValueIdent, SpaceSeparatedVector<IdentFunctionArg>>;
+
+// https://drafts.csswg.org/css-values-4/#identifier-value
+struct CustomIdent {
+    Variant<AtomString, IdentFunction> value;
+
+    bool isResolved() const { return WTF::holdsAlternative<AtomString>(value); }
+    bool isNull() const;
+
+    // Prefix test for parse-time validity checks, treating every <integer> component as "0".
+    // See https://github.com/w3c/csswg-drafts/issues/12206#issuecomment-3998743769.
+    bool startsWith(StringView prefix) const;
+
+    bool NODELETE operator==(const CustomIdent&) const;
 };
 
 template<> struct Serialize<CustomIdent> { void operator()(StringBuilder&, const SerializationContext&, const CustomIdent&); };
-template<> struct ComputedStyleDependenciesCollector<CustomIdent> { constexpr void operator()(ComputedStyleDependencies&, const CustomIdent&) { } };
-template<> struct CSSValueChildrenVisitor<CustomIdent> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const CustomIdent&) { return IterationStatus::Continue; } };
+template<> struct ComputedStyleDependenciesCollector<CustomIdent> { void operator()(ComputedStyleDependencies&, const CustomIdent&); };
+template<> struct CSSValueChildrenVisitor<CustomIdent> { IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const CustomIdent&); };
 template<> struct CSSValueCreation<CustomIdent> { Ref<CSSValue> operator()(CSSValuePool&, const CustomIdent&); };
 template<> struct DeprecatedCSSOMValueCreation<CustomIdent> { Ref<DeprecatedCSSOMValue> operator()(CSSValuePool&, CSSStyleDeclaration&, const CustomIdent&); };
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -51,6 +51,7 @@
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "StyleComputedStyle+SettersInlines.h"
+#include "StyleCustomIdent.h"
 #include "StyleCustomProperty.h"
 #include "StyleCustomPropertyData.h"
 #include "StyleCustomPropertyRegistry.h"
@@ -439,7 +440,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         style.setHasExplicitlyInheritedProperties();
 
     if (RefPtr paintImageValue = dynamicDowncast<CSSPaintImageValue>(valueToApply.get())) {
-        auto& name = paintImageValue->name().value;
+        auto name = toStyle(paintImageValue->name(), m_state).value;
         if (RefPtr paintWorklet = const_cast<Document&>(m_state->document()).paintWorkletGlobalScopeForName(name)) {
             Locker locker { paintWorklet->paintDefinitionLock() };
             if (auto* registration = paintWorklet->paintDefinitionMap().get(name)) {

--- a/Source/WebCore/style/values/primitives/StyleCustomIdent.cpp
+++ b/Source/WebCore/style/values/primitives/StyleCustomIdent.cpp
@@ -31,6 +31,8 @@
 #include "CSSMarkup.h"
 #include "DeprecatedCSSOMValue.h"
 #include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -43,9 +45,33 @@ auto ToCSS<CustomIdent>::operator()(const CustomIdent& value, const Style::Compu
     return { .value = value.value };
 }
 
-auto ToStyle<CSS::CustomIdent>::operator()(const CSS::CustomIdent& value, const BuilderState&) -> CustomIdent
+auto ToStyle<CSS::CustomIdent>::operator()(const CSS::CustomIdent& value, const BuilderState& state) -> CustomIdent
 {
-    return { .value = value.value };
+    return WTF::switchOn(value.value,
+        [&](const AtomString& resolved) -> CustomIdent {
+            return { .value = resolved };
+        },
+        [&](const CSS::IdentFunction& function) -> CustomIdent {
+            // https://drafts.csswg.org/css-values-5/#ident
+            // Concatenate the arguments in order: strings and idents contribute their
+            // codepoints, integers are serialized as the shortest base-10 representation.
+            StringBuilder builder;
+            for (auto& argument : function.parameters) {
+                WTF::switchOn(argument,
+                    [&](const CSS::IdentFunctionIdent& ident) {
+                        builder.append(ident.value);
+                    },
+                    [&](const CSS::String& string) {
+                        builder.append(string.value);
+                    },
+                    [&](const CSS::Integer<>& integer) {
+                        builder.append(toStyle(integer, state).value);
+                    }
+                );
+            }
+            return { .value = builder.toAtomString() };
+        }
+    );
 }
 
 Ref<CSSValue> CSSValueCreation<CustomIdent>::operator()(CSSValuePool& pool, const Style::ComputedStyle& style, const CustomIdent& value)


### PR DESCRIPTION
#### 7f655a4e9f5df4f6278acbe61596f8e641b06d83
<pre>
Extend CSS::CustomIdent to support an unresolved ident() function alternative
<a href="https://bugs.webkit.org/show_bug.cgi?id=284895">https://bugs.webkit.org/show_bug.cgi?id=284895</a>

Reviewed by Tim Nguyen.

Change CSS::CustomIdent&apos;s representation from a plain AtomString to
Variant&lt;AtomString, IdentFunction&gt;, where IdentFunction models
&lt;ident()&gt; = ident( &lt;ident-arg&gt;+ ), &lt;ident-arg&gt; = &lt;string&gt; | &lt;integer&gt; | &lt;ident&gt;
(<a href="https://drafts.csswg.org/css-values-5/#ident).">https://drafts.csswg.org/css-values-5/#ident).</a> Arguments are stored
unmerged so that the specified value serializes back in function form,
as required by WPT. Resolution happens in ToStyle&lt;CSS::CustomIdent&gt;,
which evaluates &lt;integer&gt; arguments (including math functions) with
BuilderState context and concatenates the argument codepoints.

Remove CustomIdent::tryResolved(), as no call site needs eager
resolution. The @counter-style/@view-transition descriptor converters
use only the plain identifier alternative, since ident() is invalid in
descriptors per the CSSWG resolution &quot;ident() is only valid within an
element context&quot; (<a href="https://github.com/w3c/csswg-drafts/issues/12219)">https://github.com/w3c/csswg-drafts/issues/12219)</a>; a
FIXME in consumeUnresolvedCustomIdent() records the parser-side
rejection needed once ident() parsing lands.
ShorthandSerializer::valueIDIncludingCustomIdent() likewise checks only
the plain identifier alternative, because the animation-name
disambiguation is about lexical ambiguity of the serialized text, which
the ident() function form can never cause. The deprecated CSSOM string
accessors return the plain identifier, falling back to the
function-form serialization.

No behavior change: nothing constructs the new alternative yet. All
code that read CustomIdent&apos;s string directly was updated to handle the
unresolved alternative explicitly.
Also add a CSSCustomIdentValue case to
CSSValue::collectComputedStyleDependencies so that a future ident()
with computed-value-time dependencies is correctly rejected in
computationally independent contexts (@property initial values).

* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::symbolFromCSSValue):
(WebCore::fallbackNameFromCSSValue):
(WebCore::extendsSystemAndFirstSymbolValueFromStyleProperties):
* Source/WebCore/css/CSSCounterValue.cpp:
(WebCore::CSSCounterValue::customCSSText):
* Source/WebCore/css/CSSCustomIdentValue.cpp:
(WebCore::CSSCustomIdentValue::stringValue):
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::collectComputedStyleDependencies):
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
(WebCore::StyleRuleViewTransition::StyleRuleViewTransition):
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
(WebCore::DeprecatedCSSOMPrimitiveValue::getStringValue):
(WebCore::DeprecatedCSSOMPrimitiveValue::getCounterValue):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::valueIDIncludingCustomIdent):
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::serializeMathFunctionArguments):
(WebCore::CSSCalc::serializeCalculationTree):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Ident.cpp:
(WebCore::CSSPropertyParserHelpers::consumeUnresolvedCustomIdent):
(WebCore::CSSPropertyParserHelpers::consumeUnresolvedCustomIdentExcluding):
(WebCore::CSSPropertyParserHelpers::consumeUnresolvedDashedIdent):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ViewTransition.cpp:
(WebCore::CSSPropertyParserHelpers::consumeViewTransitionTypes):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):
* Source/WebCore/css/values/primitives/CSSCustomIdent.cpp:
(WebCore::CSS::CustomIdent::isNull):
(WebCore::CSS::CustomIdent::startsWith):
(WebCore::CSS::CustomIdent::operator==):
(WebCore::CSS::Serialize&lt;IdentFunctionIdent&gt;::operator()):
(WebCore::CSS::Serialize&lt;CustomIdent&gt;::operator()):
(WebCore::CSS::ComputedStyleDependenciesCollector&lt;CustomIdent&gt;::operator()):
(WebCore::CSS::CSSValueChildrenVisitor&lt;CustomIdent&gt;::operator()):
(WebCore::CSS::operator&lt;&lt;):
(WebCore::CSS::add):
* Source/WebCore/css/values/primitives/CSSCustomIdent.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
* Source/WebCore/style/values/primitives/StyleCustomIdent.cpp:
(WebCore::Style::ToStyle&lt;CSS::CustomIdent&gt;::operator()):

Canonical link: <a href="https://commits.webkit.org/316524@main">https://commits.webkit.org/316524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1122c6b3ba47834ba7e86b0a5a3995625730beae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172216 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129770 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133951 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94493 "2 flakes 23 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36013 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34286 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30272 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184200 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142704 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45800 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142586 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38597 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46480 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30847 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111183 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37672 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118235 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44998 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8941 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44398 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->