### PR TITLE
Unable to re-enter website environment after short delay

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -725,13 +725,14 @@ void HTMLModelElement::deleteModelPlayer()
             modelPlayerProvider->deleteModelPlayer(*modelPlayer);
 
         RefPtr protectedThis { weakThis };
-        if (protectedThis)
+        if (protectedThis && protectedThis->m_modelPlayer == modelPlayer)
             protectedThis->m_modelPlayer = nullptr;
     };
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     // Let the document trigger the model player deletion after transitioning out the immersive element if needed
-    if (RefPtr documentImmersive = document().immersiveIfExists())
+    RefPtr documentImmersive = document().immersiveIfExists();
+    if (m_detachedForImmersive && documentImmersive)
         return documentImmersive->exitRemovedImmersiveElementIfNeeded(this, WTF::move(deleteModelPlayerBlock));
 #endif
     deleteModelPlayerBlock();
@@ -1748,8 +1749,10 @@ void HTMLModelElement::setDetachedForImmersive(bool detachedForImmersive)
 void HTMLModelElement::ensureModelPlayer(CompletionHandler<void(ExceptionOr<RefPtr<ModelPlayer>>)>&& completion)
 {
     RefPtr modelPlayer = m_modelPlayer;
-    if (modelPlayer && modelPlayer->isPlaceholder())
+    if (modelPlayer && modelPlayer->isPlaceholder()) {
         reloadModelPlayer();
+        modelPlayer = m_modelPlayer;
+    }
 
     if (modelPlayer && !modelPlayer->isPlaceholder())
         return completion(protect(modelPlayer));

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -1302,6 +1302,7 @@ void ModelProcessModelPlayerProxy::setImmersivePresentation(bool immersivePresen
     }
 
     m_immersivePresentation = immersivePresentation;
+    m_entityTransformToRestore = std::nullopt;
     computeTransform(false);
     updateTransform();
 }


### PR DESCRIPTION
#### de88d16504ceb13be2688a527acde31d24323133
<pre>
Unable to re-enter website environment after short delay
<a href="https://bugs.webkit.org/show_bug.cgi?id=317301">https://bugs.webkit.org/show_bug.cgi?id=317301</a>
<a href="https://rdar.apple.com/179867733">rdar://179867733</a>

Reviewed by Mike Wyrzykowski.

ensureModelPlayer() used a stale local after reloadModelPlayer() swapped
m_modelPlayer, falling through to sourceRequestResource() and triggering a
redundant createModelPlayer -&gt; deleteModelPlayer cascade that wiped the
in-flight immersive request state. Refresh the local after reload so the
fast path is taken.

deleteModelPlayer() routed through exitRemovedImmersiveElementIfNeeded()
whenever a DocumentImmersive existed, cancelling unrelated pending
requests. Gate it on m_detachedForImmersive, and only null m_modelPlayer
in the deletion lambda when it still matches the captured player so an
async callback can&apos;t stomp a replacement.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
setImmersivePresentation() left m_entityTransformToRestore intact across
mode flips, so didFinishLoading could apply an inline-space transform in
immersive space (modelStandardizedTransformSRT differs by a 0.36x scale).
Clear it on flip since we should&apos;t restore entity transforms in between
immersive mode changes.

Canonical link: <a href="https://commits.webkit.org/315388@main">https://commits.webkit.org/315388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93dafb8410199aa43c4efe6da882bf4238abb981

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131486 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111990 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180821 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139934 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42444 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139778 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37636 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43133 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28133 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106935 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35062 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114898 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41642 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6221 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41036 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->