### PR TITLE
Fix out-of-bounds buffer index in userVisibleURL when probing for xn--

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -943,7 +943,7 @@ String userVisibleURL(const CString& url)
                 after[afterIndex++] = c;
                 
                 // Check for "xn--" in an efficient, non-case-sensitive, way.
-                if (c == '-' && i >= 3 && !mayNeedHostNameDecoding && (after[afterIndex - 4] | 0x20) == 'x' && (after[afterIndex - 3] | 0x20) == 'n' && after[afterIndex - 2] == '-')
+                if (c == '-' && afterIndex >= 4 && !mayNeedHostNameDecoding && (after[afterIndex - 4] | 0x20) == 'x' && (after[afterIndex - 3] | 0x20) == 'n' && after[afterIndex - 2] == '-')
                     mayNeedHostNameDecoding = true;
             }
         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitURIUtilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitURIUtilities.cpp
@@ -40,10 +40,21 @@ static void testURIForDisplayAffected(Test*, gconstpointer)
     g_assert_cmpstr(displayURI.get(), ==, "http://site.com\xC3\xB7othersite.org");
 }
 
+static void testURIForDisplayShortPercentEncoded(Test*, gconstpointer)
+{
+    // A '-' that lands before four bytes have been written to the output buffer
+    // used to index it out of bounds while probing for "xn--". The leading
+    // percent escape decodes to one byte, so the input index runs ahead of the
+    // output index.
+    GUniquePtr<char> displayURI(webkit_uri_for_display("%AB-"));
+    g_assert_cmpstr(displayURI.get(), ==, "%AB-");
+}
+
 void beforeAll()
 {
     Test::add("WebKitURIUtilities", "uri-for-display-unaffected", testURIForDisplayUnaffected);
     Test::add("WebKitURIUtilities", "uri-for-display-affected", testURIForDisplayAffected);
+    Test::add("WebKitURIUtilities", "uri-for-display-short-percent-encoded", testURIForDisplayShortPercentEncoded);
 }
 
 void afterAll()


### PR DESCRIPTION
#### e08a16763c94edc94dbd8bf2a7d498f3451e5d9f
<pre>
Fix out-of-bounds buffer index in userVisibleURL when probing for xn--
<a href="https://bugs.webkit.org/show_bug.cgi?id=319161">https://bugs.webkit.org/show_bug.cgi?id=319161</a>

Reviewed by Patrick Griffis.

userVisibleURL() probes the output buffer for an &quot;xn--&quot; prefix by reading
back from the index it just wrote (after[afterIndex - 4 .. afterIndex - 2]),
but it gated those reads on the input index (i &gt;= 3) rather than the output
index. When an earlier percent escape decodes to a single byte (for example
%AB, which is &gt; 0x7f), the input index advances three positions while the
output index advances one, so a &apos;-&apos; can be reached while afterIndex &lt; 4.
afterIndex - 4 then wraps around as size_t and indexes the bounds-checked
Vector out of range.

Gate the probe on afterIndex &gt;= 4 so it tracks the buffer it actually reads.
A legitimate &quot;xn--&quot; prefix always writes four literal output bytes, so its
detection is unaffected. The input is reachable from untrusted data through
the public webkit_uri_for_display() API and Internals.userVisibleString; the
minimal trigger is &quot;%AB-&quot;.

* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::userVisibleURL):
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitURIUtilities.cpp:
(testURIForDisplayShortPercentEncoded):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/317537@main">https://commits.webkit.org/317537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcad1b3a05c7be83764a150b1dbf7ad10a834c2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184825 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/133577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136407 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/133577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36851 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33298 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5687 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187246 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36501 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/40859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145354 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48839 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145211 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39193 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49519 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33292 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115398 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40044 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121712 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/212331 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48025 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11644 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55420 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->