### PR TITLE
loading=lazy image is not reused from the list of available images

### DIFF
--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -131,7 +131,9 @@ static inline bool NODELETE pageIsBeingDismissed(Document& document)
 // https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data:list-of-available-images
 static bool canReuseFromListOfAvailableImages(const CachedResourceRequest& request, Document& document)
 {
-    RefPtr resource = MemoryCache::singleton().resourceForRequest(request.resourceRequest(), document.page()->sessionID());
+    auto resourceRequest = request.resourceRequest();
+    resourceRequest.setDomainForCachePartition(document.domainForCachePartition());
+    RefPtr resource = MemoryCache::singleton().resourceForRequest(resourceRequest, document.page()->sessionID());
     if (!resource || resource->stillNeedsLoad() || resource->isPreloaded())
         return false;
 


### PR DESCRIPTION
#### 5ce379d5be53b807639c0ead34e5ed6e6d318121
<pre>
loading=lazy image is not reused from the list of available images
<a href="https://bugs.webkit.org/show_bug.cgi?id=317311">https://bugs.webkit.org/show_bug.cgi?id=317311</a>
<a href="https://rdar.apple.com/179936714">rdar://179936714</a>

Reviewed by NOBODY (OOPS!).

When updating the image data, the list of available images [1] must be consulted
before deferring a lazy load: a loading=lazy image whose resource is already
available in the document should load immediately instead of waiting to come
near the viewport.

[1] <a href="https://html.spec.whatwg.org/multipage/images.html#the-list-of-available-images">https://html.spec.whatwg.org/multipage/images.html#the-list-of-available-images</a>

canReuseFromListOfAvailableImages() looked up the memory cache without setting
the cache partition, while the regular load path partitions by the document&apos;s
domain before its lookup. Since the list of available images is a same-document
concept, the entry was stored under this document&apos;s partition, so the
unpartitioned lookup missed it on a partitioned cache and the image was
incorrectly deferred and never loaded while below the viewport.

Set the partition by the document&apos;s domain before the lookup.

NOTE: It progresses two Web Platform Tests (below) while running manually but
our test infrastructure is showing them as PASS (might be due to cache
between runs) but we have open bug to track this issue: webkit.org/b/309945

  - image-loading-lazy-available.html: PASS now (manual run)
  - image-loading-lazy-use-list-of-available-images.html: Ditto

* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::canReuseFromListOfAvailableImages):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce379d5be53b807639c0ead34e5ed6e6d318121

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178287 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126645 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76bd552e-eabb-442c-ac25-02b84943409a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131545 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92552 "3 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9182269-ff9b-4d92-9ca7-fed426d580c6) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171893 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112049 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b67723f5-c2e1-436e-b9eb-19451b10da40) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32992 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26990 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180889 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139994 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42512 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139837 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43201 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107021 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35120 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114966 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41710 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6282 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41104 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41247 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->