### PR TITLE
REGRESSION(311797@main): linkedin.com: verification badge overlaps user's name on first load

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-subject-child-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-subject-child-mutation-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Initially 5px
+PASS Pseudo-element ::before invalidates when a matching child is added (attribute selector, child combinator)
+PASS Pseudo-element ::before invalidates when a matching child is added (class selector, child combinator)
+PASS Pseudo-element ::before invalidates when a matching descendant is added (class selector, descendant combinator)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-subject-child-mutation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-subject-child-mutation.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors Test: :has() invalidation for child mutation when subject is a pseudo-element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<style>
+  .box::before {
+    content: " ";
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+  }
+  #attr:has(> [width="16"][height="16"])::before { width: 50px; }
+  #childClass:has(> .trigger)::before { width: 50px; }
+  #descendantClass:has(.trigger)::before { width: 50px; }
+</style>
+
+<div class="box" id="attr"></div>
+<div class="box" id="childClass"></div>
+<div class="box" id="descendantClass"></div>
+
+<script>
+  function beforeWidth(element) {
+    return getComputedStyle(element, "::before").width;
+  }
+
+  test(() => {
+    assert_equals(beforeWidth(attr), "5px");
+    assert_equals(beforeWidth(childClass), "5px");
+    assert_equals(beforeWidth(descendantClass), "5px");
+  }, "Initially 5px");
+
+  test(() => {
+    const child = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    child.setAttribute("width", "16");
+    child.setAttribute("height", "16");
+    attr.appendChild(child);
+    assert_equals(beforeWidth(attr), "50px");
+  }, "Pseudo-element ::before invalidates when a matching child is added (attribute selector, child combinator)");
+
+  test(() => {
+    const child = document.createElement("div");
+    child.className = "trigger";
+    childClass.appendChild(child);
+    assert_equals(beforeWidth(childClass), "50px");
+  }, "Pseudo-element ::before invalidates when a matching child is added (class selector, child combinator)");
+
+  test(() => {
+    const child = document.createElement("div");
+    child.className = "trigger";
+    descendantClass.appendChild(child);
+    assert_equals(beforeWidth(descendantClass), "50px");
+  }, "Pseudo-element ::before invalidates when a matching descendant is added (class selector, descendant combinator)");
+</script>

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1551,8 +1551,12 @@ static std::optional<HasCompoundContext> collectHasCompoundContext(const CSSSele
 {
     HasCompoundContext context;
     for (auto* selector = hasPseudoClass.leftmostInCompound(); selector; selector = selector->followingInCompound()) {
-        if (selector != &hasPseudoClass)
-            context.compoundPeers.append(selector);
+        if (selector == &hasPseudoClass)
+            continue;
+        // Skip pseudo-elements (e.g. `.foo:has(...)::before`); the scope is the has-bearer element.
+        if (selector->match() == CSSSelector::Match::PseudoElement)
+            continue;
+        context.compoundPeers.append(selector);
     }
     if (context.compoundPeers.isEmpty())
         return { };


### PR DESCRIPTION
#### 41939d4b63f5680cd71a48cd99983fe4b0304eee
<pre>
REGRESSION(311797@main): linkedin.com: verification badge overlaps user&apos;s name on first load
<a href="https://bugs.webkit.org/show_bug.cgi?id=317313">https://bugs.webkit.org/show_bug.cgi?id=317313</a>
<a href="https://rdar.apple.com/179227702">rdar://179227702</a>

Reviewed by Alan Baradlay.

In cases like

.foo:has(&gt; .bar)::before

when computing the scope selector we fail to remove pseudo-elements from it. The selector
then matches nothing when used to construct an invalidation selector or find the invalidation
scope, causing missed style invalidation.

Test: imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-subject-child-mutation.html

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-subject-child-mutation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-pseudo-element-subject-child-mutation-expected.txt: Added.
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::collectHasCompoundContext):

Canonical link: <a href="https://commits.webkit.org/315438@main">https://commits.webkit.org/315438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f2c9a3880577086eb99e3980cb975b0af6e11a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126594 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d08bca8-4fe3-46a5-85fb-8b626f6d3cff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131500 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92519 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8395a696-0e1a-43b6-95ce-949f28beccb5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112004 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/475c5146-a839-406a-a755-e6435c3f61e6) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32945 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31655 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26939 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180838 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139948 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139792 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37663 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43150 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106960 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35077 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114915 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41659 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6236 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41053 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->