### PR TITLE
Get rid of "Update to recommended settings" Xcode warnings

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -13369,7 +13369,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					14BD59BE0A3E8F9000BAF59C = {
 						LastSwiftMigration = 2700;

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/Everything up to JavaScriptCore.xcscheme
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/Everything up to JavaScriptCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore.xcscheme
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -5459,7 +5459,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					31CDFDF32491819E00486F27 = {
 						CreatedOnToolsVersion = 12.0;

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (dynamic).xcscheme
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (dynamic).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (static).xcscheme
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (static).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE.xcscheme
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/Fuzzers (ANGLE).xcscheme
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/Fuzzers (ANGLE).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/Tools (ANGLE).xcscheme
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/Tools (ANGLE).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/ThirdParty/gmock/gmock.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/gmock/gmock.xcodeproj/project.pbxproj
@@ -343,7 +343,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					44E750C12AC7291000828AC4 = {
 						CreatedOnToolsVersion = 15.0;

--- a/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj
@@ -707,7 +707,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 			};
 			buildConfigurationList = 4FADC24608B4156D00ABE55E /* Build configuration list for PBXProject "gtest" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme
+++ b/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -24440,7 +24440,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					31339FA12CEEFECC0054D8D5 = {
 						CreatedOnToolsVersion = 16.3;

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/xcshareddata/xcschemes/libwebrtc.xcscheme
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/xcshareddata/xcschemes/libwebrtc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -4352,7 +4352,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 2640;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					DDF3081D27C44EFE006A526F = {
 						CreatedOnToolsVersion = 13.3;

--- a/Source/WTF/WTF.xcodeproj/xcshareddata/xcschemes/WTF.xcscheme
+++ b/Source/WTF/WTF.xcodeproj/xcshareddata/xcschemes/WTF.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -1754,7 +1754,7 @@
 		1C09D0351E31C32800725F18 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					1C09D03C1E31C32800725F18 = {
 						CreatedOnToolsVersion = 8.3;

--- a/Source/WebCore/PAL/ThirdParty/dav1d/dav1d.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/ThirdParty/dav1d/dav1d.xcodeproj/project.pbxproj
@@ -1118,7 +1118,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = NO;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					1C4FACD428FC70C000FFE212 = {
 						CreatedOnToolsVersion = 14.0;

--- a/Source/WebCore/WebCore.xcodeproj/xcshareddata/xcschemes/WebCore.xcscheme
+++ b/Source/WebCore/WebCore.xcodeproj/xcshareddata/xcschemes/WebCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -1274,7 +1274,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1330;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					1CA5B4F02A6F28C400E5F297 = {
 						CreatedOnToolsVersion = 15.0;

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/Everything up to WebGPU.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/Everything up to WebGPU.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSL.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSL.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSLUnitTests.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSLUnitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WebGPU.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WebGPU.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslc.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslfuzz.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslfuzz.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj
+++ b/Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj
@@ -139,7 +139,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				ORGANIZATIONNAME = Apple;
 			};
 			buildConfigurationList = A54C2250148B23DE00373FA3 /* Build configuration list for PBXProject "WebInspectorUI" */;

--- a/Source/WebInspectorUI/WebInspectorUI.xcodeproj/xcshareddata/xcschemes/WebInspectorUI.xcscheme
+++ b/Source/WebInspectorUI/WebInspectorUI.xcodeproj/xcshareddata/xcschemes/WebInspectorUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -20286,7 +20286,7 @@
 					New,
 				);
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					07275C4E2D00C934002315A5 = {
 						CreatedOnToolsVersion = 16.2;

--- a/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme
+++ b/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/webpushtool.xcscheme
+++ b/Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/webpushtool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -3171,7 +3171,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					537CF83D22EFC4C900C6EBB3 = {
 						CreatedOnToolsVersion = 11.0;

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/xcshareddata/xcschemes/WebKitLegacy.xcscheme
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/xcshareddata/xcschemes/WebKitLegacy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -2415,7 +2415,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					0F7EB8501F95504B00F1ABCB = {
 						CreatedOnToolsVersion = 9.0;

--- a/Source/bmalloc/bmalloc.xcodeproj/xcshareddata/xcschemes/bmalloc.xcscheme
+++ b/Source/bmalloc/bmalloc.xcodeproj/xcshareddata/xcschemes/bmalloc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj
+++ b/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj
@@ -932,7 +932,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					5325BDD321DFF4BD00A0DEE1 = {
 						CreatedOnToolsVersion = 10.1;

--- a/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/xcshareddata/xcschemes/DumpRenderTree.xcscheme
+++ b/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/xcshareddata/xcschemes/DumpRenderTree.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/ImageDiff/ImageDiff.xcodeproj/project.pbxproj
+++ b/Tools/ImageDiff/ImageDiff.xcodeproj/project.pbxproj
@@ -111,7 +111,7 @@
 		31A5D03A1EBBBB0400D3F11B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					31DF42CB1EBBBBFE0096ED44 = {
 						CreatedOnToolsVersion = 9.0;

--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
@@ -220,7 +220,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					8D1107260486CEB800E47090 = {
 						LastSwiftMigration = 1620;

--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 		CD1DAF8A1D709E3600017CF0 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 2700;
 				ORGANIZATIONNAME = WebKit;
 				TargetAttributes = {
 					CD1DAF911D709E3600017CF0 = {

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
@@ -240,7 +240,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1620;
-				LastUpgradeCheck = 1620;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					07A58BD32D0400B300CAB4ED = {
 						CreatedOnToolsVersion = 16.2;

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1620"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2111,7 +2111,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					0723A7492F80357300CB96E7 = {
 						CreatedOnToolsVersion = 26.0;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWGSL.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWGSL.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWTF.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWTF.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPIApp.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPIApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1520"
+   LastUpgradeVersion = "2700"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -1227,7 +1227,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					5325BDD921DFF4F500A0DEE1 = {
 						CreatedOnToolsVersion = 10.1;

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/project.pbxproj
+++ b/Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/project.pbxproj
@@ -151,7 +151,7 @@
 		7C4AB3991AF0276C003FC8D1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 2700;
 			};
 			buildConfigurationList = 7C4AB39C1AF0276C003FC8D1 /* Build configuration list for PBXProject "lldbWebKitTester" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme
+++ b/Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "2700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
#### d6c1d414aa480dded5baad1a4261ab45aa3dab5b
<pre>
Get rid of &quot;Update to recommended settings&quot; Xcode warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=317319">https://bugs.webkit.org/show_bug.cgi?id=317319</a>
<a href="https://rdar.apple.com/179948702">rdar://179948702</a>

Reviewed by Tim Horton.

These warnings are annoying and not even applicable, so ignore them.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/Everything up to JavaScriptCore.xcscheme:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore.xcscheme:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (dynamic).xcscheme:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE (static).xcscheme:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/ANGLE.xcscheme:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/Fuzzers (ANGLE).xcscheme:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/xcshareddata/xcschemes/Tools (ANGLE).xcscheme:
* Source/ThirdParty/gmock/gmock.xcodeproj/project.pbxproj:
* Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj:
* Source/ThirdParty/gtest/xcode/gtest.xcodeproj/xcshareddata/xcschemes/gtest.xcscheme:
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/xcshareddata/xcschemes/libwebrtc.xcscheme:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/WTF.xcodeproj/xcshareddata/xcschemes/WTF.xcscheme:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/ThirdParty/dav1d/dav1d.xcodeproj/project.pbxproj:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/WebCore.xcodeproj/xcshareddata/xcschemes/WebCore.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/Everything up to WebGPU.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSL.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WGSLUnitTests.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/WebGPU.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslc.xcscheme:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslfuzz.xcscheme:
* Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj:
* Source/WebInspectorUI/WebInspectorUI.xcodeproj/xcshareddata/xcschemes/WebInspectorUI.xcscheme:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/WebKit.xcscheme:
* Source/WebKit/WebKit.xcodeproj/xcshareddata/xcschemes/webpushtool.xcscheme:
* Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj:
* Source/WebKitLegacy/WebKitLegacy.xcodeproj/xcshareddata/xcschemes/WebKitLegacy.xcscheme:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/bmalloc.xcodeproj/xcshareddata/xcschemes/bmalloc.xcscheme:
* Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj:
* Tools/DumpRenderTree/DumpRenderTree.xcodeproj/xcshareddata/xcschemes/DumpRenderTree.xcscheme:
* Tools/ImageDiff/ImageDiff.xcodeproj/project.pbxproj:
* Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj:
* Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme:
* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj:
* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/xcshareddata/xcschemes/MobileMiniBrowser.xcscheme:
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj:
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/xcshareddata/xcschemes/SwiftBrowser.xcscheme:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWGSL.xcscheme:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWTF.xcscheme:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPIApp.xcscheme:
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme:
* Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/project.pbxproj:
* Tools/lldb/lldbWebKitTester/lldbWebKitTester.xcodeproj/xcshareddata/xcschemes/lldbWebKitTester.xcscheme:

Canonical link: <a href="https://commits.webkit.org/315413@main">https://commits.webkit.org/315413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f365c3fdc94796c5a82ddc90f67c55814cae9b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178291 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd9731f4-6239-4249-9ba9-0688863188e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131551 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86128a0b-36d2-47a1-88e4-e49e4d59098d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112055 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dbdd1bf-dfad-45ba-909f-71b3cdd64f23) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26994 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/243 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180893 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30193 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140000 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42516 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37642 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43205 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107025 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35125 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114970 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201617 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41714 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6285 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54118 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41108 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41251 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->