### PR TITLE
[CMake] build wrappers should prefer PATH ninja to SDK copy

### DIFF
--- a/Source/cmake/clang-wrapper
+++ b/Source/cmake/clang-wrapper
@@ -118,7 +118,8 @@ END_OF_NINJA
 
 writeFileIfChanged("$membersFolder/build.ninja", $buildNinja);
 
-exec('xcrun', 'ninja', '--quiet', '-f', "$membersFolder/build.ninja");
+chomp(my $ninja = `which ninja 2>/dev/null` || `xcrun -f ninja`);
+exec($ninja, '--quiet', '-f', "$membersFolder/build.ninja");
 die("exec ninja: $!\n");
 
 sub shellQuote {

--- a/Source/cmake/ninja-wrapper
+++ b/Source/cmake/ninja-wrapper
@@ -4,20 +4,22 @@ use warnings;
 use Cwd qw(getcwd);
 use File::Path qw(make_path);
 
+chomp(my $ninja = `which ninja 2>/dev/null` || `xcrun -f ninja`);
+
 # CMake configuration
 if (grep({ /^-t/ || /^--version$/ } @ARGV)) {
-    exec('xcrun', 'ninja', @ARGV);
+    exec($ninja, @ARGV);
 }
 
 # CMake try_compile/check_*
 if (getcwd() =~ m{/CMakeFiles/}) {
-    exec('xcrun', 'ninja', @ARGV);
+    exec($ninja, @ARGV);
 }
 
 # Real compilation
 my $bundlePolicy = $ENV{WK_UNIFIED_SOURCES_BUNDLE_POLICY};
 if (!defined($bundlePolicy)) {
-    my $dryRun = `xcrun ninja -n @ARGV 2>&1`;
+    my $dryRun = `$ninja -n @ARGV 2>&1`;
     my ($totalCommands) = $dryRun =~ m{/(\d+)\]};
 
     # No-op build
@@ -44,4 +46,4 @@ if (open(my $fh, '>', "DerivedSources/unified-sources-bundle-policy")) {
     close($fh);
 }
 
-exec('/usr/bin/caffeinate', '-i', 'xcrun', 'ninja', @ARGV);
+exec('/usr/bin/caffeinate', '-i', $ninja, @ARGV);


### PR DESCRIPTION
#### bdf07ed09f5502ed80e5ee0d80f3e7359ff9a11e
<pre>
[CMake] build wrappers should prefer PATH ninja to SDK copy
<a href="https://bugs.webkit.org/show_bug.cgi?id=317326">https://bugs.webkit.org/show_bug.cgi?id=317326</a>
<a href="https://rdar.apple.com/179953210">rdar://179953210</a>

Reviewed by Geoffrey Garen.

When a user has a custom ninja installed ninja-wrapper/clang-wrapper
prefer the SDK&apos;s ninja install over the users. This causes rebuilds when
doing the following:

cmake --build --preset mac-dev-release

followed by:

ninja -C ./WebKitBuild/cmake-mac/Release

Defaulting to the ninja in PATH and falling back to xcrun solves this
issue.

Canonical link: <a href="https://commits.webkit.org/315467@main">https://commits.webkit.org/315467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1df0f6420aeaf0447d3af99847297df6a943665

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126640 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33eda880-2c6f-45a3-bef9-55d97a2e7e59) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131541 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92549 "3 flakes 11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b7f8d24f-05e2-4e18-9dfa-9cbebcbdd64b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112045 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21d4306c-7121-45cc-b966-22fef8406d0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32983 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31696 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26985 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/231 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180884 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30184 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139988 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42507 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151283 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139831 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43196 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28185 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107016 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35124 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201608 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41705 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6273 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54112 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41099 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->