### PR TITLE
[JSC] "entries" ArrayIterator should emit ExitOK before NewArray

### DIFF
--- a/JSTests/stress/array-iterator-fast-entries-double-array-fixup-exit-ok.js
+++ b/JSTests/stress/array-iterator-fast-entries-double-array-fixup-exit-ok.js
@@ -1,0 +1,19 @@
+// Regression test for the DFG VirtualRegisterAllocationPhase crash that
+// happened when the fast Array iterator entries path emitted GetByVal on a
+// Double-storage array followed by NewArray with no intervening ExitOK,
+// causing Fixup to insert the ValueRep conversion before the GetByVal that
+// produced its operand.
+
+function inner(iterator) {
+    for (const item of iterator) { }
+}
+
+function driver() {
+    const values = [268435456, 4294967295, 268435456, 268435456, 268435456];
+    const iterator = values.entries();
+    for (let i = 0; i < 100; ++i)
+        inner(iterator);
+}
+
+for (let i = 0; i < testLoopCount; ++i)
+    driver();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1997,8 +1997,7 @@ void ByteCodeParser::inlineCall(Node* callTargetNode, Operand result, CallVarian
     m_currentExitOrigin = oldExitOrigin;
 
     // At this point, it's again OK to OSR exit.
-    m_exitOK = true;
-    addToGraph(ExitOK);
+    emitExitOK();
 
     processSetLocalQueue();
 
@@ -2408,9 +2407,8 @@ ByteCodeParser::CallOptimizationResult ByteCodeParser::handleInlining(
 
     // It's OK to exit right now, even though we set some locals. That's because those locals are not
     // user-visible.
-    m_exitOK = true;
-    addToGraph(ExitOK);
-    
+    emitExitOK();
+
     SwitchData& data = *m_graph.m_switchData.add();
     data.kind = SwitchCell;
     addToGraph(Switch, OpInfo(&data), thingToSwitchOn);
@@ -3879,8 +3877,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             // we can say exitOK for each ToObject.
             unsigned errorStringIndex = UINT32_MAX;
             Node* target = addToGraph(ToObject, OpInfo(errorStringIndex), OpInfo(SpecNone), get(virtualRegisterForArgumentIncludingThis(1, registerOffset)));
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
             addToGraph(ObjectAssign, Edge(target, KnownCellUse), Edge(get(virtualRegisterForArgumentIncludingThis(2, registerOffset))));
             setResult(target);
             return CallOptimizationResult::Inlined;
@@ -5136,8 +5133,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             // We've set some locals, but they are not user-visible since they are newly allocated for this inlined call. It's still OK to exit from here.
             // JSBoundFunction's trampoline does not have user-visible effect. So exiting to the pre-bound function location is OK.
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             // Bound function itself is completely wiped. And we should behave as if the current caller is directly calling this function.
             // If the current caller is calling the callee in a tail-call form, then it should be a tail-call.
@@ -5501,8 +5497,7 @@ bool ByteCodeParser::handleIntrinsicGetter(Operand result, SpeculatedType predic
         Node* lengthNode = addToGraph(op, OpInfo(mayBeResizableOrGrowableSharedArrayBuffer), Edge(thisNode, DataViewObjectUse));
         if (mayBeResizableOrGrowableSharedArrayBuffer)
             lengthNode->mergeFlags(NodeMustGenerate);
-        m_exitOK = true;
-        addToGraph(ExitOK);
+        emitExitOK();
 
         set(result, lengthNode);
         return true;
@@ -5535,8 +5530,7 @@ bool ByteCodeParser::handleIntrinsicGetter(Operand result, SpeculatedType predic
         NodeType op = mayBeLargeTypedArray ? GetTypedArrayLengthAsInt52 : GetArrayLength;
         Node* lengthNode = addToGraph(op, OpInfo(ArrayMode(arrayType, Array::NonArray, Array::InBounds, Array::AsIs, Array::Read, mayBeLargeTypedArray, mayBeResizableOrGrowableSharedTypedArray).asWord()), thisNode);
         // Our ArrayMode shouldn't cause us to exit here so we should be ok to exit without effects.
-        m_exitOK = true;
-        addToGraph(ExitOK);
+        emitExitOK();
 
         if (!logSize) {
             set(result, lengthNode);
@@ -5836,8 +5830,7 @@ void ByteCodeParser::emitProxyObjectLoadCall(VirtualRegister destination, Specul
     set(virtualRegisterForArgumentIncludingThis(2, registerOffset), base, ImmediateNakedSet); // FIXME: We can extend this to handle arbitrary receiver.
 
     // We've set some locals, but they are not user-visible. It's still OK to exit from here.
-    m_exitOK = true;
-    addToGraph(ExitOK);
+    emitExitOK();
 
     handleCall(destination, Call, InlineCallFrame::ProxyObjectLoadCall, osrExitIndex, functionNode, numberOfParameters - 1, registerOffset, *getByStatus.variants()[0].callLinkStatus(), prediction, nullptr);
 }
@@ -5880,8 +5873,7 @@ void ByteCodeParser::emitProxyObjectStoreCall(Node* base, Node* propertyNameNode
     set(virtualRegisterForArgumentIncludingThis(3, registerOffset), value, ImmediateNakedSet);
 
     // We've set some locals, but they are not user-visible. It's still OK to exit from here.
-    m_exitOK = true;
-    addToGraph(ExitOK);
+    emitExitOK();
 
     handleCall(VirtualRegister(), Call, InlineCallFrame::ProxyObjectStoreCall, osrExitIndex, functionNode, numberOfParameters - 1, registerOffset, *putByStatus.variants()[0].callLinkStatus(), SpecOther, nullptr, ecmaMode);
 }
@@ -5920,8 +5912,7 @@ void ByteCodeParser::emitProxyObjectInCall(VirtualRegister destination, Speculat
     set(virtualRegisterForArgumentIncludingThis(1, registerOffset), propertyNameNode, ImmediateNakedSet);
 
     // We've set some locals, but they are not user-visible. It's still OK to exit from here.
-    m_exitOK = true;
-    addToGraph(ExitOK);
+    emitExitOK();
 
     handleCall(destination, Call, InlineCallFrame::ProxyObjectInCall, osrExitIndex, functionNode, numberOfParameters - 1, registerOffset, *inByStatus.variants()[0].callLinkStatus(), prediction, nullptr);
 }
@@ -7002,9 +6993,8 @@ void ByteCodeParser::handleGetById(
     set(virtualRegisterForArgumentIncludingThis(0, registerOffset), base, ImmediateNakedSet);
 
     // We've set some locals, but they are not user-visible. It's still OK to exit from here.
-    m_exitOK = true;
-    addToGraph(ExitOK);
-    
+    emitExitOK();
+
     handleCall(
         destination, Call, InlineCallFrame::GetterCall, osrExitIndex,
         getter, numberOfParameters - 1, registerOffset, *variant.callLinkStatus(), prediction, nullptr);
@@ -7459,9 +7449,8 @@ void ByteCodeParser::handlePutById(
         set(virtualRegisterForArgumentIncludingThis(1, registerOffset), value, ImmediateNakedSet);
 
         // We've set some locals, but they are not user-visible. It's still OK to exit from here.
-        m_exitOK = true;
-        addToGraph(ExitOK);
-    
+        emitExitOK();
+
         handleCall(
             VirtualRegister(), Call, InlineCallFrame::SetterCall,
             osrExitIndex, setter, numberOfParameters - 1, registerOffset,
@@ -7773,8 +7762,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
 
             // Normally we wouldn't be allowed to exit here, but in this case we'd
             // only be re-initializing the locals and resetting the scope register
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             handleCheckTraps();
 
@@ -9671,8 +9659,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
             // The SetArgumentDefinitely nodes that follow below may exit because we may hoist type checks
             // to them. The SetLocal nodes that follow below may exit because we may choose
             // a flush format that speculates on the type of the local.
-            m_exitOK = true; 
-            addToGraph(ExitOK);
+            emitExitOK();
 
             {
                 auto addResult = m_graph.m_rootToArguments.add(m_currentBlock, ArgumentsVector());
@@ -10662,8 +10649,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 Node* badMode = addToGraph(ArithBitAnd, mode, jsConstant(jsNumber(JSPropertyNameEnumerator::GenericMode | JSPropertyNameEnumerator::OwnStructureMode)));
 
                 // We know the ArithBitAnd cannot have effects so it's ok to exit here.
-                m_exitOK = true;
-                addToGraph(ExitOK);
+                emitExitOK();
 
                 addToGraph(CheckIsConstant, OpInfo(m_graph.freezeStrong(jsNumber(0))), badMode);
 
@@ -10796,8 +10782,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 Node* badMode = addToGraph(ArithBitAnd, mode, jsConstant(jsNumber(JSPropertyNameEnumerator::GenericMode | JSPropertyNameEnumerator::OwnStructureMode)));
 
                 // We know the ArithBitAnd cannot have effects so it's ok to exit here.
-                m_exitOK = true;
-                addToGraph(ExitOK);
+                emitExitOK();
 
                 addToGraph(CheckIsConstant, OpInfo(m_graph.freezeStrong(jsNumber(0))), badMode);
 
@@ -11422,8 +11407,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             Node* andResult = addToGraph(ArithBitAnd, isArray, isKnownIterFunction);
 
             // We know the ArithBitAnd cannot have effects so it's ok to exit here.
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(branchData), andResult);
             flushForTerminal();
@@ -11498,8 +11482,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             branchData->taken = BranchTarget(kindCheckBlock);
             branchData->notTaken = BranchTarget(failedBlock);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(branchData), andResult);
             flushForTerminal();
@@ -11516,8 +11499,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             kindBranchData->taken = BranchTarget(iteratedObjectCheckBlock);
             kindBranchData->notTaken = BranchTarget(failedBlock);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(kindBranchData), isKindMatch);
             flushForTerminal();
@@ -11533,8 +11515,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             arrayBranchData->taken = BranchTarget(fastBlock);
             arrayBranchData->notTaken = BranchTarget(failedBlock);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(arrayBranchData), isIteratedArray);
             flushForTerminal();
@@ -11605,8 +11586,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             branchData->taken = BranchTarget(kindCheckBlock);
             branchData->notTaken = BranchTarget(failedBlock);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(branchData), andResult);
             flushForTerminal();
@@ -11623,8 +11603,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             kindBranchData->taken = BranchTarget(fastBlock);
             kindBranchData->notTaken = BranchTarget(failedBlock);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(kindBranchData), isKindMatch);
             flushForTerminal();
@@ -11680,8 +11659,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             branchData->taken = BranchTarget(kindCheckBlock);
             branchData->notTaken = BranchTarget(failedBlock);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(branchData), andResult);
             flushForTerminal();
@@ -11698,8 +11676,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
             kindBranchData->taken = BranchTarget(fastBlock);
             kindBranchData->notTaken = BranchTarget(failedBlock);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(kindBranchData), isKindMatch);
             flushForTerminal();
@@ -11747,8 +11724,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
 
             Node* andResult = addToGraph(ArithBitAnd, isMap, isKnownIterFunction);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(branchData), andResult);
             flushForTerminal();
@@ -11821,8 +11797,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
 
             Node* andResult = addToGraph(ArithBitAnd, isSet, isKnownIterFunction);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(branchData), andResult);
             flushForTerminal();
@@ -11892,8 +11867,7 @@ void ByteCodeParser::handleIteratorOpen(const JSInstruction* currentInstruction,
 
             Node* andResult = addToGraph(ArithBitAnd, isString, isKnownIterFunction);
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             addToGraph(Branch, OpInfo(branchData), andResult);
             flushForTerminal();
@@ -12058,8 +12032,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         else {
             Node* isFastSentinel = addToGraph(CompareEqPtr, OpInfo(frozenSentinel), get(bytecode.m_next));
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             failedBlock = allocateUntargetableBlock();
             BasicBlock* fastBlock = allocateUntargetableBlock();
@@ -12091,14 +12064,12 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
             Node* butterfly = addToGraph(GetButterfly, iteratedObject);
             Node* length = addToGraph(GetArrayLength, OpInfo(arrayMode.asWord()), Edge(iteratedObject), Edge(butterfly, KnownStorageUse));
             // GetArrayLength is pessimized prior to fixup.
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
             Node* isOutOfBounds = addToGraph(CompareGreaterEq, Edge(index, Int32Use), Edge(length, Int32Use));
 
             isDone = addToGraph(ArithBitOr, isDone, isOutOfBounds);
             // The above compare doesn't produce effects since we know the values are booleans. We don't set UseKinds because Fixup likes to add edges.
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             BranchData* branchData = m_graph.m_branchData.add();
             branchData->taken = BranchTarget(isDoneBlock);
@@ -12127,6 +12098,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
                 addVarArgChild(nullptr); // Leave room for property storage.
                 Node* element = addToGraph(Node::VarArg, GetByVal, OpInfo(arrayMode.asWord()), OpInfo(prediction));
                 if (kind == IterationKind::Entries) {
+                    emitExitOK();
                     addVarArgChild(index);
                     addVarArgChild(element);
                     unsigned vectorHint = 2;
@@ -12195,8 +12167,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         else {
             Node* isFastSentinel = addToGraph(CompareEqPtr, OpInfo(frozenSentinel), get(bytecode.m_next));
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             failedBlock = allocateUntargetableBlock();
             BasicBlock* fastMapBlock = allocateUntargetableBlock();
@@ -12349,8 +12320,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         else {
             Node* isFastSentinel = addToGraph(CompareEqPtr, OpInfo(frozenSentinel), get(bytecode.m_next));
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             failedBlock = allocateUntargetableBlock();
             BasicBlock* fastSetBlock = allocateUntargetableBlock();
@@ -12510,8 +12480,7 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         else {
             Node* isFastSentinel = addToGraph(CompareEqPtr, OpInfo(frozenSentinel), get(bytecode.m_next));
 
-            m_exitOK = true;
-            addToGraph(ExitOK);
+            emitExitOK();
 
             failedBlock = allocateUntargetableBlock();
             BasicBlock* fastStringBlock = allocateUntargetableBlock();


### PR DESCRIPTION
#### ae69ef2312c05f2d4e25f77e4bbaeaf249e2f1e4
<pre>
[JSC] &quot;entries&quot; ArrayIterator should emit ExitOK before NewArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=317327">https://bugs.webkit.org/show_bug.cgi?id=317327</a>
<a href="https://rdar.apple.com/179702753">rdar://179702753</a>

Reviewed by Marcus Plutowski.

In &quot;entries&quot; ArrayIterator, we do GetByVal, and then we do NewArray for
the result. But GetByVal can perform OSR exit, and NewArray can raise
OOM error, and OSR exit. This makes Fixup phase confused and emitting
ValueRep at a wrong position. Emit ExitOK before NewArray. This is fine
since these GetByVal and NewArray are non-user-observable (except for
OOM, which is fine).

Test: JSTests/stress/array-iterator-fast-entries-double-array-fixup-exit-ok.js
* JSTests/stress/array-iterator-fast-entries-double-array-fixup-exit-ok.js: Added.
(inner):
(driver):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::inlineCall):
(JSC::DFG::ByteCodeParser::handleInlining):
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
(JSC::DFG::ByteCodeParser::handleIntrinsicGetter):
(JSC::DFG::ByteCodeParser::emitProxyObjectLoadCall):
(JSC::DFG::ByteCodeParser::emitProxyObjectStoreCall):
(JSC::DFG::ByteCodeParser::emitProxyObjectInCall):
(JSC::DFG::ByteCodeParser::handleGetById):
(JSC::DFG::ByteCodeParser::handlePutById):
(JSC::DFG::ByteCodeParser::parseBlock):
(JSC::DFG::ByteCodeParser::handleIteratorOpen):
(JSC::DFG::ByteCodeParser::handleIteratorNext):

Canonical link: <a href="https://commits.webkit.org/315411@main">https://commits.webkit.org/315411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a340d37163f3021255da2ce843ef6ae71a2509b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178276 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126634 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131536 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112040 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26979 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/236 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180878 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30178 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139985 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42501 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139828 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43190 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107010 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25742 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35112 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Passed layout tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114955 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201602 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41699 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6278 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54110 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41093 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41348 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41236 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->