### PR TITLE
Per spec, deprecated attribute align="center" should be identical to align="middle"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html
@@ -11,11 +11,9 @@ const kMapping = {
 
   "top": ["vertical-align", "top"],
 
-  // This one requires a magic value (`-moz-middle-with-baseline` on Gecko,
+  // These two require a magic value (`-moz-middle-with-baseline` on Gecko,
   // `-webkit-baseline-middle` on WebKit-based browsers).
   "middle": ["vertical-align", undefined],
-  // These are inconsistent across browsers. WebKit maps it to "middle", Gecko
-  // to the aforementioned value.
   "center": ["vertical-align", undefined],
 
   "baseline": ["vertical-align", "baseline"],
@@ -31,6 +29,17 @@ const kInitialValues = {
   "vertical-align": "baseline",
   "float": "none",
 };
+
+const kVerticalAlignKeywords = [
+  "baseline",
+  "sub",
+  "super",
+  "text-top",
+  "text-bottom",
+  "middle",
+  "top",
+  "bottom",
+];
 
 let replaced = document.getElementById("replaced");
 let nonReplaced = document.getElementById("non-replaced");
@@ -49,7 +58,10 @@ onload = t.step_func_done(function() {
             assert_equals(actual, expected, `align=${attributeValue} should map to ${property}: ${expected}`);
           } else {
             assert_equals(property, "vertical-align");
-            assert_not_equals(actual, "baseline", `align=${attributeValue} should map a vertical-align value`);
+            assert_false(
+              kVerticalAlignKeywords.includes(actual),
+             `align=${attributeValue} should map to a special vertical-align value`
+            );
           }
         }
       }, `align=${attributeValue} on ${element == replaced ? "replaced" : "non-replaced"} elements`);

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -616,10 +616,8 @@ void HTMLElement::applyAlignmentAttributeToStyle(const AtomString& alignment, Mu
         verticalAlignValue = CSSValueTop;
     } else if (equalLettersIgnoringASCIICase(alignment, "top"_s))
         verticalAlignValue = CSSValueTop;
-    else if (equalLettersIgnoringASCIICase(alignment, "middle"_s))
+    else if (equalLettersIgnoringASCIICase(alignment, "middle"_s) || equalLettersIgnoringASCIICase(alignment, "center"_s))
         verticalAlignValue = CSSValueWebkitBaselineMiddle;
-    else if (equalLettersIgnoringASCIICase(alignment, "center"_s))
-        verticalAlignValue = CSSValueMiddle;
     else if (equalLettersIgnoringASCIICase(alignment, "bottom"_s))
         verticalAlignValue = CSSValueBaseline;
     else if (equalLettersIgnoringASCIICase(alignment, "texttop"_s))


### PR DESCRIPTION
#### de7f2d41a10c0950e6f457d081f5f90d22b613d5
<pre>
Per spec, deprecated attribute align=&quot;center&quot; should be identical to align=&quot;middle&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=317328">https://bugs.webkit.org/show_bug.cgi?id=317328</a>

Reviewed by Anne van Kesteren.

Per the specification [1], when an embed, iframe, img, or object element, or an input element whose type attribute is in the Image Button state, has an align attribute whose value is an ASCII case-insensitive match for the string &quot;center&quot; or the string &quot;middle&quot;, the user agent is expected to act as if the element&apos;s &apos;vertical-align&apos; property was set to a value that aligns the vertical middle of the element with the parent element&apos;s baseline.

[1] <a href="https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images">https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images</a>

* Source/WebCore/html/HTMLElement.cpp:
(HTMLElement::applyAlignmentAttributeToStyle):
Treat align=&quot;center&quot; the same as align=&quot;middle&quot;.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html:
Update tests for align=&quot;center&quot; and align=&quot;middle&quot;.

Canonical link: <a href="https://commits.webkit.org/315531@main">https://commits.webkit.org/315531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17e52c9809a6f1e630c4cbb6caabfdfc0218da17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131740 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92703 "8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33191 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31889 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181108 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140194 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140035 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37724 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43419 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28401 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107333 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35310 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115184 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41928 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6490 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->