### PR TITLE
[JSC] B3::Value::effects should use constant table

### DIFF
--- a/Source/JavaScriptCore/b3/B3Effects.h
+++ b/Source/JavaScriptCore/b3/B3Effects.h
@@ -87,18 +87,35 @@ struct Effects {
     // if the operation is a memory fence.
     bool fence : 1 { false };
 
+private:
+    // Sentinel for the constant-effects table in B3ValueInlines.h: marks opcodes whose effects are
+    // value-dependent. Never set on Effects describing an actual value. Declared adjacent to the
+    // bitfields above so it packs into the same allocation unit (no size growth).
+    bool m_invalid : 1 { false };
+
+public:
     // WARNING: The B3::hoistLoopInvariantValues() phase thinks that it understands this exhaustively. If you
     // add any new kinds of things that can be read or written, you should check that phase.
 
     HeapRange writes;
     HeapRange reads;
 
-    static Effects none()
+    static constexpr Effects none()
     {
         return Effects();
     }
 
-    static Effects forCall()
+    static constexpr Effects invalid()
+    {
+        Effects result;
+        result.m_invalid = true;
+        return result;
+    }
+
+    constexpr bool isValid() const { return !m_invalid; }
+    constexpr bool isInvalid() const { return m_invalid; }
+
+    static constexpr Effects forCall()
     {
         Effects result;
         result.exitsSideways = true;
@@ -110,8 +127,8 @@ struct Effects {
         result.fence = true;
         return result;
     }
-    
-    static Effects forCheck()
+
+    static constexpr Effects forCheck()
     {
         Effects result;
         result.exitsSideways = true;
@@ -120,7 +137,7 @@ struct Effects {
         return result;
     }
 
-    bool mustExecute() const
+    constexpr bool mustExecute() const
     {
         return terminal || exitsSideways || writesLocalState || writes || writesPinned || fence;
     }

--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -572,7 +572,7 @@ private:
         // since the dominated store nodes may dependent on the data
         // read from the processed block. Note that there is no need to
         // update reads info if the node is deleted.
-        m_data.reads.add(m_value->effects().reads);
+        m_data.reads.add(effects.reads);
     }
 
     // Return true if we got rid of the operation. If you changed IR in this function, you have to

--- a/Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp
@@ -48,15 +48,13 @@ bool eliminateDeadCodeImpl(Procedure& proc)
     Vector<UpsilonValue*, 128> upsilons;
     for (BasicBlock* block : proc) {
         for (Value* value : *block) {
-            Effects effects;
             // We don't care about effects of SSA operations, since we model them more
             // accurately than the effects() method does.
-            if (value->opcode() != Phi && value->opcode() != Upsilon)
-                effects = value->effects();
-            
-            if (effects.mustExecute())
-                worklist.push(value);
-            
+            if (value->opcode() != Phi && value->opcode() != Upsilon) {
+                if (value->mustExecute())
+                    worklist.push(value);
+            }
+
             if (UpsilonValue* upsilon = value->as<UpsilonValue>())
                 upsilons.append(upsilon);
         }

--- a/Source/JavaScriptCore/b3/B3Kind.h
+++ b/Source/JavaScriptCore/b3/B3Kind.h
@@ -58,11 +58,11 @@ namespace JSC { namespace B3 {
 
 class Kind {
 public:
-    Kind(Opcode opcode)
+    constexpr Kind(Opcode opcode)
         : m_opcode(opcode)
     {
     }
-    
+
     Kind()
         : Kind(Oops)
     {
@@ -113,7 +113,7 @@ public:
     // in the Procedure the trap happened. If you try to work it out using Origin, you'll have a bad
     // time because the instruction selector is too sloppy with Origin().
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=162688
-    bool hasTraps() const
+    constexpr bool hasTraps() const
     {
         switch (m_opcode) {
         case Load8Z:

--- a/Source/JavaScriptCore/b3/B3StackmapGenerationParams.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapGenerationParams.cpp
@@ -32,6 +32,7 @@
 #include "AirGenerationContext.h"
 #include "B3Procedure.h"
 #include "B3StackmapValue.h"
+#include "B3ValueInlines.h"
 
 namespace JSC { namespace B3 {
 

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -50,6 +50,8 @@
 #include "B3WasmStructGetValue.h"
 #include "B3WasmStructNewValue.h"
 #include "B3WasmStructSetValue.h"
+#include <array>
+#include <optional>
 #include <wtf/CommaPrinter.h>
 #include <wtf/ListDump.h>
 #include <wtf/StackTrace.h>
@@ -656,157 +658,128 @@ TriState Value::asTriState() const
     }
 }
 
-Effects Value::effects() const
+namespace {
+
+// Effects for an opcode that don't depend on per-Value data. Effects::invalid() means
+// value-dependent (handled by effectsSlow()). The traps suffix is applied by effects()/effectsSlow(),
+// not here.
+constexpr Effects constantEffectsForOpcode(Opcode opcode)
 {
     Effects result = Effects::none();
-    switch (opcode()) {
-    case Nop:
-    case Identity:
-    case Opaque:
-    case Const32:
-    case Const64:
-    case ConstDouble:
-    case ConstFloat:
-    case Const128:
-    case BottomTuple:
-    case SlotBase:
-    case ArgumentReg:
-    case FramePointer:
-    case Add:
-    case Sub:
-    case Mul:
-    case MulHigh:
-    case UMulHigh:
-    case Neg:
-    case PurifyNaN:
-    case BitAnd:
-    case BitOr:
-    case BitXor:
-    case Shl:
-    case SShr:
-    case ZShr:
-    case RotR:
-    case RotL:
-    case Clz:
-    case Abs:
-    case Ceil:
-    case Floor:
-    case FTrunc:
-    case Sqrt:
-    case BitwiseCast:
-    case SExt8:
-    case SExt16:
-    case SExt8To64:
-    case SExt16To64:
-    case SExt32:
-    case ZExt32:
-    case Trunc:
-    case TruncHigh:
-    case Stitch:
-    case IToD:
-    case IToF:
-    case FloatToDouble:
-    case DoubleToFloat:
-    case Equal:
-    case NotEqual:
-    case LessThan:
-    case GreaterThan:
-    case LessEqual:
-    case GreaterEqual:
-    case Above:
-    case Below:
-    case AboveEqual:
-    case BelowEqual:
-    case EqualOrUnordered:
-    case Select:
-    case Depend:
-    case Extract:
-    case FMin:
-    case FMax:
-    case VectorExtractLane:
-    case VectorReplaceLane:
-    case VectorDupElement:
-    case VectorEqual:
-    case VectorNotEqual:
-    case VectorLessThan:
-    case VectorLessThanOrEqual:
-    case VectorBelow:
-    case VectorBelowOrEqual:
-    case VectorGreaterThan:
-    case VectorGreaterThanOrEqual:
-    case VectorAbove:
-    case VectorAboveOrEqual:
-    case VectorAdd:
-    case VectorSub:
-    case VectorAddSat:
-    case VectorSubSat:
-    case VectorMul:
-    case VectorMulHigh:
-    case VectorMulLow:
-    case VectorDotProduct:
-    case VectorDiv:
-    case VectorMin:
-    case VectorMax:
-    case VectorPmin:
-    case VectorPmax:
-    case VectorNarrow:
-    case VectorNot:
-    case VectorAnd:
-    case VectorAndnot:
-    case VectorOr:
-    case VectorXor:
-    case VectorShl:
-    case VectorShr:
-    case VectorAbs:
-    case VectorNeg:
-    case VectorPopcnt:
-    case VectorCeil:
-    case VectorFloor:
-    case VectorTrunc:
-    case VectorTruncSat:
-    case VectorRelaxedTruncSat:
-    case VectorConvert:
-    case VectorConvertLow:
-    case VectorNearest:
-    case VectorSqrt:
-    case VectorExtendLow:
-    case VectorExtendHigh:
-    case VectorPromote:
-    case VectorDemote:
-    case VectorSplat:
-    case VectorAnyTrue:
-    case VectorAllTrue:
-    case VectorAvgRound:
-    case VectorBitmask:
-    case VectorBitwiseSelect:
-    case VectorExtaddPairwise:
-    case VectorMulSat:
-    case VectorSwizzle:
-    case VectorUnzipEven:
-    case VectorUnzipOdd:
-    case VectorZipLower:
-    case VectorZipHigher:
-    case VectorTransposeEven:
-    case VectorTransposeOdd:
-    case VectorReverse:
-    case VectorExtractPair:
-    case VectorMulByElement:
-    case VectorRelaxedSwizzle:
-    case VectorRelaxedMAdd:
-    case VectorRelaxedNMAdd:
-    case VectorRelaxedLaneSelect:
-    case VectorRelaxedMin:
-    case VectorRelaxedMax:
-    case VectorRelaxedQ15Mulr:
-    case VectorRelaxedDotI8x16I7x16:
-    case VectorRelaxedDotI8x16I7x16Add:
-        break;
+    switch (opcode) {
+    case Load8Z:
+    case Load8S:
+    case Load16Z:
+    case Load16S:
+    case Load:
+    case Store8:
+    case Store16:
+    case Store:
+    case MemoryCopy:
+    case MemoryFill:
+    case AtomicWeakCAS:
+    case AtomicStrongCAS:
+    case AtomicXchgAdd:
+    case AtomicXchgAnd:
+    case AtomicXchgOr:
+    case AtomicXchgSub:
+    case AtomicXchgXor:
+    case AtomicXchg:
+    case Fence:
+    case CCall:
+    case Patchpoint:
+    case WasmBoundsCheck:
+    case WasmStructGet:
+    case WasmStructSet:
+    case WasmArrayGet:
+    case WasmArraySet:
+    case WasmArrayLength:
+        return Effects::invalid();
     case Div:
     case UDiv:
     case Mod:
     case UMod:
         result.controlDependent = true;
         break;
+    case WasmAddress:
+        result.readsPinned = true;
+        break;
+    case CheckAdd:
+    case CheckSub:
+    case CheckMul:
+    case Check:
+        result = Effects::forCheck();
+        break;
+    case WasmStructNew:
+        result.reads = HeapRange::top();
+        result.writes = HeapRange::top();
+        result.exitsSideways = true;
+        break;
+    case WasmArrayNew:
+        result.reads = HeapRange::top();
+        result.writes = HeapRange::top();
+        result.exitsSideways = true;
+        break;
+    case WasmRefCast:
+        result.reads = HeapRange::top();
+        result.controlDependent = true;
+        result.exitsSideways = true;
+        break;
+    case WasmRefTest:
+        result.reads = HeapRange::top();
+        result.controlDependent = true;
+        break;
+    case Upsilon:
+    case Set:
+        result.writesLocalState = true;
+        break;
+    case Phi:
+    case Get:
+        result.readsLocalState = true;
+        break;
+    case Jump:
+    case Branch:
+    case Switch:
+    case Return:
+    case Oops:
+    case EntrySwitch:
+        result.terminal = true;
+        break;
+    default:
+        // Most opcodes (arithmetic, vectors, constants, conversions) have no effects.
+        break;
+    }
+    return result;
+}
+
+// The fast path in Value::effects() returns table entries without the traps suffix, which is only
+// sound if every trapping opcode with constant effects already subsumes it.
+constexpr bool constantEffectsTableIsTrapSafe()
+{
+    for (unsigned i = 0; i < numberOfB3Opcodes; ++i) {
+        Opcode opcode = static_cast<Opcode>(i);
+        Effects entry = constantEffectsForOpcode(opcode);
+        if (entry.isValid() && Kind(opcode).hasTraps() && !(entry.exitsSideways && entry.reads == HeapRange::top()))
+            return false;
+    }
+    return true;
+}
+static_assert(constantEffectsTableIsTrapSafe(),
+    "Trapping opcodes with constant effects must already set exitsSideways and reads=top.");
+
+} // anonymous namespace
+
+const std::array<Effects, numberOfB3Opcodes> constantEffectsTable = ([] {
+    std::array<Effects, numberOfB3Opcodes> table { };
+    for (unsigned i = 0; i < numberOfB3Opcodes; ++i)
+        table[i] = constantEffectsForOpcode(static_cast<Opcode>(i));
+    return table;
+}());
+
+Effects Value::effectsSlow() const
+{
+    Effects result;
+    switch (opcode()) {
     case Load8Z:
     case Load8S:
     case Load16Z:
@@ -863,9 +836,6 @@ Effects Value::effects() const
         result.controlDependent = true;
         break;
     }
-    case WasmAddress:
-        result.readsPinned = true;
-        break;
     case Fence: {
         const FenceValue* fence = as<FenceValue>();
         result.reads = fence->read;
@@ -878,12 +848,6 @@ Effects Value::effects() const
         break;
     case Patchpoint:
         result = as<PatchpointValue>()->effects;
-        break;
-    case CheckAdd:
-    case CheckSub:
-    case CheckMul:
-    case Check:
-        result = Effects::forCheck();
         break;
     case WasmBoundsCheck:
         switch (as<WasmBoundsCheckValue>()->boundsType()) {
@@ -909,11 +873,6 @@ Effects Value::effects() const
         result.controlDependent = true;
         break;
     }
-    case WasmStructNew:
-        result.reads = HeapRange::top();
-        result.writes = HeapRange::top();
-        result.exitsSideways = true;
-        break;
     case WasmArrayGet: {
         const auto* derived = as<WasmArrayGetValue>();
         result.reads = derived->range();
@@ -927,42 +886,15 @@ Effects Value::effects() const
         result.controlDependent = true;
         break;
     }
-    case WasmArrayNew:
-        result.reads = HeapRange::top();
-        result.writes = HeapRange::top();
-        result.exitsSideways = true;
-        break;
     case WasmArrayLength:
         result.reads = as<WasmArrayLengthValue>()->range();
         result.controlDependent = true;
         result.readsMutability = Mutability::Immutable;
         break;
-    case WasmRefCast:
-        result.reads = HeapRange::top();
-        result.controlDependent = true;
-        result.exitsSideways = true;
-        break;
-    case WasmRefTest:
-        result.reads = HeapRange::top();
-        result.controlDependent = true;
-        break;
-    case Upsilon:
-    case Set:
-        result.writesLocalState = true;
-        break;
-    case Phi:
-    case Get:
-        result.readsLocalState = true;
-        break;
-    case Jump:
-    case Branch:
-    case Switch:
-    case Return:
-    case Oops:
-    case EntrySwitch:
-        result.terminal = true;
-        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
     }
+
     // We check hasTraps() first because most Kinds don't trap and we just switched on the
     // Kind above. So in most cases the compiler won't bother loading the traps() bit.
     if (kind().hasTraps() && traps()) {

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -327,7 +327,9 @@ public:
     bool isSIMDValue() const;
     SIMDValue* asSIMDValue();
 
-    Effects effects() const;
+    inline Effects effects() const;
+
+    inline bool mustExecute() const;
 
     // This returns a ValueKey that describes that this Value returns when it executes. Returns an
     // empty ValueKey if this Value is impure. Note that an operation that returns Void could still
@@ -360,6 +362,8 @@ public:
     void walk(const Functor& functor, PhiChildren* = nullptr);
 
 protected:
+    Effects effectsSlow() const;
+
     Value* cloneImpl() const;
 
     void replaceWith(Kind, Type, BasicBlock*);

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -61,9 +61,32 @@
 #include "B3WasmStructGetValue.h"
 #include "B3WasmStructNewValue.h"
 #include "B3WasmStructSetValue.h"
+#include <array>
 #include <wtf/GraphNodeWorklist.h>
 
 namespace JSC { namespace B3 {
+
+inline constexpr unsigned numberOfB3Opcodes = static_cast<unsigned>(Oops) + 1;
+
+// Effects for opcodes whose effects are a pure function of the opcode. Invalid entries are
+// value-dependent and handled by Value::effectsSlow(). Defined once in B3Value.cpp.
+JS_EXPORT_PRIVATE extern const std::array<Effects, numberOfB3Opcodes> constantEffectsTable;
+
+ALWAYS_INLINE Effects Value::effects() const
+{
+    const Effects& entry = constantEffectsTable[opcode()];
+    if (entry.isValid()) [[likely]]
+        return entry;
+    return effectsSlow();
+}
+
+ALWAYS_INLINE bool Value::mustExecute() const
+{
+    const Effects& entry = constantEffectsTable[opcode()];
+    if (entry.isValid()) [[likely]]
+        return entry.mustExecute();
+    return effectsSlow().mustExecute();
+}
 
 #define DISPATCH_ON_KIND(MACRO) \
     switch (kind().opcode()) { \

--- a/Source/WTF/wtf/Range.h
+++ b/Source/WTF/wtf/Range.h
@@ -41,26 +41,21 @@ template<typename PassedType>
 class Range {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Range);
 public:
-    typedef PassedType Type;
-    
-    Range()
-        : m_begin(0)
-        , m_end(0)
-    {
-    }
+    using Type = PassedType;
+    constexpr Range() = default;
 
-    explicit Range(Type value)
+    explicit constexpr Range(Type value)
         : m_begin(value)
         , m_end(value + 1)
     {
-        ASSERT(m_end >= m_begin);
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(m_end >= m_begin);
     }
 
-    Range(Type begin, Type end)
+    constexpr Range(Type begin, Type end)
         : m_begin(begin)
         , m_end(end)
     {
-        ASSERT(m_end >= m_begin);
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(m_end >= m_begin);
         if (m_begin == m_end) {
             // Canonicalize empty ranges.
             m_begin = 0;
@@ -68,14 +63,14 @@ public:
         }
     }
 
-    static Range top()
+    static constexpr Range top()
     {
         return Range(std::numeric_limits<Type>::min(), std::numeric_limits<Type>::max());
     }
 
     friend bool operator==(const Range&, const Range&) = default;
 
-    explicit operator bool() const { return m_begin != m_end; }
+    explicit constexpr operator bool() const { return m_begin != m_end; }
 
     Range operator|(const Range& other) const
     {
@@ -126,8 +121,8 @@ public:
     }
 
 private:
-    Type m_begin;
-    Type m_end;
+    Type m_begin { 0 };
+    Type m_end { 0 };
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/TriState.h
+++ b/Source/WTF/wtf/TriState.h
@@ -35,12 +35,12 @@ enum class TriState : uint8_t {
     Indeterminate
 };
 
-inline TriState triState(bool boolean)
+inline constexpr TriState triState(bool boolean)
 {
     return static_cast<TriState>(boolean);
 }
 
-inline TriState invert(TriState triState)
+inline constexpr TriState invert(TriState triState)
 {
     if (triState == TriState::True)
         return TriState::False;


### PR DESCRIPTION
#### 402df7467548a870a413dc3d999169dbb2a1519b
<pre>
[JSC] B3::Value::effects should use constant table
<a href="https://bugs.webkit.org/show_bug.cgi?id=317330">https://bugs.webkit.org/show_bug.cgi?id=317330</a>
<a href="https://rdar.apple.com/179957480">rdar://179957480</a>

Reviewed by Dan Hecht and Keith Miller.

We are frequently running B3::Value::effects(), but most of effects are
constant based on opcode. This patch introduces constexpr table which can quickly
generate the effects if it is not relying on the Value&apos;s content.

* Source/JavaScriptCore/b3/B3Effects.h:
(JSC::B3::Effects::none):
(JSC::B3::Effects::forCall):
(JSC::B3::Effects::forCheck):
(JSC::B3::Effects::mustExecute const):
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
* Source/JavaScriptCore/b3/B3EliminateDeadCode.cpp:
(JSC::B3::eliminateDeadCodeImpl):
* Source/JavaScriptCore/b3/B3Kind.h:
(JSC::B3::Kind::Kind):
(JSC::B3::Kind::hasTraps const):
* Source/JavaScriptCore/b3/B3StackmapGenerationParams.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effectsSlow const):
(JSC::B3::Value::effects const): Deleted.
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
(JSC::B3::constantEffectsForOpcode):
(JSC::B3::=):
(JSC::B3::constantEffectsTableIsTrapSafe):
(JSC::B3::Value::effects const):
(JSC::B3::Value::mustExecute const):
* Source/WTF/wtf/Range.h:
(WTF::Range::Range):
(WTF::Range::top):
(WTF::Range::operator bool const):
* Source/WTF/wtf/TriState.h:
(WTF::triState):
(WTF::invert):

Canonical link: <a href="https://commits.webkit.org/315420@main">https://commits.webkit.org/315420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4622cc6868b8b5a4a6d9a4d7f85a97d5fdaf4807

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178297 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126655 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9abf22fd-148a-42a5-b199-9f7c74dc5577) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42889 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42490 "Hash 4622cc68 for PR 67366 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131556 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8230f13-70de-4089-a19d-87d8d390d781) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112060 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f967a10-9a11-47bd-a975-bc64c8fd7534) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/42490 "Hash 4622cc68 for PR 67366 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27000 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/249 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180899 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30199 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33610 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/42490 "Hash 4622cc68 for PR 67366 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140005 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42522 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139848 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43211 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25750 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35132 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114976 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201623 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41720 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6291 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54119 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41114 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41369 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->