### PR TITLE
Prevent untrusted image data from reaching ImageIO codec dispatch via WebExtension icon loading

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -634,6 +634,9 @@
 /* WKWebExtensionErrorInvalidActionIcon description for failing to load single image for browser_action or page_action */
 "Failed to load image for `default_icon` in the `browser_action` or `page_action` manifest entry." = "Failed to load image for `default_icon` in the `browser_action` or `page_action` manifest entry.";
 
+/* WKWebExtensionErrorInvalidManifestEntry description for icon with unsupported image format */
+"Failed to load image for path “%@”. The image is not in a supported format." = "Failed to load image for path “%@”. The image is not in a supported format.";
+
 /* WKWebExtensionErrorInvalidActionIcon description for failing to load images for action only */
 "Failed to load images in `default_icon` for the `action` manifest entry." = "Failed to load images in `default_icon` for the `action` manifest entry.";
 

--- a/Source/WebKit/Platform/cocoa/CocoaImage.h
+++ b/Source/WebKit/Platform/cocoa/CocoaImage.h
@@ -42,4 +42,8 @@ namespace WebKit {
 RetainPtr<NSData> transcode(CGImageRef, CFStringRef typeIdentifier);
 std::pair<RetainPtr<NSData>, RetainPtr<CFStringRef>> transcodeWithPreferredMIMEType(CGImageRef, CFStringRef preferredMIMEType);
 
+// Decodes a bitmap image from untrusted bytes, restricting ImageIO to the same set of image types
+// supported for web content (WebCore::isSupportedImageType()). Returns nil for any other type.
+RetainPtr<CocoaImage> createCocoaImageRestrictedToSupportedTypes(NSData *, double displayScale = 1);
+
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/CocoaImage.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaImage.mm
@@ -31,6 +31,12 @@
 #import <WebCore/UTIRegistry.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
+#if USE(APPKIT)
+#import <AppKit/AppKit.h>
+#else
+#import <UIKit/UIKit.h>
+#endif
+
 namespace WebKit {
 
 RetainPtr<NSData> transcode(CGImageRef image, CFStringRef typeIdentifier)
@@ -57,6 +63,31 @@ std::pair<RetainPtr<NSData>, RetainPtr<CFStringRef>> transcodeWithPreferredMIMET
     }
 
     return { nil, nil };
+}
+
+RetainPtr<CocoaImage> createCocoaImageRestrictedToSupportedTypes(NSData *data, double displayScale)
+{
+    if (!data.length)
+        return nil;
+
+    RetainPtr imageSource = adoptCF(CGImageSourceCreateWithData((__bridge CFDataRef)data, nullptr));
+    if (!imageSource)
+        return nil;
+
+    RetainPtr type = CGImageSourceGetType(imageSource.get());
+    if (!type || !WebCore::isSupportedImageType(type.get()))
+        return nil;
+
+    RetainPtr image = adoptCF(CGImageSourceCreateImageAtIndex(imageSource.get(), 0, nullptr));
+    if (!image)
+        return nil;
+
+#if USE(APPKIT)
+    UNUSED_PARAM(displayScale);
+    return adoptNS([[NSImage alloc] initWithCGImage:image.get() size:NSZeroSize]);
+#else
+    return retainPtr([UIImage imageWithCGImage:image.get() scale:displayScale orientation:UIImageOrientationUp]);
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -33,6 +33,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "CocoaHelpers.h"
+#import "CocoaImage.h"
 #import "FoundationSPI.h"
 #import "Logging.h"
 #import "WKWebExtensionInternal.h"
@@ -331,22 +332,42 @@ Expected<Ref<WebCore::Icon>, RefPtr<API::Error>> WebExtension::iconForPath(const
 
     CocoaImage *result;
 
-#if !USE(APPKIT)
     auto imageType = resourceMIMETypeForPath(imagePath);
     if (equalLettersIgnoringASCIICase(imageType, "image/svg+xml"_s)) {
+#if USE(APPKIT)
+        // The CGImageSource-backed helper below (called createCocoaImageRestrictedToSupportedTypes)
+        // only decodes bitmap formats, not vector SVG, so handle SVG separately here.
+        // This mirrors the existing iOS path below, which decodes SVG via CoreSVG.
+        if (Class svgImageRepClass = NSClassFromString(@"_NSSVGImageRep")) {
+            RetainPtr<NSImageRep> svgImageRep = adoptNS((NSImageRep *)[[svgImageRepClass alloc] initWithData:imageData]);
+            if (svgImageRep && !NSEqualSizes([svgImageRep size], NSZeroSize)) {
+                result = [[NSImage alloc] initWithSize:[svgImageRep size]];
+                [result addRepresentation:svgImageRep.get()];
+            }
+        }
+#else
         RetainPtr document = adoptCF(CGSVGDocumentCreateFromData(bridge_cast(imageData), nullptr));
         if (!document)
             return makeUnexpected(nullptr);
 
-        // Since we need to rasterize, scale the image for the densest display, so it will have enough pixels to be sharp.
-        result = [UIImage _imageWithCGSVGDocument:document.get() scale:displayScale orientation:UIImageOrientationUp];
+
+        // Since we need to rasterize, scale the image for the highest density display, so it will have enough pixels to be sharp.
+        result = [UIImage _imageWithCGSVGDocument:document scale:displayScale orientation:UIImageOrientationUp];
+#endif
     }
-#endif // !USE(APPKIT)
+
+    if (!result) {
+#if USE(APPKIT)
+        result = createCocoaImageRestrictedToSupportedTypes(imageData).autorelease();
+#else
+        result = createCocoaImageRestrictedToSupportedTypes(imageData, displayScale).autorelease();
+#endif
+    }
+
+    if (!result)
+        return makeUnexpected(createError(Error::InvalidIcon, WEB_UI_FORMAT_CFSTRING("Failed to load image for path “%@”. The image is not in a supported format.", "WKWebExtensionErrorInvalidManifestEntry description for icon with unsupported image format", bridge_cast(imagePath.createNSString().get()))));
 
 #if USE(APPKIT)
-    if (!result)
-        result = [[CocoaImage alloc] initWithData:imageData];
-
     if (!sizeForResizing.isZero()) {
         // Proportionally scale the size.
         auto originalSize = result.size;
@@ -356,25 +377,26 @@ Expected<Ref<WebCore::Icon>, RefPtr<API::Error>> WebExtension::iconForPath(const
 
         result.size = WebCore::FloatSize(originalSize.width * aspectRatio, originalSize.height * aspectRatio);
     }
-
-    if (RefPtr iconResult = WebCore::Icon::create(result))
-        return iconResult.releaseNonNull();
-    return makeUnexpected(nullptr);
 #else
-    if (!result)
-        result = [[CocoaImage alloc] initWithData:imageData scale:displayScale];
-
     // Rasterization is needed because UIImageAsset will not register the image unless it is a CGImage.
     // If the image is already a CGImage bitmap, this operation is a no-op.
     result = result._rasterizedImage;
 
-    if (!sizeForResizing.isZero() && WebCore::FloatSize(result.size) != sizeForResizing)
-        result = [result imageByPreparingThumbnailOfSize:sizeForResizing];
+    if (!sizeForResizing.isZero() && WebCore::FloatSize(result.size) != sizeForResizing) {
+        auto *rendererFormat = [[UIGraphicsImageRendererFormat alloc] init];
+        rendererFormat.scale = displayScale;
+        rendererFormat.opaque = NO;
+
+        auto *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:sizeForResizing format:rendererFormat];
+        result = [renderer imageWithActions:^(UIGraphicsImageRendererContext *) {
+            [result drawInRect:CGRectMake(0, 0, sizeForResizing.width(), sizeForResizing.height())];
+        }];
+    }
+#endif
 
     if (RefPtr iconResult = WebCore::Icon::create(result))
         return iconResult.releaseNonNull();
     return makeUnexpected(nullptr);
-#endif // not USE(APPKIT)
 }
 
 RefPtr<WebCore::Icon> WebExtension::bestIcon(RefPtr<JSON::Object> icons, WebCore::FloatSize idealSize, NOESCAPE const Function<void(Ref<API::Error>)>& reportError)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
@@ -344,6 +344,71 @@ TEST(WKWebExtension, IconErrorsOnce)
     EXPECT_EQ(testExtension.errors.count, 4u);
 }
 
+TEST(WKWebExtension, IconsWithUnsupportedFormatsAreRejected)
+{
+    static constexpr uint8_t photoshopBytes[] = {
+        '8', 'B', 'P', 'S', 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00,
+        0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x08, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00
+    };
+
+    auto *photoshopData = [NSData dataWithBytes:photoshopBytes length:sizeof(photoshopBytes)];
+    auto *photoshopDataURL = [@"data:image/png;base64," stringByAppendingString:[photoshopData base64EncodedStringWithOptions:0]];
+
+    auto *testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"version": @"1.0",
+        @"description": @"Test",
+        @"icons": @{ @"128": @"icon-128.psd" },
+        @"action": @{ @"default_icon": @{ @"128": photoshopDataURL } }
+    };
+
+    auto *resources = @{ @"icon-128.psd": photoshopData };
+
+    auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
+    EXPECT_NULL([testExtension iconForSize:CGSizeMake(128, 128)]);
+    EXPECT_NULL([testExtension actionIconForSize:CGSizeMake(128, 128)]);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, WKWebExtensionErrorInvalidManifestEntry));
+
+    // The MIME type derived from the icon path must not allow bypassing the format restriction.
+    testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"version": @"1.0",
+        @"description": @"Test",
+        @"icons": @{ @"128": @"icon-128.svg" }
+    };
+
+    resources = @{ @"icon-128.svg": photoshopData };
+
+    testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
+    EXPECT_NULL([testExtension iconForSize:CGSizeMake(128, 128)]);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, WKWebExtensionErrorInvalidManifestEntry));
+}
+
+TEST(WKWebExtension, SVGIconViaIconsKeyLoads)
+{
+    // A real SVG supplied through the plain `icons` key must still decode (via the dedicated SVG
+    // path), not be rejected by the bitmap allow-list. This is the positive companion to
+    // IconsWithUnsupportedFormatsAreRejected.
+    auto *iconSVG = @"<svg width='100' height='100' xmlns='http://www.w3.org/2000/svg'><circle cx='50' cy='50' r='50' fill='white' /></svg>";
+
+    auto *testManifestDictionary = @{
+        @"manifest_version": @3,
+        @"name": @"Test",
+        @"version": @"1.0",
+        @"description": @"Test",
+        @"icons": @{ @"128": @"icon-128.svg" }
+    };
+
+    auto *resources = @{ @"icon-128.svg": iconSVG };
+
+    auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
+    EXPECT_NOT_NULL([testExtension iconForSize:CGSizeMake(128, 128)]);
+    EXPECT_NULL(matchingError(testExtension.errors, WKWebExtensionErrorInvalidManifestEntry));
+}
+
 TEST(WKWebExtension, SymbolImageIcon)
 {
     auto *testManifestDictionary = @{


### PR DESCRIPTION
#### b9c7a1bf56857f208d51df25317dbbf9501cdd21
<pre>
Prevent untrusted image data from reaching ImageIO codec dispatch via WebExtension icon loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=316858">https://bugs.webkit.org/show_bug.cgi?id=316858</a>
<a href="https://rdar.apple.com/177404759">rdar://177404759</a>

Reviewed by Timothy Hatcher.

If an attacker provides a WebExtension icon, they can control which image decoder
gets run and can run exotic, untrusted image decoders in the UIProcess.
The attacker can change the first few magic bytes of an image to trigger a specific
image decoder to be parsed.

This attack surface is exposed via [NSImage initWithData] which reads the first few
magic bytes of an image and dispatches to a specific image decoder. These image
decoders can be for exotic image types (i.e. PSD, OpenEXR, TIFF) which are not
subject to the same security scrutiny that more common decoders are.

The first part of this fix replaces this call to [NSImage initWithData]
with a three stage approach which:
1. Extracts the type of the image with CGImageSourceGetType (CoreGraphics)
2. Check if the type is allowed in WebCore::isSupportedImageType
3. If so, decode it with CGImageSourceCreateImageAtIndex + [NSImage/UImage initWithCGImage]

There is an edge case for SVG, as it is a vector format which doesn&apos;t go through
CoreGraphics (until it is rasterized). Previous to this patch, SVG was handled by
[NSImage initWithData] on macOS and iOS had a dedicated call to [UIImage _imageWithCGSVGDocument].
Now that we are removing the call to [NSImage initWithData], SVG on macOS needs to be
routed elsewhere. I chose to route it through [_NSSVGImageRep initWithData].

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/Platform/cocoa/CocoaImage.h:
* Source/WebKit/Platform/cocoa/CocoaImage.mm:
(WebKit::createCocoaImageRestrictedToSupportedTypes):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::iconForPath):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, IconsWithUnsupportedFormatsAreRejected)):
(TestWebKitAPI::TEST(WKWebExtension, SVGIconViaIconsKeyLoads)):

Canonical link: <a href="https://commits.webkit.org/315453@main">https://commits.webkit.org/315453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88cde26b2296f59cee63f03a210c3dcba4dd1a74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126741 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131632 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112135 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33076 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31780 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27085 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180984 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140081 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42607 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37668 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43296 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107139 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35204 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115061 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41805 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6370 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41342 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->