### PR TITLE
box-shadow for fixed positioned SVG does not draw

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference: box-shadow paints on a position:fixed box</title>
+<style>
+    .shadow-box {
+        width: 100px;
+        height: 100px;
+        box-shadow: 1px 1px 5px 3px #aaaaaa;
+    }
+    .fixed-position {
+        position: fixed;
+        top: 8px;
+        left: 8px;
+    }
+</style>
+<div class="shadow-box fixed-position" style="background: red;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference: box-shadow paints on a position:fixed box</title>
+<style>
+    .shadow-box {
+        width: 100px;
+        height: 100px;
+        box-shadow: 1px 1px 5px 3px #aaaaaa;
+    }
+    .fixed-position {
+        position: fixed;
+        top: 8px;
+        left: 8px;
+    }
+</style>
+<div class="shadow-box fixed-position" style="background: red;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Backgrounds Test: box-shadow paints on a position:fixed SVG root</title>
+<link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#the-box-shadow">
+<link rel="match" href="box-shadow-svg-root-fixed-position-ref.html">
+<meta name="fuzzy" content="maxDifference=0-40;totalPixels=0-2000">
+<style>
+    .shadow-box {
+        width: 100px;
+        height: 100px;
+        box-shadow: 1px 1px 5px 3px #aaaaaa;
+    }
+    .fixed-position {
+        position: fixed;
+        top: 8px;
+        left: 8px;
+    }
+</style>
+<!-- A position:fixed SVG root must still paint its CSS box-shadow. -->
+<svg class="shadow-box fixed-position">
+    <rect x="0" y="0" width="100%" height="100%" fill="red"/>
+</svg>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -245,6 +245,7 @@ void LegacyRenderSVGRoot::layout()
     clearOverflow();
     if (!shouldApplyViewportClip())
         addVisualOverflow(computeContentsInkOverflow());
+    addVisualEffectOverflow();
 
     updateLayerTransform();
     m_hasBoxDecorations = isDocumentElementRenderer() ? hasVisibleBoxDecorationStyle() : hasVisibleBoxDecorations();


### PR DESCRIPTION
#### e0f76d9123e83226599f51f49151cbace4a07b23
<pre>
box-shadow for fixed positioned SVG does not draw
<a href="https://bugs.webkit.org/show_bug.cgi?id=106011">https://bugs.webkit.org/show_bug.cgi?id=106011</a>
<a href="https://rdar.apple.com/97098951">rdar://97098951</a>

Reviewed by Brent Fulgham.

LegacyRenderSVGRoot::layout() never called addVisualEffectOverflow(), so
box-shadow (and border-image, outline, filter outsets) was missing from
the SVG root&apos;s visual overflow. This is harmless in normal flow, but once
position:fixed/absolute makes the SVG a self-painting layer, the layer
clips to its bounds plus visual overflow and the shadow is clipped away.

Add the missing addVisualEffectOverflow() call, mirroring
RenderReplaced::layout().

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-svg-root-fixed-position.html: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::layout):

Canonical link: <a href="https://commits.webkit.org/315468@main">https://commits.webkit.org/315468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f65e70ecd350e9c52c6c2a8d6d844aa808542bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169087 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/42867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126799 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7aeb1cc2-9704-4ac8-a376-27b6a1dcf402) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131684 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/740a733f-73d1-4456-bc1e-1bc525d14d56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34139 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112187 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1bc1a60-eb0d-49ea-83d5-e758e89ae45f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33125 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27143 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181042 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33753 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36000 "Found 1 new test failure: media/media-source/media-source-real-scrub-then-play.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140133 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139975 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43354 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107229 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35252 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115119 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41863 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6429 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41257 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41512 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->