### PR TITLE
[WPE][GTK] Build broken with USE_GSTREAMER=OFF

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -523,8 +523,10 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
             if (!m_contentsBuffer && !m_contentsTiling.size.isEmpty())
                 return true;
 
+#if ENABLE(VIDEO)
             if (is<CoordinatedPlatformLayerBufferHolePunch>(m_contentsBuffer))
                 return true;
+#endif
 
             // FIXME: clip is not correctly applied with batched painting.
             if (!m_contentsClippingRect.rect().contains(m_contentsRect))
@@ -544,6 +546,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
         sk_sp<SkImage> image;
 
         if (m_contentsBuffer) {
+#if ENABLE(VIDEO)
             if (is<CoordinatedPlatformLayerBufferHolePunch>(*m_contentsBuffer)) {
 #if USE(GSTREAMER)
                 TransformationMatrix matrix = canvas.getLocalToDevice();
@@ -553,6 +556,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 paint.setBlendMode(SkBlendMode::kClear);
                 canvas.drawRect(SkRect(m_contentsRect), paint);
             } else
+#endif // ENABLE(VIDEO)
                 image = m_contentsBuffer->skiaImage();
         } else if (auto* buffer = m_imageBackingStore->buffer()) {
             image = buffer->skiaImage();


### PR DESCRIPTION
#### fab6b6f68167e99e838a8c298e23f0454c3d45ac
<pre>
[WPE][GTK] Build broken with USE_GSTREAMER=OFF
<a href="https://bugs.webkit.org/show_bug.cgi?id=317339">https://bugs.webkit.org/show_bug.cgi?id=317339</a>

Reviewed by Nikolas Zimmermann.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintContents): Sprinkle ENABLE(VIDEO)
guards to avoid using CoordinatedPlatformLayerBufferHolePunch when it
would be undeclared.

Canonical link: <a href="https://commits.webkit.org/315455@main">https://commits.webkit.org/315455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2558074c4912f723c173ee816c744a976fdab1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131574 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112077 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31727 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180921 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140021 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42544 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139863 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43233 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28277 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107059 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25766 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35148 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114998 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41742 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6364 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->