### PR TITLE
writeToDisk dereferences a disengaged std::optional when a disk write fails

### DIFF
--- a/Source/WebKit/Shared/PersistencyUtils.cpp
+++ b/Source/WebKit/Shared/PersistencyUtils.cpp
@@ -61,7 +61,7 @@ void writeToDisk(std::unique_ptr<KeyedEncoder>&& encoder, String&& path)
 
     auto writtenBytes = handle.write(rawData->span());
     if (writtenBytes != rawData->size())
-        RELEASE_LOG_ERROR(DiskPersistency, "Disk persistency: We only wrote %" PRIu64 " out of %zu bytes to disk", *writtenBytes, rawData->size());
+        RELEASE_LOG_ERROR(DiskPersistency, "Disk persistency: We only wrote %" PRIu64 " out of %zu bytes to disk", writtenBytes.value_or(0), rawData->size());
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 2ac36ae17d1f1af96b9613399b6843441caf236e
<pre>
writeToDisk dereferences a disengaged std::optional when a disk write fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=317343">https://bugs.webkit.org/show_bug.cgi?id=317343</a>
<a href="https://rdar.apple.com/179966362">rdar://179966362</a>

Reviewed by Pascoe.

FileHandle::write() returns std::optional&lt;uint64_t&gt; and yields std::nullopt on a non-EINTR write
failure. The error path compared `writtenBytes != rawData-&gt;size()` (a disengaged optional never
compares equal, so the branch is taken) and then logged `*writtenBytes`, dereferencing the
disengaged optional. Use writtenBytes.value_or(0).

* Source/WebKit/Shared/PersistencyUtils.cpp:
(WebKit::writeToDisk):

Canonical link: <a href="https://commits.webkit.org/315707@main">https://commits.webkit.org/315707@main</a>
</pre>
