### PR TITLE
[visionOS] Add analytics event call for spatial image controls interactions

### DIFF
--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -27,6 +27,7 @@
 #include "SpatialImageControls.h"
 
 #include "ContainerNodeInlines.h"
+#include "DiagnosticLoggingClient.h"
 #include "DocumentEventLoop.h"
 #include "DocumentPage.h"
 #include "ElementInlines.h"
@@ -40,6 +41,7 @@
 #include "HTMLNames.h"
 #include "HTMLSpanElement.h"
 #include "HTMLStyleElement.h"
+#include "Image.h"
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
 #include "RenderImage.h"
@@ -215,6 +217,29 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
     });
 }
 
+static void logImageControlsInteraction(const HTMLImageElement& imageElement)
+{
+    RefPtr page = imageElement.document().page();
+    if (!page)
+        return;
+
+    // We log image type for analytics as:
+    // Unknown = 0
+    int64_t imageType = 0;
+    if (RefPtr image = imageElement.image()) {
+        // Spatial = 2
+        if (image->isSpatial())
+            imageType = 2;
+        // Panoramic = 1
+        else if (image->isMaybePanoramic())
+            imageType = 1;
+    }
+
+    DiagnosticLoggingClient::ValueDictionary dictionary;
+    dictionary.set("type"_s, imageType);
+    protect(page->diagnosticLoggingClient())->logDiagnosticMessageWithValueDictionary("ImageControlsInteraction"_s, "Safari"_s, dictionary, ShouldSample::No);
+}
+
 bool handleEvent(HTMLElement& element, Event& event)
 {
     if (!isAnyClick(event))
@@ -239,6 +264,7 @@ bool handleEvent(HTMLElement& element, Event& event)
     if (SpatialImageControls::isSpatialImageControlsButtonElement(*target)) {
         RefPtr img = dynamicDowncast<HTMLImageElement>(target->shadowHost());
         img->webkitRequestFullscreen();
+        logImageControlsInteraction(*img);
 
         event.setDefaultHandled();
         return true;


### PR DESCRIPTION
#### c56c1dc7fa8018f017b56f4c5d2d3554feca1564
<pre>
[visionOS] Add analytics event call for spatial image controls interactions
<a href="https://rdar.apple.com/170126778">rdar://170126778</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317344">https://bugs.webkit.org/show_bug.cgi?id=317344</a>

Reviewed by Abrar Rahman Protyasha.

Add Safari analytics log event using `diagnosticLoggingClient` whenever a user interacts with spatial image controls

* Source/WebCore/html/shadow/SpatialImageControls.cpp:
(WebCore::SpatialImageControls::logImageControlsInteraction):
(WebCore::SpatialImageControls::handleEvent):

Canonical link: <a href="https://commits.webkit.org/315498@main">https://commits.webkit.org/315498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9f4ad68b19c178dd820de1b651d25c3cf9db385

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42940 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42541 "Hash d9f4ad68 for PR 67383 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131601 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92588 "2 flakes 12 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112104 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33045 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/42541 "Hash d9f4ad68 for PR 67383 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180950 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33661 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/42541 "Hash d9f4ad68 for PR 67383 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140049 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42573 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139891 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37692 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43262 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28249 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107088 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35169 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115027 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41771 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6336 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41165 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->