### PR TITLE
[LBSE] Switch layer-composition-inducing SVG transform attribute changes to a style recalc

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2893,6 +2893,13 @@ void Document::updateSVGRenderer(SVGElement& element, Style::SVGRendererUpdateTy
     // true and force a resolveStyle pass every animation frame.
     if (kind == Style::SVGRendererUpdateType::TransformAttributeOnly) {
         if (CheckedPtr layerRenderer = dynamicDowncast<RenderLayerModelObject>(element.renderer())) {
+            // A transform attribute crossing the identity boundary flips requiresLayer() for a
+            // transformable container, and layers are only created or destroyed in styleDidChange, so
+            // route the crossing through a style recalc, but only when really necessary.
+            if (layerRenderer->svgTransformAttributeChangeInducesLayerComposition()) {
+                element.invalidateStyleAndLayerComposition();
+                return;
+            }
             if (RefPtr frameView = view())
                 frameView->layoutContext().addPendingSVGTransformAttributeUpdate(*layerRenderer);
         }

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -698,6 +698,17 @@ bool RenderLayerModelObject::pointInSVGClippingArea(const FloatPoint& point) con
     );
 }
 
+bool RenderLayerModelObject::svgTransformAttributeChangeInducesLayerComposition()
+{
+    // True when a just-parsed SVG transform attribute flips whether this transformable
+    // container needs, so the change must create or destroy one.
+    if (!isRenderSVGTransformableContainer())
+        return false;
+    // requiresLayer() reads the cached hasSVGTransform() flag - so make sure it's not stale.
+    updateHasSVGTransformFlags();
+    return requiresLayer() != hasLayer();
+}
+
 void RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange(SVGAttributeChangeRepaintMode repaintMode)
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
@@ -706,6 +717,7 @@ void RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange
 
     // A layer is neither created nor destroyed below, so probe it once up front.
     const bool isLayered = hasLayer();
+    ASSERT(!isRenderSVGTransformableContainer() || requiresLayer() == isLayered);
 
     // Refresh the transform, returning the (previous, current) pair. For layered renderers this
     // forces a stacking context on an identity-to-non-identity transition (the batched flush skips

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -106,6 +106,7 @@ public:
         Defer
     };
     void updateTransformAndRepaintForSVGAfterAttributeChange(SVGAttributeChangeRepaintMode = SVGAttributeChangeRepaintMode::Issue);
+    bool svgTransformAttributeChangeInducesLayerComposition();
 
     LayoutPoint nominalSVGLayoutLocation() const { return flooredLayoutPoint(objectBoundingBoxWithoutTransformations().minXMinYCorner()); }
     virtual LayoutPoint currentSVGLayoutLocation() const { ASSERT_NOT_REACHED(); return { }; }


### PR DESCRIPTION
#### 320ef0cb7251585b522489eb1302c331bab790de
<pre>
[LBSE] Switch layer-composition-inducing SVG transform attribute changes to a style recalc
<a href="https://bugs.webkit.org/show_bug.cgi?id=317348">https://bugs.webkit.org/show_bug.cgi?id=317348</a>

Reviewed by Rob Buis.

Once layer creation becomes conditional, a transform attribute that crosses the
identity boundary flips requiresLayer() for a transformable container. Layers are
only created or destroyed in styleDidChange, so route that crossing through
invalidateStyleAndLayerComposition() instead of the layer-neutral transform fast
path -&gt; the common non-crossing case keeps the fast path so animations do not
resolve style every frame. Preparation for conditional SVG layer creation - does
not effect current LBSE, while every SVG renderer still gets a layer.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateSVGRenderer):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::svgTransformAttributeChangeInducesLayerComposition):
(WebCore::RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange):
* Source/WebCore/rendering/RenderLayerModelObject.h:

Canonical link: <a href="https://commits.webkit.org/315458@main">https://commits.webkit.org/315458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2678e2623afe8d49ca9ea7018da5e6b879cd3896

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131590 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33030 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31742 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27035 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180934 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140038 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42557 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139880 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43246 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28239 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107072 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25768 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35160 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115011 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41755 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6326 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->