### PR TITLE
[

### DIFF
--- a/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt
+++ b/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt
@@ -1,0 +1,4 @@
+
+PASS traversals in the same (back) direction: coalesced
+PASS traversals in the same (forward) direction: coalesced
+

--- a/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html
+++ b/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html
@@ -1,0 +1,95 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UseUIProcessForBackForwardItemLoading=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Same-document traversals during cross-document traversals</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!--
+  This case is not significantly different from
+  cross-document-traversal-cross-document-traversal.html.
+-->
+
+<body>
+<script type="module">
+import { createIframe, waitForLoad, waitForHashchange, delay, waitForPotentialNetworkLoads } from "./resources/helpers.mjs";
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+
+  // Setup
+  // Extra delay()s are necessary because if we navigate "inside" the load
+  // handler (i.e. in a promise reaction for the load handler) then it will
+  // be a replace navigation.
+  iframe.contentWindow.location.search = "?1";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.hash = "#2";
+  await waitForHashchange(iframe.contentWindow);
+  iframe.contentWindow.location.search = "?3";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+
+  iframe.contentWindow.history.back();
+  assert_equals(iframe.contentWindow.location.search, "?3", "must not go back synchronously 1 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "#2", "must not go back synchronously 1 (hash)");
+
+  iframe.contentWindow.history.back();
+  assert_equals(iframe.contentWindow.location.search, "?3", "must not go back synchronously 2 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "#2", "must not go back synchronously 2 (hash)");
+
+  await waitForLoad(iframe);
+  assert_equals(iframe.contentWindow.location.search, "?1", "first load event must be going back (search)");
+  assert_equals(iframe.contentWindow.location.hash, "", "first load event must be going back (hash)");
+
+  iframe.contentWindow.onhashchange = t.unreached_func("hashchange event");
+  iframe.onload = t.unreached_func("second load event");
+
+  await waitForPotentialNetworkLoads(t);
+  assert_equals(iframe.contentWindow.location.search, "?1", "must stay on ?1 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "", "must stay on ?1 (hash)");
+}, "traversals in the same (back) direction: coalesced");
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+
+  // Setup
+  // Extra delay()s are necessary because if we navigate "inside" the load
+  // handler (i.e. in a promise reaction for the load handler) then it will
+  // be a replace navigation.
+  iframe.contentWindow.location.search = "?1";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.search = "?2";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.hash = "#3";
+  await waitForHashchange(iframe.contentWindow);
+  iframe.contentWindow.history.back();
+  await waitForHashchange(iframe.contentWindow);
+  assert_equals(iframe.contentWindow.location.hash, "", "we made our way to ?2 for setup");
+  iframe.contentWindow.history.back();
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  assert_equals(iframe.contentWindow.location.search, "?1", "we made our way to ?1 for setup");
+
+  iframe.contentWindow.history.forward();
+  assert_equals(iframe.contentWindow.location.search, "?1", "must not go forward synchronously 1 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "", "must not go forward synchronously 1 (hash)");
+
+  iframe.contentWindow.history.forward();
+  assert_equals(iframe.contentWindow.location.search, "?1", "must not go forward synchronously 2 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "", "must not go forward synchronously 2 (hash)");
+
+  await waitForLoad(iframe);
+  assert_equals(iframe.contentWindow.location.search, "?2", "first load event must be going forward (search)");
+  assert_equals(iframe.contentWindow.location.hash, "#3", "first load event must be going forward (hash)");
+
+  iframe.contentWindow.onhashchange = t.unreached_func("hashchange event");
+  iframe.onload = t.unreached_func("second load event");
+
+  await waitForPotentialNetworkLoads(t);
+  assert_equals(iframe.contentWindow.location.search, "?2", "must stay on ?2");
+  assert_equals(iframe.contentWindow.location.hash, "#3", "must stay on ?2");
+}, "traversals in the same (forward) direction: coalesced");
+</script>

--- a/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/resources/helpers.mjs
+++ b/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/resources/helpers.mjs
@@ -1,0 +1,52 @@
+export function createIframe(t) {
+  return new Promise((resolve, reject) => {
+    const iframe = document.createElement("iframe");
+    iframe.onload = () => resolve(iframe);
+    iframe.onerror = () => reject(new Error("Could not load iframe"));
+    iframe.src = "/common/blank.html";
+
+    t.add_cleanup(() => iframe.remove());
+    document.body.append(iframe);
+  });
+}
+
+export function delay(t, ms) {
+  return new Promise(resolve => t.step_timeout(resolve, ms));
+}
+
+export function waitForLoad(obj) {
+  return new Promise(resolve => {
+    obj.addEventListener("load", resolve, { once: true });
+  });
+}
+
+export function waitForHashchange(obj) {
+  return new Promise(resolve => {
+    obj.addEventListener("hashchange", resolve, { once: true });
+  });
+}
+
+export function waitForPopstate(obj) {
+  return new Promise(resolve => {
+    obj.addEventListener("popstate", resolve, { once: true });
+  });
+}
+
+// This is used when we want to end the test by asserting some load doesn't
+// happen, but we're not sure how long to wait. We could just wait a long-ish
+// time (e.g. a second), but that makes the tests slow. Instead, assume that
+// network loads take roughly the same time. Then, you can use this function to
+// wait a small multiple of the duration of a separate iframe load; this should
+// be long enough to catch any problems.
+export async function waitForPotentialNetworkLoads(t) {
+  const before = performance.now();
+
+  // Sometimes we're doing something, like a traversal, which cancels our first
+  // attempt at iframe loading. In that case we bail out after 100 ms and try
+  // again. (Better ideas welcome...)
+  await Promise.race([createIframe(t), delay(t, 100)]);
+  await createIframe(t);
+
+  const after = performance.now();
+  await delay(t, after - before);
+}

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/001-expected.txt
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/001-expected.txt
@@ -1,0 +1,51 @@
+WARNING: This test should always be loaded in a new tab/window, to avoid browsers attempting to recover the state of frames, and history length. Do not reload the test.
+
+Running test...
+
+PASS history.length should update when loading pages in an iframe
+PASS history.length should update when setting location.hash
+PASS history.pushState must exist
+PASS history.pushState must exist within iframes
+PASS initial history.state should be null
+PASS history.length should update when pushing a state
+PASS history.state should update after a state is pushed
+PASS history.length should not decrease after going back
+PASS traversing history must traverse pushed states
+PASS traversing history must also traverse hash changes
+PASS pushState must not be allowed to create invalid URLs
+PASS pushState must not be allowed to create cross-origin URLs
+PASS pushState must not be allowed to create cross-origin URLs (about:blank)
+PASS pushState must not be allowed to create cross-origin URLs (data:URI)
+PASS security errors are expected to be thrown in the context of the document that owns the history object
+PASS location.hash must be allowed to change (part 1)
+PASS location.hash must be allowed to change (part 2)
+PASS pushState must not alter location.hash when no URL is provided
+PASS pushState must remove all history after the current state
+PASS pushState must be able to set location.hash
+FAIL pushState must remove any tasks queued by the history traversal task source assert_equals: expected "test4" but got "test"
+PASS pushState must not fire hashchange events
+PASS pushState must be able to set location.pathname
+PASS pushState must be able to set absolute URLs to the same host
+PASS pushState must not be able to use a function as data
+PASS pushState must not be able to use a DOM node as data
+PASS pushState must be able to use an error object as data
+PASS security errors are expected to be thrown in the context of the document that owns the history object (2)
+PASS pushState must be able to make structured clones of complex objects
+PASS history.state should also reference a clone of the original object
+PASS history.state should be a clone of the original object, not a reference to it
+PASS popstate event should fire when navigation occurs
+PASS popstate event should pass the state data
+PASS state data should cope with circular object references
+PASS state data should be a clone of the original object, not a reference to it
+PASS history.state should also reference a clone of the original object (2)
+PASS history.state should be a clone of the original object, not a reference to it (2)
+PASS history.state should be identical to the object passed to the event handler unless history.state is updated
+PASS pushState should not actually load the new URL
+PASS reloading a pushed state should actually load the new URL
+
+
+
+
+
+
+

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/001.html
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/001.html
@@ -1,0 +1,340 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UseUIProcessForBackForwardItemLoading=true ] -->
+<!doctype html>
+<html>
+    <head>
+        <title>history.pushState tests</title>
+        <script type="text/javascript" src="/resources/testharness.js"></script>
+        <script type="text/javascript" src="/resources/testharnessreport.js"></script>
+        <script type="text/javascript">
+//does not test for firing of popstate onload, because this was dropped from the specification on 25 March 2011
+//covers history.state after load, in accordance with the specification draft from 25 March 2011
+//history.state before load is tested in 006 and 007
+//does not test for structured cloning of FileList, File or Blob interfaces, as these require manual file selection
+
+//**This test assumes that assignments to location.hash will be synchronous - this is how all browsers implement it.
+//The spec (as of 25 March 2011) disagrees.**//
+
+var histlength, atstep = 0, lasttimer;
+setup({explicit_done:true}); //tests should take under 6 seconds + execution time
+
+window.onload = function () {
+    if( location.protocol == 'file:' ) {
+        document.getElementsByTagName('p')[0].innerHTML = 'ERROR: This test cannot be run from file: (URL resolving will not work). It must be loaded over HTTP.';
+        return;
+    } else if( location.protocol == 'https:' ) {
+        document.getElementsByTagName('p')[0].innerHTML += '<br>WARNING: Browsers may intentionally fail to update history.length when pages are loaded over HTTPS, as a privacy restriction. If possible, load this page over HTTP.';
+    }
+    //use a timeout, because some browsers intentionally do not add history entries for URL changes in the onload thread
+    setTimeout(testinit,100);
+};
+function testinit() {
+    atstep = 1;
+    histlength = history.length;
+    iframe = document.getElementsByTagName('iframe')[0].src = 'resources/blank2.html';
+    //reportload will now be called by the onload handler for the iframe
+}
+function reportload() {
+    var iframe = document.getElementsByTagName('iframe')[0], hashchng = false;
+    var canvassup = false, cloneobj;
+
+    function tests1() {
+        //Firefox may fail when reloading, because it recovers iframe state, and therefore does not see the need to alter history length
+        test(function () { assert_equals( history.length, histlength + 1, 'make sure that you loaded the test in a new tab/window' ); }, 'history.length should update when loading pages in an iframe');
+        histlength = history.length;
+        iframe.contentWindow.location.hash = 'test'; //should be synchronous **SEE COMMENT AT TOP OF FILE
+        test(function () {
+            assert_equals( history.length, histlength + 1, 'make sure that you loaded the test in a new tab/window' );
+        }, 'history.length should update when setting location.hash');
+        test(function () { assert_true( !!history.pushState, 'critical test; ignore any failures after this' ); }, 'history.pushState must exist'); //assert_own_property does not allow prototype inheritance
+        test(function () { assert_true( !!iframe.contentWindow.history.pushState, 'critical test; ignore any failures after this' ); }, 'history.pushState must exist within iframes');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state, null );
+        }, 'initial history.state should be null');
+        test(function () {
+            histlength = history.length;
+            iframe.contentWindow.history.pushState('','');
+            assert_equals( history.length, histlength + 1 );
+        }, 'history.length should update when pushing a state');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state, '' );
+        }, 'history.state should update after a state is pushed');
+        histlength = history.length;
+        iframe.contentWindow.addEventListener("popstate", tests2, {once: true});
+        history.back();
+    }
+    function tests2() {
+        test(function () {
+            assert_equals( history.length, histlength );
+        }, 'history.length should not decrease after going back');
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test' );
+        }, 'traversing history must traverse pushed states');
+        iframe.contentWindow.addEventListener("hashchange", tests3, {once: true});
+        history.go(-1);
+    }
+    function tests3() {
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), '', '(this could cause other failures later on)' );
+        }, 'traversing history must also traverse hash changes');
+
+        iframe.contentWindow.addEventListener("hashchange", tests4, {once: true});
+        //Safari 5.0.3 fails here - it navigates *this* document to the *iframe's* location, instead of just navigating the iframe
+        history.go(2);
+    }
+    async function tests4() {
+        test(function () {
+            //Firefox 4 beta 11 has a messed up error object, which does not have the right error type or .SECURITY_ERR property
+            assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','//exa mple'); });
+        }, 'pushState must not be allowed to create invalid URLs');
+        test(function () {
+            assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','http://www.example.com/'); });
+        }, 'pushState must not be allowed to create cross-origin URLs');
+        test(function () {
+            assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','about:blank'); });
+        }, 'pushState must not be allowed to create cross-origin URLs (about:blank)');
+        test(function () {
+            assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','data:text/html,'); });
+        }, 'pushState must not be allowed to create cross-origin URLs (data:URI)');
+        test(function () {
+            assert_throws_dom('SECURITY_ERR', iframe.contentWindow.DOMException, function () { iframe.contentWindow.history.pushState('','','http://www.example.com/'); });
+        }, 'security errors are expected to be thrown in the context of the document that owns the history object');
+        let hashchange =
+          new Promise(function (resolve) {
+            iframe.contentWindow.addEventListener("hashchange", resolve, {once: true});
+          });
+
+        test(function () {
+            iframe.contentWindow.location.hash = 'test2';
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test2', 'location.hash did not change when told to' );
+        }, 'location.hash must be allowed to change (part 1)');
+        await hashchange;
+        history.go(-1);
+        iframe.contentWindow.addEventListener("hashchange", tests5, {once: true});
+    }
+    function tests5() {
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test', 'location.hash did not change when going back' );
+        }, 'location.hash must be allowed to change (part 2)');
+        test(function () {
+            iframe.contentWindow.history.pushState('','');
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test', 'location.hash changed when an unrelated state was pushed' );
+        }, 'pushState must not alter location.hash when no URL is provided');
+        history.go(1); //should do nothing, since the pushState should have removed the forward history
+        setTimeout(tests6,50); //.go is queued to end of thread
+    }
+    function tests6() {
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test' );
+        }, 'pushState must remove all history after the current state');
+        test(function () {
+            iframe.contentWindow.history.pushState('','','#test3');
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test3' );
+        }, 'pushState must be able to set location.hash');
+        //begin setup for "remove any tasks queued by the history traversal task source"
+        iframe.contentWindow.location.hash = '#test4';
+        iframe.contentWindow.history.go(-1); //must be queued
+        try {
+            //must remove the queued navigation in the same browsing context
+            iframe.contentWindow.history.pushState('','');
+        } catch(unsuperr) {}
+        //allow the browser to mistakenly run the .go if it is going to
+        //do not put two .go commands in the same thread, in case the browser mistakenly calculates the history position when
+        //calling .go instead of when executing the traversal task - that could give a false PASS in the next test otherwise
+        setTimeout(tests7,50);
+    }
+    function tests7() {
+        iframe.contentWindow.history.go(-1); //must be queued, but should not be removed this time
+        iframe.contentWindow.addEventListener("popstate", tests8, {once: true});
+    }
+    function tests8() {
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test4' );
+        }, 'pushState must remove any tasks queued by the history traversal task source');
+        //end "remove any tasks queued by the history traversal task source"
+        window.addEventListener('hashchange',function () { hashchng = true; },false);
+        try {
+            //push a state that changes the hash
+            iframe.contentWindow.history.pushState('','',iframe.contentWindow.location.pathname+'#test5');
+        } catch(unsuperr) {}
+        setTimeout(tests9,50); //allow the hashchange event to process, if the browser has mistakenly fired it
+    }
+    function tests9() {
+        test(function () {
+            assert_false( hashchng );
+        }, 'pushState must not fire hashchange events');
+        test(function () {
+            iframe.contentWindow.history.pushState('','','/testing_ignore_me_404');
+            assert_equals( iframe.contentWindow.location.pathname, '/testing_ignore_me_404' );
+        }, 'pushState must be able to set location.pathname');
+        test(function () {
+            var newURL = location.href.replace(/\/[^\/]*$/)+'/testing_ignore_me_404/';
+            iframe.contentWindow.history.pushState('','',newURL);
+            assert_equals( iframe.contentWindow.location.href, newURL );
+        }, 'pushState must be able to set absolute URLs to the same host');
+        test(function () {
+            assert_throws_dom( 'DATA_CLONE_ERR', function () {
+                history.pushState({dummy:function () {}},'');
+            } );
+        }, 'pushState must not be able to use a function as data');
+        test(function () {
+            assert_throws_dom( 'DATA_CLONE_ERR', function () {
+                history.pushState({dummy:window},'');
+            } );
+        }, 'pushState must not be able to use a DOM node as data');
+        test(function () {
+            try { a.b = c; } catch(errdata) {
+                history.pushState({dummy:errdata},'');
+                assert_equals(ReferenceError.prototype, Object.getPrototypeOf(history.state.dummy));
+            }
+        }, 'pushState must be able to use an error object as data');
+        test(function () {
+            assert_throws_dom('DATA_CLONE_ERR', iframe.contentWindow.DOMException, function () {
+                iframe.contentWindow.history.pushState(document,'');
+            });
+        }, 'security errors are expected to be thrown in the context of the document that owns the history object (2)');
+        cloneobj = {
+            nulldata: null,
+            udefdata: window.undefined,
+            booldata: true,
+            numdata: 1,
+            strdata: 'string data',
+            boolobj: new Boolean(true),
+            numobj: new Number(1),
+            strobj: new String('string data'),
+            datedata: new Date(),
+            regdata: /a/g,
+            arrdata: [1]
+        };
+        cloneobj.regdata.lastIndex = 1;
+        cloneobj.looped = cloneobj;
+        //test the ImageData type, if the browser supports it
+        var canvas = document.createElement('canvas');
+        if( canvas.getContext && ( canvas = canvas.getContext('2d') ) && canvas.createImageData ) {
+            canvassup = true;
+            cloneobj.imgdata = canvas.createImageData(1,1);
+        }
+        test(function () {
+            try {
+                iframe.contentWindow.history.pushState(cloneobj,'new title');
+            } catch(e) {
+                cloneobj.looped = null;
+                //try again because this object is needed for future tests
+                iframe.contentWindow.history.pushState(cloneobj,'new title');
+                //rethrow so the browser gets a FAIL for not coping with the circular reference; "internal structured cloning algorithm" step 1
+                throw(e);
+            }
+        }, 'pushState must be able to make structured clones of complex objects');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state && iframe.contentWindow.history.state.strdata, 'string data' );
+        }, 'history.state should also reference a clone of the original object');
+        test(function () {
+            assert_not_equals( cloneobj, iframe.contentWindow.history.state );
+        }, 'history.state should be a clone of the original object, not a reference to it');
+        /*
+        behaviour is not defined per spec, and no known implementations do this
+        test(function () {
+            assert_equals( iframe.contentDocument.title, 'new title', 'not required for specification conformance' );
+        }, 'pushState MIGHT set the document title');
+        */
+        history.go(-1);
+        iframe.contentWindow.addEventListener("popstate", tests10, {once: true});
+    }
+    function tests10() {
+        var eventtime = setTimeout(function () { tests11(false); },500); //should be cleared by the event handler long before it has a chance to fire
+        iframe.contentWindow.addEventListener('popstate',function (e) { clearTimeout(eventtime); tests11(true,e); },false);
+        history.forward();
+    }
+    function tests11(hasFired,ev) {
+        test(function () {
+            assert_true( hasFired );
+        }, 'popstate event should fire when navigation occurs');
+        test(function () {
+            assert_true( !!ev && typeof(ev.state) != 'undefined', 'state information was not passed' );
+            assert_true( !!ev.state, 'state information does not contain the expected value - browser is probably stuck in the wrong history position' );
+            assert_equals( ev.state.nulldata, null, 'state null data was not correct' );
+            assert_equals( ev.state.udefdata, window.undefined, 'state undefined data was not correct' );
+            assert_true( ev.state.booldata, 'state boolean data was not correct' );
+            assert_equals( ev.state.numdata, 1, 'state numeric data was not correct' );
+            assert_equals( ev.state.strdata, 'string data', 'state string data was not correct' );
+            assert_true( !!ev.state.datedata.getTime, 'state date data was not correct' );
+            assert_own_property( ev.state, 'regdata', 'state regex data was not correct' );
+            assert_equals( ev.state.regdata.source, 'a', 'state regex pattern data was not correct' );
+            assert_true( ev.state.regdata.global, 'state regex flag data was not correct' );
+            assert_equals( ev.state.regdata.lastIndex, 0, 'state regex lastIndex data was not correct' );
+            assert_equals( ev.state.arrdata.length, 1, 'state array data was not correct' );
+            assert_true( ev.state.boolobj.valueOf(), 'state boolean data was not correct' );
+            assert_equals( ev.state.numobj.valueOf(), 1, 'state numeric data was not correct' );
+            assert_equals( ev.state.strobj.valueOf(), 'string data', 'state string data was not correct' );
+            if( canvassup ) {
+                assert_equals( ev.state.imgdata.width, 1, 'state ImageData was not correct' );
+            }
+        }, 'popstate event should pass the state data');
+        test(function () {
+            assert_equals( ev.state.looped, ev.state );
+        }, 'state data should cope with circular object references');
+        test(function () {
+            assert_not_equals( cloneobj, ev.state );
+        }, 'state data should be a clone of the original object, not a reference to it');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state && iframe.contentWindow.history.state.strdata, 'string data' );
+        }, 'history.state should also reference a clone of the original object (2)');
+        test(function () {
+            assert_not_equals( cloneobj, iframe.contentWindow.history.state );
+        }, 'history.state should be a clone of the original object, not a reference to it (2)');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state, ev.state );
+        }, 'history.state should be identical to the object passed to the event handler unless history.state is updated');
+        try {
+            iframe.contentWindow.persistval = true;
+            iframe.contentWindow.history.pushState('','', location.href.replace(/\/[^\/]*$/,'/resources/blank3.html') );
+        } catch(unsuperr) {}
+        //it's already cached, so this should be very fast if the browser mistakenly loads it
+        //it should not need to load at all, since it's just a pushed state
+        setTimeout(tests12,1000);
+    }
+    function tests12() {
+        test(function () {
+            assert_true( iframe.contentWindow.persistval && !iframe.contentWindow.forreal );
+        }, 'pushState should not actually load the new URL');
+        atstep = 3;
+        iframe.contentWindow.location.reload(); //load the real URL
+        lasttimer = setTimeout(function () { tests13(false); },3000); //should be cleared by the onload handler long before it has a chance to fire
+    }
+    function tests13(passed) {
+        test(function () {
+            assert_true( passed, 'expected a load event to fire when reloading the URL from cache, gave up waiting after 3 seconds' );
+        }, 'reloading a pushed state should actually load the new URL');
+        //try to make browsers behave when reloading so that the correct URL is recovered - does not always work
+        iframe.contentWindow.location.href = location.href.replace(/\/[^\/]*$/,'/resources/blank.html');
+        done();
+    }
+
+    if( atstep == 1 ) {
+        //blank2 has loaded
+        atstep = 2;
+        //use a timeout, because some browsers intentionally do not add history entries for URL changes in an onload thread
+        setTimeout(tests1,100);
+    } else if( atstep == 3 ) {
+        //blank3 should now have loaded after the .reload() command
+        atstep = 4;
+        clearTimeout(lasttimer);
+        tests13(true);
+    }
+}
+
+
+
+        </script>
+    </head>
+    <body>
+
+        <noscript><p>Enable JavaScript and reload</p></noscript>
+        <p>WARNING: This test should always be loaded in a new tab/window, to avoid browsers attempting to recover the state of frames, and history length. Do not reload the test.</p>
+        <div id="log">Running test...</div>
+        <p><iframe onload="reportload();" src="resources/blank.html"></iframe></p>
+        <p><iframe src="resources/blank.html"></iframe></p>
+        <p><iframe src="resources/blank2.html"></iframe></p>
+        <p><iframe src="blank3.html"></iframe></p>
+
+    </body>
+</html>

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank.html
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Dummy page 1</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank2.html
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank2.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Dummy page 2</title>
+  </head>
+  <body>
+    <script type="text/javascript">
+if( self == top || !parent.reportload ) {
+  document.write("<p>FAIL. Browser got confused when navigating forwards, and navigated the whole window to the iframe's location, instead of just navigating the iframe. It is not possible to run the testsuite.<\/p>");
+}
+    </script>
+  </body>
+</html>

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank3.html
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank3.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Dummy page 3</title>
+    <script type="text/javascript">
+var forreal = true;
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1069,7 +1069,11 @@ void EmptyFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem&, Completion
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void EmptyFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int, FrameLoadType)
+void EmptyFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int)
+{
+}
+
+void EmptyFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta(int)
 {
 }
 

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -164,7 +164,8 @@ private:
     ShouldGoToHistoryItem NODELETE shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const final;
     bool NODELETE supportsAsyncShouldGoToHistoryItem() const final;
     void NODELETE shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const final;
-    void NODELETE dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType) final;
+    void NODELETE dispatchGoToBackForwardItemAtIndex(int steps) final;
+    void NODELETE dispatchEnqueueHistoryTraversalDelta(int delta) final;
 
     void NODELETE saveViewStateToItem(HistoryItem&) final;
     bool NODELETE canCachePage() const final;

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -236,7 +236,8 @@ public:
     virtual ShouldGoToHistoryItem shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const = 0;
     virtual bool supportsAsyncShouldGoToHistoryItem() const = 0;
     virtual void shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const = 0;
-    virtual void dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType) = 0;
+    virtual void dispatchGoToBackForwardItemAtIndex(int steps) = 0;
+    virtual void dispatchEnqueueHistoryTraversalDelta(int delta) = 0;
 
     virtual bool shouldFallBack(const ResourceError&) const = 0;
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -323,7 +323,7 @@ public:
 
         if (page->settings().useUIProcessForBackForwardItemLoading()) {
             localFrame->loader().setPendingAsyncBackForwardNavigation();
-            localFrame->loader().client().dispatchGoToBackForwardItemAtIndex(m_steps, FrameLoadType::IndexedBackForward);
+            localFrame->loader().client().dispatchGoToBackForwardItemAtIndex(m_steps);
             return;
         }
 
@@ -818,14 +818,22 @@ void NavigationScheduler::scheduleHistoryNavigation(Frame& originatingFrame, int
 
     if (steps) {
         if (Ref top = m_frame->tree().top(); top.ptr() != m_frame.ptr()) {
-            if (RefPtr localTop = dynamicDowncast<LocalFrame>(top.get())) {
-                if (RefPtr localOriginating = dynamicDowncast<LocalFrame>(originatingFrame); localOriginating && !localOriginating->loader().isComplete())
-                    localOriginating->loader().completed();
-                if (m_redirect)
-                    cancel();
+            RefPtr localTop = dynamicDowncast<LocalFrame>(top.get());
+            RefPtr localOriginating = dynamicDowncast<LocalFrame>(originatingFrame);
+            if (localOriginating && !localOriginating->loader().isComplete())
+                localOriginating->loader().completed();
+            if (m_redirect)
+                cancel();
+
+            if (localTop) {
                 protect(localTop->navigationScheduler())->scheduleHistoryNavigation(originatingFrame, steps);
                 return;
             }
+            ASSERT(localOriginating);
+            if (!localOriginating)
+                return;
+            localOriginating->loader().client().dispatchEnqueueHistoryTraversalDelta(steps);
+            return;
         }
     }
 

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -61,6 +61,7 @@ public:
     Ref<WebBackForwardListFrameItem> mainFrame();
     WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
     WebBackForwardListFrameItem* NODELETE childItemAtIndex(uint64_t);
+    const Vector<Ref<WebBackForwardListFrameItem>>& children() const { return m_children; }
 
     WebBackForwardListItem* NODELETE backForwardListItem() const;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -302,6 +302,7 @@
 #include <ranges>
 #include <stdio.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/CoroutineUtilities.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/FileSystem.h>
@@ -311,6 +312,7 @@
 #include <wtf/Scope.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
 #include <wtf/URLParser.h>
@@ -879,6 +881,63 @@ static Ref<BrowsingContextGroup> getOrCreateBrowsingContextGroup(const API::Page
     return BrowsingContextGroup::create();
 }
 
+class WebPageProxy::SessionHistoryTraversalQueue final : public CanMakeCheckedPtr<WebPageProxy::SessionHistoryTraversalQueue> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SessionHistoryTraversalQueue);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SessionHistoryTraversalQueue);
+public:
+    explicit SessionHistoryTraversalQueue(WebPageProxy& page)
+        : m_pageProxy(page)
+        , m_flushTimer(RunLoop::mainSingleton(), "WebPageProxy::SessionHistoryTraversalQueue::FlushTimer"_s, this, &SessionHistoryTraversalQueue::flush)
+    {
+    }
+
+    ~SessionHistoryTraversalQueue()
+    {
+        m_flushTimer.stop();
+    }
+
+    void enqueueDelta(int32_t delta)
+    {
+        if (m_hasPending) {
+            auto sum = WTF::CheckedInt32 { m_pendingDelta } + delta;
+            if (sum.hasOverflowed()) {
+                cancel();
+                return;
+            }
+            m_pendingDelta = sum.value();
+        } else {
+            m_pendingDelta = delta;
+            m_hasPending = true;
+            m_flushTimer.startOneShot(0_s);
+        }
+    }
+
+    void cancel()
+    {
+        m_flushTimer.stop();
+        m_pendingDelta = 0;
+        m_hasPending = false;
+    }
+
+private:
+    void flush()
+    {
+        int32_t delta = std::exchange(m_pendingDelta, 0);
+        m_hasPending = false;
+
+        if (!delta)
+            return;
+
+        Ref pageProxy = m_pageProxy.get();
+        pageProxy->goToBackForwardItemAtIndex(delta);
+    }
+
+    WeakRef<WebPageProxy> m_pageProxy;
+    int32_t m_pendingDelta { 0 };
+    RunLoop::Timer m_flushTimer;
+    bool m_hasPending { false };
+};
+
 WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref<API::PageConfiguration>&& configuration)
     : m_internals(makeUniqueRefWithoutRefCountedCheck<Internals>(*this, configuration->processInheritedFromOpener()))
     , m_identifier(Identifier::generate())
@@ -897,6 +956,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #endif
     , m_navigationState(makeUniqueRefWithoutRefCountedCheck<WebNavigationState>(*this))
     , m_generatePageLoadTimingTimer(RunLoop::mainSingleton(), "WebPageProxy::GeneratePageLoadTimingTimer"_s, this, &WebPageProxy::didEndNetworkRequestsForPageLoadTimingTimerFired)
+    , m_sessionHistoryTraversalQueue(makeUniqueRefWithoutRefCountedCheck<SessionHistoryTraversalQueue>(*this))
 #if PLATFORM(COCOA)
     , m_textIndicatorFadeTimer(RunLoop::mainSingleton(), "WebPageProxy::TextIndicatorFadeTimer"_s, this, &WebPageProxy::startTextIndicatorFadeOut)
 #endif
@@ -1878,6 +1938,8 @@ void WebPageProxy::close()
     WEBPAGEPROXY_RELEASE_LOG(Loading, "close:");
 
     m_isClosed = true;
+
+    m_sessionHistoryTraversalQueue->cancel();
 
     // Make sure we do this before we clear the UIClient so that we can ask the UIClient
     // to release the wake locks.
@@ -3028,7 +3090,7 @@ void WebPageProxy::shouldGoToBackForwardListItemSync(BackForwardItemIdentifier i
     shouldGoToBackForwardListItem(itemID, false, WTF::move(completionHandler));
 }
 
-void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frameLoadType)
+void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "goToBackForwardItemAtIndex: steps=%d", steps);
 
@@ -3036,7 +3098,12 @@ void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frame
     if (!item)
         return;
 
-    goToBackForwardItem(frameItemForLegacyTraversalRouting(*item, "goToBackForwardItemAtIndex"_s), frameLoadType);
+    goToBackForwardItem(frameItemForLegacyTraversalRouting(*item, "goToBackForwardItemAtIndex"_s), FrameLoadType::IndexedBackForward);
+}
+
+void WebPageProxy::enqueueHistoryTraversalDelta(int32_t delta)
+{
+    m_sessionHistoryTraversalQueue->enqueueDelta(delta);
 }
 
 bool WebPageProxy::shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem& item)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2734,7 +2734,10 @@ RefPtr<API::Navigation> WebPageProxy::goForward()
     if (!forwardItem)
         return nullptr;
 
-    return goToBackForwardItem(protect(forwardItem->navigatedFrameItem()), FrameLoadType::Forward);
+    Ref frameItem = protect(preferences())->useUIProcessForBackForwardItemLoading()
+        ? forwardItem->mainFrameItem()
+        : forwardItem->navigatedFrameItem();
+    return goToBackForwardItem(WTF::move(frameItem), FrameLoadType::Forward);
 }
 
 RefPtr<API::Navigation> WebPageProxy::goBack()
@@ -2744,16 +2747,7 @@ RefPtr<API::Navigation> WebPageProxy::goBack()
     if (!backItem)
         return nullptr;
 
-    Ref frameItem = backItem->mainFrameItem();
-    if (RefPtr currentItem = backForwardList().currentItem()) {
-        if (RefPtr childItem = currentItem->navigatedFrameID() ? frameItem->childItemForFrameID(*currentItem->navigatedFrameID()) : nullptr) {
-            if (childItem.get() != frameItem.ptr())
-                WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "goBack: redirecting from mainFrameItem to child frameItem for navigatedFrameID=%" PRIu64, currentItem->navigatedFrameID()->toUInt64());
-            frameItem = childItem.releaseNonNull();
-        }
-    }
-
-    return goToBackForwardItem(frameItem, FrameLoadType::Back);
+    return goToBackForwardItem(frameItemForLegacyTraversalRouting(*backItem, "goBack"_s), FrameLoadType::Back);
 }
 
 RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListItem& item)
@@ -2844,13 +2838,93 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
     auto transaction = pageLoadState->transaction();
     pageLoadState->setPendingAPIRequest(transaction, { navigation->navigationID(), URL { item->url() } });
 
-    process->markProcessAsRecentlyUsed();
-
     auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item->url()));
-    process->send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(frameItem), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, shouldRestoreFromBackForwardCache, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), webPageIDInProcess(process));
-    process->startResponsivenessTimer();
+
+    if (preferences->useUIProcessForBackForwardItemLoading()) {
+        bool anySent = false;
+        if (RefPtr currentItem = backForwardList().currentItem())
+            anySent = dispatchPerFrameTraversals(protect(currentItem->mainFrameItem()), protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
+        else {
+            sendGoToBackForwardItemForFrame(protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
+            anySent = true;
+        }
+        if (!anySent)
+            WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "goToBackForwardItem: walk dispatched no GoToBackForwardItem messages — back/forward action will be silently dropped");
+    } else {
+        process->markProcessAsRecentlyUsed();
+        process->send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(frameItem), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, shouldRestoreFromBackForwardCache, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), webPageIDInProcess(process));
+        process->startResponsivenessTimer();
+    }
 
     return RefPtr<API::Navigation> { WTF::move(navigation) };
+}
+
+bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
+{
+    bool anySent = false;
+    if (fromFrame.frameState().itemSequenceNumber != toFrame.frameState().itemSequenceNumber) {
+        sendGoToBackForwardItemForFrame(toFrame, navigationID, frameLoadType, shouldRestore, publicSuffix);
+        anySent = true;
+    }
+
+    bool sameDocument = fromFrame.frameState().documentSequenceNumber == toFrame.frameState().documentSequenceNumber;
+    if (!sameDocument)
+        return anySent;
+
+    auto& toChildren = toFrame.children();
+    for (size_t i = 0; i < toChildren.size(); ++i) {
+        Ref toChild = toChildren[i];
+        auto childFrameID = toChild->frameID();
+        if (!childFrameID)
+            continue;
+        // Stored frameIDs can disagree across entries after a process swap; fall back to position, which is stable across history.
+        RefPtr fromChild = fromFrame.childItemForFrameID(*childFrameID);
+        if (!fromChild)
+            fromChild = fromFrame.childItemAtIndex(i);
+        if (!fromChild)
+            continue;
+        if (dispatchPerFrameTraversals(*fromChild, toChild, navigationID, frameLoadType, shouldRestore, publicSuffix))
+            anySent = true;
+    }
+    return anySent;
+}
+
+void WebPageProxy::sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
+{
+    Ref process = processForTheFrameItem(targetFrame);
+    auto suffixCopy = publicSuffix;
+    process->markProcessAsRecentlyUsed();
+    process->send(Messages::WebPage::GoToBackForwardItem({
+        navigationID,
+        targetFrame.copyFrameState(),
+        frameLoadType,
+        ShouldTreatAsContinuingLoad::No,
+        std::nullopt,
+        m_lastNavigationWasAppInitiated,
+        shouldRestore,
+        std::nullopt,
+        WTF::move(suffixCopy),
+        { },
+        WebCore::ProcessSwapDisposition::None
+    }), webPageIDInProcess(process));
+    process->startResponsivenessTimer();
+}
+
+Ref<WebBackForwardListFrameItem> WebPageProxy::frameItemForLegacyTraversalRouting(WebBackForwardListItem& targetItem, ASCIILiteral logTag)
+{
+    Ref frameItem = targetItem.mainFrameItem();
+    if (protect(preferences())->useUIProcessForBackForwardItemLoading())
+        return frameItem;
+    RefPtr currentItem = backForwardList().currentItem();
+    if (!currentItem)
+        return frameItem;
+    auto navigatedFrameID = currentItem->navigatedFrameID();
+    RefPtr childItem = navigatedFrameID ? frameItem->childItemForFrameID(*navigatedFrameID) : nullptr;
+    if (!childItem)
+        return frameItem;
+    if (childItem.get() != frameItem.ptr())
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "%" PUBLIC_LOG_STRING ": redirecting from mainFrameItem to child frameItem for navigatedFrameID=%" PRIu64, logTag.characters(), navigatedFrameID->toUInt64());
+    return childItem.releaseNonNull();
 }
 
 WebProcessProxy& WebPageProxy::processForTheFrameItem(WebBackForwardListFrameItem& frameItem) const
@@ -2962,16 +3036,7 @@ void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frame
     if (!item)
         return;
 
-    Ref frameItem = item->mainFrameItem();
-    if (RefPtr currentItem = backForwardList().currentItem()) {
-        if (RefPtr childItem = currentItem->navigatedFrameID() ? frameItem->childItemForFrameID(*currentItem->navigatedFrameID()) : nullptr) {
-            if (childItem.get() != frameItem.ptr())
-                WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "goToBackForwardItemAtIndex: redirecting from mainFrameItem to child frameItem for navigatedFrameID=%" PRIu64, currentItem->navigatedFrameID()->toUInt64());
-            frameItem = childItem.releaseNonNull();
-        }
-    }
-
-    goToBackForwardItem(frameItem, frameLoadType);
+    goToBackForwardItem(frameItemForLegacyTraversalRouting(*item, "goToBackForwardItemAtIndex"_s), frameLoadType);
 }
 
 bool WebPageProxy::shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem& item)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -150,6 +150,7 @@ class NotificationResources;
 class PlatformSpeechSynthesisUtterance;
 class PlatformSpeechSynthesizer;
 class PrivateClickMeasurement;
+class PublicSuffix;
 class Region;
 class RegistrableDomain;
 class ResourceError;
@@ -246,6 +247,7 @@ enum class SelectionDirection : uint8_t;
 enum class SessionHistoryVisibility : bool;
 enum class ShouldGoToHistoryItem : uint8_t;
 enum class ShouldOpenExternalURLsPolicy : uint8_t;
+enum class ShouldRestoreFromBackForwardCache : uint8_t;
 enum class ShouldSample : bool;
 enum class ShouldTreatAsContinuingLoad : uint8_t;
 enum class TextAnimationRunMode : uint8_t;
@@ -3015,6 +3017,10 @@ private:
     Ref<WebPageProxy> navigationOriginatingPage(const FrameInfoData&);
 
     RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListFrameItem&, WebCore::FrameLoadType);
+
+    bool dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);
+    void sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);
+    Ref<WebBackForwardListFrameItem> frameItemForLegacyTraversalRouting(WebBackForwardListItem& targetItem, ASCIILiteral logTag);
 
     void updateActivityState(OptionSet<WebCore::ActivityState> flagsToUpdate);
     void updateThrottleState();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1003,7 +1003,8 @@ public:
     void didChangeBackForwardList(WebBackForwardListItem* addedItem, Vector<Ref<WebBackForwardListItem>>&& removed);
     void shouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier, bool inBackForwardCache, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
     void shouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
-    void goToBackForwardItemAtIndex(int32_t steps, WebCore::FrameLoadType);
+    void goToBackForwardItemAtIndex(int32_t steps);
+    void enqueueHistoryTraversalDelta(int32_t delta);
 
     bool shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem&);
 
@@ -3744,6 +3745,9 @@ private:
     std::unique_ptr<WebPageLoadTiming> m_pageLoadTimingPendingCommit;
     HashSet<WebCore::FrameIdentifier> m_framesWithSubresourceLoadingForPageLoadTiming;
     RunLoop::Timer m_generatePageLoadTimingTimer;
+
+    class SessionHistoryTraversalQueue;
+    const UniqueRef<SessionHistoryTraversalQueue> m_sessionHistoryTraversalQueue;
 
 #if PLATFORM(COCOA)
     RunLoop::Timer m_textIndicatorFadeTimer;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -238,7 +238,8 @@ messages -> WebPageProxy {
     # BackForward messages
     ShouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier itemID, bool inBackForwardCache) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem)
     ShouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier itemID) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem) Synchronous
-    GoToBackForwardItemAtIndex(int32_t steps, enum:uint8_t WebCore::FrameLoadType frameLoadType)
+    GoToBackForwardItemAtIndex(int32_t steps)
+    EnqueueHistoryTraversalDelta(int32_t delta)
 
     # Undo/Redo messages
     RegisterEditCommandForUndo(WebKit::WebUndoStepID commandID, String label) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1468,13 +1468,22 @@ void WebLocalFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem& item, Co
     webPage->sendWithAsyncReply(Messages::WebPageProxy::ShouldGoToBackForwardListItem(item.itemID(), item.isInBackForwardCache()), WTF::move(completionHandler));
 }
 
-void WebLocalFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType frameLoadType)
+void WebLocalFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int steps)
 {
     RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
-    webPage->send(Messages::WebPageProxy::GoToBackForwardItemAtIndex(steps, frameLoadType));
+    webPage->send(Messages::WebPageProxy::GoToBackForwardItemAtIndex(steps));
+}
+
+void WebLocalFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta(int delta)
+{
+    RefPtr webPage = m_frame->page();
+    if (!webPage)
+        return;
+
+    webPage->send(Messages::WebPageProxy::EnqueueHistoryTraversalDelta(delta));
 }
 
 bool WebLocalFrameLoaderClient::shouldFallBack(const ResourceError& error) const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -178,7 +178,8 @@ private:
     bool supportsAsyncShouldGoToHistoryItem() const final;
     void shouldGoToHistoryItemAsync(WebCore::HistoryItem&, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&) const final;
 
-    void dispatchGoToBackForwardItemAtIndex(int steps, WebCore::FrameLoadType) final;
+    void dispatchGoToBackForwardItemAtIndex(int steps) final;
+    void dispatchEnqueueHistoryTraversalDelta(int delta) final;
 
     void didFinishServiceWorkerPageRegistration(bool success) final;
     

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -163,7 +163,8 @@ private:
     bool supportsAsyncShouldGoToHistoryItem() const final;
     void shouldGoToHistoryItemAsync(WebCore::HistoryItem&, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&) const final;
 
-    void dispatchGoToBackForwardItemAtIndex(int steps, WebCore::FrameLoadType) final;
+    void dispatchGoToBackForwardItemAtIndex(int steps) final;
+    void dispatchEnqueueHistoryTraversalDelta(int delta) final;
 
     void loadStorageAccessQuirksIfNeeded() final { }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1123,9 +1123,12 @@ void WebFrameLoaderClient::shouldGoToHistoryItemAsync(WebCore::HistoryItem&, Com
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void WebFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int, WebCore::FrameLoadType)
+void WebFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int)
 {
-    // Not needed in WebKitLegacy — single process, useUIProcessForBackForwardItemLoading is never enabled.
+}
+
+void WebFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta(int)
+{
 }
 
 bool WebFrameLoaderClient::shouldFallBack(const WebCore::ResourceError& error) const

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9773,4 +9773,56 @@ TEST(SiteIsolation, PasteboardReading)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "hello");
 }
 
+TEST(SiteIsolation, CrossProcessHistoryTraversalCoalesce)
+{
+    constexpr auto pageWithIframes = "<iframe src='https://webkit.org/x'></iframe><iframe src='https://apple.com/x'></iframe>"_s;
+    constexpr auto iframeBody = "x"_s;
+
+    HTTPServer server({
+        { "/a"_s, { pageWithIframes } },
+        { "/b"_s, { pageWithIframes } },
+        { "/c"_s, { pageWithIframes } },
+        { "/x"_s, { iframeBody } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)2);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)0);
+
+    auto childFrames = [webView mainFrame].childFrames;
+    EXPECT_EQ(childFrames.count, 2u);
+    pid_t mainPid = [[webView mainFrame] info]._processIdentifier;
+    pid_t pidWk = childFrames[0].info._processIdentifier;
+    pid_t pidAp = childFrames[1].info._processIdentifier;
+    EXPECT_NE(pidWk, mainPid);
+    EXPECT_NE(pidAp, mainPid);
+    EXPECT_NE(pidWk, pidAp);
+
+    __block unsigned didFinishCount = 0;
+    __block bool firstFinished = false;
+    navigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+        ++didFinishCount;
+        firstFinished = true;
+    };
+
+    [webView evaluateJavaScript:@"history.back()" inFrame:childFrames[0].info completionHandler:nil];
+    [webView evaluateJavaScript:@"history.back()" inFrame:childFrames[1].info completionHandler:nil];
+
+    TestWebKitAPI::Util::run(&firstFinished);
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    EXPECT_EQ(didFinishCount, 1u);
+    EXPECT_WK_STREQ(@"https://example.com/a", [[webView URL] absoluteString]);
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)0);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)2);
+}
+
 }


### PR DESCRIPTION
#### fbb20db3bd7bb1e0defc55ed286df25f29b5dc62
<pre>
[NavigationScheduler] history.back/forward/go(n) coalescing across processes via UIProcess session history traversal queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=317229">https://bugs.webkit.org/show_bug.cgi?id=317229</a>

Reviewed by NOBODY (OOPS!).

Follow-up to <a href="https://bugs.webkit.org/show_bug.cgi?id=317077.">https://bugs.webkit.org/show_bug.cgi?id=317077.</a>

Per HTML&apos;s &quot;traverse the history by a delta&quot; algorithm, history.back/
forward/go(n) appends a task to the top-level traversable&apos;s session
history traversal queue. The previous fix (bug 317077) implemented
per-WebProcess coalescing by forwarding to the top frame&apos;s
NavigationScheduler when reachable in this WebProcess. Under Site
Isolation, when the top frame is a RemoteFrame (a cross-site iframe
initiates the traversal), the queue lives above any single WebProcess
and the originating scheduler can&apos;t see traversals from other
processes targeting the same traversable.

Symptom: two cross-site iframes in different WebProcesses each call
history.back() in the same task; both navigations execute and the
user sees an extra intermediate document load that the spec says
should not occur.

Introduce SessionHistoryTraversalQueue, owned by WebPageProxy
(top-level traversable proxy). The queue accumulates pending delta
across all WebProcesses targeting this page and flushes on a 0-delay
timer, calling goToBackForwardItemAtIndex with the net delta (no-op
when delta == 0, matching &quot;going nowhere&quot;). NavigationScheduler&apos;s
existing per-WebProcess aggregation in scheduleHistoryNavigation now
gains a second branch: when the top frame is in another process
(top frame downcasts to RemoteFrame), forward via a new
LocalFrameLoaderClient hook (dispatchEnqueueHistoryTraversalDelta)
that posts WebPageProxy::EnqueueHistoryTraversalDelta to the
UIProcess. The originating frame&apos;s pending m_redirect and
in-progress load are completed/cancelled the same way the LocalFrame
top branch does in 317077, so an iframe&apos;s pending
ScheduledLocationChange doesn&apos;t race the queued traversal.

Trust model note: EnqueueHistoryTraversalDelta accepts an int32_t
delta from any WebProcess and forwards it to
goToBackForwardItemAtIndex on flush. This is the same trust boundary
as the existing GoToBackForwardItemAtIndex IPC; Site Isolation does
not introduce a new attack vector here. The eventual
WebBackForwardList lookup clamps to the available range, so an
out-of-range delta degrades to a no-op rather than memory unsafety.

This is the observable-coalescing approximation; the spec-faithful
&quot;sequential apply + synchronous queue jumping&quot; is left for a future
epic. The class name (SessionHistoryTraversalQueue) leaves room for
that evolution.

Out of scope here: spec-correct top-level reload semantics for
history.go(0), which remains implemented as a per-frame reload —
tracked alongside bug 317077.

Drive-by cleanup carried in this follow-up: drop the unused
FrameLoadType parameter from both this new IPC and the sibling
GoToBackForwardItemAtIndex IPC (introduced for 317077). Both call
sites in NavigationScheduler always pass IndexedBackForward and the
UIProcess methods always forward the same constant; the parameter
was dead weight. The FrameLoaderClient hooks
(dispatchGoToBackForwardItemAtIndex, dispatchEnqueueHistoryTraversalDelta)
are simplified to match.

Test plan: SiteIsolation.CrossProcessHistoryTraversalCoalesce builds
a 3-entry main-frame history (a, b, c) where each page hosts two
cross-site iframes (webkit.org and apple.com) in distinct
WebProcesses. main-frame postMessage triggers both iframes to call
history.back() in the same JS turn; the two
EnqueueHistoryTraversalDelta IPCs land in the same UIProcess flush
window and combine into one goToBackForwardItem(-2), so main goes
c-&gt;a in a single navigation (BFList: backList=0, forwardList=2). The
test is sensitive: temporarily disabling the new RemoteFrame branch
in NavigationScheduler causes the BFList state assertions to fail.
The bug 317077 API tests (WKBackForwardList.* synchronous coalescing
suite) and the SI history regression set under SiteIsolation.* do
not regress.

* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta):
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleHistoryNavigation):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::SessionHistoryTraversalQueue::SessionHistoryTraversalQueue):
(WebKit::WebPageProxy::SessionHistoryTraversalQueue::enqueueDelta):
(WebKit::WebPageProxy::SessionHistoryTraversalQueue::cancel):
(WebKit::WebPageProxy::SessionHistoryTraversalQueue::flush):
(WebKit::WebPageProxy::WebPageProxy):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::enqueueHistoryTraversalDelta):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TEST(SiteIsolation, CrossProcessHistoryTraversalCoalesce)):
</pre>
----------------------------------------------------------------------
#### 00178de35e0f66d432d7677332b1033d2524d132
<pre>
[Site Isolation] Replace navigatedFrameID heuristic with per-frame walk in UIProcess back/forward routing
<a href="https://bugs.webkit.org/show_bug.cgi?id=317090">https://bugs.webkit.org/show_bug.cgi?id=317090</a>
<a href="https://rdar.apple.com/179641336">rdar://179641336</a>

Reviewed by NOBODY (OOPS!).

WebPageProxy::goBack/goForward/goToBackForwardItemAtIndex selected the frame to
traverse from currentItem-&gt;navigatedFrameID(). That field names the iframe whose
forward-target the entry undoes, not the iframe a caller wants to traverse, so
it produces direction-asymmetric breakage: back happens to coincide with the
caller&apos;s intent in many cases, forward does not.

Replace the heuristic under useUIProcessForBackForwardItemLoading with a tree
walk in WebPageProxy::goToBackForwardItem. UIProcess walks the (current, target)
frame-item trees pair-wise; for each frame whose itemSequenceNumber differs it
dispatches a per-frame GoToBackForwardItem to that frame&apos;s process with that
frame&apos;s FrameState. Recursion only crosses same-document boundaries (matching
documentSequenceNumber); cross-document subtrees stop the recursion and rely on
the existing frameStateForBackForwardChildFrame pull at commit time. There is
no longer a &quot;primary&quot; frame chosen by heuristic — every frame whose state
differs is dispatched independently.

The three call sites (goBack, goForward, goToBackForwardItemAtIndex) now pass
the entry&apos;s mainFrameItem under the flag. With the flag off they keep the
original navigatedFrameID-based selection, so legacy behavior is unchanged.

The non-flag path is also unchanged: a single GoToBackForwardItem with the full
children-tree FrameState is sent to the primary process as today.

markProcessAsRecentlyUsed() and startResponsivenessTimer() are called per
destination process inside sendGoToBackForwardItemForFrame, since the walk
dispatches to multiple processes.

The legacy navigatedFrameID-based child redirection used by goBack and
goToBackForwardItemAtIndex is extracted into a shared helper
frameItemForLegacyTraversalRouting, which becomes a no-op once the flag is on.

dispatchPerFrameTraversals returns whether any GoToBackForwardItem message was
dispatched during the walk. The entry point in goToBackForwardItem logs an
error if a back/forward action would otherwise be silently dropped.

Test coverage adds two regression tests under http/wpt/site-isolation/, pinned
with webkit-test-runner [ SiteIsolationEnabled=true
UseUIProcessForBackForwardItemLoading=true ] so the path is exercised regardless
of the runner&apos;s default flags. These mirror two of the imported WPT cluster
tests that fail on origin/main with both flags on and pass after this patch.

* LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt: Added.
* LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html: Added.
* LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/resources/helpers.mjs: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/001-expected.txt: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/001.html: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank.html: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank2.html: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank3.html: Added.
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::children const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goForward):
(WebKit::WebPageProxy::goBack):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::dispatchPerFrameTraversals):
(WebKit::WebPageProxy::sendGoToBackForwardItemForFrame):
(WebKit::WebPageProxy::frameItemForLegacyTraversalRouting):
(WebKit::WebPageProxy::goToBackForwardItemAtIndex):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbb20db3bd7bb1e0defc55ed286df25f29b5dc62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169422 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43344 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36633 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178779 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127134 "Failed to checkout and rebase branch from PR 67386") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171288 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43547 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42972 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/178779 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/127134 "Failed to checkout and rebase branch from PR 67386") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172381 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/43547 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/36633 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/178779 "Failed to checkout and rebase branch from PR 67386") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/43547 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/42972 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27478 "Failed to checkout and rebase branch from PR 67386") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/36633 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/43547 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/36633 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181379 "Failed to checkout and rebase branch from PR 67386") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34088 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/42972 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/181379 "Failed to checkout and rebase branch from PR 67386") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43000 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/36633 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/181379 "Failed to checkout and rebase branch from PR 67386") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43689 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/36633 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107780 "Failed to checkout and rebase branch from PR 67386") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/43689 "Failed to checkout and rebase branch from PR 67386") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115454 "Failed to checkout and rebase branch from PR 67386") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42199 "Failed to checkout and rebase branch from PR 67386") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/36633 "Failed to checkout and rebase branch from PR 67386") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41592 "Failed to checkout and rebase branch from PR 67386") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41847 "Failed to checkout and rebase branch from PR 67386") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41735 "Failed to checkout and rebase branch from PR 67386") | | | | 
<!--EWS-Status-Bubble-End-->