### PR TITLE
[iOS] MediaPlayerPrivateWirelessPlayback::hasAudio should be based on the route's audio options

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/has-audio-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/has-audio-expected.txt
@@ -1,0 +1,14 @@
+
+Test that toggling a MediaDeviceRoute's audioOptions propagates to the video element's hasAudio state.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+RUN(route.audioOptions = [{ displayName: 'Audio', identifier: 'audio' }])
+EXPECTED (internals.mediaUsageState(video).hasAudio == 'true') OK
+RUN(route.audioOptions = [])
+EXPECTED (internals.mediaUsageState(video).hasAudio == 'false') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/has-audio.html
+++ b/LayoutTests/media/wireless-playback-media-player/has-audio.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                run(`route.audioOptions = [{ displayName: 'Audio', identifier: 'audio' }]`);
+                await testExpectedEventually('internals.mediaUsageState(video).hasAudio', true);
+
+                run(`route.audioOptions = []`);
+                await testExpectedEventually('internals.mediaUsageState(video).hasAudio', false);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that toggling a MediaDeviceRoute's audioOptions propagates to the video element's hasAudio state.</p>
+    </body>
+</html>

--- a/Source/WebCore/Configurations/WebCoreTestSupport.xcconfig
+++ b/Source/WebCore/Configurations/WebCoreTestSupport.xcconfig
@@ -61,7 +61,7 @@ CLANG_INSTRUMENT_FOR_OPTIMIZATION_PROFILING = NO; // Disable PGO profile generat
 WK_PGO_GEN_FLAGS = ; // Disable IR PGO profile generation
 WK_PGO_USE_CFLAGS = ; // Disable IR PGO profile use
 WK_PGO_USE_LDFLAGS = ; // Disable IR PGO profile use
-OTHER_LDFLAGS[sdk=iphone*] = $(WK_COMMON_OTHER_LDFLAGS) -lAccessibility -framework CoreText -framework Metal $(ANGLE_LDFLAGS) $(LIBWEBRTC_LDFLAGS) $(SOURCE_VERSION_LDFLAGS);
+OTHER_LDFLAGS[sdk=iphone*] = $(WK_COMMON_OTHER_LDFLAGS) -lAccessibility -framework AVKit -framework CoreText -framework Metal $(ANGLE_LDFLAGS) $(LIBWEBRTC_LDFLAGS) $(SOURCE_VERSION_LDFLAGS);
 OTHER_LDFLAGS[sdk=appletv*] = $(WK_COMMON_OTHER_LDFLAGS) -lAccessibility -framework CoreText -framework Metal $(ANGLE_LDFLAGS) $(LIBWEBRTC_LDFLAGS) $(SOURCE_VERSION_LDFLAGS);
 OTHER_LDFLAGS[sdk=xr*] = $(WK_COMMON_OTHER_LDFLAGS) -lAccessibility -framework CoreText -framework Metal $(ANGLE_LDFLAGS) $(LIBWEBRTC_LDFLAGS) $(SOURCE_VERSION_LDFLAGS);
 SECT_ORDER_FLAGS = ;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -103,7 +103,7 @@ public:
     virtual void readyDidChange(MediaDeviceRoute&) { }
     virtual void bufferingDidChange(MediaDeviceRoute&) { }
     virtual void playbackErrorDidChange(MediaDeviceRoute&) { }
-    virtual void hasAudioDidChange(MediaDeviceRoute&) { }
+    virtual void audioOptionsDidChange(MediaDeviceRoute&) { }
     virtual void currentPlaybackPositionDidChange(MediaDeviceRoute&) { }
     virtual void playingDidChange(MediaDeviceRoute&) { }
     virtual void playbackSpeedDidChange(MediaDeviceRoute&) { }
@@ -132,7 +132,7 @@ public:
     bool ready() const;
     bool buffering() const;
     std::optional<MediaPlaybackSourceError> playbackError() const;
-    bool hasAudio() const;
+    Vector<MediaSelectionOption> audioOptions() const;
     MediaTime currentPlaybackPosition() const;
     bool playing() const;
     float playbackSpeed() const;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -39,7 +39,7 @@
     Macro(timeRange, TimeRange, MediaTimeRange) \
     Macro(ready, Ready, bool) \
     Macro(buffering, Buffering, bool) \
-    Macro(hasAudio, HasAudio, bool) \
+    Macro(audioOptions, AudioOptions, Vector<MediaSelectionOption>) \
 \
 
 #define FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
@@ -275,6 +275,19 @@ static std::optional<MediaPlaybackSourceError> convert(NSError * _Nullable error
         error.domain,
         error.localizedDescription,
     };
+}
+
+static Vector<MediaSelectionOption> convert(NSArray * _Nullable options)
+{
+    return Vector<MediaSelectionOption>(options.count, [&](size_t i) {
+        id option = options[i];
+        return MediaSelectionOption {
+            [option displayName],
+            [option identifier],
+            MediaSelectionOption::Type::Audio,
+            [option extendedLanguageTag],
+        };
+    });
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaDeviceRoute);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -261,7 +261,7 @@ void MediaPlayerPrivateWirelessPlayback::pause()
 bool MediaPlayerPrivateWirelessPlayback::hasAudio() const
 {
     if (RefPtr route = this->route())
-        return route->hasAudio();
+        return !route->audioOptions().isEmpty();
     return false;
 }
 
@@ -429,6 +429,15 @@ void MediaPlayerPrivateWirelessPlayback::playbackErrorDidChange(MediaDeviceRoute
 
     if (route.playbackError())
         setNetworkState(route.ready() ? MediaPlayer::NetworkState::DecodeError : MediaPlayer::NetworkState::FormatError);
+}
+
+void MediaPlayerPrivateWirelessPlayback::audioOptionsDidChange(MediaDeviceRoute& route)
+{
+    ASSERT(&route == this->route());
+    ALWAYS_LOG(LOGIDENTIFIER, route.audioOptions().size());
+
+    if (RefPtr player = m_player.get())
+        player->characteristicChanged();
 }
 
 void MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange(MediaDeviceRoute& route)

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -130,6 +130,7 @@ private:
     void timeRangeDidChange(MediaDeviceRoute&) final;
     void readyDidChange(MediaDeviceRoute&) final;
     void playbackErrorDidChange(MediaDeviceRoute&) final;
+    void audioOptionsDidChange(MediaDeviceRoute&) final;
     void currentPlaybackPositionDidChange(MediaDeviceRoute&) final;
 
     CMTimebaseRef ensureTimebase();

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -33,6 +33,8 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 OBJC_CLASS WebMockMediaDeviceRoute;
 
@@ -63,6 +65,14 @@ public:
 
     bool hasPlaybackError() const;
     void setHasPlaybackError(bool);
+
+    struct AudioOption {
+        String displayName;
+        String identifier;
+        String extendedLanguageTag;
+    };
+    Vector<AudioOption> audioOptions() const;
+    void setAudioOptions(const Vector<AudioOption>&);
 
     float playbackRate() const;
     void setPlaybackRate(float);

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -34,6 +34,7 @@
     attribute boolean ready;
     attribute boolean playing;
     attribute boolean hasPlaybackError;
+    attribute sequence<MockMediaDeviceRouteAudioOption> audioOptions;
     attribute float playbackRate;
     attribute float currentPlaybackPosition;
     attribute MockMediaDeviceRouteTimeRange timeRange;
@@ -47,4 +48,14 @@
 ] dictionary MockMediaDeviceRouteTimeRange {
     required double start;
     required double duration;
+};
+
+[
+    Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject,
+] dictionary MockMediaDeviceRouteAudioOption {
+    required DOMString displayName;
+    required DOMString identifier;
+    DOMString extendedLanguageTag;
 };

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -29,6 +29,7 @@
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
 #import "WebMockMediaDeviceRoute.h"
+#import <AVKit/AVKit.h>
 #import <wtf/TZoneMallocInlines.h>
 
 @interface NSObject (Staging_169033633)
@@ -99,6 +100,29 @@ void MockMediaDeviceRoute::setHasPlaybackError(bool)
 {
     RetainPtr error = [NSError errorWithDomain:WebMockMediaDeviceRouteErrorDomain code:WebMockMediaDeviceRouteErrorCodePlaybackError userInfo:nil];
     [m_platformRoute setPlaybackError:error.get()];
+}
+
+Vector<MockMediaDeviceRoute::AudioOption> MockMediaDeviceRoute::audioOptions() const
+{
+    NSArray<AVInterfaceMediaSelectionOptionSource *> *options = [m_platformRoute audioOptions];
+    return Vector<AudioOption>(options.count, [&](size_t i) {
+        AVInterfaceMediaSelectionOptionSource *option = options[i];
+        return AudioOption {
+            option.displayName,
+            option.identifier,
+            option.extendedLanguageTag,
+        };
+    });
+}
+
+void MockMediaDeviceRoute::setAudioOptions(const Vector<AudioOption>& audioOptions)
+{
+    RetainPtr<NSMutableArray<AVInterfaceMediaSelectionOptionSource *>> options = [NSMutableArray arrayWithCapacity:audioOptions.size()];
+    for (auto& option : audioOptions) {
+        RetainPtr platformOption = adoptNS([[AVInterfaceMediaSelectionOptionSource alloc] initWithDisplayName:option.displayName.createNSString().get() identifier:option.identifier.createNSString().get() extendedLanguageTag:option.extendedLanguageTag.createNSString().get()]);
+        [options addObject:platformOption.get()];
+    }
+    [m_platformRoute setAudioOptions:options.get()];
 }
 
 float MockMediaDeviceRoute::playbackRate() const

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -52,6 +52,7 @@ extern NSErrorDomain const WebMockMediaDeviceRouteErrorDomain;
 @property (nonatomic, getter=isReady) BOOL ready;
 @property (nonatomic, strong, nullable) NSError *playbackError;
 @property (nonatomic) CMTimeRange timeRange;
+@property (nonatomic, copy) NSArray<AVInterfaceMediaSelectionOptionSource *> *audioOptions;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### fc73a32ca45fb849da36a44261f117cd1b6b2e75
<pre>
[iOS] MediaPlayerPrivateWirelessPlayback::hasAudio should be based on the route&apos;s audio options
<a href="https://bugs.webkit.org/show_bug.cgi?id=317350">https://bugs.webkit.org/show_bug.cgi?id=317350</a>
<a href="https://rdar.apple.com/179968775">rdar://179968775</a>

Reviewed by Jer Noble.

Based MediaPlayerPrivateWirelessPlayback::hasAudio on the route&apos;s audio options array instead of
its hasAudio boolean. The latter is being removed from the route&apos;s underlying data source.

Test: media/wireless-playback-media-player/has-audio.html

* LayoutTests/media/wireless-playback-media-player/has-audio-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/has-audio.html: Added.
* Source/WebCore/Configurations/WebCoreTestSupport.xcconfig:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
(WebCore::MediaDeviceRouteClient::audioOptionsDidChange):
(WebCore::MediaDeviceRouteClient::hasAudioDidChange): Deleted.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(WebCore::convert):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::hasAudio const):
(WebCore::MediaPlayerPrivateWirelessPlayback::audioOptionsDidChange):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::audioOptions const):
(WebCore::MockMediaDeviceRoute::setAudioOptions):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:

Canonical link: <a href="https://commits.webkit.org/315475@main">https://commits.webkit.org/315475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1165f31d5f7ea19fa5db66f12522bdaa69aad8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126721 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c7ce6fa-4534-4dd0-8e04-63a60c6dff70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131612 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4274d81b-b172-4c97-8f7b-9fcb02d61a4f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112115 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/240509b6-cf8d-4c5f-9621-886294f6ae43) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33058 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31762 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180965 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140062 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139904 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37682 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43277 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28306 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107103 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35184 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115042 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41786 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6395 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41435 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->