### PR TITLE
[LBSE] Report a viewport-establishing SVG container's viewport as its untransformed bounding box

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -52,6 +52,11 @@ public:
         return m_objectBoundingBox;
     }
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
+    // A viewport-establishing container (inner <svg>, <marker>) overrides this to return its viewport
+    // rectangle, so that it contributes its viewport (not its clipped descendant geometry) to an
+    // ancestor's "without transformations" object bounding box. Public so SVGBoundingBoxComputation
+    // can honor it while recursing.
+    virtual std::optional<FloatRect> overridenObjectBoundingBoxWithoutTransformations() const { return std::nullopt; }
     FloatRect strokeBoundingBox() const final;
 
     void invalidateCachedSVGTransformDependentBoundingBoxes() final { m_transformDependentBoundingBoxesDirty = true; }
@@ -70,7 +75,6 @@ protected:
     virtual void layoutChildren();
     virtual bool pointIsInsideViewportClip(const FloatPoint&) { return true; }
     virtual bool updateLayoutSizeIfNeeded() { return false; }
-    virtual std::optional<FloatRect> overridenObjectBoundingBoxWithoutTransformations() const { return std::nullopt; }
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
     void addFocusRingRects(Vector<LayoutRect>& rects, const LayoutPoint& additionalOffset, const RenderLayerModelObject* container) const override;
 

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -61,6 +61,20 @@ void SVGBoundingBoxComputation::recomputeTransformDependentBoundingBoxes(const R
 
 FloatRect SVGBoundingBoxComputation::computeDecoratedBoundingBox(const SVGBoundingBoxComputation::DecorationOptions& options, bool* boundingBoxValid) const
 {
+    // A viewport-establishing container (inner <svg>, <marker>) contributes its viewport rectangle
+    // (cached in overridenObjectBoundingBoxWithoutTransformations()) to an ancestor's bounding box,
+    // not its descendant geometry. This follows from viewport establishment, independent of overflow,
+    // and keeps the ancestor's recursion consistent with the box the container reports for itself.
+    if (options.contains(DecorationOption::IgnoreTransformations)) {
+        if (CheckedPtr container = dynamicDowncast<RenderSVGContainer>(m_renderer.get())) {
+            if (auto overriden = container->overridenObjectBoundingBoxWithoutTransformations()) {
+                if (boundingBoxValid)
+                    *boundingBoxValid = true;
+                return *overriden;
+            }
+        }
+    }
+
     // SVG2: Bounding boxes algorithm (https://svgwg.org/svg2-draft/coords.html#BoundingBoxes)
 
     // The following algorithm defines how to compute a bounding box for a given element. The inputs to the algorithm are:


### PR DESCRIPTION
#### 11766c4dd818baeca3a62b4efd6e814c1bd04f52
<pre>
[LBSE] Report a viewport-establishing SVG container&apos;s viewport as its untransformed bounding box
<a href="https://bugs.webkit.org/show_bug.cgi?id=317351">https://bugs.webkit.org/show_bug.cgi?id=317351</a>

Reviewed by Rob Buis.

A viewport-establishing container (inner &lt;svg&gt;, &lt;marker&gt;) must contribute its
viewport rectangle, not its clipped descendant geometry, to an ancestor&apos;s
&quot;without transformations&quot; object bounding box.

This is a preparation for conditional SVG layer creation.

* Source/WebCore/rendering/svg/RenderSVGContainer.h:
(WebCore::RenderSVGContainer::overridenObjectBoundingBoxWithoutTransformations const):
(WebCore::RenderSVGContainer::updateLayoutSizeIfNeeded):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::computeDecoratedBoundingBox const):

Canonical link: <a href="https://commits.webkit.org/315464@main">https://commits.webkit.org/315464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887d6cfb0074581ecf8c803a9527e7e44e83a091

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131589 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33028 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31740 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27039 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180938 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140037 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42561 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43250 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107076 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25771 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35163 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115015 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41759 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6320 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41153 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->