### PR TITLE
[LBSE] Simplify SVG transform paint/hit-test recursion

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3908,40 +3908,6 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
                 clipRectOptions.add(ClipRectsOption::Temporary);
             collectFragments(layerFragments, localPaintingInfo.rootLayer, paintDirtyRect, ExcludeCompositedPaginatedLayers, PaintingClipRects, clipRectOptions, offsetFromRoot);
             updatePaintingInfoForFragments(layerFragments, localPaintingInfo, localPaintFlags, shouldPaintContent, offsetFromRoot);
-
-            // When non-layer SVG ancestors (e.g. a transformed <g> without its own layer) have
-            // applied transforms to the graphics context, our fragment clip rects — computed in
-            // rootLayer coordinate space — must be inverse-mapped through the accumulated
-            // nonLayerSVGTransform so they end up in our local post-transform space, where the
-            // context is now drawing.
-            //
-            // Skip inverse mapping when rootLayer == this: a prior paintLayerByApplyingTransform
-            // promoted us to be our own rootLayer, so our clip rects (at offsetFromRoot=0 relative
-            // to self) are already in this local space; inverse-mapping would shift them incorrectly.
-            if (localPaintingInfo.nonLayerSVGTransform && localPaintingInfo.rootLayer != this) {
-                if (auto inverse = localPaintingInfo.nonLayerSVGTransform->inverse()) {
-                    float deviceScaleFactor = renderer().document().deviceScaleFactor();
-                    for (auto& fragment : layerFragments) {
-                        if (!fragment.rects.m_foregroundRect.isInfinite()) {
-                            auto mappedForegroundRect = LayoutRect(encloseRectToDevicePixels(inverse->mapRect(FloatRect(fragment.rects.m_foregroundRect.rect())), deviceScaleFactor));
-                            fragment.rects.m_foregroundRect = ClipRect(mappedForegroundRect);
-                        }
-                        if (!fragment.rects.m_backgroundRect.isInfinite()) {
-                            auto mappedBackgroundRect = LayoutRect(encloseRectToDevicePixels(inverse->mapRect(FloatRect(fragment.rects.m_backgroundRect.rect())), deviceScaleFactor));
-                            fragment.rects.m_backgroundRect = ClipRect(mappedBackgroundRect);
-                        }
-                    }
-                }
-            } else if (localPaintingInfo.nonLayerSVGTransform) {
-                // rootLayer == this: our fragment clip rects are at offsetFromRoot=0, already in
-                // this layer's local post-transform space, so the inverse mapping above is
-                // correctly skipped. Descendants will likewise compute their clip rects relative
-                // to rootLayer (=this), in this same local space. The inherited nonLayerSVGTransform
-                // — accumulated from non-layer SVG ancestors above the previous rootLayer — no
-                // longer applies; clear it so descendants do not inverse-map their clip rects
-                // through a stale transform.
-                localPaintingInfo.nonLayerSVGTransform = std::nullopt;
-            }
         }
         
         if (isPaintingCompositedBackground) {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1020,8 +1020,9 @@ public:
         OptionSet<PaintBehavior> paintBehavior;
         bool requireSecurityOriginAccessForWidgets { false };
         CheckedPtr<RegionContext> regionContext;
-        std::optional<AffineTransform> nonLayerSVGTransform;
     };
+
+    void computeRepaintRectsIncludingDescendants();
 
 private:
 
@@ -1051,11 +1052,11 @@ private:
     const Vector<SVGPaintOrderLayerItem>& childrenInDOMOrderForSVG();
     void paintChildrenInDOMOrderForSVG(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayerFragments&, OptionSet<PaintBehavior>, RenderObject*);
     void paintNonLayerChildForFragmentsForSVG(RenderElement&, const LayoutSize& accumulatedAncestorOffset, PaintPhase, const LayerFragments&, GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, RenderObject*, const LayoutPoint& containerBaseOffset, bool isSVGRoot);
-    void paintRendererByApplyingTransformForSVG(GraphicsContext&, CheckedRef<RenderElement>, const LayoutSize& positionOffset, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, const LayerFragments&, OptionSet<PaintBehavior>, RenderObject*, const LayerPaintingInfo& outerPaintingInfo, const AffineTransform& accumulatedTransform);
-    void paintSubtreeWithinTransformScopeForSVG(GraphicsContext&, RenderElement& container, const LayoutPoint& paintOffset, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>, RenderObject*, const LayerPaintingInfo& outerPaintingInfo, const AffineTransform& accumulatedTransform);
+    void paintRendererByApplyingTransformForSVG(GraphicsContext&, CheckedRef<RenderElement>, const LayoutSize& positionOffset, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>, RenderObject*, const LayoutSize& nominalPreTranslation = { });
+    void paintSubtreeWithinTransformScopeForSVG(GraphicsContext&, RenderElement& container, const LayoutPoint& paintOffset, const LayerPaintingInfo&, OptionSet<PaintLayerFlag>, OptionSet<PaintBehavior>, RenderObject*);
     HitLayer hitTestChildrenInDOMOrderForSVG(RenderLayer* rootLayer, const HitTestRequest&, HitTestResult&, const LayoutRect& hitTestRect, const HitTestLocation&, const HitTestingTransformState*, double* zOffsetForDescendants);
-    HitLayer hitTestRendererByInversingTransformForSVG(RenderElement&, const LayoutSize& positionOffset, RenderLayer* rootLayer, const HitTestRequest&, HitTestResult&, const LayoutRect& hitTestRect, const HitTestLocation&, const HitTestingTransformState*, double* zOffsetForDescendants);
-    HitLayer hitTestSubtreeWithinTransformScopeForSVG(RenderElement& container, const LayoutPoint& accumulatedOffset, RenderLayer* rootLayer, const HitTestRequest&, HitTestResult&, const LayoutRect& hitTestRect, const HitTestLocation&, const HitTestingTransformState*, double* zOffsetForDescendants);
+    HitLayer hitTestRendererByInversingTransformForSVG(RenderElement&, const LayoutSize& positionOffset, const HitTestRequest&, HitTestResult&, const LayoutRect& hitTestRect, const HitTestLocation&);
+    HitLayer hitTestSubtreeWithinTransformScopeForSVG(RenderElement& container, const LayoutPoint& accumulatedOffset, const HitTestRequest&, HitTestResult&, const LayoutRect& hitTestRect, const HitTestLocation&);
 
     struct SVGRendererTransform {
         TransformationMatrix transform;
@@ -1110,7 +1111,6 @@ private:
     }
 
     void computeRepaintRects(const RenderLayerModelObject* repaintContainer);
-    void computeRepaintRectsIncludingDescendants();
 
     void compositingStatusChanged(LayoutUpToDate);
 

--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -432,6 +432,18 @@ void RenderLayer::paintChildrenInDOMOrderForSVG(GraphicsContext& context, const 
 
         // Transformed non-layer children: apply the transform and recursively paint the subtree.
         if (childRenderer->isTransformed()) {
+            // When this container is itself a transformed SVG layer (e.g. a layered <use>), its CTM is
+            // positioned at its own nominalSVGLayoutLocation (objectBoundingBox top-left). The transform
+            // recursion paints the child additively in that CTM, so the child would inherit a spurious
+            // shift. Cancel it by folding -nominalCorrection into the child's transform scope (see
+            // paintRendererByApplyingTransformForSVG). No-op for SVG root / viewport (nominal == 0) and
+            // when not painting as a layer-scope root. Since every transformed container is layered, the
+            // only transformed renderers reaching this recursion are leaves and the anonymous outermost
+            // viewport container, so no layer descendant ever needs the inverse correction.
+            LayoutSize nominalCorrection;
+            if (this == paintingInfo.rootLayer && !isPaintingResourceLayerForSVG() && renderer().isSVGLayerAwareRenderer() && !renderer().isRenderSVGRoot())
+                nominalCorrection = toLayoutSize(renderer().nominalSVGLayoutLocation());
+
             for (const auto& fragment : layerFragments) {
                 if (!fragment.shouldPaintContent || fragment.dirtyForegroundRect().isEmpty())
                     continue;
@@ -440,10 +452,14 @@ void RenderLayer::paintChildrenInDOMOrderForSVG(GraphicsContext& context, const 
                 RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
                 clipToRect(context, stateSaver, regionContextStateSaver, paintingInfo, paintBehavior, fragment.dirtyForegroundRect());
 
+                // nominalCorrection is applied inside the scope, so TransformPaintScope concatenates it
+                // onto the CTM and inverse-maps paintDirtyRect through it together. The leaf
+                // visual-overflow cull (RenderSVGShape::paint) then compares the shifted subtree against
+                // a matching damage rect, so overhanging leaves survive incremental repaints
+                // (svg/W3C-SVG-1.1/animate-elem-80-t.svg).
                 paintRendererByApplyingTransformForSVG(context, childRenderer,
                     childToPaint.accumulatedAncestorOffset, paintingInfo, paintFlags,
-                    layerFragments, paintBehavior, subtreePaintRootForRenderer,
-                    paintingInfo, AffineTransform());
+                    paintBehavior, subtreePaintRootForRenderer, nominalCorrection);
             }
             continue;
         }
@@ -498,8 +514,7 @@ std::optional<RenderLayer::SVGRendererTransform> RenderLayer::computeRendererTra
 
 void RenderLayer::paintRendererByApplyingTransformForSVG(GraphicsContext& context, CheckedRef<RenderElement> rendererToPaint,
     const LayoutSize& positionOffset, const LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags,
-    const LayerFragments&, OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRoot,
-    const LayerPaintingInfo& outerPaintingInfo, const AffineTransform& accumulatedTransform)
+    OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRoot, const LayoutSize& nominalPreTranslation)
 {
     ASSERT(rendererToPaint->isTransformed());
     auto rendererTransform = computeRendererTransformForSVG(rendererToPaint, positionOffset);
@@ -512,25 +527,26 @@ void RenderLayer::paintRendererByApplyingTransformForSVG(GraphicsContext& contex
     ASSERT(paintingInfo.subpixelOffset.isZero());
     LayoutSize adjustedSubpixelOffset;
 
-    TransformPaintScope scope(context, paintingInfo, rendererTransform->transform, deviceScaleFactor, adjustedSubpixelOffset);
+    // Fold the container's nominal pre-translation into the scope transform rather than a separate
+    // context.translate, so TransformPaintScope concatenates it onto the CTM and inverse-maps
+    // paintDirtyRect through it together, keeping content and the leaf visual-overflow cull in one
+    // coordinate space. translateRight post-multiplies, placing the offset in this container's own
+    // space, where nominal lives.
+    auto scopeTransform = rendererTransform->transform;
+    if (!nominalPreTranslation.isZero())
+        scopeTransform.translateRight(-nominalPreTranslation.width().toFloat(), -nominalPreTranslation.height().toFloat());
+
+    TransformPaintScope scope(context, paintingInfo, scopeTransform, deviceScaleFactor, adjustedSubpixelOffset);
 
     auto adjustedPaintFlags = paintFlags;
     adjustedPaintFlags.remove(PaintLayerFlag::PaintingOverflowContents);
-
-    AffineTransform newAccumulatedTransform = accumulatedTransform;
-    newAccumulatedTransform *= scope.appliedTransform();
 
     if (rendererToPaint->hasSelfPaintingLayer()) {
         CheckedRef layerModelObject = downcast<RenderLayerModelObject>(rendererToPaint.get());
         CheckedPtr childLayer = layerModelObject->layer();
 
         LayerPaintingInfo childPaintingInfo(childLayer.get(), scope.transformedPaintingInfo().paintDirtyRect, paintBehavior, LayoutSize());
-
-        if (!accumulatedTransform.isIdentity())
-            childPaintingInfo.nonLayerSVGTransform = accumulatedTransform;
-
-        childLayer->paintLayer(context, childPaintingInfo,
-            adjustedPaintFlags | PaintLayerFlag::AppliedTransform);
+        childLayer->paintLayer(context, childPaintingInfo, adjustedPaintFlags | PaintLayerFlag::AppliedTransform);
     } else {
         // Non-layer renderer painted directly within the transform scope.
         auto& transformedPaintingInfo = scope.transformedPaintingInfo();
@@ -559,7 +575,7 @@ void RenderLayer::paintRendererByApplyingTransformForSVG(GraphicsContext& contex
                 // Outermost viewport container: coordinate system starts at (0, 0).
             } else if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererToPaint.get()))
                 recursionBase = svgModel->nominalSVGLayoutLocation();
-            paintSubtreeWithinTransformScopeForSVG(context, rendererToPaint.get(), recursionBase, transformedPaintingInfo, adjustedPaintFlags, paintBehavior, subtreePaintRoot, outerPaintingInfo, newAccumulatedTransform);
+            paintSubtreeWithinTransformScopeForSVG(context, rendererToPaint.get(), recursionBase, transformedPaintingInfo, adjustedPaintFlags, paintBehavior, subtreePaintRoot);
             paintInScope(PaintPhase::SelfOutline, selfPaintOffset);
         } else {
             paintInScope(PaintPhase::Foreground, selfPaintOffset);
@@ -570,8 +586,7 @@ void RenderLayer::paintRendererByApplyingTransformForSVG(GraphicsContext& contex
 
 void RenderLayer::paintSubtreeWithinTransformScopeForSVG(GraphicsContext& context, RenderElement& container,
     const LayoutPoint& paintOffset, const LayerPaintingInfo& paintingInfo, OptionSet<PaintLayerFlag> paintFlags,
-    OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRoot,
-    const LayerPaintingInfo& outerPaintingInfo, const AffineTransform& accumulatedTransform)
+    OptionSet<PaintBehavior> paintBehavior, RenderObject* subtreePaintRoot)
 {
     // Apply viewport clipping for nested <svg> elements without layers.
     GraphicsContextStateSaver clipSaver(context, false);
@@ -610,7 +625,7 @@ void RenderLayer::paintSubtreeWithinTransformScopeForSVG(GraphicsContext& contex
 
         if (child->isTransformed()) {
             paintRendererByApplyingTransformForSVG(context, child, toLayoutSize(paintOffset), paintingInfo, paintFlags,
-                { }, paintBehavior, subtreePaintRoot, outerPaintingInfo, accumulatedTransform);
+                paintBehavior, subtreePaintRoot);
             continue;
         }
 
@@ -622,8 +637,6 @@ void RenderLayer::paintSubtreeWithinTransformScopeForSVG(GraphicsContext& contex
             adjustedFlags.remove(PaintLayerFlag::PaintingOverflowContents);
 
             RenderLayer::LayerPaintingInfo childPaintingInfo(paintingInfo);
-            if (!accumulatedTransform.isIdentity())
-                childPaintingInfo.nonLayerSVGTransform = accumulatedTransform;
 
             if (isPaintingResourceLayerForSVG() && !paintOffset.isZero()) {
                 GraphicsContextStateSaver stateSaver(context);
@@ -640,7 +653,7 @@ void RenderLayer::paintSubtreeWithinTransformScopeForSVG(GraphicsContext& contex
             adjustedPaintOffset.moveBy(childSvgModel->currentSVGLayoutLocation());
 
         if (child->isRenderSVGContainer()) {
-            paintSubtreeWithinTransformScopeForSVG(context, child.get(), adjustedPaintOffset, paintingInfo, paintFlags, paintBehavior, subtreePaintRoot, outerPaintingInfo, accumulatedTransform);
+            paintSubtreeWithinTransformScopeForSVG(context, child.get(), adjustedPaintOffset, paintingInfo, paintFlags, paintBehavior, subtreePaintRoot);
 
             PaintInfo outlinePaintInfo(context, paintingInfo.paintDirtyRect, PaintPhase::SelfOutline, paintBehavior, subtreePaintRoot,
                 nullptr, nullptr, &paintingInfo.rootLayer->renderer(), this,
@@ -690,7 +703,7 @@ RenderLayer::HitLayer RenderLayer::hitTestChildrenInDOMOrderForSVG(RenderLayer* 
         CheckedRef childRenderer = *childRendererPtr;
 
         if (childRenderer->isTransformed()) {
-            auto hitLayer = hitTestRendererByInversingTransformForSVG(childRenderer.get(), childToPaint.accumulatedAncestorOffset, rootLayer, request, result, hitTestRect, hitTestLocation, transformState, zOffsetForDescendants);
+            auto hitLayer = hitTestRendererByInversingTransformForSVG(childRenderer.get(), childToPaint.accumulatedAncestorOffset, request, result, hitTestRect, hitTestLocation);
             if (hitLayer.layer)
                 return hitLayer;
             continue;
@@ -707,9 +720,8 @@ RenderLayer::HitLayer RenderLayer::hitTestChildrenInDOMOrderForSVG(RenderLayer* 
 }
 
 RenderLayer::HitLayer RenderLayer::hitTestRendererByInversingTransformForSVG(RenderElement& rendererToTest,
-    const LayoutSize& positionOffset, RenderLayer* rootLayer, const HitTestRequest& request, HitTestResult& result,
-    const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation,
-    const HitTestingTransformState* transformState, double* zOffsetForDescendants)
+    const LayoutSize& positionOffset, const HitTestRequest& request, HitTestResult& result,
+    const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation)
 {
     auto transformResult = computeRendererTransformForSVG(rendererToTest, positionOffset);
     if (!transformResult)
@@ -730,7 +742,7 @@ RenderLayer::HitLayer RenderLayer::hitTestRendererByInversingTransformForSVG(Ren
             if (auto* svgModel = dynamicDowncast<RenderSVGModelObject>(rendererToTest))
                 accumulatedOffset = svgModel->nominalSVGLayoutLocation();
         }
-        return hitTestSubtreeWithinTransformScopeForSVG(rendererToTest, accumulatedOffset, rootLayer, request, result, localRect, localLocation, transformState, zOffsetForDescendants);
+        return hitTestSubtreeWithinTransformScopeForSVG(rendererToTest, accumulatedOffset, request, result, localRect, localLocation);
     }
 
     LayoutPoint accumulatedOffset;
@@ -744,9 +756,8 @@ RenderLayer::HitLayer RenderLayer::hitTestRendererByInversingTransformForSVG(Ren
 }
 
 RenderLayer::HitLayer RenderLayer::hitTestSubtreeWithinTransformScopeForSVG(RenderElement& container,
-    const LayoutPoint& accumulatedOffset, RenderLayer* rootLayer, const HitTestRequest& request, HitTestResult& result,
-    const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation,
-    const HitTestingTransformState* transformState, double* zOffsetForDescendants)
+    const LayoutPoint& accumulatedOffset, const HitTestRequest& request, HitTestResult& result,
+    const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation)
 {
     for (CheckedPtr child = container.lastChild(); child; child = child->previousSibling()) {
         CheckedPtr childElement = dynamicDowncast<RenderElement>(child.get());
@@ -757,7 +768,7 @@ RenderLayer::HitLayer RenderLayer::hitTestSubtreeWithinTransformScopeForSVG(Rend
             continue;
 
         if (childElement->isTransformed()) {
-            if (auto hitLayer = hitTestRendererByInversingTransformForSVG(*childElement, toLayoutSize(accumulatedOffset), rootLayer, request, result, hitTestRect, hitTestLocation, transformState, zOffsetForDescendants); hitLayer.layer)
+            if (auto hitLayer = hitTestRendererByInversingTransformForSVG(*childElement, toLayoutSize(accumulatedOffset), request, result, hitTestRect, hitTestLocation); hitLayer.layer)
                 return hitLayer;
             continue;
         }
@@ -777,7 +788,7 @@ RenderLayer::HitLayer RenderLayer::hitTestSubtreeWithinTransformScopeForSVG(Rend
                 if (SVGRenderSupport::isOverflowHidden(*viewportContainer) && !viewportContainer->viewport().contains(hitTestLocation.point()))
                     continue;
             }
-            if (auto hitLayer = hitTestSubtreeWithinTransformScopeForSVG(*childElement, adjustedOffset, rootLayer, request, result, hitTestRect, hitTestLocation, transformState, zOffsetForDescendants); hitLayer.layer)
+            if (auto hitLayer = hitTestSubtreeWithinTransformScopeForSVG(*childElement, adjustedOffset, request, result, hitTestRect, hitTestLocation); hitLayer.layer)
                 return hitLayer;
         } else {
             if (childElement->nodeAtPoint(request, result, hitTestLocation, accumulatedOffset, HitTestAction::Foreground))


### PR DESCRIPTION
#### 7480b77ceddbea49a263c0f75126a61c06ef9cc6
<pre>
[LBSE] Simplify SVG transform paint/hit-test recursion
<a href="https://bugs.webkit.org/show_bug.cgi?id=317353">https://bugs.webkit.org/show_bug.cgi?id=317353</a>

Reviewed by Rob Buis.

Drop the now-unused nonLayerSVGTransform / accumulatedTransform / rootLayer /
transformState handling from the SVG transform paint and hit-test recursion, and
fold the container&apos;s nominal pre-translation into the TransformPaintScope
transform so painted content and the leaf visual-overflow culling share the
same coordinate space.

This is a preparation for conditional SVG layer creation.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::paintChildrenInDOMOrderForSVG):
(WebCore::RenderLayer::paintRendererByApplyingTransformForSVG):
(WebCore::RenderLayer::paintSubtreeWithinTransformScopeForSVG):
(WebCore::RenderLayer::hitTestChildrenInDOMOrderForSVG):
(WebCore::RenderLayer::hitTestRendererByInversingTransformForSVG):
(WebCore::RenderLayer::hitTestSubtreeWithinTransformScopeForSVG):

Canonical link: <a href="https://commits.webkit.org/315544@main">https://commits.webkit.org/315544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf2c620e2393243f8380b9f3aa67232e5bc4ed73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43299 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178733 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42927 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172336 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/112440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27433 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181333 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42955 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/140225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43644 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107677 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25803 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/35496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42154 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41547 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->