### PR TITLE
[JSC] Use Reverse-Post-Order in WTF::Liveness

### DIFF
--- a/Source/JavaScriptCore/b3/B3BasicBlockUtils.h
+++ b/Source/JavaScriptCore/b3/B3BasicBlockUtils.h
@@ -110,41 +110,6 @@ bool isBlockDead(BasicBlock* block)
     return block->predecessors().isEmpty();
 }
 
-template<typename BasicBlock>
-Vector<BasicBlock*> blocksInPreOrder(BasicBlock* root)
-{
-    Vector<BasicBlock*> result;
-    GraphNodeWorklist<BasicBlock*, IndexSet<BasicBlock*>> worklist;
-    worklist.push(root);
-    while (BasicBlock* block = worklist.pop()) {
-        result.append(block);
-        for (BasicBlock* successor : block->successorBlocks())
-            worklist.push(successor);
-    }
-    return result;
-}
-
-template<typename BasicBlock>
-Vector<BasicBlock*> blocksInPostOrder(BasicBlock* root)
-{
-    Vector<BasicBlock*> result;
-    PostOrderGraphNodeWorklist<BasicBlock*, IndexSet<BasicBlock*>> worklist;
-    worklist.push(root);
-    while (GraphNodeWithOrder<BasicBlock*> item = worklist.pop()) {
-        switch (item.order) {
-        case GraphVisitOrder::Pre:
-            worklist.pushPost(item.node);
-            for (BasicBlock* successor : item.node->successorBlocks())
-                worklist.push(successor);
-            break;
-        case GraphVisitOrder::Post:
-            result.append(item.node);
-            break;
-        }
-    }
-    return result;
-}
-
 } } // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3Procedure.cpp
+++ b/Source/JavaScriptCore/b3/B3Procedure.cpp
@@ -286,12 +286,18 @@ void Procedure::dump(PrintStream& out) const
 
 Vector<BasicBlock*> Procedure::blocksInPreOrder()
 {
-    return B3::blocksInPreOrder(at(0));
+    Vector<BasicBlock*> result;
+    result.reserveInitialCapacity(size());
+    appendNodesInOrder(cfg(), GraphOrder::PreOrder, result);
+    return result;
 }
 
 Vector<BasicBlock*> Procedure::blocksInPostOrder()
 {
-    return B3::blocksInPostOrder(at(0));
+    Vector<BasicBlock*> result;
+    result.reserveInitialCapacity(size());
+    appendNodesInOrder(cfg(), GraphOrder::PostOrder, result);
+    return result;
 }
 
 void Procedure::deleteVariable(Variable* variable)

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -34,7 +34,6 @@
 #include "CodeBlockWithJITType.h"
 #include "DFGBackwardsCFG.h"
 #include "DFGBackwardsDominators.h"
-#include "DFGBlockWorklist.h"
 #include "DFGCFG.h"
 #include "DFGClobberSet.h"
 #include "DFGClobbersExitState.h"
@@ -60,6 +59,7 @@
 #include "StructureInlines.h"
 #include <array>
 #include <wtf/CommaPrinter.h>
+#include <wtf/GraphOrdering.h>
 #include <wtf/ListDump.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -973,14 +973,8 @@ BlockList Graph::blocksInPreOrder()
 {
     BlockList result;
     result.reserveInitialCapacity(m_blocks.size());
-    BlockWorklist worklist;
-    for (BasicBlock* entrypoint : m_roots)
-        worklist.push(entrypoint);
-    while (BasicBlock* block = worklist.pop()) {
-        result.append(block);
-        for (unsigned i = block->numSuccessors(); i--;)
-            worklist.push(block->successor(i));
-    }
+    CFG cfg(*this);
+    appendNodesInOrder(cfg, m_roots, GraphOrder::PreOrder, result);
 
     if (validationEnabled()) {
         // When iterating over pre order, we should see dominators
@@ -1012,21 +1006,8 @@ BlockList Graph::blocksInPostOrder(bool isSafeToValidate)
 {
     BlockList result;
     result.reserveInitialCapacity(m_blocks.size());
-    PostOrderBlockWorklist worklist;
-    for (BasicBlock* entrypoint : m_roots)
-        worklist.push(entrypoint);
-    while (BlockWithOrder item = worklist.pop()) {
-        switch (item.order) {
-        case VisitOrder::Pre:
-            worklist.pushPost(item.node);
-            for (unsigned i = item.node->numSuccessors(); i--;)
-                worklist.push(item.node->successor(i));
-            break;
-        case VisitOrder::Post:
-            result.append(item.node);
-            break;
-        }
-    }
+    CFG cfg(*this);
+    appendNodesInOrder(cfg, m_roots, GraphOrder::PostOrder, result);
 
     if (isSafeToValidate && validationEnabled()) { // There are users of this where we haven't yet built the CFG enough to be able to run dominators.
         auto validateResults = [&] (auto& dominators) {

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		DD3DC87B27A4BF8E007E5B61 /* ParallelHelperPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFF19DB1BB334EB00886D91 /* ParallelHelperPool.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC87C27A4BF8E007E5B61 /* Expected.h in Headers */ = {isa = PBXBuildFile; fileRef = AD7C434A1DD2A4A70026888B /* Expected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC87D27A4BF8E007E5B61 /* GraphNodeWorklist.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEC84AE1BD825310080FF74 /* GraphNodeWorklist.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AA11GRAPHORDERING0000001 /* GraphOrdering.h in Headers */ = {isa = PBXBuildFile; fileRef = AA11GRAPHORDERING0000002 /* GraphOrdering.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC87E27A4BF8E007E5B61 /* BumpPointerAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47267151A825A004123FF /* BumpPointerAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC87F27A4BF8E007E5B61 /* Logger.h in Headers */ = {isa = PBXBuildFile; fileRef = 077CD86A1FD9CFD200828587 /* Logger.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC88127A4BF8E007E5B61 /* MetaAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472CE151A825B004123FF /* MetaAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1229,6 +1230,7 @@
 		0FEC3C5C1F368A9700F59B6C /* ReadWriteLock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReadWriteLock.cpp; sourceTree = "<group>"; };
 		0FEC3C5D1F368A9700F59B6C /* ReadWriteLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReadWriteLock.h; sourceTree = "<group>"; };
 		0FEC84AE1BD825310080FF74 /* GraphNodeWorklist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphNodeWorklist.h; sourceTree = "<group>"; };
+		AA11GRAPHORDERING0000002 /* GraphOrdering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphOrdering.h; sourceTree = "<group>"; };
 		0FEC84B01BDACD390080FF74 /* ScopedLambda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScopedLambda.h; sourceTree = "<group>"; };
 		0FED67B51B22D4D80066CE15 /* TinyPtrSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TinyPtrSet.h; sourceTree = "<group>"; };
 		0FF4B4C41E88939C00DBBE86 /* Liveness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Liveness.h; sourceTree = "<group>"; };
@@ -2507,6 +2509,7 @@
 				0F30BA8A1E78708E002CA847 /* GlobalVersion.cpp */,
 				0F30BA8B1E78708E002CA847 /* GlobalVersion.h */,
 				0FEC84AE1BD825310080FF74 /* GraphNodeWorklist.h */,
+				AA11GRAPHORDERING0000002 /* GraphOrdering.h */,
 				2CCD892915C0390200285083 /* GregorianDateTime.cpp */,
 				2C05385315BC819000F21B96 /* GregorianDateTime.h */,
 				A8A472B3151A825A004123FF /* HashCountedSet.h */,
@@ -3675,6 +3678,7 @@
 				DD3DC94727A4BF8E007E5B61 /* GetPtr.h in Headers */,
 				DD3DC96B27A4BF8E007E5B61 /* GlobalVersion.h in Headers */,
 				DD3DC87D27A4BF8E007E5B61 /* GraphNodeWorklist.h in Headers */,
+				AA11GRAPHORDERING0000001 /* GraphOrdering.h in Headers */,
 				DD3DC8F927A4BF8E007E5B61 /* GregorianDateTime.h in Headers */,
 				DD3DC8E427A4BF8E007E5B61 /* HashCountedSet.h in Headers */,
 				DD3DC91227A4BF8E007E5B61 /* Hasher.h in Headers */,
@@ -4669,7 +4673,6 @@
 				1C181C961D30800A00F5FA16 /* TextBreakIteratorInternalICUCocoa.cpp in Sources */,
 				A3E4DD931F3A803400DED0B4 /* TextStream.cpp in Sources */,
 				0F3492D722AF431C004F85FC /* TextStreamCocoa.mm in Sources */,
-				70ECA60F1B02426800449739 /* UniquedStringImpl.cpp in Sources */,
 				E311FB171F0A568B003C08DE /* ThreadGroup.cpp in Sources */,
 				A8A4744A151A825B004123FF /* Threading.cpp in Sources */,
 				A32D8FA521FFFAB400780662 /* ThreadingPOSIX.cpp in Sources */,
@@ -4680,6 +4683,7 @@
 				FE69838E2F9F1FD0004EA0A7 /* UnbarrieredMonotonicTime.cpp in Sources */,
 				467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */,
 				0FA6F39520CCACE900A03DCD /* UniqueArray.cpp in Sources */,
+				70ECA60F1B02426800449739 /* UniquedStringImpl.cpp in Sources */,
 				5CC0EE7621629F1900A1A842 /* URL.cpp in Sources */,
 				5C1F0595216437B30039302C /* URLCF.cpp in Sources */,
 				5CC0EE892162BC2200A1A842 /* URLCocoa.mm in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -121,6 +121,7 @@ set(WTF_PUBLIC_HEADERS
     GetPtr.h
     GlobalVersion.h
     GraphNodeWorklist.h
+    GraphOrdering.h
     GregorianDateTime.h
     HashCountedSet.h
     HashFunctions.h

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -26,11 +26,11 @@
 #pragma once
 
 #include <ranges>
-#include <wtf/BitSet.h>
 #include <wtf/CommaPrinter.h>
 #include <wtf/DataLog.h>
 #include <wtf/FastBitVector.h>
 #include <wtf/GraphNodeWorklist.h>
+#include <wtf/GraphOrdering.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -343,39 +343,17 @@ private:
 
         void computeReversePostorder()
         {
-            BitSet<std::numeric_limits<int16_t>::max()> visited;
-            visited.clearAll();
+            // Any valid DFS reverse-post-order works for the iterative dominance fixpoint: a node's
+            // dominator always precedes it. We reuse the shared graph-ordering utility rather than
+            // hand-rolling the traversal.
+            BitVector visited(m_graph.numNodes());
+            appendNodeIndicesInOrder(m_graph, GraphOrder::PostOrder, visited, m_reversePostorderedNodes);
 
-            Vector<int16_t, 64> workList;
-            int16_t rootIndex = m_graph.index(m_graph.root());
-            workList.append(rootIndex);
-            visited.set(rootIndex);
-
-            while (workList.size()) {
-                int16_t index = workList.takeLast();
-                if (index < 0) {
-                    // Negative indices mark nodes we're revisiting.
-                    m_reversePostorderedNodes.append(~index);
-                    continue;
-                }
-                const auto& successors = m_graph.successors(m_graph.node(index));
-                if (!successors.size()) {
-                    m_reversePostorderedNodes.append(index);
-                    continue;
-                }
-                workList.append(~index); // Revisit this index later to add it after visiting all successors.
-                for (unsigned i = 0; i < successors.size(); i ++) {
-                    int16_t index = m_graph.index(successors[i]);
-                    if (!visited.get(index)) {
-                        visited.set(index);
-                        workList.append(index);
-                    }
-                }
-            }
+            // postorder number = position in post-order = mirror of the position in reverse-post-order.
             m_postorderNumbers.fill(0, m_graph.numNodes());
             for (unsigned i = 0; i < m_reversePostorderedNodes.size(); i ++)
                 m_postorderNumbers[m_reversePostorderedNodes[i]] = i;
-            std::ranges::reverse(m_reversePostorderedNodes);
+            m_reversePostorderedNodes.reverse();
         }
 
         uint16_t intersect(uint16_t a, uint16_t b)

--- a/Source/WTF/wtf/GraphOrdering.h
+++ b/Source/WTF/wtf/GraphOrdering.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <wtf/BitVector.h>
+#include <wtf/Vector.h>
+
+namespace WTF {
+
+enum class GraphOrder : uint8_t {
+    PreOrder,
+    PostOrder,
+};
+
+// Most general form: for every node reachable from `roots`, appends projection(index) into
+// `output` in the requested order. `visited` must be sized to graph.numNodes(); it is set for
+// every node this call appends (callers may reuse it afterwards). `roots` is any iterable of
+// graph nodes; falsy roots (e.g. null Node) are skipped.
+template<typename Graph, typename Roots, typename Container, typename Projection>
+void appendNodeOrderFromRoots(Graph& graph, const Roots& roots, GraphOrder order, BitVector& visited, Container& output, NOESCAPE const Projection& projection)
+{
+    constexpr unsigned revisitFlag = 1u << 31;
+    ASSERT(static_cast<unsigned>(graph.numNodes()) < revisitFlag);
+
+    Vector<unsigned, 32> stack;
+    for (auto root : roots) {
+        if (root)
+            stack.append(graph.index(root));
+    }
+
+    while (!stack.isEmpty()) {
+        unsigned entry = stack.takeLast();
+
+        if (entry & revisitFlag) {
+            // Post-visit: all successors have been emitted.
+            output.append(projection(entry & ~revisitFlag));
+            continue;
+        }
+
+        if (visited.quickGet(entry))
+            continue;
+        visited.quickSet(entry);
+
+        if (order == GraphOrder::PreOrder)
+            output.append(projection(entry));
+        else
+            stack.append(entry | revisitFlag);
+
+        for (auto successor : graph.successors(graph.node(entry))) {
+            unsigned successorIndex = graph.index(successor);
+            if (!visited.quickGet(successorIndex))
+                stack.append(successorIndex);
+        }
+    }
+}
+
+template<typename Graph, typename Container, typename Projection>
+void appendNodeOrder(Graph& graph, GraphOrder order, BitVector& visited, Container& output, NOESCAPE const Projection& projection)
+{
+    std::array<typename Graph::Node, 1> roots { graph.root() };
+    appendNodeOrderFromRoots(graph, roots, order, visited, output, projection);
+}
+
+// Appends node indices (as held by the graph) into `output`. Used by index-based dataflow such as
+// WTF::Liveness and WTF::Dominators. `visited` is caller-owned.
+template<typename Graph, typename Container>
+void appendNodeIndicesInOrder(Graph& graph, GraphOrder order, BitVector& visited, Container& output)
+{
+    appendNodeOrder(graph, order, visited, output, [](unsigned index) { return index; });
+}
+
+template<typename Graph, typename Roots, typename Container>
+void appendNodeIndicesInOrder(Graph& graph, const Roots& roots, GraphOrder order, BitVector& visited, Container& output)
+{
+    appendNodeOrderFromRoots(graph, roots, order, visited, output, [](unsigned index) { return index; });
+}
+
+// Appends graph nodes into `output`. Used by B3/Air/DFG which produce block lists. The visited set
+// is allocated internally.
+template<typename Graph, typename Container>
+void appendNodesInOrder(Graph& graph, GraphOrder order, Container& output)
+{
+    BitVector visited(graph.numNodes());
+    appendNodeOrder(graph, order, visited, output, [&](unsigned index) { return graph.node(index); });
+}
+
+template<typename Graph, typename Roots, typename Container>
+void appendNodesInOrder(Graph& graph, const Roots& roots, GraphOrder order, Container& output)
+{
+    BitVector visited(graph.numNodes());
+    appendNodeOrderFromRoots(graph, roots, order, visited, output, [&](unsigned index) { return graph.node(index); });
+}
+
+} // namespace WTF
+
+using WTF::GraphOrder;
+using WTF::appendNodeOrder;
+using WTF::appendNodeOrderFromRoots;
+using WTF::appendNodeIndicesInOrder;
+using WTF::appendNodesInOrder;

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <ranges>
 #include <wtf/BitVector.h>
+#include <wtf/GraphOrdering.h>
 #include <wtf/IndexSparseSet.h>
 #include <wtf/SparseBitVector.h>
 #include <wtf/StdLibExtras.h>
@@ -317,8 +318,7 @@ protected:
             set[index / wordBits] |= static_cast<uint64_t>(1) << (index % wordBits);
         };
 
-        BitVector dirtyBlocks(numNodes);
-        Vector<unsigned, 64> worklist;
+        unsigned numActiveBlocks = 0;
         for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
             auto block = m_cfg.node(blockIndex);
             if (!block)
@@ -352,8 +352,22 @@ protected:
                 setBit(liveOutSet, index);
             });
 
-            dirtyBlocks.quickSet(blockIndex);
-            worklist.append(blockIndex);
+            ++numActiveBlocks;
+        }
+
+        // Seed the worklist in reverse post-order so the backward dataflow processes a block after
+        // its successors. This minimizes re-visits -- in particular the high-fan-in switch-dispatch
+        // block is finalized in one pass instead of once per contributing case, which also avoids
+        // repeating its expensive many-predecessor propagation.
+        Vector<unsigned, 64> worklist;
+        worklist.reserveInitialCapacity(numActiveBlocks);
+        BitVector dirtyBlocks(numNodes);
+        appendNodeIndicesInOrder(m_cfg, GraphOrder::PostOrder, dirtyBlocks, worklist);
+        worklist.reverse();
+        // Queue any active block the DFS did not reach (e.g. unreachable but not yet pruned).
+        for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
+            if (m_cfg.node(blockIndex) && !dirtyBlocks.quickSet(blockIndex))
+                worklist.append(blockIndex);
         }
 
         while (!worklist.isEmpty()) {


### PR DESCRIPTION
#### 3675b73e797f146ff93c1c23752260392b10800a
<pre>
[JSC] Use Reverse-Post-Order in WTF::Liveness
<a href="https://bugs.webkit.org/show_bug.cgi?id=317354">https://bugs.webkit.org/show_bug.cgi?id=317354</a>
<a href="https://rdar.apple.com/179969538">rdar://179969538</a>

Reviewed by Dan Hecht.

Use Reverse-Post-Order (RPO) to quickly converge the WTF::Liveness
results. This is effective in particular when you have switch with
massive amount of clauses.

We introduce GraphOrdering.h in WTF, which unifies all ordering
utilities into one file. And use it in DFG and B3 too.

* Source/JavaScriptCore/b3/B3BasicBlockUtils.h:
(): Deleted.
* Source/JavaScriptCore/b3/B3Procedure.cpp:
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::blocksInPreOrder):
(JSC::DFG::Graph::blocksInPostOrder):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/Dominators.h:
(WTF::Dominators::IterativeDominance::computeReversePostorder):
* Source/WTF/wtf/GraphOrdering.h: Added.
(WTF::appendNodeOrderFromRoots):
(WTF::appendNodeOrder):
(WTF::appendNodeIndicesInOrder):
(WTF::appendNodesInOrder):
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::computeDense):

Canonical link: <a href="https://commits.webkit.org/315493@main">https://commits.webkit.org/315493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ef3f36a50516f1f9413d48f76f0095cb9a1823d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169174 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43096 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36354 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126886 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/968a7113-3ec1-4491-bd42-e5767c89113b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43119 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42721 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131757 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6d09a39-e96e-4131-b510-b9a9e5a10eda) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172133 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/36354 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112260 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcafa7e7-8c0a-4d22-a327-2b4a39e38717) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/42721 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27230 "Built successfully") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/36354 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/36354 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181130 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30429 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/42721 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140210 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42752 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/36354 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140051 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43441 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/36354 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107361 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25786 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35329 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201853 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41950 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/36354 "Hash 2ef3f36a for PR 67391 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54156 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41344 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41599 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->