### PR TITLE
[LBSE] Add tests for conditional SVG layer creation

### DIFF
--- a/LayoutTests/svg/custom/layer-sibling-positioning-problem-expected.svg
+++ b/LayoutTests/svg/custom/layer-sibling-positioning-problem-expected.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+
+<svg opacity="0.5">
+    <rect x="0" y="0" width="100" height="100" fill="green"/>
+</svg>
+
+<g>
+    <text x="0" y="120">Text just below</text>
+</g>
+</svg>

--- a/LayoutTests/svg/custom/layer-sibling-positioning-problem.svg
+++ b/LayoutTests/svg/custom/layer-sibling-positioning-problem.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+
+<svg opacity="0.5">
+    <rect x="0" y="0" width="100" height="100" fill="green"/>
+</svg>
+
+<g transform="translate(10, 0)">
+    <text x="-10" y="120">Text just below</text>
+</g>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-plain-expected.svg
+++ b/LayoutTests/svg/geometry/use-direct-plain-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-plain.svg
+++ b/LayoutTests/svg/geometry/use-direct-plain.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><use xlink:href="#m"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-ref-transform-expected.svg
+++ b/LayoutTests/svg/geometry/use-direct-ref-transform-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(25)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-ref-transform.svg
+++ b/LayoutTests/svg/geometry/use-direct-ref-transform.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m" transform="rotate(25)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><use xlink:href="#m"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-transform-ref-transform-expected.svg
+++ b/LayoutTests/svg/geometry/use-direct-transform-ref-transform-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(30,30)"><g transform="scale(1.5)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-transform-ref-transform.svg
+++ b/LayoutTests/svg/geometry/use-direct-transform-ref-transform.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m" transform="scale(1.5)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><use xlink:href="#m" transform="translate(30,30)"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-transform-rotate-expected.svg
+++ b/LayoutTests/svg/geometry/use-direct-transform-rotate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(30 60 60)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-transform-rotate.svg
+++ b/LayoutTests/svg/geometry/use-direct-transform-rotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><use xlink:href="#m" transform="rotate(30 60 60)"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-transform-scale-expected.svg
+++ b/LayoutTests/svg/geometry/use-direct-transform-scale-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(40,40) scale(2)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-transform-scale.svg
+++ b/LayoutTests/svg/geometry/use-direct-transform-scale.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><use xlink:href="#m" transform="translate(40,40) scale(2)"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-transform-translate-expected.svg
+++ b/LayoutTests/svg/geometry/use-direct-transform-translate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(40,30)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-transform-translate.svg
+++ b/LayoutTests/svg/geometry/use-direct-transform-translate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><use xlink:href="#m" transform="translate(40,30)"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-xy-expected.svg
+++ b/LayoutTests/svg/geometry/use-direct-xy-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(40,30)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-xy-ref-transform-expected.svg
+++ b/LayoutTests/svg/geometry/use-direct-xy-ref-transform-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(50,40)"><g transform="rotate(25)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-xy-ref-transform.svg
+++ b/LayoutTests/svg/geometry/use-direct-xy-ref-transform.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m" transform="rotate(25)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><use xlink:href="#m" x="50" y="40"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-direct-xy.svg
+++ b/LayoutTests/svg/geometry/use-direct-xy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><use xlink:href="#m" x="40" y="30"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-g-plain-expected.svg
+++ b/LayoutTests/svg/geometry/use-in-g-plain-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(60,50)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-g-plain.svg
+++ b/LayoutTests/svg/geometry/use-in-g-plain.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><g transform="translate(60,50)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-g-rotate-expected.svg
+++ b/LayoutTests/svg/geometry/use-in-g-rotate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(20 120 120)"><g transform="translate(40,40)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-g-rotate.svg
+++ b/LayoutTests/svg/geometry/use-in-g-rotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><g transform="rotate(20 120 120)"><use xlink:href="#m" x="40" y="40"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-g-scale-expected.svg
+++ b/LayoutTests/svg/geometry/use-in-g-scale-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(20,20) scale(1.8)"><g transform="translate(20,20)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-g-scale.svg
+++ b/LayoutTests/svg/geometry/use-in-g-scale.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><g transform="translate(20,20) scale(1.8)"><use xlink:href="#m" x="20" y="20"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-g-translate-xy-expected.svg
+++ b/LayoutTests/svg/geometry/use-in-g-translate-xy-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(60,50)"><g transform="translate(20,15)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-g-translate-xy.svg
+++ b/LayoutTests/svg/geometry/use-in-g-translate-xy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><g transform="translate(60,50)"><use xlink:href="#m" x="20" y="15"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-grotate-ref-rotate-expected.svg
+++ b/LayoutTests/svg/geometry/use-in-grotate-ref-rotate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(20 120 120)"><g transform="translate(40,40)"><g transform="rotate(-35)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-grotate-ref-rotate.svg
+++ b/LayoutTests/svg/geometry/use-in-grotate-ref-rotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m" transform="rotate(-35)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><g transform="rotate(20 120 120)"><use xlink:href="#m" x="40" y="40"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-nested-g-expected.svg
+++ b/LayoutTests/svg/geometry/use-in-nested-g-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(50,40)"><g transform="rotate(25)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-nested-g-scale-rotate-expected.svg
+++ b/LayoutTests/svg/geometry/use-in-nested-g-scale-rotate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(30,30) scale(1.4)"><g transform="rotate(30)"><g transform="translate(20,10)"><g transform="rotate(-20)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-nested-g-scale-rotate.svg
+++ b/LayoutTests/svg/geometry/use-in-nested-g-scale-rotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m" transform="rotate(-20)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><g transform="translate(30,30) scale(1.4)"><g transform="rotate(30)"><use xlink:href="#m" x="20" y="10"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-nested-g-xy-expected.svg
+++ b/LayoutTests/svg/geometry/use-in-nested-g-xy-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(50,40)"><g transform="rotate(25)"><g transform="translate(30,20)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-nested-g-xy.svg
+++ b/LayoutTests/svg/geometry/use-in-nested-g-xy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><g transform="translate(50,40)"><g transform="rotate(25)"><use xlink:href="#m" x="30" y="20"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-in-nested-g.svg
+++ b/LayoutTests/svg/geometry/use-in-nested-g.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><rect x="22" y="12" width="8" height="8" fill="navy"/></g></defs><g transform="translate(50,40)"><g transform="rotate(25)"><use xlink:href="#m"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-on-use-overhang-expected.svg
+++ b/LayoutTests/svg/geometry/use-on-use-overhang-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(60,60)"><g transform="translate(20,20)"><rect width="60" height="10" fill="red"/><circle cx="30" cy="5" r="10" fill="green"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-on-use-overhang.svg
+++ b/LayoutTests/svg/geometry/use-on-use-overhang.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="g"><rect width="60" height="10" fill="red"/><circle cx="30" cy="5" r="10" fill="green"/></g><use id="u" xlink:href="#g"/></defs><g transform="translate(60,60)"><use x="20" y="20" xlink:href="#u"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-direct-expected.svg
+++ b/LayoutTests/svg/geometry/use-opacity-direct-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(50,50)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><circle cx="26" cy="16" r="6" fill="navy" opacity="0.5"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-direct.svg
+++ b/LayoutTests/svg/geometry/use-opacity-direct.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><circle cx="26" cy="16" r="6" fill="navy" opacity="0.5"/></g></defs><g transform="translate(50,50)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-in-grotate-expected.svg
+++ b/LayoutTests/svg/geometry/use-opacity-in-grotate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(20 120 120)"><g transform="translate(40,40)"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><circle cx="26" cy="16" r="6" fill="navy" opacity="0.5"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-in-grotate.svg
+++ b/LayoutTests/svg/geometry/use-opacity-in-grotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><rect width="8" height="8" fill="red"/><circle cx="26" cy="16" r="6" fill="navy" opacity="0.5"/></g></defs><g transform="rotate(20 120 120)"><use xlink:href="#m" x="40" y="40"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-overhang-grotate-expected.svg
+++ b/LayoutTests/svg/geometry/use-opacity-overhang-grotate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(25 120 120)"><g transform="translate(50,50)"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-overhang-grotate.svg
+++ b/LayoutTests/svg/geometry/use-opacity-overhang-grotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></defs><g transform="rotate(25 120 120)"><use xlink:href="#m" x="50" y="50"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-overhang-in-g-expected.svg
+++ b/LayoutTests/svg/geometry/use-opacity-overhang-in-g-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(60,60)"><rect width="60" height="10" fill="red"/><circle cx="30" cy="5" r="10" fill="green" opacity="0.5"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-overhang-in-g.svg
+++ b/LayoutTests/svg/geometry/use-opacity-overhang-in-g.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="60" height="10" fill="red"/><circle cx="30" cy="5" r="10" fill="green" opacity="0.5"/></g></defs><g transform="translate(60,60)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-overhang-rotate-xy-expected.svg
+++ b/LayoutTests/svg/geometry/use-opacity-overhang-rotate-xy-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(40 120 120)"><g transform="translate(40,40)"><rect width="60" height="10" fill="red"/><circle cx="30" cy="5" r="10" fill="green" opacity="0.5"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-opacity-overhang-rotate-xy.svg
+++ b/LayoutTests/svg/geometry/use-opacity-overhang-rotate-xy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="60" height="10" fill="red"/><circle cx="30" cy="5" r="10" fill="green" opacity="0.5"/></g></defs><g transform="rotate(40 120 120)"><use x="40" y="40" xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-overhang-direct-expected.svg
+++ b/LayoutTests/svg/geometry/use-overhang-direct-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(60,60)"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-overhang-direct.svg
+++ b/LayoutTests/svg/geometry/use-overhang-direct.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></defs><g transform="translate(60,60)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-overhang-in-grotate-expected.svg
+++ b/LayoutTests/svg/geometry/use-overhang-in-grotate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(25 120 120)"><g transform="translate(50,50)"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-overhang-in-grotate.svg
+++ b/LayoutTests/svg/geometry/use-overhang-in-grotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></defs><g transform="rotate(25 120 120)"><use xlink:href="#m" x="50" y="50"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-overhang-transform-expected.svg
+++ b/LayoutTests/svg/geometry/use-overhang-transform-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(40,40)"><g transform="rotate(20)"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-overhang-transform.svg
+++ b/LayoutTests/svg/geometry/use-overhang-transform.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></defs><g transform="translate(40,40)"><use xlink:href="#m" transform="rotate(20)"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-overhang-xy-expected.svg
+++ b/LayoutTests/svg/geometry/use-overhang-xy-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(40,40)"><g transform="translate(40,40)"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-overhang-xy.svg
+++ b/LayoutTests/svg/geometry/use-overhang-xy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m"><rect width="30" height="20" fill="green"/><circle cx="0" cy="0" r="6" fill="red"/></g></defs><g transform="translate(40,40)"><use xlink:href="#m" x="40" y="40"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-filled-offset-scaledown-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-filled-offset-scaledown-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(0,70)"><g transform="scale(0.15,0.15)"><path fill="green" d="M 100 100 L 900 100 L 900 300 L 100 300 Z"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-filled-offset-scaledown.svg
+++ b/LayoutTests/svg/geometry/use-ref-filled-offset-scaledown.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(0.15,0.15)" d="M 100 100 L 900 100 L 900 300 L 100 300 Z"/></defs>
+<g transform="translate(0,70)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-grotate-overhang-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-grotate-overhang-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(80,80)"><g transform="rotate(-45)"><rect width="60" height="10" fill="red"/><circle cx="30" cy="5" r="10" fill="green"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-grotate-overhang.svg
+++ b/LayoutTests/svg/geometry/use-ref-grotate-overhang.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><g id="m" transform="rotate(-45)"><rect width="60" height="10" fill="red"/><circle cx="30" cy="5" r="10" fill="green"/></g></defs><g transform="translate(80,80)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-large-scaledown-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-large-scaledown-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(0,70)"><g transform="scale(0.15)"><path fill="green" d="M0,0 L300,0 L300,80 L80,80 L80,200 L0,200 Z"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-large-scaledown-xy-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-large-scaledown-xy-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(20,20)"><g transform="translate(30,20)"><g transform="scale(0.15)"><path fill="green" d="M0,0 L300,0 L300,80 L80,80 L80,200 L0,200 Z"/></g></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-large-scaledown-xy.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-large-scaledown-xy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(0.15)" d="M0,0 L300,0 L300,80 L80,80 L80,200 L0,200 Z"/></defs><g transform="translate(20,20)"><use xlink:href="#m" x="30" y="20"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-large-scaledown.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-large-scaledown.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(0.15)" d="M0,0 L300,0 L300,80 L80,80 L80,200 L0,200 Z"/></defs><g transform="translate(0,70)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-offset-scale-direct-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-offset-scale-direct-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="scale(0.15,0.15)"><path fill="green" d="M 100 100 L 900 100 L 900 300 L 100 300 Z"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-offset-scale-direct.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-offset-scale-direct.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(0.15,0.15)" d="M 100 100 L 900 100 L 900 300 L 100 300 Z"/></defs>
+<use xlink:href="#m"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-plain-in-grotate-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-plain-in-grotate-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="rotate(20 120 120)"><g transform="translate(40,40)"><path fill="green" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-plain-in-grotate.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-plain-in-grotate.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></defs><g transform="rotate(20 120 120)"><use xlink:href="#m" x="40" y="40"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-rotate-in-g-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-rotate-in-g-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(40,40)"><g transform="rotate(30)"><path fill="green" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-rotate-in-g.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-rotate-in-g.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="rotate(30)" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></defs><g transform="translate(40,40)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-scale-direct-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-scale-direct-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="scale(2)"><path fill="green" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-scale-direct.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-scale-direct.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(2)" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></defs><use xlink:href="#m"/>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-scale-in-g-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-scale-in-g-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(50,40)"><g transform="scale(2)"><path fill="green" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-scale-in-g.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-scale-in-g.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(2)" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></defs><g transform="translate(50,40)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-scale-in-gtransform-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-scale-in-gtransform-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(0,70)"><g transform="scale(2)"><path fill="green" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-shape-scale-in-gtransform.svg
+++ b/LayoutTests/svg/geometry/use-ref-shape-scale-in-gtransform.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(2)" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></defs><g transform="translate(0,70)"><use xlink:href="#m"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-stroked-origin-scaledown-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-stroked-origin-scaledown-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(0,70)"><g transform="scale(0.15,0.15)"><path style="fill:none;stroke:blue;stroke-width:2" d="M 0 0 L 800 0 L 800 200 L 0 200 Z"/></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-stroked-origin-scaledown.svg
+++ b/LayoutTests/svg/geometry/use-ref-stroked-origin-scaledown.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" style="fill:none;stroke:blue" transform="scale(0.15,0.15)" d="M 0 0 L 800 0 L 800 200 L 0 200 Z"/></defs>
+<g transform="translate(0,70)"><use xlink:href="#m" style="fill:none;stroke:blue;stroke-width:2"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-stroked-path-scaledown-expected.svg
+++ b/LayoutTests/svg/geometry/use-ref-stroked-path-scaledown-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(0,70)">
+  <g transform="scale(0.15,0.15)">
+    <path style="fill:none; stroke:blue; stroke-width:2" d="M 100 200 C 200 100 300 0 400 100 C 500 200 600 300 700 200 C 800 100 900 100 900 100"/>
+  </g>
+</g>
+</svg>

--- a/LayoutTests/svg/geometry/use-ref-stroked-path-scaledown.svg
+++ b/LayoutTests/svg/geometry/use-ref-stroked-path-scaledown.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs>
+  <path id="m" style="fill:none; stroke:blue;" transform="scale(0.15,0.15)" d="M 100 200 C 200 100 300 0 400 100 C 500 200 600 300 700 200 C 800 100 900 100 900 100"/>
+</defs>
+<g transform="translate(0,70)">
+  <use xlink:href="#m" style="fill:none; stroke:blue; stroke-width:2"/>
+</g>
+</svg>

--- a/LayoutTests/svg/geometry/use-transform-ref-shape-scale-expected.svg
+++ b/LayoutTests/svg/geometry/use-transform-ref-shape-scale-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(20,20)"><g transform="rotate(20)"><g transform="scale(1.5)"><path fill="green" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></g></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-transform-ref-shape-scale.svg
+++ b/LayoutTests/svg/geometry/use-transform-ref-shape-scale.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(1.5)" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></defs><g transform="translate(20,20)"><use xlink:href="#m" transform="rotate(20)"/></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-xy-ref-shape-scale-expected.svg
+++ b/LayoutTests/svg/geometry/use-xy-ref-shape-scale-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<g transform="translate(20,20)"><g transform="translate(40,30)"><g transform="scale(1.5)"><path fill="green" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></g></g></g>
+</svg>

--- a/LayoutTests/svg/geometry/use-xy-ref-shape-scale.svg
+++ b/LayoutTests/svg/geometry/use-xy-ref-shape-scale.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="240" height="240" viewBox="0 0 240 240">
+<defs><path id="m" fill="green" transform="scale(1.5)" d="M0,0 L30,0 L30,8 L8,8 L8,20 L0,20 Z"/></defs><g transform="translate(20,20)"><use xlink:href="#m" x="40" y="30"/></g>
+</svg>


### PR DESCRIPTION
#### 202eacc028098328bbcb37eca3eae7c7f5d7629b
<pre>
[LBSE] Add tests for conditional SVG layer creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=317355">https://bugs.webkit.org/show_bug.cgi?id=317355</a>

Reviewed by Rob Buis.

Add new tests covering conditional SVG layer creations
geometry handling.

* LayoutTests/svg/custom/layer-sibling-positioning-problem-expected.svg: Added.
* LayoutTests/svg/custom/layer-sibling-positioning-problem.svg: Added.
* LayoutTests/svg/geometry/use-direct-plain-expected.svg: Added.
* LayoutTests/svg/geometry/use-direct-plain.svg: Added.
* LayoutTests/svg/geometry/use-direct-ref-transform-expected.svg: Added.
* LayoutTests/svg/geometry/use-direct-ref-transform.svg: Added.
* LayoutTests/svg/geometry/use-direct-transform-ref-transform-expected.svg: Added.
* LayoutTests/svg/geometry/use-direct-transform-ref-transform.svg: Added.
* LayoutTests/svg/geometry/use-direct-transform-rotate-expected.svg: Added.
* LayoutTests/svg/geometry/use-direct-transform-rotate.svg: Added.
* LayoutTests/svg/geometry/use-direct-transform-scale-expected.svg: Added.
* LayoutTests/svg/geometry/use-direct-transform-scale.svg: Added.
* LayoutTests/svg/geometry/use-direct-transform-translate-expected.svg: Added.
* LayoutTests/svg/geometry/use-direct-transform-translate.svg: Added.
* LayoutTests/svg/geometry/use-direct-xy-expected.svg: Added.
* LayoutTests/svg/geometry/use-direct-xy-ref-transform-expected.svg: Added.
* LayoutTests/svg/geometry/use-direct-xy-ref-transform.svg: Added.
* LayoutTests/svg/geometry/use-direct-xy.svg: Added.
* LayoutTests/svg/geometry/use-in-g-plain-expected.svg: Added.
* LayoutTests/svg/geometry/use-in-g-plain.svg: Added.
* LayoutTests/svg/geometry/use-in-g-rotate-expected.svg: Added.
* LayoutTests/svg/geometry/use-in-g-rotate.svg: Added.
* LayoutTests/svg/geometry/use-in-g-scale-expected.svg: Added.
* LayoutTests/svg/geometry/use-in-g-scale.svg: Added.
* LayoutTests/svg/geometry/use-in-g-translate-xy-expected.svg: Added.
* LayoutTests/svg/geometry/use-in-g-translate-xy.svg: Added.
* LayoutTests/svg/geometry/use-in-grotate-ref-rotate-expected.svg: Added.
* LayoutTests/svg/geometry/use-in-grotate-ref-rotate.svg: Added.
* LayoutTests/svg/geometry/use-in-nested-g-expected.svg: Added.
* LayoutTests/svg/geometry/use-in-nested-g-scale-rotate-expected.svg: Added.
* LayoutTests/svg/geometry/use-in-nested-g-scale-rotate.svg: Added.
* LayoutTests/svg/geometry/use-in-nested-g-xy-expected.svg: Added.
* LayoutTests/svg/geometry/use-in-nested-g-xy.svg: Added.
* LayoutTests/svg/geometry/use-in-nested-g.svg: Added.
* LayoutTests/svg/geometry/use-on-use-overhang-expected.svg: Added.
* LayoutTests/svg/geometry/use-on-use-overhang.svg: Added.
* LayoutTests/svg/geometry/use-opacity-direct-expected.svg: Added.
* LayoutTests/svg/geometry/use-opacity-direct.svg: Added.
* LayoutTests/svg/geometry/use-opacity-in-grotate-expected.svg: Added.
* LayoutTests/svg/geometry/use-opacity-in-grotate.svg: Added.
* LayoutTests/svg/geometry/use-opacity-overhang-grotate-expected.svg: Added.
* LayoutTests/svg/geometry/use-opacity-overhang-grotate.svg: Added.
* LayoutTests/svg/geometry/use-opacity-overhang-in-g-expected.svg: Added.
* LayoutTests/svg/geometry/use-opacity-overhang-in-g.svg: Added.
* LayoutTests/svg/geometry/use-opacity-overhang-rotate-xy-expected.svg: Added.
* LayoutTests/svg/geometry/use-opacity-overhang-rotate-xy.svg: Added.
* LayoutTests/svg/geometry/use-overhang-direct-expected.svg: Added.
* LayoutTests/svg/geometry/use-overhang-direct.svg: Added.
* LayoutTests/svg/geometry/use-overhang-in-grotate-expected.svg: Added.
* LayoutTests/svg/geometry/use-overhang-in-grotate.svg: Added.
* LayoutTests/svg/geometry/use-overhang-transform-expected.svg: Added.
* LayoutTests/svg/geometry/use-overhang-transform.svg: Added.
* LayoutTests/svg/geometry/use-overhang-xy-expected.svg: Added.
* LayoutTests/svg/geometry/use-overhang-xy.svg: Added.
* LayoutTests/svg/geometry/use-ref-filled-offset-scaledown-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-filled-offset-scaledown.svg: Added.
* LayoutTests/svg/geometry/use-ref-grotate-overhang-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-grotate-overhang.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-large-scaledown-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-large-scaledown-xy-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-large-scaledown-xy.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-large-scaledown.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-offset-scale-direct-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-offset-scale-direct.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-plain-in-grotate-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-plain-in-grotate.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-rotate-in-g-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-rotate-in-g.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-scale-direct-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-scale-direct.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-scale-in-g-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-scale-in-g.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-scale-in-gtransform-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-shape-scale-in-gtransform.svg: Added.
* LayoutTests/svg/geometry/use-ref-stroked-origin-scaledown-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-stroked-origin-scaledown.svg: Added.
* LayoutTests/svg/geometry/use-ref-stroked-path-scaledown-expected.svg: Added.
* LayoutTests/svg/geometry/use-ref-stroked-path-scaledown.svg: Added.
* LayoutTests/svg/geometry/use-transform-ref-shape-scale-expected.svg: Added.
* LayoutTests/svg/geometry/use-transform-ref-shape-scale.svg: Added.
* LayoutTests/svg/geometry/use-xy-ref-shape-scale-expected.svg: Added.
* LayoutTests/svg/geometry/use-xy-ref-shape-scale.svg: Added.

Canonical link: <a href="https://commits.webkit.org/315542@main">https://commits.webkit.org/315542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43aa12ac5b86b46fc1b9a2d635bc57766a9c4b60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126699 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131592 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112095 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33034 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31744 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27044 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180943 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140042 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139884 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43255 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28241 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107081 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25802 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35167 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41764 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6328 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41158 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->