### PR TITLE
[LBSE] Adjust existing SVG tests for conditional layer creation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-scale-scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-scale-scroll.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>foreignObject with scale transform and overflow:scroll</title>
-<meta name=fuzzy content="maxDifference=0-10;totalPixels=0-10">
+<meta name=fuzzy content="maxDifference=0-16;totalPixels=0-120">
 <link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
 <link rel="match" href="foreign-object-scale-scroll-ref.html">
 <svg width="400" height="400">

--- a/LayoutTests/platform/glib/svg/custom/recursive-pattern-expected.txt
+++ b/LayoutTests/platform/glib/svg/custom/recursive-pattern-expected.txt
@@ -1,122 +1,66 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
-  RenderSVGRoot {svg} at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderSVGViewportContainer at (0,0) size 800x600
-layer at (0,0) size 50x50
-  RenderSVGHiddenContainer {defs} at (0,0) size 50x50
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {g} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGTransformableContainer {use} at (50,50) size 100x100
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {use} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {g} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGTransformableContainer {g} at (50,50) size 100x100
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (100,0) size 100x100
-  RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (200,0) size 100x100
-  RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (0,100) size 100x100
-  RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (100,100) size 100x100
-  RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (200,100) size 100x100
-  RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (0,200) size 100x100
-  RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (100,200) size 100x100
-  RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (200,200) size 100x100
-  RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (325,0) size 0x300
-  RenderSVGPath {line} at (325,0) size 0x300 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=325.00] [y1=0.00] [x2=325.00] [y2=300.00]
-layer at (179,336) size 292x17
-  RenderSVGText {text} at (179,336) size 292x17 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 292x17
-      chunk 1 (middle anchor) text run 1 at (179.00,350.00) startOffset 0 endOffset 48 width 292.00: "Both sides of the red line should look identical"
-layer at (0,0) size 300x300
-  RenderSVGTransformableContainer {g} at (0,0) size 300x300
-layer at (0,0) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (100,0) size 100x100
-  RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (200,0) size 100x100
-  RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (0,100) size 100x100
-  RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (100,100) size 100x100
-  RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (200,100) size 100x100
-  RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (0,200) size 100x100
-  RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (100,200) size 100x100
-  RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (200,200) size 100x100
-  RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
+  RenderSVGRoot {svg} at (0,0) size 650x353
+    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+      RenderSVGResourcePattern {pattern} [id="pattern0"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGResourcePattern {pattern} [id="pattern1"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGResourcePattern {pattern} [id="pattern2"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern1"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern3"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern4"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern6"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern5"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern7"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern7"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {use} at (0,0) size 50x50
+          RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGContainer {use} at (0,0) size 50x50
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern8"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {g} at (0,0) size 150x150
+          RenderSVGContainer {use} at (50,50) size 100x100
+            RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+          RenderSVGContainer {use} at (0,0) size 50x50
+            RenderSVGContainer {g} at (0,0) size 50x50
+              RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern9"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {use} at (0,0) size 150x150
+          RenderSVGContainer {g} at (0,0) size 150x150
+            RenderSVGContainer {g} at (50,50) size 100x100
+              RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+            RenderSVGContainer {g} at (0,0) size 50x50
+              RenderSVGContainer {g} at (0,0) size 50x50
+                RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+    RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=PATTERN] [id="pattern1"]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=PATTERN] [id="pattern2"]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=PATTERN] [id="pattern3"]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=PATTERN] [id="pattern4"]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=PATTERN] [id="pattern5"]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=PATTERN] [id="pattern6"]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=PATTERN] [id="pattern7"]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=PATTERN] [id="pattern8"]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=PATTERN] [id="pattern9"]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGPath {line} at (324,0) size 2x300 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=325.00] [y1=0.00] [x2=325.00] [y2=300.00]
+    RenderSVGText {text} at (179,336) size 292x17 contains 1 chunk(s)
+      RenderSVGInlineText {#text} at (0,0) size 292x17
+        chunk 1 (middle anchor) text run 1 at (179.00,350.00) startOffset 0 endOffset 48 width 292.00: "Both sides of the red line should look identical"
+    RenderSVGContainer {g} at (350,0) size 300x300 [transform={m=((1.00,0.00)(0.00,1.00)) t=(350.00,0.00)}]
+      RenderSVGRect {rect} at (350,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (350,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (350,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]

--- a/LayoutTests/platform/ios/svg/custom/recursive-pattern-expected.txt
+++ b/LayoutTests/platform/ios/svg/custom/recursive-pattern-expected.txt
@@ -1,122 +1,66 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
-  RenderSVGRoot {svg} at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderSVGViewportContainer at (0,0) size 800x600
-layer at (0,0) size 50x50
-  RenderSVGHiddenContainer {defs} at (0,0) size 50x50
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {g} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGTransformableContainer {use} at (50,50) size 100x100
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {use} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {g} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGTransformableContainer {g} at (50,50) size 100x100
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (100,0) size 100x100
-  RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (200,0) size 100x100
-  RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (0,100) size 100x100
-  RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (100,100) size 100x100
-  RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (200,100) size 100x100
-  RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (0,200) size 100x100
-  RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (100,200) size 100x100
-  RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (200,200) size 100x100
-  RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (325,0) size 0x300
-  RenderSVGPath {line} at (325,0) size 0x300 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=325.00] [y1=0.00] [x2=325.00] [y2=300.00]
-layer at (175.69,335.50) size 298x18
-  RenderSVGText {text} at (175,335) size 300x19 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 299x18
-      chunk 1 (middle anchor) text run 1 at (175.69,350.00) startOffset 0 endOffset 48 width 298.62: "Both sides of the red line should look identical"
-layer at (0,0) size 300x300
-  RenderSVGTransformableContainer {g} at (0,0) size 300x300
-layer at (0,0) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (100,0) size 100x100
-  RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (200,0) size 100x100
-  RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (0,100) size 100x100
-  RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (100,100) size 100x100
-  RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (200,100) size 100x100
-  RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (0,200) size 100x100
-  RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (100,200) size 100x100
-  RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (200,200) size 100x100
-  RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
+  RenderSVGRoot {svg} at (0,0) size 650x354
+    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+      RenderSVGResourcePattern {pattern} [id="pattern0"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGResourcePattern {pattern} [id="pattern1"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGResourcePattern {pattern} [id="pattern2"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern1"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern3"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern4"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern6"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern5"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern7"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern7"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {use} at (0,0) size 50x50
+          RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGContainer {use} at (0,0) size 50x50
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern8"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {g} at (0,0) size 150x150
+          RenderSVGContainer {use} at (50,50) size 100x100
+            RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+          RenderSVGContainer {use} at (0,0) size 50x50
+            RenderSVGContainer {g} at (0,0) size 50x50
+              RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern9"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {use} at (0,0) size 150x150
+          RenderSVGContainer {g} at (0,0) size 150x150
+            RenderSVGContainer {g} at (50,50) size 100x100
+              RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+            RenderSVGContainer {g} at (0,0) size 50x50
+              RenderSVGContainer {g} at (0,0) size 50x50
+                RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+    RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=PATTERN] [id="pattern1"]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=PATTERN] [id="pattern2"]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=PATTERN] [id="pattern3"]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=PATTERN] [id="pattern4"]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=PATTERN] [id="pattern5"]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=PATTERN] [id="pattern6"]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=PATTERN] [id="pattern7"]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=PATTERN] [id="pattern8"]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=PATTERN] [id="pattern9"]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGPath {line} at (324,0) size 2x300 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=325.00] [y1=0.00] [x2=325.00] [y2=300.00]
+    RenderSVGText {text} at (175,335) size 300x19 contains 1 chunk(s)
+      RenderSVGInlineText {#text} at (0,0) size 299x18
+        chunk 1 (middle anchor) text run 1 at (175.69,350.00) startOffset 0 endOffset 48 width 298.62: "Both sides of the red line should look identical"
+    RenderSVGContainer {g} at (350,0) size 300x300 [transform={m=((1.00,0.00)(0.00,1.00)) t=(350.00,0.00)}]
+      RenderSVGRect {rect} at (350,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (350,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (350,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]

--- a/LayoutTests/platform/mac/svg/custom/recursive-pattern-expected.txt
+++ b/LayoutTests/platform/mac/svg/custom/recursive-pattern-expected.txt
@@ -1,122 +1,66 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
-  RenderSVGRoot {svg} at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderSVGViewportContainer at (0,0) size 800x600
-layer at (0,0) size 50x50
-  RenderSVGHiddenContainer {defs} at (0,0) size 50x50
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {g} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGTransformableContainer {use} at (50,50) size 100x100
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {use} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 150x150
-  RenderSVGHiddenContainer {pattern} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {use} at (0,0) size 150x150
-layer at (0,0) size 150x150
-  RenderSVGTransformableContainer {g} at (0,0) size 150x150
-layer at (50,50) size 100x100
-  RenderSVGTransformableContainer {g} at (50,50) size 100x100
-layer at (50,50) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGTransformableContainer {g} at (0,0) size 50x50
-layer at (0,0) size 50x50
-  RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
-layer at (0,0) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (100,0) size 100x100
-  RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (200,0) size 100x100
-  RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (0,100) size 100x100
-  RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (100,100) size 100x100
-  RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (200,100) size 100x100
-  RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (0,200) size 100x100
-  RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (100,200) size 100x100
-  RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (200,200) size 100x100
-  RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (325,0) size 0x300
-  RenderSVGPath {line} at (325,0) size 0x300 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=325.00] [y1=0.00] [x2=325.00] [y2=300.00]
-layer at (175.69,336) size 298x18
-  RenderSVGText {text} at (175,336) size 300x18 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 299x18
-      chunk 1 (middle anchor) text run 1 at (175.69,350.00) startOffset 0 endOffset 48 width 298.62: "Both sides of the red line should look identical"
-layer at (0,0) size 300x300
-  RenderSVGTransformableContainer {g} at (0,0) size 300x300
-layer at (0,0) size 100x100
-  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (100,0) size 100x100
-  RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (200,0) size 100x100
-  RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
-layer at (0,100) size 100x100
-  RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (100,100) size 100x100
-  RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (200,100) size 100x100
-  RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
-layer at (0,200) size 100x100
-  RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (100,200) size 100x100
-  RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
-layer at (200,200) size 100x100
-  RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
+  RenderSVGRoot {svg} at (0,0) size 650x354
+    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+      RenderSVGResourcePattern {pattern} [id="pattern0"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGResourcePattern {pattern} [id="pattern1"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGResourcePattern {pattern} [id="pattern2"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern1"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern3"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern4"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern6"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+      RenderSVGResourcePattern {pattern} [id="pattern5"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern7"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern7"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {use} at (0,0) size 50x50
+          RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+        RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGContainer {use} at (0,0) size 50x50
+        RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern8"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {g} at (0,0) size 150x150
+          RenderSVGContainer {use} at (50,50) size 100x100
+            RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+          RenderSVGContainer {use} at (0,0) size 50x50
+            RenderSVGContainer {g} at (0,0) size 50x50
+              RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+      RenderSVGResourcePattern {pattern} [id="pattern9"] [patternUnits=userSpaceOnUse] [patternContentUnits=userSpaceOnUse]
+        RenderSVGContainer {use} at (0,0) size 150x150
+          RenderSVGContainer {g} at (0,0) size 150x150
+            RenderSVGContainer {g} at (50,50) size 100x100
+              RenderSVGRect {rect} at (50,50) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=50.00] [y=50.00] [width=100.00] [height=100.00]
+            RenderSVGContainer {g} at (0,0) size 50x50
+              RenderSVGContainer {g} at (0,0) size 50x50
+                RenderSVGRect {rect} at (0,0) size 50x50 [fill={[type=PATTERN] [id="pattern8"]}] [x=0.00] [y=0.00] [width=50.00] [height=50.00]
+    RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=PATTERN] [id="pattern1"]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,0) size 100x100 [fill={[type=PATTERN] [id="pattern2"]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,0) size 100x100 [fill={[type=PATTERN] [id="pattern3"]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (0,100) size 100x100 [fill={[type=PATTERN] [id="pattern4"]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,100) size 100x100 [fill={[type=PATTERN] [id="pattern5"]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,100) size 100x100 [fill={[type=PATTERN] [id="pattern6"]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (0,200) size 100x100 [fill={[type=PATTERN] [id="pattern7"]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (100,200) size 100x100 [fill={[type=PATTERN] [id="pattern8"]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGRect {rect} at (200,200) size 100x100 [fill={[type=PATTERN] [id="pattern9"]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]
+    RenderSVGPath {line} at (324,0) size 2x300 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=325.00] [y1=0.00] [x2=325.00] [y2=300.00]
+    RenderSVGText {text} at (175,336) size 300x18 contains 1 chunk(s)
+      RenderSVGInlineText {#text} at (0,0) size 299x18
+        chunk 1 (middle anchor) text run 1 at (175.69,350.00) startOffset 0 endOffset 48 width 298.62: "Both sides of the red line should look identical"
+    RenderSVGContainer {g} at (350,0) size 300x300 [transform={m=((1.00,0.00)(0.00,1.00)) t=(350.00,0.00)}]
+      RenderSVGRect {rect} at (350,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,0) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=0.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (350,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,100) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=100.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (350,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=0.00] [y=200.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (450,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=100.00] [y=200.00] [width=100.00] [height=100.00]
+      RenderSVGRect {rect} at (550,200) size 100x100 [fill={[type=PATTERN] [id="pattern0"]}] [x=200.00] [y=200.00] [width=100.00] [height=100.00]

--- a/LayoutTests/svg/clip-path/clip-opacity.html
+++ b/LayoutTests/svg/clip-path/clip-opacity.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-8543" />
+<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-8574" />
 <body>
 <svg xmlns="http://www.w3.org/2000/svg" width="350">
 <defs>

--- a/LayoutTests/svg/compositing/transformed-child-in-scaled-parent.xml
+++ b/LayoutTests/svg/compositing/transformed-child-in-scaled-parent.xml
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g style="transform: scale(20)">
     <g style="transform: translate3d(0, 0, 0)">

--- a/LayoutTests/svg/custom/recursive-pattern.svg
+++ b/LayoutTests/svg/custom/recursive-pattern.svg
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
     <pattern patternUnits="userSpaceOnUse" id="pattern0" x="0" y="0" width="100" height="100">


### PR DESCRIPTION
#### cb4b647e96e5b9e08bdd963bb54de4155907c6db
<pre>
[LBSE] Adjust existing SVG tests for conditional layer creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=317356">https://bugs.webkit.org/show_bug.cgi?id=317356</a>

Reviewed by Rob Buis.

Adjust a few pre-existing SVG test drivers for conditional layer
creation: relax the fuzzy-match tolerance by small amounts.

* LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-scale-scroll.html:
* LayoutTests/platform/glib/svg/custom/recursive-pattern-expected.txt:
* LayoutTests/platform/ios/svg/custom/recursive-pattern-expected.txt:
* LayoutTests/platform/mac/svg/custom/recursive-pattern-expected.txt:
* LayoutTests/svg/clip-path/clip-opacity.html:
* LayoutTests/svg/compositing/transformed-child-in-scaled-parent.xml:
Don&apos;t run with LBSE for now during the migration to conditional layers.
We&apos;ll setup a bot anyhow, that will run all tests through LBSE...
* LayoutTests/svg/custom/recursive-pattern.svg: Ditto.

Canonical link: <a href="https://commits.webkit.org/315541@main">https://commits.webkit.org/315541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e599538b3574b6de928898879caafec42f2ea1d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127023 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131880 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172270 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112384 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27367 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181267 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140336 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140174 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43578 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107541 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25801 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35440 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42088 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6634 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41481 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->