### PR TITLE
Promote Global Privacy Control SPI to API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -141,4 +141,10 @@ WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
  */
 @property (nonatomic) BOOL allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+/*! @abstract Whether the Global Privacy Control (GPC) signal is enabled for the navigation.
+ @discussion The default value is NO. When enabled, both navigator.globalPrivacyControl and the
+ Sec-GPC: 1 request header are active for the main frame, its subframes, and their subresources.
+ */
+@property (nonatomic) BOOL globalPrivacyControlEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -555,12 +555,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _websitePolicies->allowPrivacyProxy();
 }
 
-- (void)_setGlobalPrivacyControlEnabled:(BOOL)enabled
+- (void)setGlobalPrivacyControlEnabled:(BOOL)enabled
 {
     _websitePolicies->setGlobalPrivacyControlEnabled(enabled);
 }
 
-- (BOOL)_globalPrivacyControlEnabled
+- (BOOL)globalPrivacyControlEnabled
 {
     return protect(*_websitePolicies)->globalPrivacyControlEnabled().value_or(false);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -139,6 +139,4 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 
 @property (nonatomic, setter=setOverrideReferrer:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-@property (nonatomic, setter=_setGlobalPrivacyControlEnabled:) BOOL _globalPrivacyControlEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -2290,7 +2290,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPI)
 
     __block BOOL nextNavigationGPC = YES;
     navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        [preferences _setGlobalPrivacyControlEnabled:nextNavigationGPC];
+        [preferences setGlobalPrivacyControlEnabled:nextNavigationGPC];
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView setNavigationDelegate:navigationDelegate.get()];
@@ -2341,7 +2341,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlRequestHeader)
     webView.get().navigationDelegate = delegate.get();
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        [preferences _setGlobalPrivacyControlEnabled:YES];
+        [preferences setGlobalPrivacyControlEnabled:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView loadRequest:server.requestWithLocalhost("/main"_s)];
@@ -2366,7 +2366,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPIInSubframe)
     RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if (action.targetFrame.mainFrame)
-            [preferences _setGlobalPrivacyControlEnabled:YES];
+            [preferences setGlobalPrivacyControlEnabled:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView setNavigationDelegate:delegate.get()];
@@ -2413,7 +2413,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlRequestHeaderInSubframe)
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if (action.targetFrame.mainFrame)
-            [preferences _setGlobalPrivacyControlEnabled:YES];
+            [preferences setGlobalPrivacyControlEnabled:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView loadRequest:server.requestWithLocalhost("/main"_s)];


### PR DESCRIPTION
#### 40d6c85f577fdbc39145243932fe4bf94425cf0a
<pre>
Promote Global Privacy Control SPI to API
<a href="https://bugs.webkit.org/show_bug.cgi?id=317360">https://bugs.webkit.org/show_bug.cgi?id=317360</a>
<a href="https://rdar.apple.com/80500366">rdar://80500366</a>

Reviewed by Richard Robinson.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences setGlobalPrivacyControlEnabled:]):
(-[WKWebpagePreferences globalPrivacyControlEnabled]):
(-[WKWebpagePreferences _setGlobalPrivacyControlEnabled:]): Deleted.
(-[WKWebpagePreferences _globalPrivacyControlEnabled]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm:

Canonical link: <a href="https://commits.webkit.org/315425@main">https://commits.webkit.org/315425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0debf49e3ac5f286af01fe926f5218f6d2217c3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178352 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40205f52-59ee-4b06-a594-adf7fc2785b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42545 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d208bb0-3ff6-4848-90ee-d6b8b84889b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112107 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84223a9f-0ffd-4e9b-8910-8405eb56ec6b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27055 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180954 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140051 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42577 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139893 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43266 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107092 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35172 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41775 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6339 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41169 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/41424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41312 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->