### PR TITLE
HTMLLinkElement.as should reflect "json"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/preload/reflected-as-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/reflected-as-value-expected.txt
@@ -10,6 +10,6 @@ PASS Link preload "as" value for "video" should be "video".
 PASS Link preload "as" value for "audio" should be "audio".
 PASS Link preload "as" value for "track" should be "track".
 PASS Link preload "as" value for "fetch" should be "fetch".
-FAIL Link preload "as" value for "json" should be "json". assert_equals: expected "json" but got ""
+PASS Link preload "as" value for "json" should be "json".
 FAIL Link preload "as" value for "text" should be "text". assert_equals: expected "text" but got ""
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -274,6 +274,7 @@ String HTMLLinkElement::as() const
     String as = attributeWithoutSynchronization(asAttr);
     if (equalLettersIgnoringASCIICase(as, "fetch"_s)
         || equalLettersIgnoringASCIICase(as, "image"_s)
+        || equalLettersIgnoringASCIICase(as, "json"_s)
         || equalLettersIgnoringASCIICase(as, "script"_s)
         || equalLettersIgnoringASCIICase(as, "style"_s)
         || (document().settings().mediaPreloadingEnabled() && (equalLettersIgnoringASCIICase(as, "video"_s) || equalLettersIgnoringASCIICase(as, "audio"_s)))

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -102,6 +102,12 @@ void LinkLoader::triggerEvents(const CachedResource& resource)
         client->linkLoaded();
 }
 
+void LinkLoader::triggerLoad()
+{
+    if (RefPtr client = m_client.get())
+        client->linkLoaded();
+}
+
 void LinkLoader::triggerError()
 {
     if (RefPtr client = m_client.get())
@@ -356,6 +362,15 @@ RefPtr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const LinkLoadPara
     } else if (params.relAttribute.isLinkPreload) {
         ASSERT(document.settings().linkPreloadEnabled());
         type = LinkLoader::resourceTypeFromAsAttribute(params.as, document, ShouldLog::Yes);
+        if (!type && equalLettersIgnoringASCIICase(params.as, "json"_s)) {
+            // `json` is reflected by HTMLLinkElement::as as a known value, but is only a valid
+            // preload destination for <link rel=modulepreload>. For a plain preload we perform
+            // no fetch; fire the load event (rather than staying silent) so listeners are not
+            // left waiting indefinitely. This matches Firefox.
+            if (loader)
+                loader->triggerLoad();
+            return nullptr;
+        }
     }
 
     if (!type)

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -72,6 +72,7 @@ public:
     static bool isSupportedType(CachedResource::Type, const String& mimeType, Document&);
 
     void triggerEvents(const CachedResource&);
+    void triggerLoad();
     void triggerError();
     void cancelLoad();
 


### PR DESCRIPTION
#### d866e4a260d01467425564d6f3741af632dfd2fd
<pre>
HTMLLinkElement.as should reflect &quot;json&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=317361">https://bugs.webkit.org/show_bug.cgi?id=317361</a>
<a href="https://rdar.apple.com/179975685">rdar://179975685</a>

Reviewed by NOBODY (OOPS!).

The `as` IDL attribute is reflected &quot;limited to only known values&quot;, and
`json` is a known potential destination keyword for module preloads [1].
WebKit&apos;s getter used a stale hardcoded allowlist that omitted `json`, so
`link.as = &quot;json&quot;; link.as` returned the empty string instead of &quot;json&quot;.

Adding `json` to the getter&apos;s allowlist exposes a pre-existing tension in
the preload code path. `json` is not a valid preload destination for a
plain &lt;link rel=preload&gt; (it is only honored for &lt;link rel=modulepreload&gt;,
as of <a href="https://commits.webkit.org/315422@main">315422@main</a>), so LinkLoader::preloadIfNeeded() performs no fetch for
it and previously returned silently, firing neither `load` nor `error`. As
long as the getter returned the empty string, tests that gate on the
reflected value (e.g. fetch-destination.https.html, which skips its
`as=json` subtest when `link.as != &quot;json&quot;`) never noticed. Once the getter
honestly reflects &quot;json&quot;, that subtest stops skipping and instead waits
forever for an event that never arrives.

Match Firefox: for a plain &lt;link rel=preload as=json&gt;, fire the `load`
event (without performing any fetch) rather than staying silent, so that
listeners are not left waiting indefinitely. This is gated to `json`
specifically -- it is the only value the getter reflects that the loader
will not preload (every other reflected value maps to a real resource and
fetches normally), so unknown (`foobarxmlthing`) and empty `as` values
remain silent and onerror-event.html / onload-event.html continue to pass.
No network request is issued, so supported-as-values.html?as=json (which
asserts zero resource-timing entries) also continues to pass.

[1] <a href="https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload">https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload</a>

* LayoutTests/imported/w3c/web-platform-tests/preload/reflected-as-value-expected.txt: Progression
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::as const):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::triggerLoad):
(WebCore::LinkLoader::preloadIfNeeded):
* Source/WebCore/loader/LinkLoader.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d866e4a260d01467425564d6f3741af632dfd2fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126959 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/967d2759-f660-466e-b16a-3abc643736f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42795 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131822 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92767 "1 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49917b2d-7dfd-4e70-b8c7-33249cf05bac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112326 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c052da2-61b1-4495-b34f-7365cb6f8a59) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33338 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31967 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27303 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181203 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36136 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140276 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42825 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140116 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43514 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28483 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107435 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35388 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115279 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42024 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6572 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41417 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41672 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41560 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->