### PR TITLE
[Page Loading] WiFi captive popup stuck at blank screen

### DIFF
--- a/LayoutTests/fast/loader/cancel-load-during-port-block-timer-expected.txt
+++ b/LayoutTests/fast/loader/cancel-load-during-port-block-timer-expected.txt
@@ -1,2 +1,1 @@
-CONSOLE MESSAGE: Not allowed to use restricted network port 22: http://127.0.0.1:22/
-If this does crash, the test has passed.
+If this does not crash, the test has passed.

--- a/LayoutTests/fast/loader/cancel-load-during-port-block-timer.html
+++ b/LayoutTests/fast/loader/cancel-load-during-port-block-timer.html
@@ -9,4 +9,4 @@
     if (window.testRunner)
         testRunner.notifyDone();
 </script>
-If this does crash, the test has passed.
+If this does not crash, the test has passed.

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2349,6 +2349,12 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
             }
         }
 
+        if (platformStrategies()->loaderStrategy()->isBlockedError(mainResourceOrError.error())) {
+            DOCUMENTLOADER_RELEASE_LOG("loadMainResource: Unable to load main resource, port is blocked");
+            cancelMainResourceLoad(mainResourceOrError.error());
+            return;
+        }
+
         DOCUMENTLOADER_RELEASE_LOG("loadMainResource: Unable to load main resource, returning empty document");
 
         setRequest(ResourceRequest());

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1496,12 +1496,6 @@ void FrameLoader::loadFrameRequest(FrameLoadRequest&& request, Event* event, Ref
         return;
     }
 
-    if (!portAllowed(url)) {
-        FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadFrameRequest: canceling - port not allowed");
-        reportBlockedLoadFailed(frame, url);
-        return;
-    }
-
     if (isIPAddressDisallowed(url)) {
         FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadFrameRequest: canceling - IP address is not allowed");
         reportBlockedLoadFailed(frame, url);

--- a/Source/WebCore/loader/LoaderStrategy.h
+++ b/Source/WebCore/loader/LoaderStrategy.h
@@ -104,6 +104,7 @@ public:
 
     virtual ResourceError cancelledError(const ResourceRequest&) const = 0;
     virtual ResourceError blockedError(const ResourceRequest&) const = 0;
+    virtual bool isBlockedError(const ResourceError&) const = 0;
     virtual ResourceError blockedByContentBlockerError(const ResourceRequest&) const = 0;
     virtual ResourceError cannotShowURLError(const ResourceRequest&) const = 0;
     virtual ResourceError interruptedForPolicyChangeError(const ResourceRequest&) const = 0;

--- a/Source/WebKit/Shared/WebErrors.cpp
+++ b/Source/WebKit/Shared/WebErrors.cpp
@@ -31,6 +31,7 @@
 #include "APIError.h"
 #include "Logging.h"
 #include <WebCore/LocalizedStrings.h>
+#include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
 
@@ -40,6 +41,11 @@ using namespace WebCore;
 ResourceError blockedError(const ResourceRequest& request)
 {
     return ResourceError(API::Error::webKitPolicyErrorDomain(), API::Error::Policy::CannotUseRestrictedPort, request.url(), WEB_UI_STRING("Not allowed to use restricted network port", "WebKitErrorCannotUseRestrictedPort description"));
+}
+
+bool isBlockedError(const ResourceError& error)
+{
+    return error.domain() == API::Error::webKitPolicyErrorDomain() && error.errorCode() == API::Error::Policy::CannotUseRestrictedPort;
 }
 
 ResourceError blockedByContentBlockerError(const ResourceRequest& request)

--- a/Source/WebKit/Shared/WebErrors.h
+++ b/Source/WebKit/Shared/WebErrors.h
@@ -37,6 +37,7 @@ namespace WebKit {
 
 WebCore::ResourceError cancelledError(const WebCore::ResourceRequest&);
 WebCore::ResourceError blockedError(const WebCore::ResourceRequest&);
+bool isBlockedError(const WebCore::ResourceError&);
 WebCore::ResourceError blockedByContentBlockerError(const WebCore::ResourceRequest&);
 WebCore::ResourceError cannotShowURLError(const WebCore::ResourceRequest&);
 WebCore::ResourceError wasBlockedByRestrictionsError(const WebCore::ResourceRequest&);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -1197,6 +1197,11 @@ ResourceError WebLoaderStrategy::blockedError(const ResourceRequest& request) co
     return WebKit::blockedError(request);
 }
 
+bool WebLoaderStrategy::isBlockedError(const WebCore::ResourceError& error) const
+{
+    return WebKit::isBlockedError(error);
+}
+
 ResourceError WebLoaderStrategy::blockedByContentBlockerError(const ResourceRequest& request) const
 {
     return WebKit::blockedByContentBlockerError(request);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -115,6 +115,7 @@ private:
 
     WebCore::ResourceError cancelledError(const WebCore::ResourceRequest&) const final;
     WebCore::ResourceError blockedError(const WebCore::ResourceRequest&) const final;
+    bool isBlockedError(const WebCore::ResourceError&) const final;
     WebCore::ResourceError blockedByContentBlockerError(const WebCore::ResourceRequest&) const final;
     WebCore::ResourceError cannotShowURLError(const WebCore::ResourceRequest&) const final;
     WebCore::ResourceError interruptedForPolicyChangeError(const WebCore::ResourceRequest&) const final;

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -88,6 +88,7 @@ private:
 
     WebCore::ResourceError cancelledError(const WebCore::ResourceRequest&) const final;
     WebCore::ResourceError blockedError(const WebCore::ResourceRequest&) const final;
+    bool isBlockedError(const WebCore::ResourceError&) const final;
     WebCore::ResourceError blockedByContentBlockerError(const WebCore::ResourceRequest&) const final;
     WebCore::ResourceError cannotShowURLError(const WebCore::ResourceRequest&) const final;
     WebCore::ResourceError interruptedForPolicyChangeError(const WebCore::ResourceRequest&) const final;

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm
@@ -57,6 +57,11 @@ WebCore::ResourceError WebResourceLoadScheduler::blockedErrorFromRequest(const W
     return [NSError _webKitErrorWithDomain:WebKitErrorDomain code:WebKitErrorCannotUseRestrictedPort URL:request.url().createNSURL().get()];
 }
 
+bool WebResourceLoadScheduler::isBlockedError(const WebCore::ResourceError& error) const
+{
+    return error.domain() == String(WebKitErrorDomain) && error.errorCode() == WebKitErrorCannotUseRestrictedPort;
+}
+
 WebCore::ResourceError WebResourceLoadScheduler::blockedByContentBlockerError(const WebCore::ResourceRequest& request) const
 {
     RELEASE_ASSERT_NOT_REACHED(); // Content blockers are not enabled in WebKit1.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm
@@ -49,6 +49,7 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebpagePreferencesPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/WebKitErrorsPrivate.h>
 #import <WebKit/_WKFeature.h>
 #import <WebKit/_WKPageLoadTiming.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
@@ -5694,4 +5695,35 @@ TEST(Navigation, NavigationInitiatingFrameInClientInputNavigation)
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://thirdSite.com/thirdSite"]]];
     TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WKNavigation, JSInitiatedNavigationWithRestrictedPortFailsProvisionalNavigation)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300)]);
+    [webView synchronouslyLoadHTMLString:@"<html></html>"];
+
+    __block bool didCallDecidePolicyForNavigationAction = false;
+    __block bool didCallDidStartProvisionalNavigation = false;
+    __block bool didCallDidFailProvisionalNavigation = false;
+
+    RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+    delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        didCallDecidePolicyForNavigationAction = true;
+        decisionHandler(WKNavigationActionPolicyAllow);
+    };
+    delegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *) {
+        didCallDidStartProvisionalNavigation = true;
+    };
+    delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
+        EXPECT_EQ(error.code, WebKitErrorCannotUseRestrictedPort);
+        didCallDidFailProvisionalNavigation = true;
+    };
+    [webView setNavigationDelegate:delegate.get()];
+
+    [webView evaluateJavaScript:@"location.href = 'https://example.com:5061'" completionHandler:nil];
+
+    EXPECT_TRUE(TestWebKitAPI::Util::runFor(&didCallDidFailProvisionalNavigation, 5_s));
+    EXPECT_TRUE(didCallDecidePolicyForNavigationAction);
+    EXPECT_TRUE(didCallDidStartProvisionalNavigation);
+    EXPECT_TRUE(didCallDidFailProvisionalNavigation);
 }


### PR DESCRIPTION
#### 65e6c589b7014ac5e27f1add81f949d8e1f9c261
<pre>
[Page Loading] WiFi captive popup stuck at blank screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=317357">https://bugs.webkit.org/show_bug.cgi?id=317357</a>
<a href="https://rdar.apple.com/159376485">rdar://159376485</a>

Reviewed by Brady Eidson.

When a WiFi captive network returns the URL that the user must use to authenticate
and access the WiFi, this URL is loaded in a WebSheet via a WebView. In this case,
nothing loads and the WebSheet remains blank.

The sysdiagnose shows that the load is being blocked because the JavaScript at that
URL is redirecting to another URL which contains a blocked port. WebKit blocks the
load. The issue is that WebKit doesn&apos;t notify the client (WebSheet) that this load
has been blocked.

JavaScript initiated navigations go through FrameLoader::loadFrameRequest(). This
function early returns if the navigation is to a blocked port (this check was added
in <a href="https://commits.webkit.org/236675@main).">https://commits.webkit.org/236675@main).</a> The problem is that this function is
called before WebKit lets the client know that a navigation has been requested
(via the decidePolicyForNavigationAction delegate), so the client (WebSheet) is not
notified that a navigation has begun or that it failed. It can&apos;t handle the error
and choose to show an error page. This is why the popup gets stuck at blank.

In order to notify the client, WebKit must call the decidePolicyForNavigationAction
delegate and later the didFailProvisionalNavigation delegate. So the check for blocked
ports must come later. And this check already exists. If we don&apos;t early return from
FrameLoader::loadFrameRequest, we will continue on:

1. FrameLoader::loadFrameRequest
2. FrameLoader::loadURL
3. PolicyChecker::checkNavigationPolicy
4. decidePolicyForNavigationAction delegate (client allows the navigation)
5. FrameLoader::continueLoadAfterNavigationPolicy
6. FrameLoader::prepareForLoadStart
7. didStartProvisionalNavigation delegate
8. DocumentLoader::startLoadingMainResource
9. DocumentLoader::loadMainResource (DocumentLoader.cpp:2277)
10. CachedResourceLoader::requestMainResource
11. CachedResourceLoader::requestResource
    --&gt; This does the blocked port check and returns an error.

So by removing the early return in FrameLoader::loadFrameRequest(), the code will
continue on and notify the client about the navigation.

Currently, when CachedResourceLoader::requestResource() returns the port blocked
error, DocumentLoader::loadMainResource() does not cancel the load with an error
but rather just displays an empty page. So the client is not notified that the
navigation has failed. So we modify this to cancel the load with an error so that
the didFailProvisionalNavigation delegate will be called and allow the the client
to handle the error as they see fit.

The fact that DocumentLoader::loadMainResource() simply loads an empty document
is also the reason why Safari will display the about:blank empty document if you
type in a URL with an invalid port in the search bar. Making the change to cause
didFailProvisionalNavigation to be called changes the behavior in Safari so that
it instead displays an error message describing that the port is blocked (this
aligns with Firefox &amp; Chrome).

We were unable to reproduce the issue with the WiFi captive portal, but we do have
a new API test that convers this scenario:
JSInitiatedNavigationWithRestrictedPortFailsProvisionalNavigation.

We also update the layout test cancel-load-during-port-block-timer.html
(1) The console message now no longer comes synchronously, it comes after the
    client responds to the decidePolicyForNavigationAction delegate. But the
    test calls document.write() which calls document.open() which stops the
    policy check and the load if delegateIsDecidingNavigationPolicy. So the
    port check doesn&apos;t happen anymore.
(2) It looks like the test passes if it *doesn&apos;t* crash.

* LayoutTests/fast/loader/cancel-load-during-port-block-timer-expected.txt:
* LayoutTests/fast/loader/cancel-load-during-port-block-timer.html:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadFrameRequest):
* Source/WebCore/loader/LoaderStrategy.h:
* Source/WebKit/Shared/WebErrors.cpp:
(WebKit::isBlockedError):
* Source/WebKit/Shared/WebErrors.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::isBlockedError const):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm:
(WebResourceLoadScheduler::isBlockedError const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/Navigation.mm:
(TEST(WKNavigation, JSInitiatedNavigationWithRestrictedPortFailsProvisionalNavigation)):

Canonical link: <a href="https://commits.webkit.org/315513@main">https://commits.webkit.org/315513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f65d8d80c312ff4f71d62f446ca5c8d5f5e0aed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126889 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0842aa12-c32c-4519-b115-0ba26e384c36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131761 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cbe0145-87a8-400c-b0e9-d04aab9a7ef4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112264 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af3215fa-f20e-493b-966c-ba5e2190244d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27233 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181133 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36078 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140214 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140055 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43444 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107364 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25793 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35330 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115209 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41953 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6513 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41347 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41490 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->