### PR TITLE
Add Global Privacy Control support to WebPage.NavigationPreferences Swift API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
@@ -62,6 +62,7 @@ extension WKWebpagePreferences {
 
         self.alternateRequest = wrapped.alternateRequest
         self.overrideReferrer = wrapped.overrideReferrer
+        self.globalPrivacyControlEnabled = wrapped.isGlobalPrivacyControlEnabled
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -140,6 +140,15 @@ extension WebPage {
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
         public var overrideReferrer: Swift.String? = nil
+
+        /// Whether the Global Privacy Control (GPC) signal is enabled for the navigation.
+        ///
+        /// The default value of this property is `false`. When enabled, both `navigator.globalPrivacyControl`
+        /// and the `Sec-GPC: 1` request header are active for the main frame, its subframes, and their subresources.
+        @available(TBA, *)
+        @available(watchOS, unavailable)
+        @available(tvOS, unavailable)
+        public var isGlobalPrivacyControlEnabled: Bool = false
     }
 }
 
@@ -200,6 +209,7 @@ extension WebPage.NavigationPreferences {
 
         self.alternateRequest = wrapped.alternateRequest
         self.overrideReferrer = wrapped.overrideReferrer
+        self.isGlobalPrivacyControlEnabled = wrapped.globalPrivacyControlEnabled
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -99,6 +99,24 @@ struct WebPageTests {
         #expect(actions[1].request.url!.absoluteString == "http://webkit.org/#fragment")
     }
 
+    @Test(arguments: [true, false])
+    func globalPrivacyControlEnabledForNavigation(enabled: Bool) async throws {
+        let decider = TestNavigationDecider()
+        decider.preferencesMutation = { preferences in
+            preferences.isGlobalPrivacyControlEnabled = enabled
+        }
+
+        let page = WebPage(navigationDecider: decider)
+        try await page.load(html: "<body></body>").wait()
+
+        let result = try await page.callJavaScript(returning: Bool.self) {
+            """
+            return navigator.globalPrivacyControl;
+            """
+        }
+        #expect(result == enabled)
+    }
+
     @Test
     func javaScriptEvaluation() async throws {
         let page = WebPage()


### PR DESCRIPTION
#### 08d53f0991b068974e5ac2a8dfa42e162ecd0581
<pre>
Add Global Privacy Control support to WebPage.NavigationPreferences Swift API
<a href="https://bugs.webkit.org/show_bug.cgi?id=317366">https://bugs.webkit.org/show_bug.cgi?id=317366</a>
<a href="https://rdar.apple.com/179982182">rdar://179982182</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

Expose isGlobalPrivacyControlEnabled on WebPage.NavigationPreferences, the Swift API equivalent of
the Objective-C WKWebpagePreferences.globalPrivacyControlEnabled property, and bridge between the
two.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
(isGlobalPrivacyControlEnabled):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.globalPrivacyControlEnabledForNavigation):

Canonical link: <a href="https://commits.webkit.org/315441@main">https://commits.webkit.org/315441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3225610818af6a483b337a3027d084625c65c4a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126738 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f5418e9-f1c6-441e-b22a-0b2e886a4783) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131627 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a79c24ab-114a-43d1-a742-84da80c114d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b240c1ca-75d9-4a46-a890-3bd2c4515a1f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31778 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27082 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180981 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140077 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42604 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139919 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43293 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107131 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25756 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35197 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115058 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41802 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6369 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41196 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41451 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->