### PR TITLE
[git-webkit] Add `git-webkit apply` to apply a triage-attached revert or fix from a radar

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='7.0.2',
+    version='7.0.3',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(7, 0, 2)
+version = Version(7, 0, 3)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSafe', wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -25,6 +25,7 @@ import logging
 import os
 import sys
 
+from .apply import Apply
 from .blame import Blame
 from .branch import Branch
 from .canonicalize import Canonicalize
@@ -96,7 +97,7 @@ def main(
     subparser.set_defaults(main=lambda *args, **kwargs: parser.print_help())
 
     programs = [
-        Blame, Branch, Canonicalize, Checkout,
+        Apply, Blame, Branch, Canonicalize, Checkout,
         Clean, Clone, Conflict, CreateBug, Diff, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Review, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import sys
+import tempfile
+
+from .command import Command
+
+from webkitbugspy import radar, Tracker
+from webkitcorepy import run
+from webkitscmpy import local, log
+
+
+class Apply(Command):
+    name = 'apply'
+    help = "Apply a proposed revert or build fix that build-failure triage attached to a radar"
+
+    # Stable attachment names produced by `combine triage --llm-enhance`.
+    WHICH = ('revert', 'fix')
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'which', type=str.lower, choices=cls.WHICH,
+            help="Which attached patch to apply: 'revert' or 'fix'",
+        )
+        parser.add_argument(
+            'issue', type=str,
+            help='Radar the patch is attached to (rdar://<id>, a bare id, or a radar URL)',
+        )
+        parser.add_argument(
+            '--no-commit', default=True, action='store_false', dest='commit',
+            help='Apply the patch to the working tree only, instead of committing it with `git am`',
+        )
+
+    @classmethod
+    def attachment_name(cls, which):
+        return 'triage-{}.patch'.format(which)
+
+    @classmethod
+    def radar_tracker(cls):
+        '''The registered radar.Tracker, if any -- triage only ever attaches patches to radars.'''
+        for tracker in Tracker._trackers:
+            if isinstance(tracker, radar.Tracker):
+                return tracker
+        instance = Tracker.instance()
+        return instance if isinstance(instance, radar.Tracker) else None
+
+    @classmethod
+    def resolve_issue(cls, string):
+        '''Resolve a radar link, URL, or bare id to a webkitbugspy issue.'''
+        issue = Tracker.from_string(string)
+        if issue:
+            return issue
+        # from_string rejects a bare number; resolve one against the radar tracker, digits-only so a
+        # malformed link is never coerced into the wrong id.
+        if string.strip().isdigit():
+            tracker = cls.radar_tracker()
+            if tracker:
+                return tracker.issue(int(string.strip()))
+        return None
+
+    @classmethod
+    def contents(cls, issue, name):
+        '''Bytes of the attachment named `name` on `issue`, or None. Emits a specific reason to
+        stderr for every failure (unsupported tracker, fetch/download error, locked, or genuinely
+        absent), so the caller does not need to -- and must not -- print its own.'''
+        client = getattr(getattr(issue, 'tracker', None), 'client', None)
+        if not client:
+            sys.stderr.write('{} does not support attachments\n'.format(getattr(issue, 'link', 'This tracker')))
+            return None
+        # radar_for_id raises (rather than returning None) on a missing/unauthorized radar, and the
+        # download is a network call -- report either cleanly instead of crashing.
+        try:
+            radar_object = client.radar_for_id(issue.id)
+            attachments = list(radar_object.attachments.items()) if radar_object else []
+        except Exception as error:
+            sys.stderr.write('Could not read attachments from {}: {}\n'.format(issue.link, error))
+            return None
+        for attachment in attachments:
+            if attachment.fileName != name:
+                continue
+            if getattr(attachment, 'locked', False):
+                sys.stderr.write("'{}' on {} is locked and cannot be downloaded\n".format(name, issue.link))
+                return None
+            try:
+                return attachment.content()
+            except Exception as error:
+                sys.stderr.write("Could not download '{}' from {}: {}\n".format(name, issue.link, error))
+                return None
+        sys.stderr.write("No '{}' attachment found on {}\n".format(name, issue.link))
+        return None
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not isinstance(repository, local.Git):
+            sys.stderr.write("Can only '{}' on a native Git repository\n".format(cls.name))
+            return 1
+        if repository.modified():
+            sys.stderr.write('Please commit or stash your changes before applying a patch\n')
+            return 1
+
+        issue = cls.resolve_issue(args.issue)
+        if not issue:
+            sys.stderr.write("Could not resolve '{}' to a radar\n".format(args.issue))
+            return 1
+
+        # The patch is radar-attachment content -- whoever can attach to the radar controls these
+        # bytes, applied via git am/apply: the same trust as applying any colleague's patch.
+        content = cls.contents(issue, cls.attachment_name(args.which))
+        if content is None:
+            return 1
+        if not isinstance(content, bytes):
+            content = content.encode('utf-8')
+        if not content.strip():
+            sys.stderr.write("'{}' on {} is empty\n".format(cls.attachment_name(args.which), issue.link))
+            return 1
+
+        handle, patch_path = tempfile.mkstemp(suffix='.patch')
+        try:
+            with os.fdopen(handle, 'wb') as patch_file:
+                patch_file.write(content)
+
+            if args.commit:
+                result = run([repository.executable(), 'am', patch_path], cwd=repository.root_path)
+            else:
+                result = run([repository.executable(), 'apply', '--3way', patch_path], cwd=repository.root_path)
+
+            if result.returncode:
+                sys.stderr.write('Failed to apply the {} from {}\n'.format(args.which, issue.link))
+                if args.commit:
+                    run([repository.executable(), 'am', '--abort'], cwd=repository.root_path, capture_output=True)
+                    sys.stderr.write('Re-run with --no-commit to apply it to the working tree and resolve conflicts by hand.\n')
+                else:
+                    sys.stderr.write('Conflicting hunks were left as conflict markers / .rej files; `git checkout -- .` to discard.\n')
+                return 1
+        finally:
+            os.remove(patch_path)
+
+        log.info('Applied the {} from {}'.format(args.which, issue.link))
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py
@@ -1,0 +1,208 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+from webkitcorepy import OutputCapture
+from webkitscmpy import local
+from webkitscmpy.program.apply import Apply
+
+
+class TestApply(unittest.TestCase):
+    @staticmethod
+    def _attachment(file_name, content=b'PATCH', locked=False):
+        attachment = MagicMock(fileName=file_name, locked=locked)
+        attachment.content.return_value = content
+        return attachment
+
+    def _issue_with_attachments(self, attachments):
+        issue = MagicMock(id=42, link='rdar://42')
+        issue.tracker.client.radar_for_id.return_value.attachments.items.return_value = attachments
+        return issue
+
+    def _repo(self, modified=None):
+        repository = MagicMock(spec=local.Git)
+        repository.modified.return_value = modified or {}
+        repository.executable.return_value = 'git'
+        repository.root_path = '/repo'
+        return repository
+
+    def test_attachment_name(self):
+        self.assertEqual(Apply.attachment_name('revert'), 'triage-revert.patch')
+        self.assertEqual(Apply.attachment_name('fix'), 'triage-fix.patch')
+
+    def test_contents_returns_matching_attachment(self):
+        issue = self._issue_with_attachments([
+            self._attachment('unrelated.txt', content=b'NOPE'),
+            self._attachment('triage-revert.patch', content=b'REVERT'),
+        ])
+        self.assertEqual(Apply.contents(issue, 'triage-revert.patch'), b'REVERT')
+
+    def test_contents_missing_returns_none(self):
+        issue = self._issue_with_attachments([self._attachment('triage-fix.patch')])
+        with OutputCapture():
+            self.assertIsNone(Apply.contents(issue, 'triage-revert.patch'))
+
+    def test_contents_locked_returns_none(self):
+        issue = self._issue_with_attachments([self._attachment('triage-revert.patch', locked=True)])
+        with OutputCapture():
+            self.assertIsNone(Apply.contents(issue, 'triage-revert.patch'))
+
+    def test_contents_without_attachment_support_returns_none(self):
+        issue = MagicMock(id=1, link='rdar://1')
+        issue.tracker.client = None
+        with OutputCapture():
+            self.assertIsNone(Apply.contents(issue, 'triage-revert.patch'))
+
+    def test_contents_fetch_error_returns_none(self):
+        # radar_for_id raises (not returns None) for a missing/unauthorized radar.
+        issue = MagicMock(id=7, link='rdar://7')
+        issue.tracker.client.radar_for_id.side_effect = RuntimeError('access denied')
+        with OutputCapture() as captured:
+            self.assertIsNone(Apply.contents(issue, 'triage-revert.patch'))
+        self.assertIn('Could not read attachments', captured.stderr.getvalue())
+
+    def test_resolve_issue_via_link(self):
+        issue = MagicMock()
+        with patch('webkitscmpy.program.apply.Tracker.from_string', return_value=issue):
+            self.assertIs(Apply.resolve_issue('rdar://7'), issue)
+
+    def test_resolve_issue_bare_id_via_radar_tracker(self):
+        issue = MagicMock()
+        tracker = MagicMock()
+        tracker.issue.return_value = issue
+        with patch('webkitscmpy.program.apply.Tracker.from_string', return_value=None), \
+             patch.object(Apply, 'radar_tracker', return_value=tracker):
+            self.assertIs(Apply.resolve_issue('179875292'), issue)
+            tracker.issue.assert_called_once_with(179875292)
+
+    def test_resolve_issue_does_not_coerce_non_numeric_string(self):
+        # A malformed link must NOT be reduced to its digits and resolved as the wrong radar.
+        with patch('webkitscmpy.program.apply.Tracker.from_string', return_value=None), \
+             patch.object(Apply, 'radar_tracker') as radar_tracker:
+            self.assertIsNone(Apply.resolve_issue('rdar://problem/42?x=9'))
+            radar_tracker.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_rejects_non_git_repository(self, mock_run):
+        with OutputCapture() as captured:
+            result = Apply.main(Namespace(which='revert', issue='rdar://5', commit=True), MagicMock(spec=local.Svn))
+        self.assertEqual(result, 1)
+        self.assertEqual(captured.stderr.getvalue(), "Can only 'apply' on a native Git repository\n")
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_rejects_dirty_tree(self, mock_run):
+        with OutputCapture():
+            result = Apply.main(Namespace(which='revert', issue='rdar://5', commit=True), self._repo(modified={'f': 1}))
+        self.assertEqual(result, 1)
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_when_issue_unresolvable(self, mock_run):
+        with patch.object(Apply, 'resolve_issue', return_value=None), OutputCapture() as captured:
+            result = Apply.main(Namespace(which='revert', issue='bogus', commit=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertEqual(captured.stderr.getvalue(), "Could not resolve 'bogus' to a radar\n")
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_when_attachment_missing(self, mock_run):
+        with patch.object(Apply, 'resolve_issue', return_value=MagicMock(link='rdar://5')), \
+             patch.object(Apply, 'contents', return_value=None), OutputCapture():
+            result = Apply.main(Namespace(which='revert', issue='rdar://5', commit=True), self._repo())
+        self.assertEqual(result, 1)
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_on_empty_content(self, mock_run):
+        with patch.object(Apply, 'resolve_issue', return_value=MagicMock(link='rdar://5')), \
+             patch.object(Apply, 'contents', return_value=b'   \n'), OutputCapture() as captured:
+            result = Apply.main(Namespace(which='fix', issue='rdar://5', commit=False), self._repo())
+        self.assertEqual(result, 1)
+        self.assertIn('is empty', captured.stderr.getvalue())
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_commits_with_git_am(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch.object(Apply, 'resolve_issue', return_value=MagicMock(link='rdar://5')), \
+             patch.object(Apply, 'contents', return_value=b'PATCH'), OutputCapture():
+            result = Apply.main(Namespace(which='revert', issue='rdar://5', commit=True), self._repo())
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_run.call_args.args[0][:2], ['git', 'am'])
+        self.assertEqual(mock_run.call_args.kwargs.get('cwd'), '/repo')
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_no_commit_uses_git_apply_3way(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch.object(Apply, 'resolve_issue', return_value=MagicMock(link='rdar://5')), \
+             patch.object(Apply, 'contents', return_value=b'PATCH'), OutputCapture():
+            result = Apply.main(Namespace(which='fix', issue='rdar://5', commit=False), self._repo())
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_run.call_args.args[0][:3], ['git', 'apply', '--3way'])
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_aborts_am_on_conflict(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        with patch.object(Apply, 'resolve_issue', return_value=MagicMock(link='rdar://5')), \
+             patch.object(Apply, 'contents', return_value=b'PATCH'), OutputCapture():
+            result = Apply.main(Namespace(which='revert', issue='rdar://5', commit=True), self._repo())
+        self.assertEqual(result, 1)
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertEqual(commands[0][:2], ['git', 'am'])
+        self.assertIn(['git', 'am', '--abort'], commands)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_no_commit_failure_does_not_abort(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        with patch.object(Apply, 'resolve_issue', return_value=MagicMock(link='rdar://5')), \
+             patch.object(Apply, 'contents', return_value=b'PATCH'), OutputCapture():
+            result = Apply.main(Namespace(which='fix', issue='rdar://5', commit=False), self._repo())
+        self.assertEqual(result, 1)
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertNotIn(['git', 'am', '--abort'], commands)
+        self.assertEqual(len(commands), 1)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_removes_tempfile_even_on_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        with patch.object(Apply, 'resolve_issue', return_value=MagicMock(link='rdar://5')), \
+             patch.object(Apply, 'contents', return_value=b'PATCH'), OutputCapture():
+            Apply.main(Namespace(which='revert', issue='rdar://5', commit=True), self._repo())
+        patch_path = mock_run.call_args_list[0].args[0][2]
+        self.assertFalse(os.path.exists(patch_path))
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_encodes_str_content(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch.object(Apply, 'resolve_issue', return_value=MagicMock(link='rdar://5')), \
+             patch.object(Apply, 'contents', return_value='PATCH-AS-STR'), OutputCapture():
+            result = Apply.main(Namespace(which='fix', issue='rdar://5', commit=False), self._repo())
+        self.assertEqual(result, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### 109c3a722a2f6273f139e5fb14e37fedd0e6e670
<pre>
[git-webkit] Add `git-webkit apply` to apply a triage-attached revert or fix from a radar
<a href="https://bugs.webkit.org/show_bug.cgi?id=NEEDS_BUG">https://bugs.webkit.org/show_bug.cgi?id=NEEDS_BUG</a>

Reviewed by NOBODY (OOPS!).

`combine triage --llm-enhance` attaches a proposed revert (triage-revert.patch)
and, when it has one, a build fix (triage-fix.patch) to the radar it files for a
build failure. These are git am-able mbox patches. This adds a command to fetch
and apply one of them directly:

    git-webkit apply revert &lt;radar&gt;
    git-webkit apply fix &lt;radar&gt;

By default the patch is applied with `git am`, reconstructing the commit and its
message in one step; `--no-commit` applies it to the working tree with
`git apply --3way`. The radar may be given as <a href="https://rdar.apple.com/&lt">rdar://&lt</a>;id&gt;, a bare id, or a radar
URL. A missing/unauthorized radar or a failed download is reported cleanly, a
locked, absent, or empty attachment is rejected, and a failed `git am` is aborted.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py: Added.
(Apply):
(Apply.parser):
(Apply.attachment_name):
(Apply.radar_tracker):
(Apply.resolve_issue):
(Apply.contents):
(Apply.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py: Added.


| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169016 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42587 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36181 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170882 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42961 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42562 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171975 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/42961 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/36181 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/168337 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/42961 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/42562 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/36181 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/42961 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/36181 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/42562 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/168416 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42594 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/36181 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43283 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/36181 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107114 "Build is being retried. Recent messages:") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/43283 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41792 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/36181 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41186 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41441 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41329 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | | | | 
<!--EWS-Status-Bubble-End--><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe092fc27d2c7161acd874209d5f5fd60426dd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36182 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/178371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/178371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171976 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/178371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/168338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/27073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/180972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/180972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/168417 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/42595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/180972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/43284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/43284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41793 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41187 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41442 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/41330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->