### PR TITLE
Use `[[msvc::no_unique_address]]` extension attribute to enable object layout optimization on the MSVC ABI

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -1023,21 +1023,8 @@ private:
     ApproximateTime m_creationTime;
 
     std::unique_ptr<RareData> m_rareData;
-#if OS(WINDOWS) && !ENABLE(CODEBLOCK_CRASH_ANALYSIS)
-    CrashChecker& checker()
-    {
-        // This is needed because the Windows build appears to be using more space
-        // in CodeBlock than other ports for unknown reasons. The addition of
-        // m_checker appears to push it pass 224 bytes and fails the static_assert
-        // below. NO_UNIQUE_ADDRESS appears to not be supported on the Windows build
-        // as well. So, we'll apply this workaround of using a static stub instead.
-        static CrashChecker noOpCheckerStub;
-        return noOpCheckerStub;
-    }
-#else
     NO_UNIQUE_ADDRESS CrashChecker m_checker;
     ALWAYS_INLINE CrashChecker& checker() { return m_checker; }
-#endif
 
 #if ASSERT_ENABLED
     Lock m_cachedIdentifierUidsLock;

--- a/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheHandler.h
@@ -170,9 +170,7 @@ protected:
     std::unique_ptr<PropertyInlineCacheClearingWatchpoint> m_watchpoint;
 };
 
-// The MSVC ABI ignores [[no_unique_address]], so RefCountedBase's NO_UNIQUE_ADDRESS member occupies
-// storage and shifts every field by 8 on Windows. Skip the layout guard there.
-#if !ASSERT_ENABLED && !ASAN_ENABLED && CPU(ARM64) && CPU(ADDRESS64) && !OS(WINDOWS)
+#if !ASSERT_ENABLED && !ASAN_ENABLED && CPU(ARM64) && CPU(ADDRESS64)
 static_assert(InlineCacheHandler::offsetOfUid() == 40, "InlineCacheHandler hot field layout drifted.");
 #endif
 

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -635,7 +635,9 @@
 /* NO_UNIQUE_ADDRESS */
 
 #if !defined(NO_UNIQUE_ADDRESS)
-#if COMPILER_HAS_CPP_ATTRIBUTE(no_unique_address)
+#if COMPILER_HAS_CPP_ATTRIBUTE(msvc::no_unique_address)
+#define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]] // NOLINT: check-webkit-style does not understand annotations.
+#elif COMPILER_HAS_CPP_ATTRIBUTE(no_unique_address)
 #define NO_UNIQUE_ADDRESS [[no_unique_address]] // NOLINT: check-webkit-style does not understand annotations.
 #else
 #define NO_UNIQUE_ADDRESS

--- a/Source/WTF/wtf/RefCountDebugger.cpp
+++ b/Source/WTF/wtf/RefCountDebugger.cpp
@@ -32,7 +32,7 @@ bool RefCountDebuggerBase::areThreadingChecksEnabledGlobally { false };
 // This is a convenience that makes IPC serialization easier.
 static_assert(sizeof(RefCountedBase) == sizeof(ThreadSafeRefCountedBase));
 
-#if defined(NDEBUG) && !ASSERT_ENABLED && !ENABLE(SECURITY_ASSERTIONS) && COMPILER(CLANG) && !OS(WINDOWS)
+#if defined(NDEBUG) && !ASSERT_ENABLED && !ENABLE(SECURITY_ASSERTIONS) && COMPILER(CLANG)
 static_assert(sizeof(RefCountedBase) == sizeof(unsigned), "RefCountedBase should stay small");
 #endif
 


### PR DESCRIPTION
#### 87d57a3fc39c408dd484cd3341a9448f3be2208d
<pre>
Use `[[msvc::no_unique_address]]` extension attribute to enable object layout optimization on the MSVC ABI
<a href="https://bugs.webkit.org/show_bug.cgi?id=317369">https://bugs.webkit.org/show_bug.cgi?id=317369</a>

Reviewed by Yusuke Suzuki.

Currently the WTF NO_UNIQUE_ADDRESS macro doesn&apos;t support MSVC ABI since
the standard attribute is ignored by clang-cl even when compiling with C++23.

Use MSVC extension attribute to enable the optimization for Windows builds.

* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::checker):
* Source/JavaScriptCore/bytecode/InlineCacheHandler.h:
* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/RefCountDebugger.cpp:

Canonical link: <a href="https://commits.webkit.org/315460@main">https://commits.webkit.org/315460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cadc9e10d4de38dafb3babccb81dce7d41e9c9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126731 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131629 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33073 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31777 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27075 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/322 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180974 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30274 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140078 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42597 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139920 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37672 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43286 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107123 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35200 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115051 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201698 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41795 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6365 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54131 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->