### PR TITLE
[git-webkit] Add `git-webkit apply` to apply a patch attached to a bug tracker issue

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.15.2',
+    version='0.15.3',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(0, 15, 2)
+version = Version(0, 15, 3)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import base64
 import calendar
 import re
 import sys
@@ -415,7 +416,48 @@ class Tracker(GenericTracker):
                 if issue.link not in refs:
                     issue._references.append(dupe)
 
+        if member == 'attachments':
+            issue._attachments = []
+            response = self.session.get(
+                '{url}/rest/bug/{id}/attachment{query}'.format(
+                    url=self.url, id=issue.id,
+                    query=self._login_arguments(required=False, query='exclude_fields=data'),
+                ), timeout=self.timeout,
+            )
+            if response.status_code // 100 == 4 and self._logins_left:
+                self._logins_left -= 1
+            attachments = response.json().get('bugs', {}).get(str(issue.id)) if response.status_code == 200 else None
+            if attachments is None:
+                sys.stderr.write("Failed to fetch attachments for '{}'\n".format(issue.link))
+            else:
+                for attachment in attachments:
+                    if attachment.get('is_obsolete'):
+                        continue
+                    issue._attachments.append(Issue.Attachment(
+                        name=attachment.get('file_name'),
+                        content_type=attachment.get('content_type'),
+                        contents=lambda id=attachment.get('id'): self._attachment_contents(id),
+                    ))
+
         return issue
+
+    def _attachment_contents(self, attachment_id):
+        '''Download a single attachment's bytes, or None. Fetched lazily so that listing an issue's
+        attachments does not download every attachment's content.'''
+        response = self.session.get(
+            '{url}/rest/bug/attachment/{id}{query}'.format(
+                url=self.url, id=attachment_id,
+                query=self._login_arguments(required=False, query='include_fields=data'),
+            ), timeout=self.timeout,
+        )
+        if response.status_code // 100 == 4 and self._logins_left:
+            self._logins_left -= 1
+        if response.status_code // 100 != 2:
+            sys.stderr.write('Failed to download attachment {}\n'.format(attachment_id))
+            return None
+        data = response.json().get('attachments', {}).get(str(attachment_id), {}).get('data')
+        return base64.b64decode(data) if data is not None else None
+
 
     def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, state=None, substate=None, cc=None, see_also=None, **properties):
         update_dict = dict()

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -53,6 +53,30 @@ class Issue(object):
                 self.content,
             )
 
+    class Attachment(object):
+        PATCH_SUFFIXES = ('.patch', '.diff')
+
+        def __init__(self, name, content_type=None, contents=None):
+            self.name = name
+            self.content_type = content_type
+            self._contents = contents
+
+        def __repr__(self):
+            return self.name or '<unnamed attachment>'
+
+        @property
+        def is_patch(self):
+            return bool(self.name) and self.name.lower().endswith(self.PATCH_SUFFIXES)
+
+        def contents(self):
+            '''The attachment's bytes, retrieved and cached on first access. `contents` passed to the
+            constructor may be the bytes themselves or a zero-argument callable that fetches them, so
+            that a tracker can defer downloading until a caller actually wants the data. Returns None
+            if the content could not be retrieved (for example, a locked radar attachment).'''
+            if callable(self._contents):
+                self._contents = self._contents()
+            return self._contents
+
     def __init__(self, id, tracker):
         self.id = int(id)
         self.tracker = tracker
@@ -84,6 +108,8 @@ class Issue(object):
         self._classification = None
 
         self._source_changes = None
+
+        self._attachments = None
 
         self.tracker.populate(self, None)
 
@@ -273,6 +299,22 @@ class Issue(object):
         if self._source_changes is None:
             self.tracker.populate(self, 'source_changes')
         return self._source_changes
+
+    @property
+    def attachments(self):
+        '''The issue's attachments, or None if the tracker has no concept of attachments.'''
+        if self._attachments is None:
+            self.tracker.populate(self, 'attachments')
+        return self._attachments
+
+    @property
+    def patches(self):
+        '''The subset of `attachments` that look like patches, or None if the tracker has no concept
+        of attachments.'''
+        attachments = self.attachments
+        if attachments is None:
+            return None
+        return [attachment for attachment in attachments if attachment.is_patch]
 
     def add_source_change(self, line):
         parts = line.split(', ')

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import base64
 import json
 import re
 import time
@@ -29,7 +30,7 @@ from .base import Base
 
 from webkitbugspy import User, Issue
 from webkitbugspy.mocks.radar import Radar as RadarMock
-from webkitcorepy import mocks
+from webkitcorepy import mocks, string_utils
 
 
 class Bugzilla(Base, mocks.Requests):
@@ -269,6 +270,57 @@ class Bugzilla(Base, mocks.Requests):
             )],
         ), url=url)
 
+    def _attachment_records(self):
+        records = []
+        global_id = 0
+        for bug_id in sorted(self.issues.keys()):
+            for attachment in self.issues[bug_id].get('attachments', []):
+                global_id += 1
+                records.append((global_id, bug_id, attachment))
+        return records
+
+    def _attachment_json(self, attachment_id, bug_id, attachment, include_data=True):
+        result = dict(
+            id=attachment_id,
+            bug_id=bug_id,
+            file_name=attachment['fileName'],
+            content_type=attachment.get('content_type', 'text/plain'),
+            is_patch=1 if attachment.get('is_patch') else 0,
+            is_obsolete=1 if attachment.get('is_obsolete') else 0,
+        )
+        if include_data:
+            result['data'] = base64.b64encode(string_utils.encode(attachment.get('data', b''))).decode('ascii')
+        return result
+
+    def _attachments(self, url, id, query=None):
+        if id not in self.issues:
+            return mocks.Response(
+                url=url,
+                headers={'Content-Type': 'text/json'},
+                status_code=404,
+                text=json.dumps(dict(
+                    code=101,
+                    error=True,
+                    message="Bug #{} does not exist.".format(id),
+                )),
+            )
+
+        include_data = 'exclude_fields=data' not in (query or '')
+        return mocks.Response.fromJson(dict(
+            bugs={str(id): [
+                self._attachment_json(attachment_id, bug_id, attachment, include_data=include_data)
+                for attachment_id, bug_id, attachment in self._attachment_records() if bug_id == id
+            ]},
+        ), url=url)
+
+    def _attachment(self, url, attachment_id):
+        for record_id, bug_id, attachment in self._attachment_records():
+            if record_id == attachment_id:
+                return mocks.Response.fromJson(dict(
+                    attachments={str(attachment_id): self._attachment_json(attachment_id, bug_id, attachment)},
+                ), url=url)
+        return mocks.Response.create404(url)
+
     def _comments(self, url, id):
         if id not in self.issues:
             return mocks.Response(
@@ -462,6 +514,14 @@ class Bugzilla(Base, mocks.Requests):
             return self._comments(url, int(match.group('id')))
         if match and method == 'POST':
             return self._post_comment(url, int(match.group('id')), match.group('credentials'), json)
+
+        match = re.match(r'{}/rest/bug/attachment/(?P<id>\d+)(?:\?(?P<query>\S*))?$'.format(self.hosts[0]), stripped_url)
+        if match and method == 'GET':
+            return self._attachment(url, int(match.group('id')))
+
+        match = re.match(r'{}/rest/bug/(?P<id>\d+)/attachment(?:\?(?P<query>\S*))?$'.format(self.hosts[0]), stripped_url)
+        if match and method == 'GET':
+            return self._attachments(url, int(match.group('id')), query=match.group('query'))
 
         match = re.match(r'{}/rest/product_enterable(?P<credentials>\?login=\S+\&password=\S+)?$'.format(self.hosts[0]), stripped_url)
         if match and method == 'GET':

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -145,6 +145,17 @@ class RadarModel(object):
         def __init__(self, name):
             self.name = name
 
+    class Attachment(object):
+        def __init__(self, file_name, data=b'', locked=False):
+            self.fileName = file_name
+            self._data = data if isinstance(data, bytes) else string_utils.encode(data)
+            self.locked = locked
+
+        def content(self, client=None):
+            if self.locked:
+                raise Radar.exceptions.AttachmentLockedException("'{}' is locked".format(self.fileName))
+            return self._data
+
     def __init__(self, client, issue, additional_fields=None):
         from datetime import datetime, timedelta, timezone
 
@@ -181,6 +192,13 @@ class RadarModel(object):
         ])
         self.cc_memberships = self.CollectionProperty(self, *[
             self.CCMembership(Radar.transform_user(watcher)) for watcher in issue.get('watchers', [])
+        ])
+        self.attachments = self.CollectionProperty(self, *[
+            RadarModel.Attachment(
+                attachment['fileName'],
+                data=attachment.get('data', b''),
+                locked=attachment.get('locked', False),
+            ) for attachment in issue.get('attachments', [])
         ])
 
         self.milestone = Radar.Milestone(issue.get('milestone', '?'))
@@ -551,6 +569,9 @@ class Radar(Base, ContextStack):
             pass
 
         class RadarAccessDeniedResponseException(Exception):
+            pass
+
+        class AttachmentLockedException(Exception):
             pass
 
     class RetryPolicy(object):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -285,6 +285,8 @@ class Tracker(GenericTracker):
         issue._link = 'rdar://{}'.format(issue.id)
         issue._labels = []
         issue._related_links = []  # We don't yet have a defined idiom for "related links" in radar
+        if member == 'attachments':
+            issue._attachments = []
         if (not self.client or not self.library) and member:
             sys.stderr.write('radarclient inaccessible on this machine\n')
             return issue
@@ -325,6 +327,13 @@ class Tracker(GenericTracker):
             issue._source_changes = []
             if radar.sourceChanges is not None:
                 issue._source_changes = radar.sourceChanges.splitlines()
+
+        if member == 'attachments':
+            for attachment in radar.attachments.items():
+                issue._attachments.append(Issue.Attachment(
+                    name=attachment.fileName,
+                    contents=lambda attachment=attachment: self._attachment_contents(attachment),
+                ))
 
         if member == 'keywords':
             issue._keywords = [kw.name for kw in (radar.keywords() or [])]
@@ -395,6 +404,14 @@ class Tracker(GenericTracker):
                 issue._related[r.type].append(self.issue(r.related_radar_id))
 
         return issue
+
+    def _attachment_contents(self, attachment):
+        '''Download an attachment's bytes, or None if it is locked.'''
+        try:
+            return attachment.content(client=self.client)
+        except self.radarclient().exceptions.AttachmentLockedException:
+            sys.stderr.write("'{}' is locked and cannot be downloaded\n".format(attachment.fileName))
+            return None
 
     @handle_access_exception
     def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, state=None, substate=None, resolution=None, see_also=None, **properties):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -32,6 +32,34 @@ from webkitcorepy import mocks as wkmocks
 from webkitbugspy import Tracker, User, bugzilla, mocks, radar
 
 
+ATTACHMENT_ISSUES = [
+    dict(
+        id=1,
+        title='Issue with attachments',
+        timestamp=1639536160,
+        modified=1710884407,
+        opened=True,
+        creator=mocks.USERS['Felix Filer'],
+        assignee=mocks.USERS['Tim Contributor'],
+        description='An example issue with attachments',
+        attachments=[
+            dict(fileName='fix.patch', data=b'FIX PATCH BYTES', content_type='text/plain', is_patch=True),
+            dict(fileName='notes.txt', data=b'not a patch', content_type='text/plain'),
+            dict(fileName='old.patch', data=b'OBSOLETE', content_type='text/plain', is_patch=True, is_obsolete=True),
+        ],
+    ), dict(
+        id=2,
+        title='Issue without attachments',
+        timestamp=1639540010,
+        modified=1710884407,
+        opened=True,
+        creator=mocks.USERS['Felix Filer'],
+        assignee=mocks.USERS['Tim Contributor'],
+        description='An example issue without attachments',
+    ),
+]
+
+
 class TestBugzilla(unittest.TestCase):
     URL = 'https://bugs.example.com'
 
@@ -150,6 +178,23 @@ class TestBugzilla(unittest.TestCase):
                 User.Encoder().default(comments[0].user),
                 dict(name='Felix Filer', username='ffiler@example.com', emails=['ffiler@example.com']),
             )
+
+    def test_attachments(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], issues=ATTACHMENT_ISSUES):
+            attachments = bugzilla.Tracker(self.URL).issue(1).attachments
+            self.assertEqual([attachment.name for attachment in attachments], ['fix.patch', 'notes.txt'])
+            self.assertEqual(attachments[0].content_type, 'text/plain')
+
+    def test_patches(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], issues=ATTACHMENT_ISSUES):
+            patches = bugzilla.Tracker(self.URL).issue(1).patches
+            self.assertEqual([patch.name for patch in patches], ['fix.patch'])
+            self.assertEqual(patches[0].contents(), b'FIX PATCH BYTES')
+
+    def test_no_attachments(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], issues=ATTACHMENT_ISSUES):
+            self.assertEqual(bugzilla.Tracker(self.URL).issue(2).attachments, [])
+            self.assertEqual(bugzilla.Tracker(self.URL).issue(2).patches, [])
 
     def test_watchers(self):
         with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -28,6 +28,35 @@ from webkitcorepy import mocks as wkmocks, OutputCapture
 
 RELATED_BLANK = {'related-to': [], 'blocked-by': [], 'blocking': [], 'parent-of': [], 'subtask-of': [], 'cause-of': [], 'caused-by': [], 'duplicate-of': [], 'original-of': [], 'clone-of': [], 'cloned-to': []}
 
+ATTACHMENT_ISSUES = [
+    dict(
+        id=1,
+        title='Issue with attachments',
+        timestamp=1639536160,
+        modified=1710884407,
+        opened=True,
+        creator=mocks.USERS['Felix Filer'],
+        assignee=mocks.USERS['Tim Contributor'],
+        description='An example issue with attachments',
+        attachments=[
+            dict(fileName='triage-revert.patch', data=b'REVERT PATCH BYTES'),
+            dict(fileName='triage-fix.patch', data=b'FIX PATCH BYTES'),
+            dict(fileName='build-log.txt', data=b'not a patch'),
+            dict(fileName='cve.diff', data=b'DIFF BYTES'),
+            dict(fileName='locked.patch', data=b'SECRET', locked=True),
+        ],
+    ), dict(
+        id=2,
+        title='Issue without attachments',
+        timestamp=1639540010,
+        modified=1710884407,
+        opened=True,
+        creator=mocks.USERS['Felix Filer'],
+        assignee=mocks.USERS['Tim Contributor'],
+        description='An example issue without attachments',
+    ),
+]
+
 
 class TestRadar(unittest.TestCase):
     def test_encoding(self):
@@ -131,6 +160,38 @@ class TestRadar(unittest.TestCase):
                 User.Encoder().default(comments[0].user),
                 dict(name='Felix Filer', username=809, emails=['ffiler@example.com']),
             )
+
+    def test_attachments(self):
+        with mocks.Radar(issues=ATTACHMENT_ISSUES):
+            attachments = radar.Tracker().issue(1).attachments
+            self.assertEqual(
+                [attachment.name for attachment in attachments],
+                ['triage-revert.patch', 'triage-fix.patch', 'build-log.txt', 'cve.diff', 'locked.patch'],
+            )
+
+    def test_patches(self):
+        with mocks.Radar(issues=ATTACHMENT_ISSUES):
+            self.assertEqual(
+                [patch.name for patch in radar.Tracker().issue(1).patches],
+                ['triage-revert.patch', 'triage-fix.patch', 'cve.diff', 'locked.patch'],
+            )
+
+    def test_patch_contents(self):
+        with mocks.Radar(issues=ATTACHMENT_ISSUES):
+            patches = {patch.name: patch for patch in radar.Tracker().issue(1).patches}
+            self.assertEqual(patches['triage-fix.patch'].contents(), b'FIX PATCH BYTES')
+            self.assertEqual(patches['cve.diff'].contents(), b'DIFF BYTES')
+
+    def test_locked_attachment(self):
+        with mocks.Radar(issues=ATTACHMENT_ISSUES), OutputCapture() as captured:
+            patches = {patch.name: patch for patch in radar.Tracker().issue(1).patches}
+            self.assertIsNone(patches['locked.patch'].contents())
+        self.assertIn('is locked', captured.stderr.getvalue())
+
+    def test_no_attachments(self):
+        with mocks.Radar(issues=ATTACHMENT_ISSUES):
+            self.assertEqual(radar.Tracker().issue(2).attachments, [])
+            self.assertEqual(radar.Tracker().issue(2).patches, [])
 
     def test_watchers(self):
         with mocks.Radar(issues=mocks.ISSUES):

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='7.0.2',
+    version='7.0.3',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -50,14 +50,14 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(7, 0, 2)
+version = Version(7, 0, 3)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSafe', wheel=True))
 AutoInstall.register(Package('jinja2', Version(3, 1, 4), implicit_deps=['markupsafe']))
 AutoInstall.register(Package('monotonic', Version(1, 5)))
 AutoInstall.register(Package('xmltodict', Version(0, 11, 0)))
-AutoInstall.register(Package('webkitbugspy', Version(0, 15, 1)), local=True)
+AutoInstall.register(Package('webkitbugspy', Version(0, 15, 3)), local=True)
 
 if sys.version_info >= (3, 10):
     AutoInstall.register(Package('rapidfuzz', Version(3, 14, 3), wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -27,6 +27,7 @@ import re
 import sys
 import traceback
 
+from .apply import Apply
 from .blame import Blame
 from .branch import Branch
 from .canonicalize import Canonicalize
@@ -98,7 +99,7 @@ def main(
     subparser.set_defaults(main=lambda *args, **kwargs: parser.print_help())
 
     programs = [
-        Blame, Branch, Canonicalize, Checkout,
+        Apply, Blame, Branch, Canonicalize, Checkout,
         Clean, Clone, Conflict, CreateBug, Diff, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Review, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py
@@ -1,0 +1,159 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import sys
+import tempfile
+
+from .command import Command
+from .diff.html_diff import HTMLDiff
+
+from webkitbugspy import radar, Tracker
+from webkitcorepy import run, Terminal
+from webkitscmpy import local, log
+
+
+class Apply(Command):
+    name = 'apply'
+    help = 'Apply a patch attached to a bug tracker issue (for example, a proposed revert or build fix)'
+
+    # Patch names build-failure triage tends to attach, most-preferred first. When an issue has more
+    # than one patch and the user does not name one, the first of these that is present is the
+    # default selection in the chooser.
+    PREFERRED_PATCHES = ('triage-revert.patch', 'triage-fix.patch')
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            'issue', type=str,
+            help='Issue the patch is attached to (an issue URL, rdar://<id>, or a bare radar id)',
+        )
+        parser.add_argument(
+            'name', type=str, default=None, nargs='?',
+            help='Name of the attached patch to apply; if omitted, choose from the issue\'s patches',
+        )
+        parser.add_argument(
+            '--no-commit', default=True, action='store_false', dest='commit',
+            help='Apply the patch to the working tree only, instead of committing it with `git am`',
+        )
+
+    @classmethod
+    def resolve_issue(cls, string):
+        '''Resolve a tracker link, URL, or bare radar id to a webkitbugspy issue.'''
+        issue = Tracker.from_string(string)
+        if issue:
+            return issue
+        # from_string rejects a bare number; a bare id is only meaningful for radar, so resolve one
+        # against the radar tracker -- digits-only, so a malformed link is never coerced into an id.
+        stripped = string.strip()
+        if stripped.isdigit():
+            for tracker in Tracker._trackers:
+                if isinstance(tracker, radar.Tracker):
+                    return tracker.issue(int(stripped))
+        return None
+
+    @classmethod
+    def select_patch(cls, patches, name=None):
+        '''Pick one attachment from `patches`. With an explicit `name`, return the exact match (or
+        None if there is none). Otherwise return the only patch, or prompt the user to choose,
+        defaulting to the most-preferred known patch that is present.'''
+        by_name = {patch.name: patch for patch in patches}
+        if name:
+            return by_name.get(name)
+        if len(patches) == 1:
+            return patches[0]
+        options = sorted(by_name.keys())
+        default = next((name for name in cls.PREFERRED_PATCHES if name in by_name), options[0])
+        return by_name.get(Terminal.choose(
+            'Which patch would you like to apply?',
+            options=options, default=default, numbered=True,
+        ))
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        if not isinstance(repository, local.Git):
+            sys.stderr.write("Can only '{}' on a native Git repository\n".format(cls.name))
+            return 1
+        if repository.modified():
+            sys.stderr.write('Please commit or stash your changes before applying a patch\n')
+            return 1
+
+        issue = cls.resolve_issue(args.issue)
+        if not issue:
+            sys.stderr.write("Could not resolve '{}' to an issue\n".format(args.issue))
+            return 1
+
+        patches = issue.patches
+        if patches is None:
+            sys.stderr.write('{} does not support patch attachments\n'.format(issue.tracker.NAME))
+            return 1
+        if not patches:
+            sys.stderr.write('No patches are attached to {}\n'.format(issue.link))
+            return 1
+
+        patch = cls.select_patch(patches, name=args.name)
+        if not patch:
+            sys.stderr.write("No '{}' patch is attached to {}\n".format(args.name, issue.link))
+            return 1
+
+        # The patch is issue-attachment content -- whoever can attach to the issue controls these
+        # bytes, applied via git am/apply: the same trust as applying any colleague's patch.
+        content = patch.contents()
+        if content is None:
+            sys.stderr.write("Could not download '{}' from {}\n".format(patch.name, issue.link))
+            return 1
+        if not isinstance(content, bytes):
+            content = content.encode('utf-8')
+        if not content.strip():
+            sys.stderr.write("'{}' on {} is empty\n".format(patch.name, issue.link))
+            return 1
+
+        # On an interactive terminal, open the patch as an HTML diff and block until the viewer is
+        # dismissed -- these bytes came from an attachment, so let the user see what they're applying
+        # first. Dismissing the diff continues; a user who disagrees interrupts the program instead.
+        if Terminal.isatty(sys.stdout) and Terminal.isatty(sys.stdin):
+            with HTMLDiff(block=True, repository=repository) as diff_viewer:
+                diff_viewer.add_lines(content.decode('utf-8', errors='replace').splitlines())
+
+        handle, patch_path = tempfile.mkstemp(suffix='.patch')
+        try:
+            with os.fdopen(handle, 'wb') as patch_file:
+                patch_file.write(content)
+
+            if args.commit:
+                result = run([repository.executable(), 'am', patch_path], cwd=repository.root_path)
+            else:
+                result = run([repository.executable(), 'apply', '--3way', patch_path], cwd=repository.root_path)
+
+            if result.returncode:
+                sys.stderr.write("Failed to apply '{}' from {}\n".format(patch.name, issue.link))
+                if args.commit:
+                    run([repository.executable(), 'am', '--abort'], cwd=repository.root_path, capture_output=True)
+                    sys.stderr.write('Re-run with --no-commit to apply it to the working tree and resolve conflicts by hand.\n')
+                else:
+                    sys.stderr.write('Conflicting hunks were left as conflict markers / .rej files; `git checkout -- .` to discard.\n')
+                return 1
+        finally:
+            os.remove(patch_path)
+
+        log.info("Applied '{}' from {}".format(patch.name, issue.link))
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py
@@ -1,0 +1,285 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import unittest
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+from webkitbugspy import Issue, radar
+from webkitbugspy import mocks as bmocks
+from webkitcorepy import OutputCapture
+from webkitscmpy import local
+from webkitscmpy.program.apply import Apply
+
+
+class TestApply(unittest.TestCase):
+    @staticmethod
+    def _patch(name, contents=b'PATCH'):
+        return Issue.Attachment(name=name, contents=contents)
+
+    @staticmethod
+    def _issue(patches=None, link='rdar://5', tracker_name='Radar'):
+        issue = MagicMock(link=link)
+        issue.patches = patches
+        issue.tracker.NAME = tracker_name
+        return issue
+
+    def _repo(self, modified=None):
+        repository = MagicMock(spec=local.Git)
+        repository.modified.return_value = modified or {}
+        repository.executable.return_value = 'git'
+        repository.root_path = '/repo'
+        return repository
+
+    def test_resolve_issue_via_link(self):
+        issue = MagicMock()
+        with patch('webkitscmpy.program.apply.Tracker.from_string', return_value=issue):
+            self.assertIs(Apply.resolve_issue('rdar://7'), issue)
+
+    def test_resolve_issue_bare_id_via_radar_tracker(self):
+        issue = MagicMock()
+        tracker = MagicMock(spec=radar.Tracker)
+        tracker.issue.return_value = issue
+        with patch('webkitscmpy.program.apply.Tracker.from_string', return_value=None), \
+             patch('webkitscmpy.program.apply.Tracker._trackers', [tracker]):
+            self.assertIs(Apply.resolve_issue('179875292'), issue)
+            tracker.issue.assert_called_once_with(179875292)
+
+    def test_resolve_issue_does_not_coerce_non_numeric_string(self):
+        # A malformed link must NOT be reduced to its digits and resolved as the wrong radar.
+        tracker = MagicMock(spec=radar.Tracker)
+        with patch('webkitscmpy.program.apply.Tracker.from_string', return_value=None), \
+             patch('webkitscmpy.program.apply.Tracker._trackers', [tracker]):
+            self.assertIsNone(Apply.resolve_issue('rdar://problem/42?x=9'))
+            tracker.issue.assert_not_called()
+
+    def test_select_patch_by_name(self):
+        patches = [self._patch('triage-fix.patch'), self._patch('triage-revert.patch')]
+        self.assertIs(Apply.select_patch(patches, name='triage-revert.patch'), patches[1])
+
+    def test_select_patch_by_name_missing(self):
+        self.assertIsNone(Apply.select_patch([self._patch('triage-fix.patch')], name='absent.patch'))
+
+    def test_select_patch_single(self):
+        patches = [self._patch('only.patch')]
+        self.assertIs(Apply.select_patch(patches), patches[0])
+
+    def test_select_patch_prompts_with_preferred_default(self):
+        patches = [self._patch('triage-revert.patch'), self._patch('triage-fix.patch'), self._patch('other.patch')]
+        with patch('webkitscmpy.program.apply.Terminal.choose', return_value='other.patch') as choose:
+            selected = Apply.select_patch(patches)
+        self.assertEqual(selected.name, 'other.patch')
+        self.assertEqual(choose.call_args.kwargs['default'], 'triage-revert.patch')
+        self.assertEqual(choose.call_args.kwargs['options'], ['other.patch', 'triage-fix.patch', 'triage-revert.patch'])
+
+    def test_select_patch_defaults_to_first_when_none_preferred(self):
+        patches = [self._patch('zeta.patch'), self._patch('alpha.patch')]
+        with patch('webkitscmpy.program.apply.Terminal.choose', return_value='alpha.patch') as choose:
+            Apply.select_patch(patches)
+        self.assertEqual(choose.call_args.kwargs['default'], 'alpha.patch')
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_rejects_non_git_repository(self, mock_run):
+        with OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), MagicMock(spec=local.Svn))
+        self.assertEqual(result, 1)
+        self.assertEqual(captured.stderr.getvalue(), "Can only 'apply' on a native Git repository\n")
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_rejects_dirty_tree(self, mock_run):
+        with OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo(modified={'f': 1}))
+        self.assertEqual(result, 1)
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_when_issue_unresolvable(self, mock_run):
+        with patch.object(Apply, 'resolve_issue', return_value=None), OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='bogus', name=None, commit=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertEqual(captured.stderr.getvalue(), "Could not resolve 'bogus' to an issue\n")
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_when_attachments_unsupported(self, mock_run):
+        issue = self._issue(patches=None, tracker_name='GitHub Issue')
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='https://github.example.com/x/1', name=None, commit=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertEqual(captured.stderr.getvalue(), 'GitHub Issue does not support patch attachments\n')
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_when_no_patches(self, mock_run):
+        issue = self._issue(patches=[])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertIn('No patches are attached', captured.stderr.getvalue())
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_when_named_patch_missing(self, mock_run):
+        issue = self._issue(patches=[self._patch('triage-fix.patch')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='rdar://5', name='absent.patch', commit=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertIn("No 'absent.patch' patch is attached", captured.stderr.getvalue())
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_on_download_failure(self, mock_run):
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=None)])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        self.assertEqual(result, 1)
+        self.assertIn('Could not download', captured.stderr.getvalue())
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_errors_on_empty_content(self, mock_run):
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'   \n')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture() as captured:
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+        self.assertEqual(result, 1)
+        self.assertIn('is empty', captured.stderr.getvalue())
+        mock_run.assert_not_called()
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_commits_with_git_am(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_run.call_args.args[0][:2], ['git', 'am'])
+        self.assertEqual(mock_run.call_args.kwargs.get('cwd'), '/repo')
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_no_commit_uses_git_apply_3way(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_run.call_args.args[0][:3], ['git', 'apply', '--3way'])
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_aborts_am_on_conflict(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        self.assertEqual(result, 1)
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertEqual(commands[0][:2], ['git', 'am'])
+        self.assertIn(['git', 'am', '--abort'], commands)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_no_commit_failure_does_not_abort(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+        self.assertEqual(result, 1)
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        self.assertNotIn(['git', 'am', '--abort'], commands)
+        self.assertEqual(len(commands), 1)
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_removes_tempfile_even_on_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        patch_path = mock_run.call_args_list[0].args[0][2]
+        self.assertFalse(os.path.exists(patch_path))
+
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_encodes_str_content(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents='PATCH-AS-STR')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=False), self._repo())
+        self.assertEqual(result, 0)
+
+    def test_main_downloads_named_patch_from_radar(self):
+        # End-to-end through real webkitbugspy + the radar mock: resolve rdar://1, fetch the named
+        # patch's bytes via Issue.patches / Attachment.contents(), and hand them to `git am`.
+        issues = [dict(
+            id=1,
+            title='Build failure',
+            timestamp=1639536160,
+            modified=1710884407,
+            opened=True,
+            creator=bmocks.USERS['Felix Filer'],
+            assignee=bmocks.USERS['Tim Contributor'],
+            description='triage output',
+            attachments=[
+                dict(fileName='triage-fix.patch', data=b'FIX BYTES'),
+                dict(fileName='triage-revert.patch', data=b'REVERT BYTES'),
+            ],
+        )]
+        written = {}
+
+        def fake_run(command, **kwargs):
+            if command[1] == 'am':
+                with open(command[2], 'rb') as patch_file:
+                    written['content'] = patch_file.read()
+            return MagicMock(returncode=0)
+
+        with bmocks.Radar(issues=issues), \
+             patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]), \
+             patch('webkitscmpy.program.apply.run', side_effect=fake_run), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://1', name='triage-fix.patch', commit=True), self._repo())
+        self.assertEqual(result, 0)
+        self.assertEqual(written.get('content'), b'FIX BYTES')
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_previews_diff_when_interactive(self, mock_run, mock_htmldiff):
+        mock_run.return_value = MagicMock(returncode=0)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), \
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=True), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        self.assertEqual(result, 0)
+        mock_htmldiff.assert_called_once()
+        self.assertEqual(mock_htmldiff.call_args.kwargs.get('block'), True)
+        self.assertEqual(mock_run.call_args.args[0][:2], ['git', 'am'])
+
+    @patch('webkitscmpy.program.apply.HTMLDiff')
+    @patch('webkitscmpy.program.apply.run')
+    def test_main_skips_diff_when_not_interactive(self, mock_run, mock_htmldiff):
+        mock_run.return_value = MagicMock(returncode=0)
+        issue = self._issue(patches=[self._patch('triage-fix.patch', contents=b'PATCH')])
+        with patch.object(Apply, 'resolve_issue', return_value=issue), \
+             patch('webkitscmpy.program.apply.Terminal.isatty', return_value=False), OutputCapture():
+            result = Apply.main(Namespace(issue='rdar://5', name=None, commit=True), self._repo())
+        self.assertEqual(result, 0)
+        mock_htmldiff.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### 590d1e9137936246434463aef7c785f05889d5e0
<pre>
[git-webkit] Add `git-webkit apply` to apply a patch attached to a bug tracker issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=317370">https://bugs.webkit.org/show_bug.cgi?id=317370</a>
<a href="https://rdar.apple.com/179992085">rdar://179992085</a>

Reviewed by Jonathan Bedard.

`git-webkit apply &lt;issue&gt; [name]` downloads a patch attached to a bug
tracker issue and applies it with `git am` (or `git apply --3way` when
--no-commit is passed). It resolves any tracker webkitbugspy knows about --
an issue URL, <a href="https://rdar.apple.com/&lt">rdar://&lt</a>;id&gt;, or a bare radar id -- lists every attached
patch, and lets the user choose which one to apply, defaulting to a known
triage patch when one is present. On an interactive terminal it opens the
chosen patch as an HTML diff and waits until the viewer is dismissed before
applying (interrupt to abort).

The concept of an attachment is pushed down into webkitbugspy so the
sub-program just asks the issue for its patches and gets None back when the
tracker has no notion of attachments. Radar and Bugzilla implement it;
Bugzilla lists attachment metadata and downloads a patch&apos;s contents lazily.

* Tools/Scripts/libraries/webkitbugspy/setup.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Bump to 0.15.3.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.Attachment): Added.
(Issue.Attachment.is_patch):
(Issue.Attachment.contents): Lazily fetch and cache the attachment&apos;s bytes.
(Issue.__init__): Initialize _attachments.
(Issue.attachments): Added; None when the tracker has no attachment concept.
(Issue.patches): Added; the attachments that look like patches.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.populate): Populate attachments from radar.attachments.
(Tracker._attachment_contents): Download an attachment&apos;s bytes, or None if locked.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate): List attachment metadata (without downloading contents).
(Tracker._attachment_contents): Download a single attachment&apos;s bytes lazily.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarModel.Enclosure): Added.
(RadarModel.Attachment): Added.
(RadarModel.__init__): Expose attachments.
(Radar.exceptions.AttachmentLockedException): Added.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla.request): Route the attachment list and single-attachment endpoints.
(Bugzilla._attachment_records):
(Bugzilla._attachment_json):
(Bugzilla._attachments):
(Bugzilla._attachment):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
(TestRadar.test_attachments):
(TestRadar.test_patches):
(TestRadar.test_patch_contents):
(TestRadar.test_locked_attachment):
(TestRadar.test_no_attachments):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_attachments):
(TestBugzilla.test_patches):
(TestBugzilla.test_no_attachments):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Require webkitbugspy 0.15.3.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/apply.py: Added.
(Apply):
(Apply.parser):
(Apply.resolve_issue): Resolve a link, URL, or bare radar id to an issue.
(Apply.select_patch): Pick a patch by name, or choose from the issue&apos;s patches.
(Apply.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/apply_unittest.py: Added.
(TestApply):

Canonical link: <a href="https://commits.webkit.org/316684@main">https://commits.webkit.org/316684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc3a06d0a3583cf20d08962f82bab83cbe6db325

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182741 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/05108c28-7faf-4ef1-b12d-c5ecd445f982) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4a5b9c7-7e26-4602-b806-bbfdfb8bb68a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176126 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72a46b8c-28e0-494b-b795-667d8c1cec6e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172489 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31226 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185163 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172568 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46768 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143369 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38702 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47447 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38329 "Passed tests") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45953 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9702 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45355 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45412 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->