### PR TITLE
[iOS] WebMockMediaDeviceRoute should conform to AVPlaybackControl

### DIFF
--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -32,11 +32,6 @@
 #import <AVKit/AVKit.h>
 #import <wtf/TZoneMallocInlines.h>
 
-@interface NSObject (Staging_169033633)
-@property (nonatomic) CMTime currentPlaybackPosition;
-@property (nonatomic) CMTime currentValue;
-@end
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MockMediaDeviceRoute);
@@ -93,20 +88,20 @@ void MockMediaDeviceRoute::setPlaying(bool playing)
 
 bool MockMediaDeviceRoute::hasPlaybackError() const
 {
-    return !![m_platformRoute playbackError];
+    return !![m_platformRoute error];
 }
 
 void MockMediaDeviceRoute::setHasPlaybackError(bool)
 {
     RetainPtr error = [NSError errorWithDomain:WebMockMediaDeviceRouteErrorDomain code:WebMockMediaDeviceRouteErrorCodePlaybackError userInfo:nil];
-    [m_platformRoute setPlaybackError:error.get()];
+    [m_platformRoute setError:error.get()];
 }
 
 Vector<MockMediaDeviceRoute::AudioOption> MockMediaDeviceRoute::audioOptions() const
 {
-    NSArray<AVInterfaceMediaSelectionOptionSource *> *options = [m_platformRoute audioOptions];
+    NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *options = [m_platformRoute audioOptions];
     return Vector<AudioOption>(options.count, [&](size_t i) {
-        AVInterfaceMediaSelectionOptionSource *option = options[i];
+        AVPlaybackUserInterfaceMediaSelectionOption *option = options[i];
         return AudioOption {
             option.displayName,
             option.identifier,
@@ -117,9 +112,9 @@ Vector<MockMediaDeviceRoute::AudioOption> MockMediaDeviceRoute::audioOptions() c
 
 void MockMediaDeviceRoute::setAudioOptions(const Vector<AudioOption>& audioOptions)
 {
-    RetainPtr<NSMutableArray<AVInterfaceMediaSelectionOptionSource *>> options = [NSMutableArray arrayWithCapacity:audioOptions.size()];
+    RetainPtr options = [NSMutableArray arrayWithCapacity:audioOptions.size()];
     for (auto& option : audioOptions) {
-        RetainPtr platformOption = adoptNS([[AVInterfaceMediaSelectionOptionSource alloc] initWithDisplayName:option.displayName.createNSString().get() identifier:option.identifier.createNSString().get() extendedLanguageTag:option.extendedLanguageTag.createNSString().get()]);
+        RetainPtr platformOption = adoptNS([[AVPlaybackUserInterfaceMediaSelectionOption alloc] initWithDisplayName:option.displayName.createNSString().get() identifier:option.identifier.createNSString().get() extendedLanguageTag:option.extendedLanguageTag.createNSString().get() mediaCharacteristics:@[]]);
         [options addObject:platformOption.get()];
     }
     [m_platformRoute setAudioOptions:options.get()];
@@ -137,20 +132,12 @@ void MockMediaDeviceRoute::setPlaybackRate(float playbackRate)
 
 float MockMediaDeviceRoute::currentPlaybackPosition() const
 {
-    if ([m_platformRoute respondsToSelector:@selector(currentPlaybackPosition)])
-        return CMTimeGetSeconds([m_platformRoute currentPlaybackPosition]);
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return CMTimeGetSeconds([m_platformRoute currentValue]);
-ALLOW_DEPRECATED_DECLARATIONS_END
+    return CMTimeGetSeconds([[m_platformRoute playbackPosition] position]);
 }
 
 void MockMediaDeviceRoute::setCurrentPlaybackPosition(float currentPlaybackPosition)
 {
-    if ([m_platformRoute respondsToSelector:@selector(setCurrentPlaybackPosition:)])
-        return [m_platformRoute setCurrentPlaybackPosition:CMTimeMakeWithSeconds(currentPlaybackPosition, 1000)];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [m_platformRoute setCurrentValue:CMTimeMakeWithSeconds(currentPlaybackPosition, 1000)];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    [m_platformRoute seekToPosition:CMTimeMakeWithSeconds(currentPlaybackPosition, 1000) tolerance:kCMTimeZero];
 }
 
 MockMediaDeviceRoute::TimeRange MockMediaDeviceRoute::timeRange() const

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -46,13 +46,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSErrorDomain const WebMockMediaDeviceRouteErrorDomain;
 
-@interface WebMockMediaDeviceRoute : NSObject <AVMediaSource, WebMediaDevicePlatformRoute>
+@interface WebMockMediaDeviceRoute : NSObject <AVPlaybackControl, WebMediaDevicePlatformRoute>
 @property (nonatomic, nullable, setter=setURLCallback:) WebCore::MockMediaDeviceRouteURLCallback* urlCallback;
 @property (copy) NSString *routeDisplayName;
 @property (nonatomic, getter=isReady) BOOL ready;
-@property (nonatomic, strong, nullable) NSError *playbackError;
+@property (nonatomic, strong, nullable) NSError *error;
 @property (nonatomic) CMTimeRange timeRange;
-@property (nonatomic, copy) NSArray<AVInterfaceMediaSelectionOptionSource *> *audioOptions;
+@property (nonatomic, copy) NSArray<AVPlaybackUserInterfaceMediaSelectionOption *> *audioOptions;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -28,9 +28,6 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
-// FIXME: rdar://178753306
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-
 #import "MockMediaDeviceRouteURLCallback.h"
 #import <WebCore/JSDOMPromise.h>
 #import <wtf/BlockPtr.h>
@@ -40,21 +37,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRouteErrorDomain";
 
-@interface WebMockMediaDeviceRoute (Staging_169033633)
-@property (nonatomic) CMTime currentPlaybackPosition;
-@property (nonatomic) CMTime currentValue;
+@interface WebMockMediaDeviceRoute ()
+@property (nonatomic, strong) AVPlaybackUserInterfacePlaybackPosition *playbackPosition;
 @end
 
 @implementation WebMockMediaDeviceRoute {
     RefPtr<WebCore::MockMediaDeviceRouteURLCallback> _urlCallback;
     RefPtr<WebCore::DOMPromise> _urlPromise;
-    CMTime _currentPlaybackPosition;
 }
 
 @synthesize timeRange;
 @synthesize segments;
 @synthesize currentSegment;
 @synthesize seekableTimeRanges;
+@synthesize playbackPosition;
 @synthesize ready;
 @synthesize playing;
 @synthesize buffering;
@@ -63,10 +59,12 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
 @synthesize state;
 @synthesize supportedSeekCapabilities;
 @synthesize containsLiveStreamingContent;
-@synthesize playbackError;
+@synthesize error;
 @synthesize currentAudioOption;
+@synthesize currentAudioDescriptionOption;
 @synthesize currentLegibleOption;
 @synthesize audioOptions;
+@synthesize audioDescriptionOptions;
 @synthesize legibleOptions;
 @synthesize hasAudio;
 @synthesize muted;
@@ -74,27 +72,11 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
 @synthesize metadata;
 @synthesize routeDisplayName;
 
-- (CMTime)currentPlaybackPosition
+- (void)seekToPosition:(CMTime)position tolerance:(CMTime)tolerance
 {
-    return _currentPlaybackPosition;
+    RetainPtr playbackPosition = adoptNS([[AVPlaybackUserInterfacePlaybackPosition alloc] initWithPosition:position hostTime:CMClockGetTime(CMClockGetHostTimeClock()) rate:0]);
+    self.playbackPosition = playbackPosition.get();
 }
-
-- (void)setCurrentPlaybackPosition:(CMTime)currentPlaybackPosition
-{
-    _currentPlaybackPosition = currentPlaybackPosition;
-}
-
-ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
-- (CMTime)currentValue
-{
-    return self.currentPlaybackPosition;
-}
-
-- (void)setCurrentValue:(CMTime)currentValue
-{
-    self.currentPlaybackPosition = currentValue;
-}
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (WebCore::MockMediaDeviceRouteURLCallback* _Nullable)urlCallback
 {
@@ -106,7 +88,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _urlCallback = urlCallback;
 }
 
-- (void)startWithURL:(NSURL *)url completionHandler:(void (^)(NSError * _Nullable, NSObject<AVMediaSource> * _Nullable))completionHandler
+- (void)startWithURL:(NSURL *)url completionHandler:(void (^)(NSError * _Nullable, NSObject<AVPlaybackControl> * _Nullable))completionHandler
 {
     if (!_urlCallback)
         return completionHandler([NSError errorWithDomain:WebMockMediaDeviceRouteErrorDomain code:WebMockMediaDeviceRouteErrorCodeInvalidState userInfo:nil], nil);
@@ -137,7 +119,5 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 @end
 
 NS_ASSUME_NONNULL_END
-
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)


### PR DESCRIPTION
#### eef520e81686779b2126d0a5255ec8eb36644eaf
<pre>
[iOS] WebMockMediaDeviceRoute should conform to AVPlaybackControl
<a href="https://bugs.webkit.org/show_bug.cgi?id=317372">https://bugs.webkit.org/show_bug.cgi?id=317372</a>
<a href="https://rdar.apple.com/179992867">rdar://179992867</a>

Reviewed by Eric Carlson.

Migrated WebMockMediaDeviceRoute from conforming to AVInterfaceControllable to AVPlaybackControl.

No new tests. Covered by existing tests.

* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::hasPlaybackError const):
(WebCore::MockMediaDeviceRoute::setHasPlaybackError):
(WebCore::MockMediaDeviceRoute::audioOptions const):
(WebCore::MockMediaDeviceRoute::setAudioOptions):
(WebCore::MockMediaDeviceRoute::currentPlaybackPosition const):
(WebCore::MockMediaDeviceRoute::setCurrentPlaybackPosition):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute seekToPosition:tolerance:]):
(-[WebMockMediaDeviceRoute startWithURL:completionHandler:]):
(-[WebMockMediaDeviceRoute currentPlaybackPosition]): Deleted.
(-[WebMockMediaDeviceRoute setCurrentPlaybackPosition:]): Deleted.
(-[WebMockMediaDeviceRoute currentValue]): Deleted.
(-[WebMockMediaDeviceRoute setCurrentValue:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/315500@main">https://commits.webkit.org/315500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d40ca9a71230d227903705c5267faf642556ab86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126893 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23a47d9f-54e0-4364-90ca-a0d9c795bb1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131766 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/224125c7-b7a3-49e2-89f9-96955a8a8201) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172140 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112269 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/544fec07-21d1-4b4a-b0da-d62b984a0f0a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27237 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181137 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140218 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42759 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140059 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37693 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43448 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107368 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35336 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115213 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41957 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6517 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41351 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41606 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->