### PR TITLE
Crash when rehashing DOMWrapperWorld::m_wrappers hash map

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -31,14 +31,123 @@
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/MainThread.h>
 
+#if PLATFORM(COCOA)
+#include <mutex>
+#include <sys/mman.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/PageBlock.h>
+#include <wtf/WeakRandomNumber.h>
+#endif
+
 namespace WebCore {
 using namespace JSC;
+
+#if PLATFORM(COCOA)
+
+bool gGuardWrapperMaps = false;
+
+// Guard ~1 in N WebContent processes (tuning knob: lower the average Speedometer cost to rate x full).
+static constexpr unsigned kWrapperMapGuardSampleRate = 64;
+
+static void initializeWrapperMapGuardingOnce()
+{
+    static std::once_flag flag;
+    std::call_once(flag, [] {
+        gGuardWrapperMaps = !(weakRandomNumber<unsigned>() % kWrapperMapGuardSampleRate);
+    });
+}
+
+thread_local WrapperMutationScope* WrapperMutationScope::s_active { nullptr };
+
+// Registry of live page-aligned m_wrappers backings, so free() knows the mmap length to unmap.
+static Lock backingRegistryLock;
+static HashMap<void*, size_t>& backingRegistry() WTF_REQUIRES_LOCK(backingRegistryLock)
+{
+    static NeverDestroyed<HashMap<void*, size_t>> registry;
+    return registry;
+}
+
+void* WrapperMapTableMalloc::allocate(size_t size)
+{
+    size_t pageSize = WTF::pageSize();
+    size_t requested = size ? size : 1;
+    size_t rounded = (requested + pageSize - 1) & ~(pageSize - 1);
+    void* base = mmap(nullptr, rounded, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    RELEASE_ASSERT(base != MAP_FAILED);
+    {
+        Locker locker { backingRegistryLock };
+        backingRegistry().set(base, rounded);
+    }
+    // Newly allocated table starts writable; the surrounding WrapperMutationScope re-protects it.
+    if (auto* world = WrapperMutationScope::currentlyMutatedWorld())
+        world->noteTableBacking(base, rounded);
+    return base;
+}
+
+void* WrapperMapTableMalloc::malloc(size_t size) { return gGuardWrapperMaps ? allocate(size) : WTF::fastMalloc(size); }
+void* WrapperMapTableMalloc::zeroedMalloc(size_t size) { return gGuardWrapperMaps ? allocate(size) : WTF::fastZeroedMalloc(size); } // mmap(MAP_ANON) is zero-filled.
+
+void WrapperMapTableMalloc::free(void* p)
+{
+    if (!p)
+        return;
+    // gGuardWrapperMaps is fixed for the process before the first allocation, so the allocation path
+    // and this free path always agree.
+    if (!gGuardWrapperMaps) {
+        WTF::fastFree(p);
+        return;
+    }
+    size_t size = 0;
+    {
+        Locker locker { backingRegistryLock };
+        size = backingRegistry().take(p);
+    }
+    RELEASE_ASSERT(size);
+    if (auto* world = WrapperMutationScope::currentlyMutatedWorld())
+        world->forgetTableBacking(p);
+    munmap(p, size);
+}
+
+void DOMWrapperWorld::setWrappersTableWritable(bool writable)
+{
+    if (writable) {
+        if (m_wrappersTableWritableDepth++)
+            return;
+    } else {
+        ASSERT(m_wrappersTableWritableDepth);
+        if (--m_wrappersTableWritableDepth)
+            return;
+    }
+    if (m_wrappersTableBase)
+        RELEASE_ASSERT(!mprotect(m_wrappersTableBase, m_wrappersTableSize, PROT_READ | (writable ? PROT_WRITE : 0)));
+}
+
+void WrapperMutationScope::enter()
+{
+    m_previous = s_active;
+    s_active = this;
+    m_world->setWrappersTableWritable(true);
+}
+
+void WrapperMutationScope::leave()
+{
+    m_world->setWrappersTableWritable(false);
+    s_active = m_previous;
+}
+
+#endif // PLATFORM(COCOA)
 
 DOMWrapperWorld::DOMWrapperWorld(JSC::VM& vm, Type type, const String& name)
     : m_vm(vm)
     , m_name(name)
     , m_type(type)
 {
+#if PLATFORM(COCOA)
+    initializeWrapperMapGuardingOnce();
+#endif
     VM::ClientData* clientData = m_vm.clientData;
     ASSERT(clientData);
     downcast<JSVMClientData>(clientData)->rememberWorld(*this);
@@ -49,6 +158,15 @@ DOMWrapperWorld::~DOMWrapperWorld()
     VM::ClientData* clientData = m_vm.clientData;
     ASSERT(clientData);
     downcast<JSVMClientData>(clientData)->forgetWorld(*this);
+
+    // The m_wrappers member destructor (runs after this body) destroys buckets and frees the
+    // table, which writes to it; make the read-only backing writable so those writes don't fault.
+#if PLATFORM(COCOA)
+    if (m_wrappersTableBase) {
+        mprotect(m_wrappersTableBase, m_wrappersTableSize, PROT_READ | PROT_WRITE);
+        m_wrappersTableWritableDepth = 0;
+    }
+#endif
 
     // These items are created lazily.
     while (!m_jsWindowProxies.isEmpty())
@@ -64,7 +182,10 @@ void DOMWrapperWorld::clearWrappers()
             eventListener->invalidate();
     }
 
-    m_wrappers.clear();
+    {
+        WrapperMutationScope scope { *this };
+        m_wrappers.clear();
+    }
 
     // These items are created lazily.
     while (!m_jsWindowProxies.isEmpty())

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -29,9 +29,34 @@ namespace WebCore {
 class JSEventListener;
 class WindowProxy;
 
-typedef HashMap<void*, JSC::Weak<JSC::JSObject>> DOMObjectWrapperMap;
+#if PLATFORM(COCOA)
+// Diagnostic (rdar://157587352): allocate the m_wrappers hash-table backing in its own page(s)
+// so it can be kept read-only except during the world's own mutating operations. Any stray write
+// that corrupts the map (the bug we are hunting) then faults immediately with the writer's stack.
+// To keep the cost off Speedometer, guarding is sampled per-process: gGuardWrapperMaps is decided
+// once at startup, and when false the allocator falls back to FastMalloc and the scopes are no-ops.
+// The whole facility relies on mmap/mprotect and is only built on Cocoa; elsewhere m_wrappers is a
+// plain HashMap and none of this code exists.
+WEBCORE_EXPORT extern bool gGuardWrapperMaps;
+
+struct WrapperMapTableMalloc {
+    WEBCORE_EXPORT static void* malloc(size_t);
+    WEBCORE_EXPORT static void* zeroedMalloc(size_t);
+    WEBCORE_EXPORT static void free(void*);
+private:
+    static void* allocate(size_t);
+};
+
+using DOMObjectWrapperMap = HashMap<void*, JSC::Weak<JSC::JSObject>, WTF::DefaultHash<void*>, WTF::HashTraits<void*>, WTF::HashTraits<JSC::Weak<JSC::JSObject>>, WTF::HashTableTraits, WTF::ShouldValidateKey::Yes, WrapperMapTableMalloc>;
+#else
+using DOMObjectWrapperMap = HashMap<void*, JSC::Weak<JSC::JSObject>>;
+#endif
 
 class DOMWrapperWorld : public RefCounted<DOMWrapperWorld>, public CanMakeSingleThreadWeakPtr<DOMWrapperWorld> {
+#if PLATFORM(COCOA)
+    friend struct WrapperMapTableMalloc;
+    friend class WrapperMutationScope;
+#endif
 public:
     enum class Type {
         Normal,   // Main (e.g. Page)
@@ -101,6 +126,19 @@ private:
     HashSet<WindowProxy*> m_jsWindowProxies;
     DOMObjectWrapperMap m_wrappers;
 
+#if PLATFORM(COCOA)
+    // Diagnostic page-protection state for m_wrappers (rdar://157587352). The backing is kept
+    // read-only except inside a WrapperMutationScope; WrapperMapTableMalloc reports each (re)allocated
+    // backing here so the scope can re-protect the current (possibly grown/shrunk) table. The whole
+    // facility relies on mmap/mprotect and is only built on Cocoa.
+    void noteTableBacking(void* base, size_t size) { m_wrappersTableBase = base; m_wrappersTableSize = size; }
+    void forgetTableBacking(void* base) { if (m_wrappersTableBase == base) { m_wrappersTableBase = nullptr; m_wrappersTableSize = 0; } }
+    void setWrappersTableWritable(bool);
+    void* m_wrappersTableBase { nullptr };
+    size_t m_wrappersTableSize { 0 };
+    unsigned m_wrappersTableWritableDepth { 0 };
+#endif
+
     WeakHashSet<JSEventListener> m_eventListeners;
 
     String m_name;
@@ -115,6 +153,46 @@ private:
     bool m_allowNodeSerialization : 1 { false };
     bool m_allowPostLegacySynchronousMessage : 1 { false };
     bool m_isMediaControls : 1 { false };
+};
+
+// RAII guard bracketing a mutating operation on a world's m_wrappers. On Cocoa it makes the
+// page-protected backing writable for the duration and read-only again afterwards (re-reading the
+// current backing, which may have been reallocated by a rehash during the operation); it is a cheap
+// branch on gGuardWrapperMaps when this process does not guard its wrapper maps. Off Cocoa the
+// diagnostic does not exist and the scope is an empty no-op, so call sites can construct it
+// unconditionally on every platform. rdar://157587352.
+class WrapperMutationScope {
+public:
+#if PLATFORM(COCOA)
+    explicit WrapperMutationScope(DOMWrapperWorld& world)
+        : m_world(world)
+    {
+        if (gGuardWrapperMaps) [[unlikely]]
+            enter();
+    }
+    ~WrapperMutationScope()
+    {
+        if (gGuardWrapperMaps) [[unlikely]]
+            leave();
+    }
+
+    // The world whose m_wrappers backing is currently being mutated on this thread (so the backing
+    // allocator can record each (re)allocated table on it), or nullptr when no scope is active.
+    static DOMWrapperWorld* currentlyMutatedWorld() { return s_active ? s_active->m_world.ptr() : nullptr; }
+#else
+    explicit WrapperMutationScope(DOMWrapperWorld&) { }
+#endif
+    WrapperMutationScope(const WrapperMutationScope&) = delete;
+    WrapperMutationScope& operator=(const WrapperMutationScope&) = delete;
+
+#if PLATFORM(COCOA)
+private:
+    WEBCORE_EXPORT void enter();
+    WEBCORE_EXPORT void leave();
+    static thread_local WrapperMutationScope* s_active;
+    SingleThreadWeakRef<DOMWrapperWorld> m_world;
+    WrapperMutationScope* m_previous { nullptr };
+#endif
 };
 
 DOMWrapperWorld& NODELETE normalWorld(JSC::VM&);

--- a/Source/WebCore/bindings/js/JSDOMWrapperCache.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapperCache.h
@@ -173,6 +173,7 @@ template<typename DOMClass, typename WrapperClass> inline void cacheWrapper(DOMW
     JSC::WeakHandleOwner* owner = wrapperOwner(world, domObject);
     if (setInlineCachedWrapper(world, domObject, wrapper, owner))
         return;
+    WrapperMutationScope scope { world }; // rdar://157587352: keep the page-protected backing writable for this mutation when guarding is enabled (no-op otherwise).
     weakAdd(world.wrappers(), wrapperKey(domObject), JSC::Weak<JSC::JSObject>(wrapper, owner, &world));
 }
 
@@ -180,6 +181,7 @@ template<typename DOMClass, typename WrapperClass> inline void uncacheWrapper(DO
 {
     if (clearInlineCachedWrapper(world, domObject, wrapper))
         return;
+    WrapperMutationScope scope { world }; // rdar://157587352: keep the page-protected backing writable for this mutation when guarding is enabled (no-op otherwise).
     weakRemove(world.wrappers(), wrapperKey(domObject), wrapper);
 }
 


### PR DESCRIPTION
#### d2af128b149fdd26b795ade265924b8b904afaa1
<pre>
Crash when rehashing DOMWrapperWorld::m_wrappers hash map
<a href="https://bugs.webkit.org/show_bug.cgi?id=317371">https://bugs.webkit.org/show_bug.cgi?id=317371</a>
<a href="https://rdar.apple.com/179144468">rdar://179144468</a>

Reviewed by Ben Nham.

We are seeing a high volume of crashes in JSC::WeakImpl::clear() while
rehashing DOMWrapperWorld::m_wrappers, caused by a corrupt entry whose
Weak&lt;JSObject&gt; holds a garbage WeakImpl pointer. The same corruption shows
up in other unrelated WTF hash tables (e.g. CodeBlockSet) with the same
reused-memory fingerprint. We have been unable to reproduce it locally,
even with ASAN and stress tests.

This patch adds opt-in diagnostic instrumentation to catch the corrupting
write at its source, with the writer&apos;s stack. The m_wrappers hash-table
backing is allocated in its own page(s) and kept read-only except during the
world&apos;s own mutating operations (cacheWrapper/uncacheWrapper/clearWrappers),
so any stray write faults immediately at the point of corruption rather than
much later during an unrelated rehash.

Because keeping the backing read-only between mutations costs two mprotect()
calls per mutation (a ~1.2% Speedometer regression when always on), guarding
is sampled per-process: the decision is made once at startup, and in the
common (unguarded) case the allocator falls back to FastMalloc and the
mutation scopes become no-ops, so there is no measurable cost. The sampled
fraction pays the full cost but provides full fidelity, keeping the
fleet-average cost negligible.

This is a temporary diagnostic facility. It should be removed once
the <a href="https://rdar.apple.com/179144468">rdar://179144468</a> root cause is found.

* Source/WebCore/bindings/js/DOMWrapperWorld.cpp:
(WebCore::initializeWrapperMapGuardingOnce):
(WebCore::backingRegistryLock):
(WebCore::backingRegistry):
(WebCore::WrapperMapTableMalloc::allocate):
(WebCore::WrapperMapTableMalloc::malloc):
(WebCore::WrapperMapTableMalloc::zeroedMalloc):
(WebCore::WrapperMapTableMalloc::free):
(WebCore::DOMWrapperWorld::setWrappersTableWritable):
(WebCore::WrapperMutationScope::WrapperMutationScope):
(WebCore::WrapperMutationScope::~WrapperMutationScope):
(WebCore::DOMWrapperWorld::DOMWrapperWorld):
(WebCore::DOMWrapperWorld::~DOMWrapperWorld):
(WebCore::DOMWrapperWorld::clearWrappers):
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::noteTableBacking):
(WebCore::DOMWrapperWorld::forgetTableBacking):
* Source/WebCore/bindings/js/JSDOMWrapperCache.h:
(WebCore::cacheWrapper):
(WebCore::uncacheWrapper):

Canonical link: <a href="https://commits.webkit.org/315505@main">https://commits.webkit.org/315505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4481773d99e4ccb313f8e61826ff06f009afe25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169230 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126942 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86994578-fb25-4dc0-a874-5e991a19aefd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0105d2e-6072-4abd-a712-0c0c6924a29d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172189 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112314 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69748d71-b055-47d2-bf10-d73879353b50) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27286 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181186 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33896 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140271 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42808 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140104 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37696 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43497 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107418 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35375 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115262 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42007 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6560 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41400 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41655 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->