### PR TITLE
[Site Isolation] Report genuine cross-origin frame removal in Page.frameDetached

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-dynamic-cross-origin-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-dynamic-cross-origin-frame-expected.txt
@@ -1,0 +1,13 @@
+Test that a dynamically added cross-origin frame appears in the frame model and a genuine removal is reported under site isolation.
+
+
+== Running test suite: SiteIsolation.NetworkManager.DynamicCrossOriginFrame
+-- Running test case: SiteIsolation.NetworkManager.DynamicCrossOriginFrame.AddThenRemove
+PASS: Cross-origin child frame should appear in WI.networkManager.frames after being added.
+PASS: Added cross-origin child's parent should be the main frame.
+PASS: Cross-origin child should still be in the frame model (process-swap frameDetached must be suppressed).
+PASS: Removing the iframe should fire FrameWasRemoved for the cross-origin child (genuine detach is reported).
+PASS: Cross-origin child should no longer be in WI.networkManager.frames after removal.
+PASS: frameForIdentifier should return null for the removed cross-origin child.
+PASS: Main frame should remain after the child is removed.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-dynamic-cross-origin-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/network-manager-dynamic-cross-origin-frame.html
@@ -1,0 +1,91 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.id = "child-frame-element";
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame.html`;
+    document.body.appendChild(iframe);
+}
+
+function removeCrossOriginIFrame() {
+    document.getElementById("child-frame-element").remove();
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.NetworkManager.DynamicCrossOriginFrame");
+
+    suite.addTestCase({
+        name: "SiteIsolation.NetworkManager.DynamicCrossOriginFrame.AddThenRemove",
+        description: "A dynamically-added cross-origin frame should appear in the frame model (surviving the spurious process-swap frameDetached), and a genuine removal must then fire frameDidDetach and drop it from the model. This guards both the swap-suppression heuristic and that real detaches are still reported.",
+        async test() {
+            let frameTarget = (await (async () => {
+                let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+                InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+                return (await targetAddedPromise).data.target;
+            })());
+
+            // The cross-origin child commits in its own process (CommitTiming::WaitForLoad), then
+            // immediately swaps out of its original process -- which fires a spurious frameDetached
+            // that the proxy must suppress. Drive the child's execution context and poll until it
+            // settles into the frame model.
+            let child;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                if (!frameTarget.executionContext) {
+                    await Promise.race([
+                        frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                        new Promise((resolve) => setTimeout(resolve, 100)),
+                    ]);
+                }
+                child = WI.networkManager.frames.find((frame) => frame.url && frame.url.endsWith("/resource-tree-frame.html"));
+                if (child)
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 20));
+            }
+
+            InspectorTest.expectThat(!!child, "Cross-origin child frame should appear in WI.networkManager.frames after being added.");
+            if (!child)
+                return;
+
+            let childId = child.id;
+            InspectorTest.expectThat(child.parentFrame === WI.networkManager.mainFrame, "Added cross-origin child's parent should be the main frame.");
+
+            // The swap-suppression heuristic ignores frameDetached while the frame is still in the
+            // WebFrameProxy tree. Give any lingering spurious swap-out detaches a chance to arrive
+            // and confirm the frame is NOT removed by them.
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            InspectorTest.expectThat(WI.networkManager.frameForIdentifier(childId) === child, "Cross-origin child should still be in the frame model (process-swap frameDetached must be suppressed).");
+
+            // Now remove the iframe element: this is a genuine removal and must be reported as a
+            // real detach that drops the frame from the model.
+            let removedFrame = null;
+            let removedPromise = new Promise((resolve) => {
+                WI.networkManager.addEventListener(WI.NetworkManager.Event.FrameWasRemoved, function listener(event) {
+                    if (event.data.frame.id === childId) {
+                        WI.networkManager.removeEventListener(WI.NetworkManager.Event.FrameWasRemoved, listener);
+                        resolve(event.data.frame);
+                    }
+                });
+            });
+            InspectorTest.evaluateInPage("removeCrossOriginIFrame()");
+            removedFrame = await Promise.race([
+                removedPromise,
+                new Promise((resolve) => setTimeout(() => resolve(null), 2000)),
+            ]);
+
+            InspectorTest.expectThat(!!removedFrame, "Removing the iframe should fire FrameWasRemoved for the cross-origin child (genuine detach is reported).");
+            InspectorTest.expectThat(!WI.networkManager.frames.includes(child), "Cross-origin child should no longer be in WI.networkManager.frames after removal.");
+            InspectorTest.expectEqual(WI.networkManager.frameForIdentifier(childId), null, "frameForIdentifier should return null for the removed cross-origin child.");
+            InspectorTest.expectThat(!!WI.networkManager.mainFrame, "Main frame should remain after the child is removed.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that a dynamically added cross-origin frame appears in the frame model and a genuine removal is reported under site isolation.</p>
+</body>

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -136,14 +136,23 @@ void ProxyingPageAgent::loadEventFired(double timestamp)
     m_frontendDispatcher->loadEventFired(timestamp);
 }
 
-void ProxyingPageAgent::frameDetached(FrameIdentifier frameID)
+void ProxyingPageAgent::frameDetached(FrameIdentifier)
 {
-    // A cross-origin process swap tears down the frame's LocalFrame in its old process,
-    // firing frameDetached there -- but the frame still exists, now hosted by another
-    // process (the authoritative WebFrameProxy tree still contains it). Forwarding that to
-    // the frontend would remove a live frame. Only report frames that are genuinely gone
-    // from the tree. See webkit.org/b/308896.
-    if (WebFrameProxy::webFrame(frameID))
+    // Intentionally ignored under Site Isolation. This IPC fires in a WebContent process whenever
+    // a frame's LocalFrame is torn down -- which also happens on a cross-origin process swap, where
+    // the frame persists (now hosted by another process). The two cases are indistinguishable here:
+    // the frame is still in the WebFrameProxy registry in both. The authoritative "frame is
+    // genuinely gone" signal is the destruction of its UIProcess WebFrameProxy, reported via
+    // frameDestroyed(). Reporting here would remove live frames on every swap. See webkit.org/b/308896.
+}
+
+void ProxyingPageAgent::frameDestroyed(FrameIdentifier frameID)
+{
+    // Called from WebFrameProxy's destruction path (via WebPageInspectorController::willDestroyFrame).
+    // A WebFrameProxy outlives process swaps and is destroyed only on genuine removal, so this is
+    // where cross-origin (and same-origin) frame removals are reported to the frontend. The protocol
+    // id is computed while the frame is still in the registry, matching the id used by frameNavigated.
+    if (!m_enabled)
         return;
 
     m_cachedFrameDocumentInfo.remove(frameID);

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
@@ -69,6 +69,11 @@ public:
     void enableInstrumentationForProcess(WebKit::WebProcessProxy&, WebCore::PageIdentifier);
     void disableInstrumentationForProcess(WebKit::WebProcessProxy&, WebCore::PageIdentifier);
 
+    // Authoritative "frame is genuinely gone" signal, reported from the WebFrameProxy destruction
+    // path. Unlike the WebContent-process frameDetached IPC (which also fires on a process swap),
+    // a WebFrameProxy is destroyed only when the frame is truly removed. See webkit.org/b/308896.
+    void frameDestroyed(WebCore::FrameIdentifier);
+
     // PageBackendDispatcherHandler
     CommandResult<void> enable() final;
     CommandResult<void> disable() final;

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -390,6 +390,11 @@ void WebPageInspectorController::willDestroyFrame(const WebFrameProxy& frame)
     if (pageAgent && pageAgent->isEnabled()) {
         if (auto pageID = frame.webPageIDInCurrentProcess())
             pageAgent->disableInstrumentationForProcess(process, *pageID);
+
+        // A WebFrameProxy is destroyed only when the frame is genuinely removed (never on a
+        // process swap, where it persists), so this is the authoritative point to report the
+        // frame's removal to the frontend. See webkit.org/b/308896.
+        pageAgent->frameDestroyed(frame.frameID());
     }
 
     removeTarget(getTargetID(frame));


### PR DESCRIPTION
#### db01478790f15df74389fcec237abc0417c65ec3
<pre>
[Site Isolation] Report genuine cross-origin frame removal in Page.frameDetached
<a href="https://bugs.webkit.org/show_bug.cgi?id=316668">https://bugs.webkit.org/show_bug.cgi?id=316668</a>
<a href="https://rdar.apple.com/179117697">rdar://179117697</a>

Reviewed by BJ Burg.

The UIProcess ProxyingPageAgent suppressed the WebContent-process frameDetached
IPC whenever the frame was still in the WebFrameProxy registry, to avoid removing
a live frame on a cross-origin process swap (the swap tears down the old
LocalFrame and fires frameDetached, but the frame persists). That heuristic was
over-broad: a genuine cross-origin frame removal also fires frameDetached while
the WebFrameProxy is momentarily still registered, so real removals were silently
dropped and the frame lingered in WI.networkManager.frames forever.

The authoritative &quot;frame is genuinely gone&quot; signal is the destruction of the
UIProcess WebFrameProxy, which outlives process swaps and is destroyed only on
real removal. Report frameDetached from there (WebPageInspectorController::
willDestroyFrame -&gt; ProxyingPageAgent::frameDestroyed), and make the
WebContent-process frameDetached IPC a no-op under Site Isolation (it cannot
distinguish a swap from a removal). The protocol id is computed while the frame
is still in the registry, matching the id used by frameNavigated.

Resolves the removal-ordering open question; covered by the new
network-manager-dynamic-cross-origin-frame.html test (add then genuine remove).

* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp:
(Inspector::ProxyingPageAgent::frameDetached):
(Inspector::ProxyingPageAgent::frameDestroyed):
Make the WebContent-process frameDetached IPC a no-op under Site Isolation (it cannot
distinguish a process swap from a genuine removal) and report genuine removals from the
new frameDestroyed() instead.

* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::willDestroyFrame):
Call frameDestroyed() from the WebFrameProxy destruction path -- the authoritative
&quot;frame is genuinely gone&quot; signal, which never fires on a process swap.

* LayoutTests/http/tests/site-isolation/inspector/page/network-manager-dynamic-cross-origin-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/network-manager-dynamic-cross-origin-frame-expected.txt: Added.
Assert a dynamically-added cross-origin frame survives the spurious process-swap
frameDetached and that a genuine removal then fires frameDidDetach and drops it from the
frame model.

Canonical link: <a href="https://commits.webkit.org/315602@main">https://commits.webkit.org/315602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2009df05c80a619f6e70433cef7366a5cbea0040

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126744 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0045dc8-fdc8-424f-a45a-38152e7c4973) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131635 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92615 "layout-tests (failure) (timed out)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e98a8b7-933c-4667-b8c3-d7cd5075b495) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112138 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/042964f7-644d-424d-975d-353113cd7c36) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33079 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31784 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27088 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180987 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140084 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37771 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43299 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107146 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35207 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115064 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41808 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6383 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41202 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41457 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41345 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->