### PR TITLE
Test that purging inactive font data clears the shaped text cache

### DIFF
--- a/Source/WebCore/platform/graphics/TextMeasurementCache.h
+++ b/Source/WebCore/platform/graphics/TextMeasurementCache.h
@@ -182,6 +182,8 @@ public:
         m_map.clear();
     }
 
+    bool isEmpty() const { return m_singleCharMap.isEmpty() && m_map.isEmpty(); }
+
 private:
 
     CachedType* addSlowCase(StringView text, CachedType&& entry)

--- a/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
@@ -25,7 +25,10 @@
  */
 
 #include "config.h"
+#include <WebCore/FontCache.h>
 #include <WebCore/FontCascade.h>
+#include <WebCore/FontCascadeFonts.h>
+#include <WebCore/TextShapingResultAndDisplayList.h>
 
 namespace TestWebKitAPI {
 
@@ -151,5 +154,29 @@ TEST(FontCascadeTest, characterRangeCodePath_Surrogates)
     testSupplementaryCodePath(0x16B16, CodePath::Complex);
     testSupplementaryCodePath(0x16B30, CodePath::Complex);
     testSupplementaryCodePath(0x16B8F, CodePath::Complex);
+}
+
+// Purging inactive font data must flush the per-FontCascadeFonts shaped text caches.
+// A GlyphBuffer cached there holds only weak Font references, so a Font referenced only by a
+// cached shaped run can be destroyed by FontCache::purgeInactiveFontData (it has one ref); if the
+// cache is not flushed on purge, a later paint may dereference an expired weak pointer in
+// FontCascade::drawGlyphBuffer and crash. rdar://173222307
+TEST(FontCascadeTest, PurgeInactiveFontDataClearsShapedTextCache)
+{
+    FontCascadeDescription description;
+    description.setOneFamily("Times"_s);
+    description.setComputedSize(16);
+    FontCascade font(WTF::move(description));
+    font.update();
+
+    RefPtr fonts = font.fonts();
+    ASSERT_TRUE(fonts);
+
+    fonts->shapedTextCache().add("hello world"_str, makeUnique<TextShapingResultAndDisplayList>());
+    EXPECT_FALSE(fonts->shapedTextCache().isEmpty());
+
+    FontCache::forCurrentThread().purgeInactiveFontData();
+
+    EXPECT_TRUE(fonts->shapedTextCache().isEmpty());
 }
 }


### PR DESCRIPTION
#### 7055d79c3bd497977a15e4dd44b74d8ea6cb047b
<pre>
Test that purging inactive font data clears the shaped text cache

<a href="https://bugs.webkit.org/show_bug.cgi?id=317374">https://bugs.webkit.org/show_bug.cgi?id=317374</a>
<a href="https://rdar.apple.com/179997994">rdar://179997994</a>

Reviewed by Tim Nguyen.

308842@main made GlyphBuffer hold weak Font references, so a GlyphBuffer cached
in a FontCascadeFonts shaped text cache can outlive its Fonts once they are
purged. 315309@main fixed this by clearing those caches in
FontCache::purgeInactiveFontData. Add a regression test that populates the
shaped text cache, purges inactive font data, and verifies the cache is
emptied. Expose TextMeasurementCache::isEmpty so the test can observe the cache.

* Source/WebCore/platform/graphics/TextMeasurementCache.h:
(WebCore::TextMeasurementCache::isEmpty const):
* Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/315462@main">https://commits.webkit.org/315462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45aabd94b832fde2c9180b28eeaafe31a1c956e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126749 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/615b93eb-1e7c-4b8f-a24f-ff61a8ebd8ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131639 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22e4bec5-9b1b-47c1-a780-fbf61126e693) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112142 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12298723-cfdf-4bc6-b82a-a2cf6b2b65de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33085 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31788 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27093 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180992 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35957 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140089 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 15 flakes 2 failures; Uploaded test results; layout-tests; Passed layout tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42615 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139931 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37673 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43304 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107154 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35211 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115069 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41813 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6381 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41350 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->