### PR TITLE
CSP applies script-src to JSON module imports instead of connect-src

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-json-import-allowed.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-json-import-allowed.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL import should be allowed promise_test: Unhandled rejection with value: "Should not raise securitypolicyviolation."
+PASS import should be allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-json-import-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-json-import-blocked.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL connect-src-json-import-blocked assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS connect-src-json-import-blocked
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -519,10 +519,13 @@ bool CachedResourceLoader::allowedByContentSecurityPolicy(CachedResource::Type t
         return contentSecurityPolicy->allowObjectFromSource(url, document->currentParserSourcePosition(), redirectResponseReceived, preRedirectURL);
 
     switch (type) {
+    case CachedResource::Type::JSON:
+        if (!contentSecurityPolicy->allowConnectToSource(url, document->currentParserSourcePosition(), redirectResponseReceived, preRedirectURL))
+            return false;
+        break;
 #if ENABLE(XSLT)
     case CachedResource::Type::XSLStyleSheet:
 #endif
-    case CachedResource::Type::JSON:
     case CachedResource::Type::Script:
         if (!contentSecurityPolicy->allowScriptFromSource(url, document->currentParserSourcePosition(), redirectResponseReceived, preRedirectURL, options.integrity, options.nonce))
             return false;


### PR DESCRIPTION
#### 150a3a12e5801be315f86481589b750a41fd7e57
<pre>
CSP applies script-src to JSON module imports instead of connect-src
<a href="https://bugs.webkit.org/show_bug.cgi?id=317377">https://bugs.webkit.org/show_bug.cgi?id=317377</a>
<a href="https://rdar.apple.com/180006320">rdar://180006320</a>

Reviewed by Anne van Kesteren.

JSON module imports should be controlled by connect-src but are currently controlled
by script-src. Fix by enforcing connect-src for JSON module imports.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-json-import-allowed.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-json-import-blocked.sub-expected.txt:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::allowedByContentSecurityPolicy const):

Canonical link: <a href="https://commits.webkit.org/315497@main">https://commits.webkit.org/315497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62c1b3cabfb4cdb515e790e201cc259a9441db8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126829 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bdc48bd-dbca-4e55-85ca-ff10b303eee7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131708 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aeb843ea-1486-4e57-8c1f-d9873bffcca7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34164 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112211 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e952d1a-38ef-4718-972e-57b3888becc2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33150 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31858 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27173 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181081 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140171 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42695 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140012 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37690 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43384 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107282 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35280 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115149 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41893 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6524 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41542 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41430 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->