### PR TITLE
[GTK][WPE] Skia compositor: disable deferred display list by default

### DIFF
--- a/LayoutTests/css3/masking/clip-path-border-radius-content-box-001.html
+++ b/LayoutTests/css3/masking/clip-path-border-radius-content-box-001.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-300">
+<meta name="fuzzy" content="maxDifference=0-75; totalPixels=0-300">
 <style>
     .clip {
         width: 100px;

--- a/LayoutTests/css3/masking/clip-path-border-radius-fill-box-001.html
+++ b/LayoutTests/css3/masking/clip-path-border-radius-fill-box-001.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-300">
+<meta name="fuzzy" content="maxDifference=0-75; totalPixels=0-300">
 <style>
     .clip {
         width: 100px;

--- a/LayoutTests/css3/masking/clip-path-border-radius-padding-box-001.html
+++ b/LayoutTests/css3/masking/clip-path-border-radius-padding-box-001.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-310">
+<meta name="fuzzy" content="maxDifference=0-75; totalPixels=0-310">
 <style>
     .clip {
         width: 100px;

--- a/LayoutTests/css3/masking/clip-path-inset-corners.html
+++ b/LayoutTests/css3/masking/clip-path-inset-corners.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-70; totalPixels=0-500" />
+<meta name="fuzzy" content="maxDifference=0-71; totalPixels=0-500" />
 <style>
 .container {
     width: 100px;

--- a/LayoutTests/css3/masking/clip-path-inset.html
+++ b/LayoutTests/css3/masking/clip-path-inset.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta name="fuzzy" content="maxDifference=0-80; totalPixels=0-830">
+<meta name="fuzzy" content="maxDifference=0-120; totalPixels=0-830">
 <style>
 div {
     width: 180px;

--- a/LayoutTests/fast/masking/clip-path-inset-large-radii.html
+++ b/LayoutTests/fast/masking/clip-path-inset-large-radii.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-800" />
+<meta name="fuzzy" content="maxDifference=0-79; totalPixels=0-800" />
 <style>
     div {
         width: 200px;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -125,8 +125,8 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
 
         if (m_useSkia) {
             PlatformDisplay::sharedDisplay().setSkiaGLContextForCurrentThread(WTF::move(context));
-            const auto disableDDL = CStringView::unsafeFromUTF8(getenv("WEBKIT_SKIA_DISABLE_DDL"));
-            if (!disableDDL || disableDDL == "0"_s)
+            const auto enableDDL = CStringView::unsafeFromUTF8(getenv("WEBKIT_SKIA_ENABLE_DDL"));
+            if (enableDDL && enableDDL != "0"_s)
                 m_threadSafeGrContext = PlatformDisplay::sharedDisplay().skiaGrContext()->threadSafeProxy();
         } else {
             m_context = WTF::move(context);


### PR DESCRIPTION
#### 1675d92dcc4f0a2ef54674bf8e4fe9e89b93f337
<pre>
[GTK][WPE] Skia compositor: disable deferred display list by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=317390">https://bugs.webkit.org/show_bug.cgi?id=317390</a>

Reviewed by Nikolas Zimmermann.

It caused regressions in suits and leaves motion mark tests.

* LayoutTests/css3/masking/clip-path-border-radius-content-box-001.html:
* LayoutTests/css3/masking/clip-path-border-radius-fill-box-001.html:
* LayoutTests/css3/masking/clip-path-border-radius-padding-box-001.html:
* LayoutTests/css3/masking/clip-path-inset-corners.html:
* LayoutTests/css3/masking/clip-path-inset.html:
* LayoutTests/fast/masking/clip-path-inset-large-radii.html:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_renderTimer):

Canonical link: <a href="https://commits.webkit.org/315461@main">https://commits.webkit.org/315461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ddb5a5dc8ba336bedf1cd95a725a09e3d4f1ed0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169090 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/42826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126802 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131686 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34142 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112189 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27146 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181045 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140135 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139977 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43357 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107232 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25769 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35255 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115122 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41866 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6425 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->