### PR TITLE
[SVG] dominant-baseline: hanging on <text> not applied to <tspan> content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-on-tspan-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-on-tspan-expected.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <title>Reference: hanging baseline applied directly on &#x3c;text&#x3e;</title>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <text dominant-baseline="hanging" fill="green" font-size="50" font-family="Ahem" x="10" y="10">X</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-on-tspan.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-on-tspan.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <title>'dominant-baseline: hanging' on &#x3c;text&#x3e; applies to &#x3c;tspan&#x3e; child with auto</title>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty"/>
+    <h:link rel="match" href="dominant-baseline-hanging-on-tspan-expected.svg"/>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <!-- 'auto' on the tspan must keep the parent text element's hanging baseline,
+       so the glyph top edge aligns with y=10 rather than the alphabetic baseline. -->
+  <text dominant-baseline="hanging" fill="green" font-size="50" font-family="Ahem">
+    <tspan x="10" y="10">X</tspan>
+  </text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getextentofchar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getextentofchar-expected.txt
@@ -2,5 +2,5 @@ abcd
 abc
 
 PASS Multiple chunks in a tspan
-FAIL With dominant-baseline assert_approx_equals: expected 147.5 +/- 1 but got 136
+PASS With dominant-baseline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt
@@ -4,9 +4,9 @@ ABC
 ABC
 ABC
 
-FAIL vertical-rl assert_equals: expected 113 but got 103
-FAIL vertical-lr assert_equals: expected 113 but got 103
-FAIL sideways-rl assert_equals: expected 113 but got 103
-FAIL sideways-lr assert_equals: expected 97 but got 107
+FAIL vertical-rl assert_equals: expected 110 but got 100
+FAIL vertical-lr assert_equals: expected 110 but got 100
+FAIL sideways-rl assert_equals: expected 110 but got 100
+FAIL sideways-lr assert_equals: expected 100 but got 110
 PASS tspan
 

--- a/LayoutTests/platform/mac/svg/custom/alignment-baseline-modes-expected.txt
+++ b/LayoutTests/platform/mac/svg/custom/alignment-baseline-modes-expected.txt
@@ -122,13 +122,13 @@ layer at (0,0) size 400x400
         RenderSVGInlineText {#text} at (67,18) size 33x23
           chunk 1 text run 1 at (77.77,33.00) startOffset 0 endOffset 5 width 32.77: " test"
       RenderSVGPath {line} at (10,344) size 100x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=15.00] [x2=110.00] [y2=15.00]
-    RenderSVGContainer {g} at (10,357) size 101x41 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,360.00)}]
-      RenderSVGText {text} at (10,-3) size 101x41 contains 1 chunk(s)
-        RenderSVGInlineText {#text} at (0,18) size 41x23
+    RenderSVGContainer {g} at (10,374) size 101x24 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,360.00)}]
+      RenderSVGText {text} at (10,15) size 101x23 contains 1 chunk(s)
+        RenderSVGInlineText {#text} at (0,0) size 41x23
           chunk 1 text run 1 at (10.00,33.00) startOffset 0 endOffset 5 width 40.56: "This "
         RenderSVGTSpan {tspan} at (40,0) size 28x23
           RenderSVGInlineText {#text} at (40,0) size 28x23
-            chunk 1 text run 1 at (50.56,15.00) startOffset 0 endOffset 4 width 27.22: "is a"
-        RenderSVGInlineText {#text} at (67,18) size 33x23
+            chunk 1 text run 1 at (50.56,33.00) startOffset 0 endOffset 4 width 27.22: "is a"
+        RenderSVGInlineText {#text} at (67,0) size 33x23
           chunk 1 text run 1 at (77.77,33.00) startOffset 0 endOffset 5 width 32.77: " test"
       RenderSVGPath {line} at (10,374) size 100x2 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x1=10.00] [y1=15.00] [x2=110.00] [y2=15.00]

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -61,13 +61,17 @@ AlignmentBaseline SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseli
 
     DominantBaseline baseline = textRenderer.style().dominantBaseline();
     if (baseline == DominantBaseline::Auto) {
-        // Per SVG2 and CSS Inline 3, auto maps to alphabetic in horizontal writing
-        // modes and to central in vertical writing modes. The CSS Inline 3 spec
-        // distinguishes text-orientation values for vertical text, but SVG2 says
-        // "the origin point of glyphs is always handled as for central in vertical
-        // writing modes" for backwards compatibility.
-        // https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline
+        // SVG2/CSS Inline 3 make 'dominant-baseline' inherited. WebCore still stores it
+        // as non-inherited, so a tspan computes to 'auto'; resolve 'auto' on an SVG inline
+        // against the parent text content element to match that effective behavior.
         // https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty
+        if (textRenderer.isRenderSVGInline() && textRenderer.parent())
+            return dominantBaselineToAlignmentBaseline(isVerticalText, *textRenderer.parent());
+
+        // On the outermost 'text' element, auto maps to alphabetic in horizontal writing
+        // modes and to central in vertical writing modes (per SVG2, for backwards
+        // compatibility, glyph origins are always handled as central when vertical).
+        // https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline
         if (isVerticalText)
             baseline = DominantBaseline::Central;
         else

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -326,15 +326,6 @@ bool SVGTextQuery::startPositionOfCharacterCallback(Data* queryData, const SVGTe
 
     data->startPosition = FloatPoint(fragment.x, fragment.y);
 
-    // Subtract baseline shift so the returned position reflects the y attribute
-    // value, not the visually shifted position. This matches Chrome/Firefox behavior.
-    if (fragment.baselineShift) {
-        if (queryData->isVerticalText)
-            data->startPosition.move(-fragment.baselineShift, 0);
-        else
-            data->startPosition.move(0, fragment.baselineShift);
-    }
-
     if (startPosition) {
         SVGTextMetrics metrics = SVGTextMetrics::measureCharacterRange(*queryData->textRenderer, fragment.characterOffset, startPosition);
         if (queryData->isVerticalText)
@@ -345,10 +336,20 @@ bool SVGTextQuery::startPositionOfCharacterCallback(Data* queryData, const SVGTe
 
     AffineTransform fragmentTransform;
     fragment.buildFragmentTransform(fragmentTransform, SVGTextFragment::TransformIgnoringTextLength);
-    if (fragmentTransform.isIdentity())
-        return true;
+    if (!fragmentTransform.isIdentity())
+        data->startPosition = fragmentTransform.mapPoint(data->startPosition);
 
-    data->startPosition = fragmentTransform.mapPoint(data->startPosition);
+    // Subtract the baseline shift so the returned position reflects the y attribute value,
+    // not the visually shifted position (matching Chrome/Firefox). This must happen after the
+    // orientation transform: for rotated (vertical) glyphs the shift is along a screen axis,
+    // so subtracting it pre-transform leaves a residual that depends on the rotation.
+    if (fragment.baselineShift) {
+        if (queryData->isVerticalText)
+            data->startPosition.move(-fragment.baselineShift, 0);
+        else
+            data->startPosition.move(0, fragment.baselineShift);
+    }
+
     return true;
 }
 
@@ -388,15 +389,6 @@ bool SVGTextQuery::endPositionOfCharacterCallback(Data* queryData, const SVGText
 
     data->endPosition = FloatPoint(fragment.x, fragment.y);
 
-    // Subtract baseline shift so the returned position reflects the y attribute
-    // value, not the visually shifted position. This matches Chrome/Firefox behavior.
-    if (fragment.baselineShift) {
-        if (queryData->isVerticalText)
-            data->endPosition.move(-fragment.baselineShift, 0);
-        else
-            data->endPosition.move(0, fragment.baselineShift);
-    }
-
     SVGTextMetrics metrics = SVGTextMetrics::measureCharacterRange(*queryData->textRenderer, fragment.characterOffset, startPosition + 1);
     if (queryData->isVerticalText)
         data->endPosition.move(0, metrics.height());
@@ -405,10 +397,18 @@ bool SVGTextQuery::endPositionOfCharacterCallback(Data* queryData, const SVGText
 
     AffineTransform fragmentTransform;
     fragment.buildFragmentTransform(fragmentTransform, SVGTextFragment::TransformIgnoringTextLength);
-    if (fragmentTransform.isIdentity())
-        return true;
+    if (!fragmentTransform.isIdentity())
+        data->endPosition = fragmentTransform.mapPoint(data->endPosition);
 
-    data->endPosition = fragmentTransform.mapPoint(data->endPosition);
+    // Subtract the baseline shift after the orientation transform; see
+    // startPositionOfCharacterCallback for why this must follow the transform.
+    if (fragment.baselineShift) {
+        if (queryData->isVerticalText)
+            data->endPosition.move(-fragment.baselineShift, 0);
+        else
+            data->endPosition.move(0, fragment.baselineShift);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
#### 99641ff06aebaa6bd711a585fc1e5df22ddff4de
<pre>
[SVG] dominant-baseline: hanging on &lt;text&gt; not applied to &lt;tspan&gt; content
<a href="https://bugs.webkit.org/show_bug.cgi?id=317118">https://bugs.webkit.org/show_bug.cgi?id=317118</a>
<a href="https://rdar.apple.com/179690799">rdar://179690799</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

SVG2/CSS Inline 3 make &apos;dominant-baseline&apos; an inherited property, so a
value set on &lt;text&gt; reaches descendant tspans. WebCore still implements
it as non-inherited, so the glyph-run renderer and its &lt;tspan&gt; ancestors
compute dominant-baseline to &apos;auto&apos;, and the layout engine collapsed
every &apos;auto&apos; straight to alphabetic (or central in vertical writing
modes). As a result a dominant-baseline set on &lt;text&gt; had no effect once
the glyphs lived inside a child &lt;tspan&gt; -- they were laid out on the
alphabetic baseline instead of the requested one.

Resolve &apos;auto&apos; against the parent when it occurs on an SVG inline
(&apos;tspan&apos;, &apos;tref&apos;, &apos;altGlyph&apos;, &apos;textPath&apos;), matching the inherited
behavior; the outermost &lt;text&gt; keeps the existing alphabetic/central
mapping. This also matches Chrome and Firefox.

Diversifying the resolved baseline exposed a latent bug in the
getStartPositionOfChar/getEndPositionOfChar query path (bug 311553):
the dominant-baseline shift was subtracted before the fragment&apos;s
orientation transform was applied. For horizontal text the transform is
identity so this was harmless, but vertical glyphs carry a 90-degree
orientation rotation that maps the shift onto the wrong axis, leaving a
rotation-dependent residual in the returned position. Subtract the shift
after the orientation transform so it is removed along the same screen
axis the layout engine applied it

* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-on-tspan-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-on-tspan.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getextentofchar-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar-expected.txt: Rebaseline
* LayoutTests/platform/mac/svg/custom/alignment-baseline-modes-expected.txt: Rebaseline (but now matches other browser)
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
(WebCore::SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseline const):
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(WebCore::SVGTextQuery::startPositionOfCharacterCallback const):
(WebCore::SVGTextQuery::endPositionOfCharacterCallback const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99641ff06aebaa6bd711a585fc1e5df22ddff4de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126785 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00cd8939-6efd-480c-89ca-31f12d520b90) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42620 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131673 "Found 1 new test failure: svg/custom/alignment-baseline-modes.svg (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92645 "2 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2684bbc6-a731-4109-81eb-25a8f5f14501) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172032 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34129 "Found 1 new test failure: svg/custom/alignment-baseline-modes.svg (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112176 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b0ab5d4-c99d-4430-b324-30fe7acf057f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33115 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/user-valid.html imported/w3c/web-platform-tests/svg/text/scripted/getextentofchar.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31820 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27129 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181028 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35989 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140122 "Found 1 new test failure: svg/custom/alignment-baseline-modes.svg (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42651 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151424 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139964 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43340 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28327 "1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107212 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35243 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115105 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41849 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6416 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41243 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41386 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->