### PR TITLE
Rename Damage::regionForTesting() -> Damage::region()

### DIFF
--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -279,7 +279,9 @@ public:
         return m_rects.rects;
     }
 
-    Region regionForTesting() const
+    // Non-overlapping (disjoint) cover of the damage - safe to restrict translucent compositing to,
+    // unlike rects() which may return overlapping rects.
+    Region region() const
     {
         Region region;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
@@ -226,7 +226,7 @@ void NonCompositedFrameRenderer::updateRendering()
 #if ENABLE(DAMAGE_TRACKING)
         if (m_frameDamage) {
             if (m_frameDamageHistoryForTesting)
-                m_frameDamageHistoryForTesting->append(m_frameDamage->regionForTesting());
+                m_frameDamageHistoryForTesting->append(m_frameDamage->region());
             m_surface->setFrameDamage(WTF::move(*m_frameDamage));
             resetFrameDamage();
         }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -332,7 +332,7 @@ void ThreadedCompositor::paintToTextureMapper(const TransformationMatrix& matrix
         WTFEndSignpost(this, CollectDamage);
 
         if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
-            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage.regionForTesting());
+            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage.region());
 
         if (!frameDamage.isEmpty())
             m_surface->setFrameDamage(WTF::move(frameDamage));
@@ -402,7 +402,7 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
 #if ENABLE(DAMAGE_TRACKING)
     if (frameDamage) {
         if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
-            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage->regionForTesting());
+            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage->region());
 
         if (!frameDamage->isEmpty())
             m_surface->setFrameDamage(WTF::move(*frameDamage));

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
@@ -259,7 +259,7 @@ void ThreadedCompositor::paintToCurrentGLContext(const TransformationMatrix& mat
         WTFEndSignpost(this, CollectDamage);
 
         if (m_damage.shouldNotifyFrameDamageForTesting && m_layerTreeHost)
-            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage.regionForTesting());
+            m_layerTreeHost->notifyFrameDamageForTesting(frameDamage.region());
 
         if (!frameDamage.isEmpty())
             m_surface->setFrameDamage(WTF::move(frameDamage));


### PR DESCRIPTION
#### 60b29786995b14032f7ab8d2e52de035af1c91f7
<pre>
Rename Damage::regionForTesting() -&gt; Damage::region()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317392">https://bugs.webkit.org/show_bug.cgi?id=317392</a>

The method builds a disjoint Region from the damage rects. It is no
longer test-only: the upcoming damage-restricted compositing uses it to
plan the per-frame repaint area, so the &quot;ForTesting&quot; suffix is dropped.

No behavior change.

* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::region const):
(WebCore::Damage::regionForTesting const): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp:
(WebKit::NonCompositedFrameRenderer::updateRendering):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::paintToTextureMapper):
(WebKit::ThreadedCompositor::paintToSkiaCanvas):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp:
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60b29786995b14032f7ab8d2e52de035af1c91f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178428 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131676 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92647 "2 flakes 7 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33116 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31822 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27130 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/372 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181029 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140123 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42652 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139965 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43341 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28328 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107213 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35244 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115106 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41850 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6417 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->