### PR TITLE
REGRESSION(315436@main): WebKit SPI audit fails on Rave debug with unrecognized symbol "CGImageSetCachingFlags"

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -337,3 +337,10 @@ request = "rdar://171940190"
 selectors = [
     { name = "endSessionWithCompletion:", class = "NFSession" },
 ]
+
+[[temporary-usage]]
+request = "rdar://180017345"
+cleanup = "rdar://180017469"
+symbols = [
+    "CGImageSetCachingFlags",
+]


### PR DESCRIPTION
#### 14aaf69ac680739157f0507cec645dcf88718e77
<pre>
REGRESSION(315436@main): WebKit SPI audit fails on Rave debug with unrecognized symbol &quot;CGImageSetCachingFlags&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=317396">https://bugs.webkit.org/show_bug.cgi?id=317396</a>
<a href="https://rdar.apple.com/180011932">rdar://180011932</a>

Unreviewed.

315436@main added a use of CGImageSetCachingFlags in the WebKit framework, but
the symbol is only present in WebCore&apos;s SPI allowlist, not WebKit&apos;s. Add
CGImageSetCachingFlags to WebKit&apos;s allowlist as a temporary-usage entry, tracked
by request <a href="https://rdar.apple.com/180017345">rdar://180017345</a> (CoreGraphics) and cleanup <a href="https://rdar.apple.com/180017469">rdar://180017469</a>
(WebKit | SPI Usage).

* Source/WebKit/Configurations/AllowedSPI.toml:

Canonical link: <a href="https://commits.webkit.org/315457@main">https://commits.webkit.org/315457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/293b206fe6946689d654855e6e1c2b169dcc4072

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169080 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/42651 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/178434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/126792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/43025 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/42627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/178434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/126792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/172039 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/43025 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/36251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/178434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/43025 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/42627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/27136 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/36251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/43025 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/36251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/181035 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/33746 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/42627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/181035 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/42658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/36251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/181035 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/43347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/36251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/107222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25767 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/43347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115112 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/41856 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/36251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/41250 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/41505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/41393 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->