### PR TITLE
Testing ES against non-localhost/loopback

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1106,8 +1106,7 @@ void NetworkResourceLoader::sendDidReceiveResponseWithPotentialProcessSwap(const
         shouldConsiderProcessSwapForEnhancedSecurity = browsingContextGroupSwitchDecision == BrowsingContextGroupSwitchDecision::StayInGroup
             && m_parameters.shouldConsiderEnhancedSecurityForInsecureResponse
             && m_parameters.navigationID
-            && response.url().protocolIs("http"_s)
-            && !WebCore::SecurityOrigin::isLocalHostOrLoopbackIPAddress(response.url().host());
+            && response.url().protocolIs("http"_s);
     }
 
     if (!shouldConsiderProcessSwapForEnhancedSecurity && browsingContextGroupSwitchDecision == BrowsingContextGroupSwitchDecision::StayInGroup) {

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -175,7 +175,7 @@ void EnhancedSecurityTracking::trackSameSiteNavigation(const API::Navigation& na
 
 static bool isURLCandidateForEnhancedSecurity(const URL& url)
 {
-    return url.protocolIs("http"_s) && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(url.host());
+    return url.protocolIs("http"_s);
 }
 
 bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigation, bool httpFallbackInProgress)


### PR DESCRIPTION
#### c92434500811ffb0fe33c2bd4efc9490b6ad6b7c
<pre>
Testing ES against non-localhost/loopback

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::sendDidReceiveResponseWithPotentialProcessSwap):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::isURLCandidateForEnhancedSecurity):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c92434500811ffb0fe33c2bd4efc9490b6ad6b7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169083 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/42873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178437 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126795 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/987a6b4c-d87c-41ac-a0c9-3492608829f3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8eb1a3c-4c00-45aa-abfe-e9de48d7b76e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34134 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151963 "Found 20 new API test failures: TestWebKitAPI.WebpagePreferences.GlobalPrivacyControlRequestHeaderInSubframe, TestWebKitAPI.Challenge.BasicProposedCredential, TestWebKitAPI.ResourceLoadDelegate.LoadInfo, TestWebKitAPI.WebpagePreferences.GlobalPrivacyControlNavigatorAPIInSubframe, TestWebKitAPI.ProcessSwap.ReuseProcessAfterNavigatingToSameOriginThroughAboutPage, TestWebKitAPI.WebLocks.LockRequestWaitingOnAnotherPageInSameProcess, TestWebKitAPI.ServiceWorker.ServiceWorkerIdleOnMemoryPressure, TestWebKitAPI.ServiceWorkers.LoadAboutBlankBeforeNavigatingThroughInProcessServiceWorker, TestWebKitAPI.ServiceWorkers.OutOfProcessServiceWorker, TestWebKitAPI.WKDownload.FailNoResumeData ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112184 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d24e4b6a-359f-4f8d-a492-1b9b1ac44c1f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33120 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31828 "Found 24 new API test failures: TestWebKitAPI.WebpagePreferences.GlobalPrivacyControlRequestHeaderInSubframe, TestWebKitAPI.Challenge.BasicProposedCredential, TestWebKitAPI.Badging.SetAppBadgeFromWorkerOriginSpoof, TestWebKitAPI.ResourceLoadDelegate.LoadInfo, TestWebKitAPI.WebpagePreferences.GlobalPrivacyControlNavigatorAPIInSubframe, TestWebKitAPI.ProcessSwap.ReuseProcessAfterNavigatingToSameOriginThroughAboutPage, TestWebKitAPI.WebLocks.LockRequestWaitingOnAnotherPageInSameProcess, TestWebKitAPI.ServiceWorker.ServiceWorkerIdleOnMemoryPressure, TestWebKitAPI.ServiceWorkers.LoadAboutBlankBeforeNavigatingThroughInProcessServiceWorker, TestWebKitAPI.ServiceWorkers.OutOfProcessServiceWorker ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27139 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143111 "Found 17 new API test failures: TestWebKitAPI.WebpagePreferences.GlobalPrivacyControlRequestHeaderInSubframe, TestWebKitAPI.Challenge.BasicProposedCredential, TestWebKitAPI.ResourceLoadDelegate.LoadInfo, TestWebKitAPI.WebpagePreferences.GlobalPrivacyControlNavigatorAPIInSubframe, TestWebKitAPI.ProcessSwap.ReuseProcessAfterNavigatingToSameOriginThroughAboutPage, TestWebKitAPI.WebLocks.LockRequestWaitingOnAnotherPageInSameProcess, TestWebKitAPI.ServiceWorkers.LoadAboutBlankBeforeNavigatingThroughInProcessServiceWorker, TestWebKitAPI.ServiceWorkers.OutOfProcessServiceWorker, TestWebKitAPI.WKDownload.FailNoResumeData, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureSubframe ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181038 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140130 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42661 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139972 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43350 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107225 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35249 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115115 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41859 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6426 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41253 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->