### PR TITLE
Header map wrong if source dir is called WebKit

### DIFF
--- a/Source/cmake/WebKitHeaderMap.cmake
+++ b/Source/cmake/WebKitHeaderMap.cmake
@@ -73,6 +73,8 @@ function(WEBKIT_GENERATE_HEADER_MAPS)
     execute_process(
         COMMAND "${PYTHON_EXECUTABLE}" "${TOOLS_DIR}/Scripts/generate-header-map"
                 --header-maps-dir "${CMAKE_BINARY_DIR}/HeaderMaps"
+                --root "${CMAKE_SOURCE_DIR}"
+                --root "${CMAKE_BINARY_DIR}"
         RESULT_VARIABLE _result
     )
     if (NOT _result EQUAL 0)

--- a/Tools/Scripts/generate-header-map
+++ b/Tools/Scripts/generate-header-map
@@ -50,7 +50,16 @@ def _load_hmaptool():
     return module
 
 
-def collect_mappings(directories, framework=None):
+def _project_relative_components(path, roots):
+    # Components of 'path' that are within any of the 'roots'.
+    path = os.path.abspath(path)
+    for root in sorted((os.path.abspath(r) for r in roots or ()), key=len, reverse=True):
+        if path == root or path.startswith(root + os.sep):
+            return path[len(root):].split(os.sep)
+    return path.split(os.sep)
+
+
+def collect_mappings(directories, framework=None, roots=None):
     mappings = {}
     lowercase_owners = {}
     # When --framework NAME is set, also scan a `<dir>/<NAME>/` subdirectory if
@@ -63,7 +72,7 @@ def collect_mappings(directories, framework=None):
     if framework:
         for d in directories:
             d_abs = os.path.abspath(d)
-            if framework not in d_abs.split(os.sep):
+            if framework not in _project_relative_components(d_abs, roots):
                 continue
             sub = os.path.join(d_abs, framework)
             if os.path.isdir(sub):
@@ -97,14 +106,14 @@ def collect_mappings(directories, framework=None):
     return mappings
 
 
-def _generate(directories, framework, output, write_headermap):
-    mappings = collect_mappings([d for d in directories if d], framework)
+def _generate(directories, framework, output, write_headermap, roots=None):
+    mappings = collect_mappings([d for d in directories if d], framework, roots)
     # Sort keys for deterministic output (clang header maps are order-sensitive
     # in their bucket layout; sorting keeps regenerated maps byte-stable).
     write_headermap(dict(sorted(mappings.items())), output)
 
 
-def run_header_maps_dir(header_maps_dir):
+def run_header_maps_dir(header_maps_dir, roots=None):
     # Batch mode: every *.hmap.manifest in header_maps_dir is self-describing --
     # line 1 is the output .hmap path, line 2 the framework, lines 3+ the
     # directories. One interpreter launch and one hmaptool import for all
@@ -116,7 +125,7 @@ def run_header_maps_dir(header_maps_dir):
         with open(os.path.join(header_maps_dir, name)) as f:
             lines = f.read().splitlines()
         output, framework, directories = lines[0], lines[1] or None, lines[2:]
-        _generate(directories, framework, output, write_headermap)
+        _generate(directories, framework, output, write_headermap, roots)
     return 0
 
 
@@ -132,16 +141,22 @@ def main():
                         help='if set, also emit FRAMEWORK/Header.h entries so '
                              '<FRAMEWORK/Header.h> resolves to the source/derived path '
                              'without requiring a physical PrivateHeaders/ copy')
+    parser.add_argument('--root', action='append', dest='roots', default=[],
+                        help='a project root (source or build tree) to strip before '
+                             'judging whether a directory is framework-staged. May be '
+                             'repeated. Prevents an ancestor dir that happens to be '
+                             'named like the framework (e.g. a checkout under ~/WebKit) '
+                             'from falsely matching the staging heuristic.')
     args = parser.parse_args()
 
     if args.header_maps_dir:
-        return run_header_maps_dir(args.header_maps_dir)
+        return run_header_maps_dir(args.header_maps_dir, args.roots)
 
     if not args.dirs_file or not args.output:
         parser.error('--dirs-file and --output are required unless --header-maps-dir is given')
     with open(args.dirs_file) as f:
         directories = [line.strip() for line in f if line.strip()]
-    _generate(directories, args.framework, args.output, _load_hmaptool().write_headermap)
+    _generate(directories, args.framework, args.output, _load_hmaptool().write_headermap, args.roots)
     return 0
 
 


### PR DESCRIPTION
#### 94a43fa5221fe4ae5baf60673e83d3416df2c452
<pre>
Header map wrong if source dir is called WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=317397">https://bugs.webkit.org/show_bug.cgi?id=317397</a>
<a href="https://rdar.apple.com/180020322">rdar://180020322</a>

Reviewed by Geoffrey Garen.

This fixes the headermap generation script to behave the same way regardless of
the absolute directory in which the build is run. Previously, it would consider
elements of the build directory root when considering whether a header belonged
to a framework; if the build was occurring somewhere within a directory called
WebKit this would give a faulty headermap and various compile errors.

Canonical link: <a href="https://commits.webkit.org/315474@main">https://commits.webkit.org/315474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c10e415e31c745ae16709d6c3da00e1d5bafe96d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169130 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/43052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178484 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126842 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30d9c467-ef9a-4969-975d-1b2657f943c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131719 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcfd16bc-9d0f-4d7f-9108-9652a90a27a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34177 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112222 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b7df857-6002-406e-9a34-dbe9a7b4360d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27186 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/425 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181086 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30385 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140175 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42708 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37677 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43397 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107300 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35291 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201809 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41906 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6470 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54149 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41300 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41443 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->