### PR TITLE
Out-line style-getter accessors to fix non-unified "used but never defined" warnings

### DIFF
--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -62,6 +62,7 @@
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
 #include "Settings.h"
+#include "StyleComputedStyle+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+EvaluationMinimum.h"
 #include <wtf/SetForScope.h>
@@ -114,6 +115,11 @@ RenderTableSection* RenderTable::bottomSection() const
             return tableSection;
     }
     return m_head.get();
+}
+
+bool RenderTable::collapseBorders() const
+{
+    return style().borderCollapse() == BorderCollapse::Collapse;
 }
 
 void RenderTable::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -57,7 +57,7 @@ public:
     LayoutUnit hBorderSpacing() const { return m_hSpacing; }
     LayoutUnit vBorderSpacing() const { return m_vSpacing; }
     
-    bool collapseBorders() const { return style().borderCollapse() == BorderCollapse::Collapse; }
+    bool collapseBorders() const;
 
     LayoutUnit borderStart() const final { return m_borderStart; }
     LayoutUnit borderEnd() const final { return m_borderEnd; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp
@@ -71,6 +71,12 @@ void RenderMathMLFencedOperator::updateOperatorContent(const String& operatorStr
     updateMathOperator();
 }
 
+// minsize always has the default value "1em".
+LayoutUnit RenderMathMLFencedOperator::minSize() const
+{
+    return LayoutUnit(style().fontCascade().size());
+}
+
 LayoutUnit RenderMathMLFencedOperator::leadingSpace() const
 {
     MathMLElement::Length leadingSpace;

--- a/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.h
@@ -48,8 +48,7 @@ private:
     LayoutUnit leadingSpace() const final;
     LayoutUnit trailingSpace() const final;
 
-    // minsize always has the default value "1em".
-    LayoutUnit minSize() const final { return LayoutUnit(style().fontCascade().size()); }
+    LayoutUnit minSize() const final;
 
     // maxsize always has the default value "infinity".
     LayoutUnit maxSize() const final { return intMaxForLayoutUnit; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -89,6 +89,11 @@ bool RenderMathMLOperator::hasOperatorFlag(MathMLOperatorDictionary::Flag flag) 
     return element().hasProperty(flag);
 }
 
+bool RenderMathMLOperator::isLargeOperatorInDisplayStyle() const
+{
+    return !hasOperatorFlag(MathMLOperatorDictionary::Stretchy) && hasOperatorFlag(MathMLOperatorDictionary::LargeOp) && style().mathStyle() == MathStyle::Normal;
+}
+
 LayoutUnit RenderMathMLOperator::leadingSpace() const
 {
     // FIXME: Negative leading spaces must be implemented (https://webkit.org/b/124830).

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.h
@@ -53,7 +53,7 @@ public:
     bool isStretchWidthLocked() const { return m_isStretchWidthLocked; }
 
     virtual bool hasOperatorFlag(MathMLOperatorDictionary::Flag) const;
-    bool isLargeOperatorInDisplayStyle() const { return !hasOperatorFlag(MathMLOperatorDictionary::Stretchy) && hasOperatorFlag(MathMLOperatorDictionary::LargeOp) && style().mathStyle() == MathStyle::Normal; }
+    bool isLargeOperatorInDisplayStyle() const;
     bool shouldMoveLimits() const { return hasOperatorFlag(MathMLOperatorDictionary::MovableLimits); }
     virtual bool isVertical() const;
     LayoutUnit italicCorrection() const { return m_mathOperator.italicCorrection(); }


### PR DESCRIPTION
#### 537638c77c921750f0689f442891494ccff4c1a4
<pre>
Out-line style-getter accessors to fix non-unified &quot;used but never defined&quot; warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=317405">https://bugs.webkit.org/show_bug.cgi?id=317405</a>

Reviewed by Frédéric Wang Nélar.

collapseBorders(), isLargeOperatorInDisplayStyle() and minSize() each wrapped a
Style getter whose body lives in StyleComputedStyle+GettersInlines.h. Moving
them to their .cpp keeps that expensive header out of consumers (preserving
315217@main) while materializing the inline bodies.

Canonical link: <a href="https://commits.webkit.org/315588@main">https://commits.webkit.org/315588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32cf57ab6d508913efd47337e3ac732e536974eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131715 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92680 "2 flakes 8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33157 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31865 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181079 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33790 "Found 4 new failures in dom/Element.cpp, rendering/RenderTableCell.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140168 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42702 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140010 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43391 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107289 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25817 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35285 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115156 "Found 2 new failures in rendering/RenderTableCell.cpp") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41900 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6461 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->