### PR TITLE
Migrate cloning cell terminal JS values to JSC

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -3653,6 +3653,7 @@
 		BC0C10DE5E000000000B002A /* CloneDeserializerBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CloneDeserializerBase.h; sourceTree = "<group>"; };
 		BC0C105E5E000000000B003A /* CloneSerializerBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CloneSerializerBase.h; sourceTree = "<group>"; };
 		BC0C10C1A5C0000000B004A0 /* StructuredCloneTags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StructuredCloneTags.h; sourceTree = "<group>"; };
+		BC0C10C1A5C0000000C004A0 /* StructuredCloneTags.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StructuredCloneTags.cpp; sourceTree = "<group>"; };
 		0FE0501E1AA9095600D33B33 /* ScopedArguments.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScopedArguments.cpp; sourceTree = "<group>"; };
 		0FE0501F1AA9095600D33B33 /* ScopedArguments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScopedArguments.h; sourceTree = "<group>"; };
 		0FE050201AA9095600D33B33 /* ScopedArgumentsTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScopedArgumentsTable.h; sourceTree = "<group>"; };
@@ -9561,6 +9562,7 @@
 				7E4EE7080EBB7963005934AA /* StructureChain.h */,
 				276B386E2A71D0F900252F4E /* StructureChainInlines.h */,
 				0FD2C92516D01EE900C7803F /* StructureCreateInlines.h */,
+				BC0C10C1A5C0000000C004A0 /* StructuredCloneTags.cpp */,
 				BC0C10C1A5C0000000B004A0 /* StructuredCloneTags.h */,
 				537FEEC82742BDA300C9EFEE /* StructureID.h */,
 				0FD2C92316D01EE900C7803F /* StructureInlines.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1089,6 +1089,7 @@ runtime/Structure.cpp
 runtime/StructureCache.cpp
 runtime/StructureChain.cpp
 runtime/StructureRareData.cpp
+runtime/StructuredCloneTags.cpp
 runtime/SuppressedError.cpp
 runtime/SuppressedErrorConstructor.cpp
 runtime/SuppressedErrorPrototype.cpp

--- a/Source/JavaScriptCore/runtime/CloneBase.h
+++ b/Source/JavaScriptCore/runtime/CloneBase.h
@@ -42,10 +42,12 @@ inline constexpr bool verboseCloneTrace = false;
     } while (false)
 
 class JSGlobalObject;
+class CachedString;
 
 // Shared infrastructure for both CloneSerializerBase and CloneDeserializerBase.
 class CloneBase {
     WTF_FORBID_HEAP_ALLOCATION;
+    friend class CachedString;
 protected:
     CloneBase(JSGlobalObject* lexicalGlobalObject)
         : m_lexicalGlobalObject(lexicalGlobalObject)

--- a/Source/JavaScriptCore/runtime/CloneDeserializerBase.h
+++ b/Source/JavaScriptCore/runtime/CloneDeserializerBase.h
@@ -25,8 +25,21 @@
 
 #pragma once
 
+#include <JavaScriptCore/BigIntObject.h>
+#include <JavaScriptCore/BooleanObject.h>
 #include <JavaScriptCore/CloneBase.h>
+#include <JavaScriptCore/DateInstance.h>
+#include <JavaScriptCore/JSBigInt.h>
+#include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/JSString.h>
+#include <JavaScriptCore/NumberObject.h>
+#include <JavaScriptCore/RegExpObject.h>
+#include <JavaScriptCore/StringObject.h>
+#include <JavaScriptCore/YarrFlags.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Vector.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/WTFString.h>
 
 namespace JSC {
 
@@ -66,11 +79,47 @@ template<typename T> inline bool readLittleEndian(std::span<const uint8_t>& span
 
 } // namespace StructuredCloneInternal
 
+class CachedString {
+public:
+    CachedString(String&& string)
+        : m_string(WTF::move(string))
+    {
+    }
+
+    JSValue jsString(CloneBase&);
+    const String& string() const { return m_string; }
+    String takeString() { return WTF::move(m_string); }
+
+private:
+    String m_string;
+    JSValue m_jsString;
+};
+
+class CachedStringRef {
+public:
+    CachedStringRef() = default;
+
+    CachedStringRef(Vector<CachedString>* base, size_t index)
+        : m_base(base)
+        , m_index(index)
+    {
+    }
+
+    CachedString* operator->() { ASSERT(m_base); return &m_base->at(m_index); }
+
+private:
+    Vector<CachedString>* m_base { nullptr };
+    size_t m_index { 0 };
+};
+
+enum class ShouldAtomize : bool { No, Yes };
+
 template<typename Derived>
 class CloneDeserializerBase : public CloneBase {
 protected:
-    CloneDeserializerBase(JSGlobalObject* lexicalGlobalObject, std::span<const uint8_t> data)
+    CloneDeserializerBase(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, std::span<const uint8_t> data)
         : CloneBase(lexicalGlobalObject)
+        , m_globalObject(globalObject)
         , m_data(data)
     {
     }
@@ -100,6 +149,22 @@ protected:
         return true;
     }
 
+    bool read(bool& b)
+    {
+        if (m_majorVersion >= 14) {
+            uint8_t integer;
+            if (!read(integer) || integer > 1)
+                return false;
+            b = !!integer;
+            return true;
+        }
+        int32_t integer;
+        if (!read(integer) || integer > 1)
+            return false;
+        b = !!integer;
+        return true;
+    }
+
     SerializationTag readTag()
     {
         if (m_data.empty()) {
@@ -109,6 +174,257 @@ protected:
         auto tag = static_cast<SerializationTag>(consume(m_data));
         SERIALIZE_TRACE("deserialize ", tag);
         return tag;
+    }
+
+    bool readAndStoreVersion()
+    {
+        unsigned version;
+        if (!read(version))
+            return false;
+        m_majorVersion = majorVersionFor(version);
+        m_minorVersion = minorVersionFor(version);
+        return true;
+    }
+
+    bool isValid() const
+    {
+        if (m_majorVersion > CurrentMajorVersion)
+            return false;
+        if (m_majorVersion == 12)
+            return m_minorVersion <= 1;
+        return !m_minorVersion;
+    }
+
+    bool shouldRetryWithVersionUpgrade() const
+    {
+        if (m_majorVersion == 14 && !m_minorVersion)
+            return true;
+        if (m_majorVersion == 12 && !m_minorVersion)
+            return true;
+        return false;
+    }
+
+    void upgradeVersion()
+    {
+        ASSERT(shouldRetryWithVersionUpgrade());
+        if (m_majorVersion == 14 && !m_minorVersion) {
+            m_majorVersion = 15;
+            return;
+        }
+        if (m_majorVersion == 12 && !m_minorVersion)
+            m_minorVersion = 1;
+    }
+
+    template<typename T>
+    std::optional<uint32_t> readConstantPoolIndex(const T& constantPool)
+    {
+        if (constantPool.size() <= 0xFF) {
+            uint8_t i8;
+            if (!read(i8))
+                return std::nullopt;
+            return i8;
+        }
+        if (constantPool.size() <= 0xFFFF) {
+            uint16_t i16;
+            if (!read(i16))
+                return std::nullopt;
+            return i16;
+        }
+        uint32_t i;
+        if (!read(i))
+            return std::nullopt;
+        return i;
+    }
+
+    std::optional<uint32_t> readStringIndex()
+    {
+        return readConstantPoolIndex(m_constantPool);
+    }
+
+    static bool readString(std::span<const uint8_t>& span, String& str, unsigned length, bool is8Bit, ShouldAtomize shouldAtomize)
+    {
+        if (length >= std::numeric_limits<int32_t>::max() / sizeof(char16_t))
+            return false;
+
+        if (is8Bit) {
+            if (span.size() < length)
+                return false;
+            if (shouldAtomize == ShouldAtomize::Yes)
+                str = AtomString(byteCast<Latin1Character>(consumeSpan(span, length)));
+            else
+                str = String(byteCast<Latin1Character>(consumeSpan(span, length)));
+            return true;
+        }
+
+        size_t size = length * sizeof(char16_t);
+        if (span.size() < size)
+            return false;
+
+#if JSC_ASSUME_LITTLE_ENDIAN
+        auto stringSpan = consumeSpan(span, size);
+        if (shouldAtomize == ShouldAtomize::Yes)
+            str = AtomString(spanReinterpretCast<const char16_t>(stringSpan));
+        else
+            str = String(spanReinterpretCast<const char16_t>(stringSpan));
+#else
+        std::span<char16_t> characters;
+        str = String::createUninitialized(length, characters);
+        for (unsigned i = 0; i < length; ++i) {
+            uint16_t c;
+            StructuredCloneInternal::readLittleEndian(span, c);
+            characters[i] = c;
+        }
+        if (shouldAtomize == ShouldAtomize::Yes)
+            str = AtomString { str };
+#endif
+        return true;
+    }
+
+    bool readStringData(CachedStringRef& cachedString, ShouldAtomize shouldAtomize = ShouldAtomize::No)
+    {
+        bool scratch;
+        return readStringData(cachedString, scratch, shouldAtomize);
+    }
+
+    bool readStringData(CachedStringRef& cachedString, bool& wasTerminator, ShouldAtomize shouldAtomize = ShouldAtomize::No)
+    {
+        if (m_failed)
+            return false;
+        uint32_t length = 0;
+        if (!read(length))
+            return false;
+        if (length == TerminatorTag) {
+            wasTerminator = true;
+            return false;
+        }
+        if (length == StringPoolTag) {
+            auto index = readStringIndex();
+            if (!index || *index >= m_constantPool.size()) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return false;
+            }
+            cachedString = CachedStringRef(&m_constantPool, *index);
+            return true;
+        }
+        bool is8Bit = length & StringDataIs8BitFlag;
+        length &= ~StringDataIs8BitFlag;
+        String str;
+        if (!readString(m_data, str, length, is8Bit, shouldAtomize)) {
+            SERIALIZE_TRACE("FAIL deserialize");
+            fail();
+            return false;
+        }
+        m_constantPool.append(WTF::move(str));
+        cachedString = CachedStringRef(&m_constantPool, m_constantPool.size() - 1);
+        return true;
+    }
+
+    bool readNullableString(String& nullableString, ShouldAtomize shouldAtomize = ShouldAtomize::No)
+    {
+        bool isNull;
+        if (!read(isNull))
+            return false;
+        if (isNull)
+            return true;
+        CachedStringRef stringData;
+        if (!readStringData(stringData, shouldAtomize))
+            return false;
+        nullableString = stringData->string();
+        return true;
+    }
+
+    JSValue readBigInt()
+    {
+        // Sign is always written as a single byte.
+        // FIXME: Why not read this back as a bool since it's written as one?
+        uint8_t signByte;
+        if (!read(signByte))
+            return JSValue();
+        bool sign = !!signByte;
+        uint32_t numberOfUint64Elements = 0;
+        if (!read(numberOfUint64Elements))
+            return JSValue();
+
+        if (!numberOfUint64Elements) {
+#if USE(BIGINT32)
+            return jsBigInt32(0);
+#else
+            JSBigInt* bigInt = JSBigInt::tryCreateZero(m_lexicalGlobalObject->vm());
+            if (!bigInt) [[unlikely]] {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            return bigInt;
+#endif
+        }
+
+#if USE(BIGINT32)
+        static_assert(sizeof(JSBigInt::Digit) == sizeof(uint64_t));
+        if (numberOfUint64Elements == 1) {
+            uint64_t digit64 = 0;
+            if (!read(digit64))
+                return JSValue();
+            if (sign) {
+                if (digit64 <= static_cast<uint64_t>(-static_cast<int64_t>(INT32_MIN)))
+                    return jsBigInt32(static_cast<int32_t>(-static_cast<int64_t>(digit64)));
+            } else {
+                if (digit64 <= INT32_MAX)
+                    return jsBigInt32(static_cast<int32_t>(digit64));
+            }
+            ASSERT(digit64);
+            JSBigInt* bigInt = JSBigInt::tryCreateFrom(nullptr, m_lexicalGlobalObject->vm(), sign, std::span { &digit64, 1 });
+            if (!bigInt) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            return tryConvertToBigInt32(bigInt);
+        }
+#endif
+        Vector<JSBigInt::Digit, 16> digits;
+        if constexpr (sizeof(JSBigInt::Digit) == sizeof(uint64_t)) {
+            digits.reserveInitialCapacity(numberOfUint64Elements);
+            for (uint32_t index = 0; index < numberOfUint64Elements; ++index) {
+                uint64_t digit64 = 0;
+                if (!read(digit64))
+                    return JSValue();
+                digits.append(digit64);
+            }
+        } else {
+            ASSERT(sizeof(JSBigInt::Digit) == sizeof(uint32_t));
+            auto actualBigIntLength = WTF::checkedProduct<uint32_t>(numberOfUint64Elements, 2);
+            if (actualBigIntLength.hasOverflowed()) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            digits.reserveInitialCapacity(actualBigIntLength.value());
+            for (uint32_t index = 0; index < numberOfUint64Elements; ++index) {
+                uint64_t digit64 = 0;
+                if (!read(digit64))
+                    return JSValue();
+                digits.append(static_cast<uint32_t>(digit64));
+                digits.append(static_cast<uint32_t>(digit64 >> 32));
+            }
+        }
+
+        auto* bigInt = JSBigInt::tryCreateFrom(nullptr, m_lexicalGlobalObject->vm(), sign, digits.span());
+        if (!bigInt) {
+            SERIALIZE_TRACE("FAIL deserialize");
+            fail();
+            return JSValue();
+        }
+        return tryConvertToBigInt32(bigInt);
+    }
+
+    template<SerializationTag tag>
+    void addToObjectPool(JSValue object)
+    {
+        static_assert(canBeAddedToObjectPool(tag));
+        m_objectPool.appendWithCrashOnOverflow(object);
+        appendObjectPoolTag(tag);
     }
 
     ALWAYS_INLINE JSValue readTerminalImpl(SerializationTag tag)
@@ -137,6 +453,124 @@ protected:
             if (!read(d))
                 return JSValue();
             return jsNumber(d);
+        }
+        case StringTag: {
+            CachedStringRef cachedString;
+            if (!readStringData(cachedString))
+                return JSValue();
+            return cachedString->jsString(*this);
+        }
+        case EmptyStringTag:
+            return jsEmptyString(m_lexicalGlobalObject->vm());
+        case BigIntTag:
+            return readBigInt();
+        case DateTag: {
+            double d;
+            if (!read(d))
+                return JSValue();
+            return DateInstance::create(m_lexicalGlobalObject->vm(), m_globalObject->dateStructure(), d);
+        }
+        case RegExpTag: {
+            CachedStringRef pattern;
+            if (!readStringData(pattern))
+                return JSValue();
+            CachedStringRef flags;
+            if (!readStringData(flags))
+                return JSValue();
+            auto reFlags = Yarr::parseFlags(flags->string());
+            if (!reFlags.has_value())
+                return JSValue();
+            VM& vm = m_lexicalGlobalObject->vm();
+            RegExp* regExp = RegExp::create(vm, pattern->string(), reFlags.value());
+            return RegExpObject::create(vm, m_globalObject->regExpStructure(), regExp);
+        }
+        case NumberObjectTag: {
+            double d;
+            if (!read(d))
+                return JSValue();
+            NumberObject* obj = constructNumber(m_globalObject, jsNumber(d));
+            addToObjectPool<NumberObjectTag>(obj);
+            return obj;
+        }
+        case StringObjectTag: {
+            CachedStringRef cachedString;
+            if (!readStringData(cachedString))
+                return JSValue();
+            StringObject* obj = constructString(m_lexicalGlobalObject->vm(), m_globalObject, cachedString->jsString(*this));
+            addToObjectPool<StringObjectTag>(obj);
+            return obj;
+        }
+        case EmptyStringObjectTag: {
+            VM& vm = m_lexicalGlobalObject->vm();
+            StringObject* obj = constructString(vm, m_globalObject, jsEmptyString(vm));
+            addToObjectPool<EmptyStringObjectTag>(obj);
+            return obj;
+        }
+        case FalseObjectTag: {
+            BooleanObject* obj = BooleanObject::create(m_lexicalGlobalObject->vm(), m_globalObject->booleanObjectStructure());
+            obj->setInternalValue(m_lexicalGlobalObject->vm(), jsBoolean(false));
+            addToObjectPool<FalseObjectTag>(obj);
+            return obj;
+        }
+        case TrueObjectTag: {
+            BooleanObject* obj = BooleanObject::create(m_lexicalGlobalObject->vm(), m_globalObject->booleanObjectStructure());
+            obj->setInternalValue(m_lexicalGlobalObject->vm(), jsBoolean(true));
+            addToObjectPool<TrueObjectTag>(obj);
+            return obj;
+        }
+        case BigIntObjectTag: {
+            JSValue bigInt = readBigInt();
+            if (!bigInt)
+                return JSValue();
+            ASSERT(bigInt.isBigInt());
+            BigIntObject* obj = BigIntObject::create(m_lexicalGlobalObject->vm(), m_globalObject, bigInt);
+            addToObjectPool<BigIntObjectTag>(obj);
+            return obj;
+        }
+        case ErrorInstanceTag: {
+            SerializableErrorType serializedErrorType;
+            if (!readSerializableErrorType(serializedErrorType)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            String message;
+            if (!readNullableString(message)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            uint32_t line;
+            if (!read(line)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            uint32_t column;
+            if (!read(column)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            String sourceURL;
+            if (!readNullableString(sourceURL)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            String stackString;
+            if (!readNullableString(stackString)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            String causeString;
+            if (!readNullableString(causeString)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
+            return ErrorInstance::create(m_lexicalGlobalObject, WTF::move(message), toErrorType(serializedErrorType), { line, column }, WTF::move(sourceURL), WTF::move(stackString), WTF::move(causeString));
         }
         default:
             return static_cast<Derived*>(this)->readDerivedTerminal(tag);
@@ -167,7 +601,30 @@ protected:
         return result;
     }
 
+    bool readSerializableErrorType(SerializableErrorType& errorType)
+    {
+        std::underlying_type_t<SerializableErrorType> errorTypeInt;
+        if (!read(errorTypeInt) || errorTypeInt > std::to_underlying(SerializableErrorType::Last))
+            return false;
+        errorType = static_cast<SerializableErrorType>(errorTypeInt);
+        return true;
+    }
+
+    JSGlobalObject* const m_globalObject;
     std::span<const uint8_t> m_data;
+    Vector<CachedString> m_constantPool;
+    unsigned m_majorVersion { 0xFFFFFFFFu };
+    unsigned m_minorVersion { 0xFFFFFFFFu };
 };
+
+inline JSValue CachedString::jsString(CloneBase& deserializer)
+{
+    if (!m_jsString) {
+        auto& vm = deserializer.m_lexicalGlobalObject->vm();
+        m_jsString = JSC::jsString(vm, m_string);
+        deserializer.m_keepAliveBuffer.appendWithCrashOnOverflow(m_jsString);
+    }
+    return m_jsString;
+}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/CloneSerializerBase.h
+++ b/Source/JavaScriptCore/runtime/CloneSerializerBase.h
@@ -25,10 +25,22 @@
 
 #pragma once
 
+#include <JavaScriptCore/BigIntObject.h>
+#include <JavaScriptCore/BooleanObject.h>
 #include <JavaScriptCore/CloneBase.h>
+#include <JavaScriptCore/DateInstance.h>
+#include <JavaScriptCore/Identifier.h>
+#include <JavaScriptCore/JSBigInt.h>
 #include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSString.h>
+#include <JavaScriptCore/NumberObject.h>
+#include <JavaScriptCore/RegExpObject.h>
+#include <JavaScriptCore/StringObject.h>
+#include <JavaScriptCore/YarrFlags.h>
+#include <wtf/HashMap.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
+#include <wtf/text/AtomString.h>
 
 namespace JSC {
 
@@ -89,6 +101,9 @@ template<> inline bool writeLittleEndian<uint8_t>(Vector<uint8_t>& buffer, std::
 template<typename Derived>
 class CloneSerializerBase : public CloneBase {
 protected:
+    using ObjectPoolMap = HashMap<JSObject*, uint32_t>;
+    using StringConstantPool = HashMap<RefPtr<AtomStringImpl>, uint32_t, IdentifierRepHash>;
+
     CloneSerializerBase(JSGlobalObject* lexicalGlobalObject, Vector<uint8_t>& buffer)
         : CloneBase(lexicalGlobalObject)
         , m_buffer(buffer)
@@ -113,6 +128,206 @@ protected:
     void write(double d)
     {
         StructuredCloneInternal::writeLittleEndian(m_buffer, std::bit_cast<int64_t>(d));
+    }
+
+    template<class T>
+    void writeConstantPoolIndex(const T& constantPool, unsigned i)
+    {
+        ASSERT(i < constantPool.size());
+        if (constantPool.size() <= 0xFF)
+            write(static_cast<uint8_t>(i));
+        else if (constantPool.size() <= 0xFFFF)
+            write(static_cast<uint16_t>(i));
+        else
+            write(static_cast<uint32_t>(i));
+    }
+
+    void writeStringIndex(unsigned i)
+    {
+        writeConstantPoolIndex(m_constantPool, i);
+    }
+
+    void writeObjectIndex(unsigned i)
+    {
+        writeConstantPoolIndex(m_objectPoolMap, i);
+    }
+
+    template<SerializationTag tag1, SerializationTag tag2 = ErrorTag, SerializationTag tag3 = ErrorTag>
+    bool writeObjectReferenceIfDupe(JSObject* object)
+    {
+        static_assert(canBeAddedToObjectPool(tag1)
+            && (canBeAddedToObjectPool(tag2) || tag2 == ErrorTag)
+            && (canBeAddedToObjectPool(tag3) || tag3 == ErrorTag));
+
+        // Record object for graph reconstruction
+        auto found = m_objectPoolMap.find(object);
+
+        // Handle duplicate references
+        if (found != m_objectPoolMap.end()) {
+            write(ObjectReferenceTag);
+            ASSERT(found->value < m_objectPoolMap.size());
+            writeObjectIndex(found->value);
+            return true; // is dupe.
+        }
+        return false; // not dupe.
+    }
+
+    template<SerializationTag tag1, SerializationTag tag2 = ErrorTag, SerializationTag tag3 = ErrorTag>
+    bool addToObjectPool(JSObject* object)
+    {
+        static_assert(canBeAddedToObjectPool(tag1)
+            && (canBeAddedToObjectPool(tag2) || tag2 == ErrorTag)
+            && (canBeAddedToObjectPool(tag3) || tag3 == ErrorTag));
+
+        m_objectPoolMap.add(object, m_objectPoolMap.size());
+        m_objectPool.appendWithCrashOnOverflow(object);
+
+        if constexpr (tag2 == ErrorTag)
+            appendObjectPoolTag(tag1);
+
+        return true; // new object added.
+    }
+
+    template<SerializationTag tag1, SerializationTag tag2 = ErrorTag, SerializationTag tag3 = ErrorTag>
+    bool addToObjectPoolIfNotDupe(JSObject* object)
+    {
+        static_assert(canBeAddedToObjectPool(tag1)
+            && (canBeAddedToObjectPool(tag2) || tag2 == ErrorTag)
+            && (canBeAddedToObjectPool(tag3) || tag3 == ErrorTag));
+
+        if (writeObjectReferenceIfDupe<tag1, tag2, tag3>(object))
+            return false; // new object NOT added. It's a dupe.
+
+        addToObjectPool<tag1, tag2, tag3>(object);
+        return true; // new object added.
+    }
+
+    void write(const AtomString& ident)
+    {
+        const String& str = ident.string();
+        StringConstantPool::AddResult addResult = m_constantPool.add(ident.impl(), m_constantPool.size());
+        if (!addResult.isNewEntry) {
+            write(StringPoolTag);
+            writeStringIndex(addResult.iterator->value);
+            return;
+        }
+
+        unsigned length = str.length();
+
+        // Guard against overflow
+        if (length > (std::numeric_limits<uint32_t>::max() - sizeof(uint32_t)) / sizeof(char16_t)) {
+            fail();
+            return;
+        }
+
+        if (str.is8Bit())
+            StructuredCloneInternal::writeLittleEndian<uint32_t>(m_buffer, length | StringDataIs8BitFlag);
+        else
+            StructuredCloneInternal::writeLittleEndian<uint32_t>(m_buffer, length);
+
+        if (!length)
+            return;
+        if (str.is8Bit()) {
+            if (!StructuredCloneInternal::writeLittleEndian(m_buffer, str.span8()))
+                fail();
+            return;
+        }
+        if (!StructuredCloneInternal::writeLittleEndian(m_buffer, str.span16()))
+            fail();
+    }
+
+    void write(const String& str)
+    {
+        if (str.isNull())
+            write(emptyAtom());
+        else
+            write(AtomString(str));
+    }
+
+    void writeNullableString(const String& str)
+    {
+        bool isNull = str.isNull();
+        write(isNull);
+        if (!isNull)
+            write(AtomString(str));
+    }
+
+    void dumpString(const String& string)
+    {
+        if (string.isEmpty())
+            write(EmptyStringTag);
+        else {
+            write(StringTag);
+            write(string);
+        }
+    }
+
+    void dumpStringObject(const String& string)
+    {
+        if (string.isEmpty()) {
+            appendObjectPoolTag(EmptyStringObjectTag);
+            write(EmptyStringObjectTag);
+        } else {
+            appendObjectPoolTag(StringObjectTag);
+            write(StringObjectTag);
+            write(string);
+        }
+    }
+
+    void dumpBigIntData(JSValue value)
+    {
+        ASSERT(value.isBigInt());
+#if USE(BIGINT32)
+        if (value.isBigInt32()) {
+            dumpBigInt32Data(value.bigInt32AsInt32());
+            return;
+        }
+#endif
+        dumpHeapBigIntData(downcast<JSBigInt>(value));
+    }
+
+#if USE(BIGINT32)
+    void dumpBigInt32Data(int32_t integer)
+    {
+        write(integer < 0);
+        if (!integer) {
+            write(static_cast<uint32_t>(0)); // Length-in-uint64_t
+            return;
+        }
+        write(static_cast<uint32_t>(1)); // Length-in-uint64_t
+        int64_t value = static_cast<int64_t>(integer);
+        if (value < 0)
+            value = -value;
+        write(static_cast<uint64_t>(value));
+    }
+#endif
+
+    void dumpHeapBigIntData(JSBigInt* bigInt)
+    {
+        write(bigInt->sign());
+        if constexpr (sizeof(JSBigInt::Digit) == sizeof(uint64_t)) {
+            write(static_cast<uint32_t>(bigInt->length()));
+            for (unsigned index = 0; index < bigInt->length(); ++index)
+                write(static_cast<uint64_t>(bigInt->digit(index)));
+        } else {
+            ASSERT(sizeof(JSBigInt::Digit) == sizeof(uint32_t));
+            uint32_t numberOfUint64Elements = bigInt->length() / 2;
+            if (bigInt->length() & 0x1)
+                ++numberOfUint64Elements;
+            write(numberOfUint64Elements);
+            uint64_t value = 0;
+            for (unsigned index = 0; index < bigInt->length(); ++index) {
+                if (!(index & 0x1))
+                    value = bigInt->digit(index);
+                else {
+                    value = (static_cast<uint64_t>(bigInt->digit(index)) << 32) | value;
+                    write(static_cast<uint64_t>(value));
+                    value = 0;
+                }
+            }
+            if (bigInt->length() & 0x1)
+                write(static_cast<uint64_t>(value));
+        }
     }
 
     ALWAYS_INLINE bool dumpIfTerminal(JSValue value, SerializationReturnCode& code)
@@ -150,10 +365,81 @@ protected:
             write(value.isTrue() ? TrueTag : FalseTag);
             return true;
         }
+        if (value.isString()) {
+            dumpString(asString(value)->value(m_lexicalGlobalObject));
+            return true;
+        }
+        if (value.isBigInt()) {
+            write(BigIntTag);
+            dumpBigIntData(value);
+            return true;
+        }
+        if (value.isObject()) {
+            auto* obj = asObject(value);
+            if (auto* dateObject = dynamicDowncast<DateInstance>(obj)) {
+                write(DateTag);
+                write(dateObject->internalNumber());
+                return true;
+            }
+            if (auto* regExp = dynamicDowncast<RegExpObject>(obj)) {
+                write(RegExpTag);
+                write(regExp->regExp()->pattern());
+                write(String::fromLatin1(JSC::Yarr::flagsString(regExp->regExp()->flags()).data()));
+                return true;
+            }
+            if (auto* booleanObject = dynamicDowncast<BooleanObject>(obj)) {
+                if (!addToObjectPoolIfNotDupe<TrueObjectTag, FalseObjectTag>(booleanObject))
+                    return true;
+                auto tag = booleanObject->internalValue().toBoolean(m_lexicalGlobalObject) ? TrueObjectTag : FalseObjectTag;
+                write(tag);
+                appendObjectPoolTag(tag);
+                return true;
+            }
+            if (auto* stringObject = dynamicDowncast<StringObject>(obj)) {
+                if (!addToObjectPoolIfNotDupe<EmptyStringObjectTag, StringObjectTag>(stringObject))
+                    return true;
+                auto str = asString(stringObject->internalValue())->value(m_lexicalGlobalObject);
+                dumpStringObject(str);
+                return true;
+            }
+            if (auto* numberObject = dynamicDowncast<NumberObject>(obj)) {
+                if (!addToObjectPoolIfNotDupe<NumberObjectTag>(numberObject))
+                    return true;
+                write(NumberObjectTag);
+                write(numberObject->internalValue().asNumber());
+                return true;
+            }
+            if (auto* bigIntObject = dynamicDowncast<BigIntObject>(obj)) {
+                if (!addToObjectPoolIfNotDupe<BigIntObjectTag>(bigIntObject))
+                    return true;
+                write(BigIntObjectTag);
+                JSValue bigIntValue = bigIntObject->internalValue();
+                ASSERT(bigIntValue.isBigInt());
+                dumpBigIntData(bigIntValue);
+                return true;
+            }
+            if (auto* errorInstance = dynamicDowncast<ErrorInstance>(obj)) {
+                auto errorInformation = extractErrorInformationFromErrorInstance(m_lexicalGlobalObject, *errorInstance);
+                if (!errorInformation)
+                    return false;
+
+                write(ErrorInstanceTag);
+                write(static_cast<uint8_t>(errorNameToSerializableErrorType(errorInformation->errorTypeString)));
+                writeNullableString(errorInformation->message);
+                write(errorInformation->line);
+                write(errorInformation->column);
+                writeNullableString(errorInformation->sourceURL);
+                writeNullableString(errorInformation->stack);
+                writeNullableString(errorInformation->cause);
+                return true;
+            }
+        }
         return static_cast<Derived*>(this)->dumpDerivedTerminal(value, code);
     }
 
     Vector<uint8_t>& m_buffer;
+    StringConstantPool m_constantPool;
+    ObjectPoolMap m_objectPoolMap;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StructuredCloneTags.cpp
+++ b/Source/JavaScriptCore/runtime/StructuredCloneTags.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2009-2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StructuredCloneTags.h"
+
+#include "ErrorInstance.h"
+#include "ExceptionScope.h"
+#include "JSGlobalObject.h"
+#include "PropertyDescriptor.h"
+#include "ThrowScope.h"
+
+namespace JSC {
+
+std::optional<ErrorInformation> extractErrorInformationFromErrorInstance(JSGlobalObject* lexicalGlobalObject, ErrorInstance& errorInstance)
+{
+    ASSERT(lexicalGlobalObject);
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto errorTypeValue = errorInstance.get(lexicalGlobalObject, vm.propertyNames->name);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    String errorTypeString = errorTypeValue.toWTFString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    PropertyDescriptor messageDescriptor;
+    String message;
+    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->message, messageDescriptor) && messageDescriptor.isDataDescriptor()) {
+        EXCEPTION_ASSERT(!scope.exception());
+        message = messageDescriptor.value().toWTFString(lexicalGlobalObject);
+    }
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    PropertyDescriptor lineDescriptor;
+    unsigned line = 0;
+    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->line, lineDescriptor) && lineDescriptor.isDataDescriptor()) {
+        EXCEPTION_ASSERT(!scope.exception());
+        line = lineDescriptor.value().toNumber(lexicalGlobalObject);
+    }
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    PropertyDescriptor columnDescriptor;
+    unsigned column = 0;
+    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->column, columnDescriptor) && columnDescriptor.isDataDescriptor()) {
+        EXCEPTION_ASSERT(!scope.exception());
+        column = columnDescriptor.value().toNumber(lexicalGlobalObject);
+    }
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    PropertyDescriptor sourceURLDescriptor;
+    String sourceURL;
+    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->sourceURL, sourceURLDescriptor) && sourceURLDescriptor.isDataDescriptor()) {
+        EXCEPTION_ASSERT(!scope.exception());
+        sourceURL = sourceURLDescriptor.value().toWTFString(lexicalGlobalObject);
+    }
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    PropertyDescriptor stackDescriptor;
+    String stack;
+    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->stack, stackDescriptor) && stackDescriptor.isDataDescriptor()) {
+        EXCEPTION_ASSERT(!scope.exception());
+        stack = stackDescriptor.value().toWTFString(lexicalGlobalObject);
+    }
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    PropertyDescriptor causeDescriptor;
+    String cause;
+    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->cause, causeDescriptor) && causeDescriptor.isDataDescriptor()) {
+        EXCEPTION_ASSERT(!scope.exception());
+        cause = causeDescriptor.value().toWTFString(lexicalGlobalObject);
+    }
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    return { ErrorInformation { errorTypeString, message, line, column, sourceURL, stack, cause } };
+}
+
+} // namespace JSC
+
+namespace WTF {
+
+void printInternal(PrintStream& out, JSC::SerializationTag tag)
+{
+    auto tagName = JSC::name(tag);
+    if (tagName[0U] != '<')
+        out.print(tagName);
+    else
+        out.print("<unknown tag "_s, static_cast<unsigned>(tag), ">"_s);
+}
+
+} // namespace WTF

--- a/Source/JavaScriptCore/runtime/StructuredCloneTags.h
+++ b/Source/JavaScriptCore/runtime/StructuredCloneTags.h
@@ -25,9 +25,11 @@
 
 #pragma once
 
+#include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <wtf/PrintStream.h>
 #include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/StringCommon.h>
 
 // Most CPUs we support are little-endian and accept unaligned loads of the
 // integer widths the wire format uses, so the read/write helpers fast-path
@@ -362,6 +364,68 @@ enum class SerializationReturnCode {
     UnspecifiedError
 };
 
+enum class SerializableErrorType : uint8_t {
+    Error,
+    EvalError,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+    URIError,
+    Last = URIError
+};
+
+struct ErrorInformation {
+    String errorTypeString;
+    String message;
+    unsigned line { 0 };
+    unsigned column { 0 };
+    String sourceURL;
+    String stack;
+    String cause;
+};
+
+class ErrorInstance;
+JS_EXPORT_PRIVATE std::optional<ErrorInformation> extractErrorInformationFromErrorInstance(JSGlobalObject*, ErrorInstance&);
+
+inline SerializableErrorType errorNameToSerializableErrorType(const String& name)
+{
+    if (equalLettersIgnoringASCIICase(name, "evalerror"_s))
+        return SerializableErrorType::EvalError;
+    if (equalLettersIgnoringASCIICase(name, "rangeerror"_s))
+        return SerializableErrorType::RangeError;
+    if (equalLettersIgnoringASCIICase(name, "referenceerror"_s))
+        return SerializableErrorType::ReferenceError;
+    if (equalLettersIgnoringASCIICase(name, "syntaxerror"_s))
+        return SerializableErrorType::SyntaxError;
+    if (equalLettersIgnoringASCIICase(name, "typeerror"_s))
+        return SerializableErrorType::TypeError;
+    if (equalLettersIgnoringASCIICase(name, "urierror"_s))
+        return SerializableErrorType::URIError;
+    return SerializableErrorType::Error;
+}
+
+inline ErrorType toErrorType(SerializableErrorType value)
+{
+    switch (value) {
+    case SerializableErrorType::Error:
+        return ErrorType::Error;
+    case SerializableErrorType::EvalError:
+        return ErrorType::EvalError;
+    case SerializableErrorType::RangeError:
+        return ErrorType::RangeError;
+    case SerializableErrorType::ReferenceError:
+        return ErrorType::ReferenceError;
+    case SerializableErrorType::SyntaxError:
+        return ErrorType::SyntaxError;
+    case SerializableErrorType::TypeError:
+        return ErrorType::TypeError;
+    case SerializableErrorType::URIError:
+        return ErrorType::URIError;
+    }
+    return ErrorType::Error;
+}
+
 constexpr unsigned CurrentMajorVersion = 15;
 constexpr unsigned CurrentMinorVersion = 0;
 inline constexpr unsigned NODELETE majorVersionFor(unsigned version) { return version & 0x00FFFFFF; }
@@ -394,6 +458,7 @@ inline constexpr unsigned NODELETE makeVersion(unsigned major, unsigned minor)
  * Version 14. encode booleans as uint8_t instead of int32_t.
  * Version 15. changed the terminator of the indexed property section in array.
  */
+// FIXME: We should have two versions one for JSC version changes and one for WebCore version changes.
 inline constexpr unsigned NODELETE currentVersion() { return makeVersion(CurrentMajorVersion, CurrentMinorVersion); }
 constexpr unsigned TerminatorTag = 0xFFFFFFFF;
 constexpr unsigned StringPoolTag = 0xFFFFFFFE;
@@ -538,15 +603,6 @@ inline ASCIILiteral name(SerializationTag tag)
 
 namespace WTF {
 
-void printInternal(PrintStream&, JSC::SerializationTag);
-
-void printInternal(PrintStream& out, JSC::SerializationTag tag)
-{
-    auto tagName = JSC::name(tag);
-    if (tagName[0U] != '<')
-        out.print(tagName);
-    else
-        out.print("<unknown tag "_s, static_cast<unsigned>(tag), ">"_s);
-}
+JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::SerializationTag);
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -150,10 +150,10 @@ inline bool operator==(const AtomString& a, ASCIILiteral b) { return WTF::equal(
 inline bool operator==(const AtomString& a, const Vector<char16_t>& b) { return a.impl() && equal(a.impl(), b.span()); }
 inline bool operator==(const AtomString& a, const String& b) { return equal(a.impl(), b.impl()); }
 
-bool equalIgnoringASCIICase(const AtomString&, const AtomString&);
-bool equalIgnoringASCIICase(const AtomString&, const String&);
-bool equalIgnoringASCIICase(const String&, const AtomString&);
-bool equalIgnoringASCIICase(const AtomString&, ASCIILiteral);
+bool NODELETE equalIgnoringASCIICase(const AtomString&, const AtomString&);
+bool NODELETE equalIgnoringASCIICase(const AtomString&, const String&);
+bool NODELETE equalIgnoringASCIICase(const String&, const AtomString&);
+bool NODELETE equalIgnoringASCIICase(const AtomString&, ASCIILiteral);
 
 bool equalLettersIgnoringASCIICase(const AtomString&, ASCIILiteral);
 bool startsWithLettersIgnoringASCIICase(const AtomString&, ASCIILiteral);
@@ -299,22 +299,22 @@ inline bool startsWithLettersIgnoringASCIICase(const AtomString& string, ASCIILi
     return startsWithLettersIgnoringASCIICase(string.string(), literal);
 }
 
-inline bool equalIgnoringASCIICase(const AtomString& a, const AtomString& b)
+inline bool NODELETE equalIgnoringASCIICase(const AtomString& a, const AtomString& b)
 {
     return equalIgnoringASCIICase(a.string(), b.string());
 }
 
-inline bool equalIgnoringASCIICase(const AtomString& a, const String& b)
+inline bool NODELETE equalIgnoringASCIICase(const AtomString& a, const String& b)
 {
     return equalIgnoringASCIICase(a.string(), b);
 }
 
-inline bool equalIgnoringASCIICase(const String& a, const AtomString& b)
+inline bool NODELETE equalIgnoringASCIICase(const String& a, const AtomString& b)
 {
     return equalIgnoringASCIICase(a, b.string());
 }
 
-inline bool equalIgnoringASCIICase(const AtomString& a, ASCIILiteral b)
+inline bool NODELETE equalIgnoringASCIICase(const AtomString& a, ASCIILiteral b)
 {
     return equalIgnoringASCIICase(a.string(), b);
 }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -334,8 +334,8 @@ inline bool operator==(const String& a, const String& b) { return equal(a.impl()
 inline bool operator==(const String& a, ASCIILiteral b) { return equal(a.impl(), b); }
 template<size_t inlineCapacity> inline bool operator==(const String& a, const Vector<char, inlineCapacity>& b) { return b == a; }
 
-bool equalIgnoringASCIICase(const String&, const String&);
-bool equalIgnoringASCIICase(const String&, ASCIILiteral);
+bool NODELETE equalIgnoringASCIICase(const String&, const String&);
+bool NODELETE equalIgnoringASCIICase(const String&, ASCIILiteral);
 
 bool equalLettersIgnoringASCIICase(const String&, ASCIILiteral);
 bool startsWithLettersIgnoringASCIICase(const String&, ASCIILiteral);
@@ -551,12 +551,12 @@ inline bool equalLettersIgnoringASCIICase(const String& string, ASCIILiteral lit
     return equalLettersIgnoringASCIICase(string.impl(), literal);
 }
 
-inline bool equalIgnoringASCIICase(const String& a, const String& b)
+inline bool NODELETE equalIgnoringASCIICase(const String& a, const String& b)
 {
     return equalIgnoringASCIICase(a.impl(), b.impl());
 }
 
-inline bool equalIgnoringASCIICase(const String& a, ASCIILiteral b)
+inline bool NODELETE equalIgnoringASCIICase(const String& a, ASCIILiteral b)
 {
     return equalIgnoringASCIICase(a.impl(), b);
 }

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -307,55 +307,6 @@ static unsigned NODELETE typedArrayElementSize(ArrayBufferViewSubtag tag)
     }
 }
 
-enum class SerializableErrorType : uint8_t {
-    Error,
-    EvalError,
-    RangeError,
-    ReferenceError,
-    SyntaxError,
-    TypeError,
-    URIError,
-    Last = URIError
-};
-
-static SerializableErrorType errorNameToSerializableErrorType(const String& name)
-{
-    if (equalLettersIgnoringASCIICase(name, "evalerror"_s))
-        return SerializableErrorType::EvalError;
-    if (equalLettersIgnoringASCIICase(name, "rangeerror"_s))
-        return SerializableErrorType::RangeError;
-    if (equalLettersIgnoringASCIICase(name, "referenceerror"_s))
-        return SerializableErrorType::ReferenceError;
-    if (equalLettersIgnoringASCIICase(name, "syntaxerror"_s))
-        return SerializableErrorType::SyntaxError;
-    if (equalLettersIgnoringASCIICase(name, "typeerror"_s))
-        return SerializableErrorType::TypeError;
-    if (equalLettersIgnoringASCIICase(name, "urierror"_s))
-        return SerializableErrorType::URIError;
-    return SerializableErrorType::Error;
-}
-
-static ErrorType NODELETE toErrorType(SerializableErrorType value)
-{
-    switch (value) {
-    case SerializableErrorType::Error:
-        return ErrorType::Error;
-    case SerializableErrorType::EvalError:
-        return ErrorType::EvalError;
-    case SerializableErrorType::RangeError:
-        return ErrorType::RangeError;
-    case SerializableErrorType::ReferenceError:
-        return ErrorType::ReferenceError;
-    case SerializableErrorType::SyntaxError:
-        return ErrorType::SyntaxError;
-    case SerializableErrorType::TypeError:
-        return ErrorType::TypeError;
-    case SerializableErrorType::URIError:
-        return ErrorType::URIError;
-    }
-    return ErrorType::Error;
-}
-
 enum class PredefinedColorSpaceTag : uint8_t {
     SRGB = 0,
 #if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
@@ -832,56 +783,6 @@ private:
         return object->inherits<JSSet>();
     }
 
-    template<SerializationTag tag1, SerializationTag tag2 = ErrorTag, SerializationTag tag3 = ErrorTag>
-    bool writeObjectReferenceIfDupe(JSObject* object)
-    {
-        static_assert(canBeAddedToObjectPool(tag1)
-            && (canBeAddedToObjectPool(tag2) || tag2 == ErrorTag)
-            && (canBeAddedToObjectPool(tag3) || tag3 == ErrorTag));
-
-        // Record object for graph reconstruction
-        auto found = m_objectPoolMap.find(object);
-
-        // Handle duplicate references
-        if (found != m_objectPoolMap.end()) {
-            write(ObjectReferenceTag);
-            ASSERT(found->value < m_objectPoolMap.size());
-            writeObjectIndex(found->value);
-            return true; // is dupe.
-        }
-        return false; // not dupe.
-    }
-
-    template<SerializationTag tag1, SerializationTag tag2 = ErrorTag, SerializationTag tag3 = ErrorTag>
-    bool addToObjectPool(JSObject* object)
-    {
-        static_assert(canBeAddedToObjectPool(tag1)
-            && (canBeAddedToObjectPool(tag2) || tag2 == ErrorTag)
-            && (canBeAddedToObjectPool(tag3) || tag3 == ErrorTag));
-
-        m_objectPoolMap.add(object, m_objectPoolMap.size());
-        m_objectPool.appendWithCrashOnOverflow(object);
-
-        if constexpr (tag2 == ErrorTag)
-            appendObjectPoolTag(tag1);
-
-        return true; // new object added.
-    }
-
-    template<SerializationTag tag1, SerializationTag tag2 = ErrorTag, SerializationTag tag3 = ErrorTag>
-    bool addToObjectPoolIfNotDupe(JSObject* object)
-    {
-        static_assert(canBeAddedToObjectPool(tag1)
-            && (canBeAddedToObjectPool(tag2) || tag2 == ErrorTag)
-            && (canBeAddedToObjectPool(tag3) || tag3 == ErrorTag));
-
-        if (writeObjectReferenceIfDupe<tag1, tag2, tag3>(object))
-            return false; // new object NOT added. It's a dupe.
-
-        addToObjectPool<tag1, tag2, tag3>(object);
-        return true; // new object added.
-    }
-
     void endObject()
     {
         write(TerminatorTag);
@@ -893,84 +794,6 @@ private:
         if (object->methodTable()->getOwnPropertySlot(object, m_lexicalGlobalObject, propertyName, slot))
             return slot.getValue(m_lexicalGlobalObject, propertyName);
         return JSValue();
-    }
-
-    void dumpString(const String& string)
-    {
-        if (string.isEmpty())
-            write(EmptyStringTag);
-        else {
-            write(StringTag);
-            write(string);
-        }
-    }
-
-    void dumpStringObject(const String& string)
-    {
-        if (string.isEmpty()) {
-            appendObjectPoolTag(EmptyStringObjectTag);
-            write(EmptyStringObjectTag);
-        } else {
-            appendObjectPoolTag(StringObjectTag);
-            write(StringObjectTag);
-            write(string);
-        }
-    }
-
-    void dumpBigIntData(JSValue value)
-    {
-        ASSERT(value.isBigInt());
-#if USE(BIGINT32)
-        if (value.isBigInt32()) {
-            dumpBigInt32Data(value.bigInt32AsInt32());
-            return;
-        }
-#endif
-        dumpHeapBigIntData(downcast<JSBigInt>(value));
-    }
-
-#if USE(BIGINT32)
-    void dumpBigInt32Data(int32_t integer)
-    {
-        write(integer < 0);
-        if (!integer) {
-            write(static_cast<uint32_t>(0)); // Length-in-uint64_t
-            return;
-        }
-        write(static_cast<uint32_t>(1)); // Length-in-uint64_t
-        int64_t value = static_cast<int64_t>(integer);
-        if (value < 0)
-            value = -value;
-        write(static_cast<uint64_t>(value));
-    }
-#endif
-
-    void dumpHeapBigIntData(JSBigInt* bigInt)
-    {
-        write(bigInt->sign());
-        if constexpr (sizeof(JSBigInt::Digit) == sizeof(uint64_t)) {
-            write(static_cast<uint32_t>(bigInt->length()));
-            for (unsigned index = 0; index < bigInt->length(); ++index)
-                write(static_cast<uint64_t>(bigInt->digit(index)));
-        } else {
-            ASSERT(sizeof(JSBigInt::Digit) == sizeof(uint32_t));
-            uint32_t numberOfUint64Elements = bigInt->length() / 2;
-            if (bigInt->length() & 0x1)
-                ++numberOfUint64Elements;
-            write(numberOfUint64Elements);
-            uint64_t value = 0;
-            for (unsigned index = 0; index < bigInt->length(); ++index) {
-                if (!(index & 0x1))
-                    value = bigInt->digit(index);
-                else {
-                    value = (static_cast<uint64_t>(bigInt->digit(index)) << 32) | value;
-                    write(static_cast<uint64_t>(value));
-                    value = 0;
-                }
-            }
-            if (bigInt->length() & 0x1)
-                write(static_cast<uint64_t>(value));
-        }
     }
 
     JSC::JSValue toJSArrayBuffer(ArrayBuffer& arrayBuffer)
@@ -1408,33 +1231,7 @@ private:
 public:
     bool dumpDerivedTerminal(JSValue value, SerializationReturnCode& code)
     {
-        if (!value.isCell()) {
-            // The JSC base handles every other immediate JSValue (null,
-            // undefined, int, double, boolean). The only residual non-cell
-            // case here is BigInt32; anything else is an unrecognized
-            // primitive.
-#if USE(BIGINT32)
-            if (value.isBigInt32()) {
-                write(BigIntTag);
-                dumpBigIntData(value);
-                return true;
-            }
-#endif
-            code = SerializationReturnCode::DataCloneError;
-            return true;
-        }
         ASSERT(value.isCell());
-
-        if (value.isString()) {
-            dumpString(asString(value)->value(m_lexicalGlobalObject));
-            return true;
-        }
-
-        if (value.isHeapBigInt()) {
-            write(BigIntTag);
-            dumpBigIntData(value);
-            return true;
-        }
 
         if (value.isSymbol()) {
             code = SerializationReturnCode::DataCloneError;
@@ -1447,42 +1244,6 @@ public:
 
         if (value.isObject()) {
             auto* obj = asObject(value);
-            if (auto* dateObject = dynamicDowncast<DateInstance>(obj)) {
-                write(DateTag);
-                write(dateObject->internalNumber());
-                return true;
-            }
-            if (auto* booleanObject = dynamicDowncast<BooleanObject>(obj)) {
-                if (!addToObjectPoolIfNotDupe<TrueObjectTag, FalseObjectTag>(booleanObject))
-                    return true;
-                auto tag = booleanObject->internalValue().toBoolean(m_lexicalGlobalObject) ? TrueObjectTag : FalseObjectTag;
-                write(tag);
-                appendObjectPoolTag(tag);
-                return true;
-            }
-            if (auto* stringObject = dynamicDowncast<StringObject>(obj)) {
-                if (!addToObjectPoolIfNotDupe<EmptyStringObjectTag, StringObjectTag>(stringObject))
-                    return true;
-                auto str = asString(stringObject->internalValue())->value(m_lexicalGlobalObject);
-                dumpStringObject(str);
-                return true;
-            }
-            if (auto* numberObject = dynamicDowncast<NumberObject>(obj)) {
-                if (!addToObjectPoolIfNotDupe<NumberObjectTag>(numberObject))
-                    return true;
-                write(NumberObjectTag);
-                write(numberObject->internalValue().asNumber());
-                return true;
-            }
-            if (auto* bigIntObject = dynamicDowncast<BigIntObject>(obj)) {
-                if (!addToObjectPoolIfNotDupe<BigIntObjectTag>(bigIntObject))
-                    return true;
-                write(BigIntObjectTag);
-                JSValue bigIntValue = bigIntObject->internalValue();
-                ASSERT(bigIntValue.isBigInt());
-                dumpBigIntData(bigIntValue);
-                return true;
-            }
             if (RefPtr file = JSFile::toWrapped(vm, obj)) {
                 write(FileTag);
                 write(*file);
@@ -1525,27 +1286,6 @@ public:
                 write(dataLength);
                 write(protect(data->data().arrayBufferView())->span());
                 write(data->colorSpace());
-                return true;
-            }
-            if (auto* regExp = dynamicDowncast<RegExpObject>(obj)) {
-                write(RegExpTag);
-                write(regExp->regExp()->pattern());
-                write(String::fromLatin1(JSC::Yarr::flagsString(regExp->regExp()->flags()).data()));
-                return true;
-            }
-            if (auto* errorInstance = dynamicDowncast<ErrorInstance>(obj)) {
-                auto errorInformation = extractErrorInformationFromErrorInstance(m_lexicalGlobalObject, *errorInstance);
-                if (!errorInformation)
-                    return false;
-
-                write(ErrorInstanceTag);
-                write(errorNameToSerializableErrorType(errorInformation->errorTypeString));
-                writeNullableString(errorInformation->message);
-                write(errorInformation->line);
-                write(errorInformation->column);
-                writeNullableString(errorInformation->sourceURL);
-                writeNullableString(errorInformation->stack);
-                writeNullableString(errorInformation->cause);
                 return true;
             }
             if (obj->inherits<JSMessagePort>()) {
@@ -1820,11 +1560,6 @@ public:
 private:
     using Base::write;
 
-    void write(SerializableErrorType errorType)
-    {
-        write(std::to_underlying(errorType));
-    }
-
     void write(DestinationColorSpaceTag tag)
     {
         JSC::StructuredCloneInternal::writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
@@ -1855,80 +1590,9 @@ private:
         JSC::StructuredCloneInternal::writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
     }
 
-    void writeStringIndex(unsigned i)
-    {
-        writeConstantPoolIndex(m_constantPool, i);
-    }
-
     void writeImageDataIndex(unsigned i)
     {
         writeConstantPoolIndex(m_imageDataPool, i);
-    }
-    
-    void writeObjectIndex(unsigned i)
-    {
-        writeConstantPoolIndex(m_objectPoolMap, i);
-    }
-
-    template <class T> void writeConstantPoolIndex(const T& constantPool, unsigned i)
-    {
-        ASSERT(i < constantPool.size());
-        if (constantPool.size() <= 0xFF)
-            write(static_cast<uint8_t>(i));
-        else if (constantPool.size() <= 0xFFFF)
-            write(static_cast<uint16_t>(i));
-        else
-            write(static_cast<uint32_t>(i));
-    }
-
-    void write(const AtomString& ident)
-    {
-        const String& str = ident.string();
-        StringConstantPool::AddResult addResult = m_constantPool.add(ident.impl(), m_constantPool.size());
-        if (!addResult.isNewEntry) {
-            write(StringPoolTag);
-            writeStringIndex(addResult.iterator->value);
-            return;
-        }
-
-        unsigned length = str.length();
-
-        // Guard against overflow
-        if (length > (std::numeric_limits<uint32_t>::max() - sizeof(uint32_t)) / sizeof(char16_t)) {
-            fail();
-            return;
-        }
-
-        if (str.is8Bit())
-            JSC::StructuredCloneInternal::writeLittleEndian<uint32_t>(m_buffer, length | StringDataIs8BitFlag);
-        else
-            JSC::StructuredCloneInternal::writeLittleEndian<uint32_t>(m_buffer, length);
-
-        if (!length)
-            return;
-        if (str.is8Bit()) {
-            if (!JSC::StructuredCloneInternal::writeLittleEndian(m_buffer, str.span8()))
-                fail();
-            return;
-        }
-        if (!JSC::StructuredCloneInternal::writeLittleEndian(m_buffer, str.span16()))
-            fail();
-    }
-
-    void write(const String& str)
-    {
-        if (str.isNull())
-            write(emptyAtom());
-        else
-            write(AtomString(str));
-    }
-
-    void writeNullableString(const String& str)
-    {
-        bool isNull = str.isNull();
-        write(isNull);
-        if (!isNull)
-            write(AtomString(str));
     }
 
     void write(const Vector<uint8_t>& vector)
@@ -2259,7 +1923,6 @@ private:
 
     // m_buffer lives in the JSC::CloneSerializerBase template.
     Vector<URLKeepingBlobAlive>& m_blobHandles;
-    ObjectPoolMap m_objectPoolMap;
     ObjectPoolMap m_transferredMessagePorts;
     ObjectPoolMap m_transferredArrayBuffers;
     ObjectPoolMap m_transferredImageBitmaps;
@@ -2277,8 +1940,6 @@ private:
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
     ObjectPoolMap m_transferredMediaSourceHandles;
 #endif
-    using StringConstantPool = HashMap<RefPtr<AtomStringImpl>, uint32_t, IdentifierRepHash>;
-    StringConstantPool m_constantPool;
     using ImageDataPool = HashMap<Ref<ImageData>, uint32_t>;
     ImageDataPool m_imageDataPool;
     SerializationContext m_context;
@@ -2577,7 +2238,6 @@ class CloneDeserializer : public JSC::CloneDeserializerBase<CloneDeserializer> {
     using Base = JSC::CloneDeserializerBase<CloneDeserializer>;
     WTF_FORBID_HEAP_ALLOCATION;
 public:
-    enum class ShouldAtomize : bool { No, Yes };
     static String deserializeString(const Vector<uint8_t>& buffer, ShouldAtomize shouldAtomize = ShouldAtomize::No)
     {
         if (buffer.isEmpty())
@@ -2709,45 +2369,6 @@ public:
     }
 
 private:
-    struct CachedString {
-        CachedString(String&& string)
-            : m_string(WTF::move(string))
-        {
-        }
-
-        JSValue jsString(CloneDeserializer& deserializer)
-        {
-            if (!m_jsString) {
-                auto& vm = deserializer.m_lexicalGlobalObject->vm();
-                m_jsString = JSC::jsString(vm, m_string);
-                deserializer.m_keepAliveBuffer.appendWithCrashOnOverflow(m_jsString);
-            }
-            return m_jsString;
-        }
-        const String& NODELETE string() { return m_string; }
-        String NODELETE takeString() { return WTF::move(m_string); }
-
-    private:
-        String m_string;
-        JSValue m_jsString;
-    };
-
-    struct CachedStringRef {
-        CachedStringRef() = default;
-
-        CachedStringRef(Vector<CachedString>* base, size_t index)
-            : m_base(base)
-            , m_index(index)
-        {
-        }
-        
-        CachedString* NODELETE operator->() { ASSERT(m_base); return &m_base->at(m_index); }
-        
-    private:
-        Vector<CachedString>* m_base { nullptr };
-        size_t m_index { 0 };
-    };
-
     CloneDeserializer(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<Ref<MessagePort>>& messagePorts, ArrayBufferContentsArray* arrayBufferContents, Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps, const Vector<uint8_t>& buffer
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases = { }
@@ -2777,12 +2398,9 @@ private:
         , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles = { }
 #endif
         )
-        : Base(lexicalGlobalObject, buffer.span())
-        , m_globalObject(globalObject)
+        : Base(lexicalGlobalObject, globalObject, buffer.span())
         , m_isDOMGlobalObject(globalObject->inherits<JSDOMGlobalObject>())
         , m_canCreateDOMObject(m_isDOMGlobalObject && !globalObject->inherits<JSIDBSerializationGlobalObject>())
-        , m_majorVersion(0xFFFFFFFF)
-        , m_minorVersion(0xFFFFFFFF)
         , m_messagePorts(messagePorts)
         , m_arrayBufferContents(arrayBufferContents)
         , m_arrayBuffers(arrayBufferContents ? arrayBufferContents->size() : 0)
@@ -2827,11 +2445,7 @@ private:
         , m_mediaStreamTrackHandles(m_detachedMediaStreamTrackHandles.size())
 #endif
     {
-        unsigned version;
-        if (read(version)) {
-            m_majorVersion = majorVersionFor(version);
-            m_minorVersion = minorVersionFor(version);
-        }
+        readAndStoreVersion();
     }
 
     CloneDeserializer(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<Ref<MessagePort>>& messagePorts, ArrayBufferContentsArray* arrayBufferContents, const Vector<uint8_t>& buffer, const Vector<String>& blobURLs, const Vector<String> blobFilePaths, ArrayBufferContentsArray* sharedBuffers, Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps
@@ -2863,12 +2477,9 @@ private:
         , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles = { }
 #endif
         )
-        : JSC::CloneDeserializerBase<CloneDeserializer>(lexicalGlobalObject, buffer.span())
-        , m_globalObject(globalObject)
+        : JSC::CloneDeserializerBase<CloneDeserializer>(lexicalGlobalObject, globalObject, buffer.span())
         , m_isDOMGlobalObject(globalObject->inherits<JSDOMGlobalObject>())
         , m_canCreateDOMObject(m_isDOMGlobalObject && !globalObject->inherits<JSIDBSerializationGlobalObject>())
-        , m_majorVersion(0xFFFFFFFF)
-        , m_minorVersion(0xFFFFFFFF)
         , m_messagePorts(messagePorts)
         , m_arrayBufferContents(arrayBufferContents)
         , m_arrayBuffers(arrayBufferContents ? arrayBufferContents->size() : 0)
@@ -2916,11 +2527,7 @@ private:
         , m_mediaStreamTrackHandles(m_detachedMediaStreamTrackHandles.size())
 #endif
     {
-        unsigned version;
-        if (read(version)) {
-            m_majorVersion = majorVersionFor(version);
-            m_minorVersion = minorVersionFor(version);
-        }
+        readAndStoreVersion();
     }
 
     enum class VisitNamedMemberResult : uint8_t { Error, Break, Start, Unknown };
@@ -2999,181 +2606,11 @@ private:
     Vector<RefPtr<DetachedMediaSourceHandle>> takeDetachedMediaSourceHandles() { return std::exchange(m_detachedMediaSourceHandles, { }); }
 #endif
 
-    bool NODELETE isValid() const
-    {
-        if (m_majorVersion > CurrentMajorVersion)
-            return false;
-        if (m_majorVersion == 12)
-            return m_minorVersion <= 1;
-        return !m_minorVersion;
-    }
-    bool NODELETE shouldRetryWithVersionUpgrade()
-    {
-        if (m_majorVersion == 14 && !m_minorVersion)
-            return true;
-        if (m_majorVersion == 12 && !m_minorVersion)
-            return true;
-        return false;
-    }
-    void NODELETE upgradeVersion()
-    {
-        ASSERT(shouldRetryWithVersionUpgrade());
-        if (m_majorVersion == 14 && !m_minorVersion) {
-            m_majorVersion = 15;
-            return;
-        }
-        if (m_majorVersion == 12 && !m_minorVersion)
-            m_minorVersion = 1;
-    }
-
-    template<SerializationTag tag>
-    inline void addToObjectPool(JSValue object)
-    {
-        static_assert(canBeAddedToObjectPool(tag));
-        m_objectPool.appendWithCrashOnOverflow(object);
-        appendObjectPoolTag(tag);
-    }
-
     using Base::read;
-
-    enum class ForceReadingAs8Bit : bool { No, Yes };
-    bool NODELETE read(bool& b, ForceReadingAs8Bit forceReadingAs8Bit = ForceReadingAs8Bit::No)
-    {
-        if (m_majorVersion >= 14 || forceReadingAs8Bit == ForceReadingAs8Bit::Yes) {
-            uint8_t integer;
-            if (!read(integer) || integer > 1)
-                return false;
-            b = !!integer;
-        } else {
-            int32_t integer;
-            if (!read(integer) || integer > 1)
-                return false;
-            b = !!integer;
-        }
-        return true;
-    }
-
-    std::optional<uint32_t> NODELETE readStringIndex()
-    {
-        return readConstantPoolIndex(m_constantPool);
-    }
 
     std::optional<uint32_t> NODELETE readImageDataIndex()
     {
         return readConstantPoolIndex(m_imageDataPool);
-    }
-
-    template<typename T> std::optional<uint32_t> NODELETE readConstantPoolIndex(const T& constantPool)
-    {
-        if (constantPool.size() <= 0xFF) {
-            uint8_t i8;
-            if (!read(i8))
-                return std::nullopt;
-            return i8;
-        }
-        if (constantPool.size() <= 0xFFFF) {
-            uint16_t i16;
-            if (!read(i16))
-                return std::nullopt;
-            return i16;
-        }
-        uint32_t i;
-        if (!read(i))
-            return std::nullopt;
-        return i;
-    }
-
-    static bool readString(std::span<const uint8_t>& span, String& str, unsigned length, bool is8Bit, ShouldAtomize shouldAtomize)
-    {
-        if (length >= std::numeric_limits<int32_t>::max() / sizeof(char16_t))
-            return false;
-
-        if (is8Bit) {
-            if (span.size() < length)
-                return false;
-            if (shouldAtomize == ShouldAtomize::Yes)
-                str = AtomString(byteCast<Latin1Character>(consumeSpan(span, length)));
-            else
-                str = String(byteCast<Latin1Character>(consumeSpan(span, length)));
-            return true;
-        }
-
-        size_t size = length * sizeof(char16_t);
-        if (span.size() < size)
-            return false;
-
-#if JSC_ASSUME_LITTLE_ENDIAN
-        auto stringSpan = consumeSpan(span, size);
-        if (shouldAtomize == ShouldAtomize::Yes)
-            str = AtomString(spanReinterpretCast<const char16_t>(stringSpan));
-        else
-            str = String(spanReinterpretCast<const char16_t>(stringSpan));
-#else
-        std::span<char16_t> characters;
-        str = String::createUninitialized(length, characters);
-        for (unsigned i = 0; i < length; ++i) {
-            uint16_t c;
-            JSC::StructuredCloneInternal::readLittleEndian(span, c);
-            characters[i] = c;
-        }
-        if (shouldAtomize == ShouldAtomize::Yes)
-            str = AtomString { str };
-#endif
-        return true;
-    }
-
-    bool readNullableString(String& nullableString, ShouldAtomize shouldAtomize = ShouldAtomize::No)
-    {
-        bool isNull;
-        if (!read(isNull))
-            return false;
-        if (isNull)
-            return true;
-        CachedStringRef stringData;
-        if (!readStringData(stringData, shouldAtomize))
-            return false;
-        nullableString = stringData->string();
-        return true;
-    }
-
-    bool readStringData(CachedStringRef& cachedString, ShouldAtomize shouldAtomize = ShouldAtomize::No)
-    {
-        bool scratch;
-        return readStringData(cachedString, scratch, shouldAtomize);
-    }
-
-    bool readStringData(CachedStringRef& cachedString, bool& wasTerminator, ShouldAtomize shouldAtomize = ShouldAtomize::No)
-    {
-        if (m_failed)
-            return false;
-        uint32_t length = 0;
-        if (!read(length))
-            return false;
-        if (length == TerminatorTag) {
-            wasTerminator = true;
-            return false;
-        }
-        if (length == StringPoolTag) {
-            auto index = readStringIndex();
-            if (!index || *index >= m_constantPool.size()) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return false;
-            }
-            cachedString = CachedStringRef(&m_constantPool, *index);
-            return true;
-        }
-        bool is8Bit = length & StringDataIs8BitFlag;
-        length &= ~StringDataIs8BitFlag;
-        String str;
-        if (!readString(m_data, str, length, is8Bit, shouldAtomize)) {
-            SERIALIZE_TRACE("FAIL deserialize");
-            fail();
-            return false;
-        }
-        m_constantPool.append(WTF::move(str));
-        cachedString = CachedStringRef(&m_constantPool, m_constantPool.size() - 1);
-        return true;
     }
 
     bool NODELETE readArrayBufferViewSubtag(ArrayBufferViewSubtag& tag)
@@ -3856,16 +3293,6 @@ private:
         return true;
     }
 
-    bool NODELETE read(SerializableErrorType& errorType)
-    {
-        std::underlying_type_t<SerializableErrorType> errorTypeInt;
-        if (!read(errorTypeInt) || errorTypeInt > std::to_underlying(SerializableErrorType::Last))
-            return false;
-
-        errorType = static_cast<SerializableErrorType>(errorTypeInt);
-        return true;
-    }
-
     template<class T>
     JSValue getJSValue(T&& nativeObj)
     {
@@ -3898,9 +3325,12 @@ private:
     template<class T>
     JSValue readDOMMatrix()
     {
-        bool is2D;
-        if (!read(is2D, ForceReadingAs8Bit::Yes))
+        // Always read is2D as a single byte.
+        // FIXME: Why not read this back as a bool since it's written as one?
+        uint8_t is2DByte;
+        if (!read(is2DByte))
             return { };
+        bool is2D = !!is2DByte;
 
         if (is2D) {
             double m11;
@@ -4497,88 +3927,6 @@ private:
         return getJSValue(handle);
     }
 
-    JSValue readBigInt()
-    {
-        bool sign;
-        if (!read(sign, ForceReadingAs8Bit::Yes))
-            return JSValue();
-        uint32_t numberOfUint64Elements = 0;
-        if (!read(numberOfUint64Elements))
-            return JSValue();
-
-        if (!numberOfUint64Elements) {
-#if USE(BIGINT32)
-            return jsBigInt32(0);
-#else
-            JSBigInt* bigInt = JSBigInt::tryCreateZero(m_lexicalGlobalObject->vm());
-            if (!bigInt) [[unlikely]] {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            return bigInt;
-#endif
-        }
-
-#if USE(BIGINT32)
-        static_assert(sizeof(JSBigInt::Digit) == sizeof(uint64_t));
-        if (numberOfUint64Elements == 1) {
-            uint64_t digit64 = 0;
-            if (!read(digit64))
-                return JSValue();
-            if (sign) {
-                if (digit64 <= static_cast<uint64_t>(-static_cast<int64_t>(INT32_MIN)))
-                    return jsBigInt32(static_cast<int32_t>(-static_cast<int64_t>(digit64)));
-            } else {
-                if (digit64 <= INT32_MAX)
-                    return jsBigInt32(static_cast<int32_t>(digit64));
-            }
-            ASSERT(digit64 != 0);
-            JSBigInt* bigInt = JSBigInt::tryCreateFrom(nullptr, m_lexicalGlobalObject->vm(), sign, std::span { &digit64, 1 });
-            if (!bigInt) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            return tryConvertToBigInt32(bigInt);
-        }
-#endif
-        Vector<JSBigInt::Digit, 16> digits;
-        if constexpr (sizeof(JSBigInt::Digit) == sizeof(uint64_t)) {
-            digits.reserveInitialCapacity(numberOfUint64Elements);
-            for (uint32_t index = 0; index < numberOfUint64Elements; ++index) {
-                uint64_t digit64 = 0;
-                if (!read(digit64))
-                    return JSValue();
-                digits.append(digit64);
-            }
-        } else {
-            ASSERT(sizeof(JSBigInt::Digit) == sizeof(uint32_t));
-            auto actualBigIntLength = WTF::checkedProduct<uint32_t>(numberOfUint64Elements, 2);
-            if (actualBigIntLength.hasOverflowed()) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            digits.reserveInitialCapacity(actualBigIntLength.value());
-            for (uint32_t index = 0; index < numberOfUint64Elements; ++index) {
-                uint64_t digit64 = 0;
-                if (!read(digit64))
-                    return JSValue();
-                digits.append(static_cast<uint32_t>(digit64));
-                digits.append(static_cast<uint32_t>(digit64 >> 32));
-            }
-        }
-
-        auto* bigInt = JSBigInt::tryCreateFrom(nullptr, m_lexicalGlobalObject->vm(), sign, digits.span());
-        if (!bigInt) {
-            SERIALIZE_TRACE("FAIL deserialize");
-            fail();
-            return JSValue();
-        }
-        return tryConvertToBigInt32(bigInt);
-    }
-
 public:
     bool isTagExposed(SerializationTag tag) const
     {
@@ -4588,43 +3936,6 @@ public:
     JSValue readDerivedTerminal(SerializationTag tag)
     {
         switch (tag) {
-        case FalseObjectTag: {
-            BooleanObject* obj = BooleanObject::create(m_lexicalGlobalObject->vm(), m_globalObject->booleanObjectStructure());
-            obj->setInternalValue(m_lexicalGlobalObject->vm(), jsBoolean(false));
-            addToObjectPool<FalseObjectTag>(obj);
-            return obj;
-        }
-        case TrueObjectTag: {
-            BooleanObject* obj = BooleanObject::create(m_lexicalGlobalObject->vm(), m_globalObject->booleanObjectStructure());
-            obj->setInternalValue(m_lexicalGlobalObject->vm(), jsBoolean(true));
-            addToObjectPool<TrueObjectTag>(obj);
-            return obj;
-        }
-        case BigIntTag:
-            return readBigInt();
-        case NumberObjectTag: {
-            double d;
-            if (!read(d))
-                return JSValue();
-            NumberObject* obj = constructNumber(m_globalObject, jsNumber(d));
-            addToObjectPool<NumberObjectTag>(obj);
-            return obj;
-        }
-        case BigIntObjectTag: {
-            JSValue bigInt = readBigInt();
-            if (!bigInt)
-                return JSValue();
-            ASSERT(bigInt.isBigInt());
-            BigIntObject* obj = BigIntObject::create(m_lexicalGlobalObject->vm(), m_globalObject, bigInt);
-            addToObjectPool<BigIntObjectTag>(obj);
-            return obj;
-        }
-        case DateTag: {
-            double d;
-            if (!read(d))
-                return JSValue();
-            return DateInstance::create(m_lexicalGlobalObject->vm(), m_globalObject->dateStructure(), d);
-        }
         case FileTag: {
             RefPtr<File> file;
             if (!readFile(file))
@@ -4719,87 +4030,6 @@ public:
             if (!m_canCreateDOMObject)
                 return jsNull();
             return getJSValue(Blob::deserialize(protect(executionContext(m_lexicalGlobalObject)).get(), URL { url->string() }, type->string(), size, memoryCost, blobFilePathForBlobURL(url->string())).get());
-        }
-        case StringTag: {
-            CachedStringRef cachedString;
-            if (!readStringData(cachedString))
-                return JSValue();
-            return cachedString->jsString(*this);
-        }
-        case EmptyStringTag:
-            return jsEmptyString(m_lexicalGlobalObject->vm());
-        case StringObjectTag: {
-            CachedStringRef cachedString;
-            if (!readStringData(cachedString))
-                return JSValue();
-            StringObject* obj = constructString(m_lexicalGlobalObject->vm(), m_globalObject, cachedString->jsString(*this));
-            addToObjectPool<StringObjectTag>(obj);
-            return obj;
-        }
-        case EmptyStringObjectTag: {
-            VM& vm = m_lexicalGlobalObject->vm();
-            StringObject* obj = constructString(vm, m_globalObject, jsEmptyString(vm));
-            addToObjectPool<EmptyStringObjectTag>(obj);
-            return obj;
-        }
-        case RegExpTag: {
-            CachedStringRef pattern;
-            if (!readStringData(pattern))
-                return JSValue();
-            CachedStringRef flags;
-            if (!readStringData(flags))
-                return JSValue();
-            auto reFlags = Yarr::parseFlags(flags->string());
-            if (!reFlags.has_value())
-                return JSValue();
-            VM& vm = m_lexicalGlobalObject->vm();
-            RegExp* regExp = RegExp::create(vm, pattern->string(), reFlags.value());
-            return RegExpObject::create(vm, m_globalObject->regExpStructure(), regExp);
-        }
-        case ErrorInstanceTag: {
-            SerializableErrorType serializedErrorType;
-            if (!read(serializedErrorType)) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            String message;
-            if (!readNullableString(message)) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            uint32_t line;
-            if (!read(line)) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            uint32_t column;
-            if (!read(column)) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            String sourceURL;
-            if (!readNullableString(sourceURL)) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            String stackString;
-            if (!readNullableString(stackString)) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            String causeString;
-            if (!readNullableString(causeString)) {
-                SERIALIZE_TRACE("FAIL deserialize");
-                fail();
-                return JSValue();
-            }
-            return ErrorInstance::create(m_lexicalGlobalObject, WTF::move(message), toErrorType(serializedErrorType), { line, column }, WTF::move(sourceURL), WTF::move(stackString), WTF::move(causeString));
         }
         case ObjectReferenceTag: {
             auto index = readConstantPoolIndex(m_objectPool);
@@ -5086,12 +4316,8 @@ private:
         return false;
     }
 
-    JSGlobalObject* const m_globalObject;
     const bool m_isDOMGlobalObject;
     const bool m_canCreateDOMObject;
-    unsigned m_majorVersion;
-    unsigned m_minorVersion;
-    Vector<CachedString> m_constantPool;
     Vector<Ref<ImageData>> m_imageDataPool;
     const Vector<Ref<MessagePort>>& m_messagePorts;
     ArrayBufferContentsArray* m_arrayBufferContents;
@@ -6434,67 +5660,6 @@ IDBValue SerializedScriptValue::writeBlobsToDiskForIndexedDBSynchronously(bool i
     waitWithSTWParticipation(semaphore, vm);
 
     return value;
-}
-
-std::optional<ErrorInformation> extractErrorInformationFromErrorInstance(JSC::JSGlobalObject* lexicalGlobalObject, ErrorInstance& errorInstance)
-{
-    ASSERT(lexicalGlobalObject);
-    auto& vm = lexicalGlobalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto errorTypeValue = errorInstance.get(lexicalGlobalObject, vm.propertyNames->name);
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
-    String errorTypeString = errorTypeValue.toWTFString(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
-
-    PropertyDescriptor messageDescriptor;
-    String message;
-    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->message, messageDescriptor) && messageDescriptor.isDataDescriptor()) {
-        EXCEPTION_ASSERT(!scope.exception());
-        message = messageDescriptor.value().toWTFString(lexicalGlobalObject);
-    }
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
-
-    PropertyDescriptor lineDescriptor;
-    unsigned line = 0;
-    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->line, lineDescriptor) && lineDescriptor.isDataDescriptor()) {
-        EXCEPTION_ASSERT(!scope.exception());
-        line = lineDescriptor.value().toNumber(lexicalGlobalObject);
-    }
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
-
-    PropertyDescriptor columnDescriptor;
-    unsigned column = 0;
-    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->column, columnDescriptor) && columnDescriptor.isDataDescriptor()) {
-        EXCEPTION_ASSERT(!scope.exception());
-        column = columnDescriptor.value().toNumber(lexicalGlobalObject);
-    }
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
-
-    PropertyDescriptor sourceURLDescriptor;
-    String sourceURL;
-    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->sourceURL, sourceURLDescriptor) && sourceURLDescriptor.isDataDescriptor()) {
-        EXCEPTION_ASSERT(!scope.exception());
-        sourceURL = sourceURLDescriptor.value().toWTFString(lexicalGlobalObject);
-    }
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
-
-    PropertyDescriptor stackDescriptor;
-    String stack;
-    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->stack, stackDescriptor) && stackDescriptor.isDataDescriptor()) {
-        EXCEPTION_ASSERT(!scope.exception());
-        stack = stackDescriptor.value().toWTFString(lexicalGlobalObject);
-    }
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
-
-    PropertyDescriptor causeDescriptor;
-    String cause;
-    if (errorInstance.getOwnPropertyDescriptor(lexicalGlobalObject, vm.propertyNames->cause, causeDescriptor) && causeDescriptor.isDataDescriptor()) {
-        EXCEPTION_ASSERT(!scope.exception());
-        cause = causeDescriptor.value().toWTFString(lexicalGlobalObject);
-    }
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
-
-    return { ErrorInformation { errorTypeString, message, line, column, sourceURL, stack, cause } };
 }
 
 auto SerializedScriptValue::deserializationBehavior(JSC::JSObject& object) -> DeserializationBehavior

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -28,6 +28,7 @@
 
 #include <JavaScriptCore/Forward.h>
 #include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/StructuredCloneTags.h>
 #include <WebCore/FileSystemHandleGlobalIdentifier.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -74,17 +75,8 @@ enum class SerializationErrorMode : bool { NonThrowing, Throwing };
 enum class SerializationContext : bool { Default, CloneAcrossWorlds };
 enum class SerializationForStorage : bool { No, Yes };
 
-struct ErrorInformation {
-    String errorTypeString;
-    String message;
-    unsigned line { 0 };
-    unsigned column { 0 };
-    String sourceURL;
-    String stack;
-    String cause;
-};
-
-std::optional<ErrorInformation> extractErrorInformationFromErrorInstance(JSC::JSGlobalObject*, JSC::ErrorInstance&);
+using JSC::ErrorInformation;
+using JSC::extractErrorInformationFromErrorInstance;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
 class SerializedScriptValue : public ThreadSafeRefCounted<SerializedScriptValue> {


### PR DESCRIPTION
#### e0d162e570c6fdb5e7566067d4519e8fb152519e
<pre>
Migrate cloning cell terminal JS values to JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=317403">https://bugs.webkit.org/show_bug.cgi?id=317403</a>
<a href="https://rdar.apple.com/180030830">rdar://180030830</a>

Reviewed by Yijia Huang.

  Continues moving JSC-type serialization into JSC. The previous patch
  (315074@main) introduced the JSC base templates and moved the non-cell
  immediate JSValues. This patch moves every remaining &quot;terminal&quot; JSC
  type (types that emit a single tag plus inline data, with no walker
  re-entry). JSC now owns the wire format for: StringTag, EmptyStringTag,
  BigIntTag, DateTag, RegExpTag, NumberObjectTag, StringObjectTag /
  EmptyStringObjectTag, TrueObjectTag / FalseObjectTag, BigIntObjectTag,
  and ErrorInstanceTag.

Helpers and state moved into the JSC bases along with their tags:

  - String constant pool: StringConstantPool on the serializer, a
    Vector&lt;CachedString&gt; on the deserializer. CachedString /
    CachedStringRef move alongside, plus the wire helpers
    write(AtomString), write(String), dumpString, dumpStringObject,
    writeNullableString, readNullableString, readStringData / readString,
    readStringIndex / readConstantPoolIndex.

  - BigInt helpers: dumpBigIntData (BigInt32 + heap variants) and
      readBigInt.

  - Object pool: ObjectPoolMap + m_objectPoolMap, the templated
    addToObjectPool / writeObjectReferenceIfDupe / addToObjectPoolIfNotDupe
    family, and writeObjectIndex. Cycle detection across the
    JSC&lt;-&gt;WebCore boundary now goes through a single unified pool in the
    JSC base — required so that an object graph with a cycle that
    crosses both type universes (e.g. a Blob referenced from a JS
    object that points to itself) round-trips.

  - Destination global: m_globalObject moves into
    CloneDeserializerBase. Date / RegExp / wrapper-object
    deserialization needs the destination global&apos;s structures
    (dateStructure, regExpStructure, booleanObjectStructure, etc).

  - Wire-format version: m_majorVersion / m_minorVersion, plus
    readAndStoreVersion(), isValid(), shouldRetryWithVersionUpgrade(),
    and upgradeVersion(), all live on CloneDeserializerBase. The wire
    format itself is currently JSC-owned, so its version state belongs
    there.

  - Version-aware read(bool&amp;): JSC base reads bool as int32_t for
    v &lt; 14 and uint8_t otherwise, matching what write(bool) emits.
    ErrorInstance was added in v13 with 4-byte bools.

  - Error helpers: SerializableErrorType, errorNameToSerializableErrorType,
    and toErrorType move into StructuredCloneTags.h. ErrorInformation
    and extractErrorInformationFromErrorInstance are declared there
    too, with the body in a new StructuredCloneTags.cpp. Keeping the
    body out of the header avoids pulling ErrorInstance,
    PropertyDescriptor, ThrowScope, and ExceptionScope into every
    WebCore TU that includes SerializedScriptValue.h. Existing
    WebCore call sites (Navigation.cpp) reach JSC::ErrorInformation /
    JSC::extractErrorInformationFromErrorInstance through `using`
    re-exports in SerializedScriptValue.h.

Other cleanups:

- WebCore&apos;s ForceReadingAs8Bit enum and the explicit-force overload
  of read(bool&amp;) are gone. Just read as a uint8_t and convert to a
  bool.

- The `!value.isCell()` branch in WebCore&apos;s dumpDerivedTerminal
  becomes `ASSERT(value.isCell())`: the JSC base now handles every
  non-cell case (including BigInt32) before falling through.

- Add NODELETE unnecessarily to equalIgnoringASCIICase to appease our
  SaferCPP overlord.

Canonical link: <a href="https://commits.webkit.org/315504@main">https://commits.webkit.org/315504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2494800889399d7bbabdd702542acc9b67a81918

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169199 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126911 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acdd523c-bf69-4975-8fb0-511f872e19d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171065 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/43217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131788 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c09e4af1-b315-4971-aa3d-804af5eff25b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172158 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34238 "Unable to confirm if test failures are introduced by change, retrying build") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112292 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/393023db-8434-46f0-a38a-065f789162f3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27255 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/492 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181155 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30454 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140242 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42777 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140083 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43466 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107386 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25791 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35351 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115231 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201878 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41976 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6537 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54158 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->