### PR TITLE
[GTK][WPE] Skia compositor: move the decision to enable DDL to SkiaPaintingEngine

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -79,7 +79,7 @@ static bool canPerformAcceleratedRendering()
 SkiaPaintingEngine::SkiaPaintingEngine(sk_sp<GrContextThreadSafeProxy>&& threadSafeGrContext)
     : m_threadSafeGrContext(WTF::move(threadSafeGrContext))
 {
-    if (canPerformAcceleratedRendering() && !m_threadSafeGrContext) {
+    if (canPerformAcceleratedRendering() && !canUseDDL()) {
         if (auto numberOfGPUThreads = numberOfGPUPaintingThreads())
             m_paintingWorkerPool = WorkerPool::create("SkiaGPUWorker"_s, numberOfGPUThreads);
 
@@ -119,7 +119,7 @@ void SkiaPaintingEngine::paintIntoGraphicsContext(const GraphicsLayer& layer, Gr
 Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode renderingMode, const IntSize& size, bool contentsOpaque) const
 {
     if (renderingMode == RenderingMode::Accelerated) {
-        if (useThreadedRendering() && m_threadSafeGrContext)
+        if (useThreadedRendering() && canUseDDL())
             return CoordinatedAcceleratedTileBuffer::create(m_threadSafeGrContext, size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
 
         PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
@@ -154,7 +154,7 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
         isDMABufBackedTexture = true;
 #endif
 
-    auto atlas = SkiaGPUAtlas::create(layout, WTF::move(texture), Ref { uploadCondition }, m_threadSafeGrContext);
+    auto atlas = SkiaGPUAtlas::create(layout, WTF::move(texture), Ref { uploadCondition }, canUseDDL() ? m_threadSafeGrContext : nullptr);
     if (!atlas)
         return nullptr;
 
@@ -226,7 +226,7 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     SkPictureRecorder pictureRecorder;
     auto* recordingCanvas = pictureRecorder.beginRecording(recordRect.width(), recordRect.height());
     GraphicsContextSkia recordingContext(*recordingCanvas, renderingMode, RenderingPurpose::LayerBacking);
-    recordingContext.beginRecording(GraphicsContextSkia::RecordingMode::Tile, m_threadSafeGrContext);
+    recordingContext.beginRecording(GraphicsContextSkia::RecordingMode::Tile, canUseDDL() ? m_threadSafeGrContext : nullptr);
     paintIntoGraphicsContext(layer, recordingContext, recordRect, contentsOpaque, contentsScale);
     auto recordingData = recordingContext.endRecording();
 
@@ -285,12 +285,15 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordin
     Ref platformLayer = layer.coordinatedPlatformLayer();
     platformLayer->willPaintTile();
 
+    sk_sp<GrContextThreadSafeProxy> threadSafeGrContext;
+    if (canUseDDL())
+        threadSafeGrContext = m_threadSafeGrContext;
     auto renderingMode = recording->renderingMode();
-    auto bufferSize = renderingMode == RenderingMode::Accelerated && useThreadedRendering() && m_threadSafeGrContext ? tileRect.size() : dirtyRect.size();
+    auto bufferSize = renderingMode == RenderingMode::Accelerated && useThreadedRendering() && threadSafeGrContext ? tileRect.size() : dirtyRect.size();
     auto buffer = createBuffer(renderingMode, bufferSize, recording->contentsOpaque());
     buffer->beginPainting();
 
-    m_paintingWorkerPool->postTask([platformLayer = WTF::move(platformLayer), buffer = Ref { buffer }, tileRect, dirtyRect, recording = WTF::move(recording), threadSafeGrContext = m_threadSafeGrContext]() mutable {
+    m_paintingWorkerPool->postTask([platformLayer = WTF::move(platformLayer), buffer = Ref { buffer }, tileRect, dirtyRect, recording = WTF::move(recording), threadSafeGrContext = WTF::move(threadSafeGrContext)]() mutable {
         if (auto* canvas = buffer->canvas()) {
             auto replayPicture = [](const sk_sp<SkPicture>& picture, SkCanvas* canvas, const IntRect& recordRect, const IntRect& tileRect, const IntRect& dirtyRect, bool isDDLBuffer) {
                 canvas->save();
@@ -423,6 +426,27 @@ bool SkiaPaintingEngine::shouldUseVivanteSuperTiledTileTextures()
     });
 
     return shouldUseVivanteSuperTiledTextures;
+}
+
+bool SkiaPaintingEngine::isDDLEnabled()
+{
+    static std::once_flag onceFlag;
+    static bool isDDLEnabled = false;
+
+    std::call_once(onceFlag, [] {
+        if (const char* envString = getenv("WEBKIT_SKIA_ENABLE_DDL")) {
+            auto envStringView = StringView::fromLatin1(envString);
+            if (envStringView == "1"_s)
+                isDDLEnabled = true;
+        }
+    });
+
+    return isDDLEnabled;
+}
+
+bool SkiaPaintingEngine::canUseDDL() const
+{
+    return m_threadSafeGrContext && isDDLEnabled();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -62,6 +62,7 @@ public:
     static bool shouldUseDMABufAtlasTextures();
     static bool shouldUseLinearTileTextures();
     static bool shouldUseVivanteSuperTiledTileTextures();
+    static bool isDDLEnabled();
 
     bool useThreadedRendering() const { return m_paintingWorkerPool; }
 
@@ -74,6 +75,7 @@ private:
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
     RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&);
     bool tryReuseCachedAtlases(SkiaRecordingResult&, unsigned fingerprint);
+    bool canUseDDL() const;
 
     sk_sp<GrContextThreadSafeProxy> m_threadSafeGrContext;
     RefPtr<WorkerPool> m_paintingWorkerPool;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -125,9 +125,7 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
 
         if (m_useSkia) {
             PlatformDisplay::sharedDisplay().setSkiaGLContextForCurrentThread(WTF::move(context));
-            const auto enableDDL = CStringView::unsafeFromUTF8(getenv("WEBKIT_SKIA_ENABLE_DDL"));
-            if (enableDDL && enableDDL != "0"_s)
-                m_threadSafeGrContext = PlatformDisplay::sharedDisplay().skiaGrContext()->threadSafeProxy();
+            m_threadSafeGrContext = PlatformDisplay::sharedDisplay().skiaGrContext()->threadSafeProxy();
         } else {
             m_context = WTF::move(context);
             m_textureMapper = TextureMapper::create();


### PR DESCRIPTION
#### 88a917ccf55e82e50b4873ff23c62df9a1ee465d
<pre>
[GTK][WPE] Skia compositor: move the decision to enable DDL to SkiaPaintingEngine
<a href="https://bugs.webkit.org/show_bug.cgi?id=317407">https://bugs.webkit.org/show_bug.cgi?id=317407</a>

Reviewed by Nikolas Zimmermann.

We are deciding in ThreadedCompositor so that we only get a thread safe
gr context if DDL is enabled, but the thread safe gr context could be
used to create promised image independently of DDL. So, move the
decision to SkiaPaintingEngine which is where DDL is actually used and
create the thread safe gr context always when skia compositor is
enabled.

* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::SkiaPaintingEngine):
(WebCore::SkiaPaintingEngine::createBuffer const):
(WebCore::SkiaPaintingEngine::createAtlas):
(WebCore::SkiaPaintingEngine::record):
(WebCore::SkiaPaintingEngine::replay):
(WebCore::SkiaPaintingEngine::isDDLEnabled):
(WebCore::SkiaPaintingEngine::canUseDDL const):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_renderTimer):

Canonical link: <a href="https://commits.webkit.org/315519@main">https://commits.webkit.org/315519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3353e8c1b3c19ae83dd88625a599e95de2f3fc97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126837 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33159 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27181 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181080 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140170 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42703 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140011 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43392 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28373 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107295 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25794 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35286 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115157 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41901 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6462 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41295 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41438 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->