### PR TITLE
[Site Isolation] Replace navigatedFrameID heuristic with per-frame walk in UIProcess back/forward routing

### DIFF
--- a/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt
+++ b/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt
@@ -1,0 +1,4 @@
+
+PASS traversals in the same (back) direction: coalesced
+PASS traversals in the same (forward) direction: coalesced
+

--- a/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html
+++ b/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html
@@ -1,0 +1,95 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UseUIProcessForBackForwardItemLoading=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Same-document traversals during cross-document traversals</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!--
+  This case is not significantly different from
+  cross-document-traversal-cross-document-traversal.html.
+-->
+
+<body>
+<script type="module">
+import { createIframe, waitForLoad, waitForHashchange, delay, waitForPotentialNetworkLoads } from "./resources/helpers.mjs";
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+
+  // Setup
+  // Extra delay()s are necessary because if we navigate "inside" the load
+  // handler (i.e. in a promise reaction for the load handler) then it will
+  // be a replace navigation.
+  iframe.contentWindow.location.search = "?1";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.hash = "#2";
+  await waitForHashchange(iframe.contentWindow);
+  iframe.contentWindow.location.search = "?3";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+
+  iframe.contentWindow.history.back();
+  assert_equals(iframe.contentWindow.location.search, "?3", "must not go back synchronously 1 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "#2", "must not go back synchronously 1 (hash)");
+
+  iframe.contentWindow.history.back();
+  assert_equals(iframe.contentWindow.location.search, "?3", "must not go back synchronously 2 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "#2", "must not go back synchronously 2 (hash)");
+
+  await waitForLoad(iframe);
+  assert_equals(iframe.contentWindow.location.search, "?1", "first load event must be going back (search)");
+  assert_equals(iframe.contentWindow.location.hash, "", "first load event must be going back (hash)");
+
+  iframe.contentWindow.onhashchange = t.unreached_func("hashchange event");
+  iframe.onload = t.unreached_func("second load event");
+
+  await waitForPotentialNetworkLoads(t);
+  assert_equals(iframe.contentWindow.location.search, "?1", "must stay on ?1 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "", "must stay on ?1 (hash)");
+}, "traversals in the same (back) direction: coalesced");
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+
+  // Setup
+  // Extra delay()s are necessary because if we navigate "inside" the load
+  // handler (i.e. in a promise reaction for the load handler) then it will
+  // be a replace navigation.
+  iframe.contentWindow.location.search = "?1";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.search = "?2";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.hash = "#3";
+  await waitForHashchange(iframe.contentWindow);
+  iframe.contentWindow.history.back();
+  await waitForHashchange(iframe.contentWindow);
+  assert_equals(iframe.contentWindow.location.hash, "", "we made our way to ?2 for setup");
+  iframe.contentWindow.history.back();
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  assert_equals(iframe.contentWindow.location.search, "?1", "we made our way to ?1 for setup");
+
+  iframe.contentWindow.history.forward();
+  assert_equals(iframe.contentWindow.location.search, "?1", "must not go forward synchronously 1 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "", "must not go forward synchronously 1 (hash)");
+
+  iframe.contentWindow.history.forward();
+  assert_equals(iframe.contentWindow.location.search, "?1", "must not go forward synchronously 2 (search)");
+  assert_equals(iframe.contentWindow.location.hash, "", "must not go forward synchronously 2 (hash)");
+
+  await waitForLoad(iframe);
+  assert_equals(iframe.contentWindow.location.search, "?2", "first load event must be going forward (search)");
+  assert_equals(iframe.contentWindow.location.hash, "#3", "first load event must be going forward (hash)");
+
+  iframe.contentWindow.onhashchange = t.unreached_func("hashchange event");
+  iframe.onload = t.unreached_func("second load event");
+
+  await waitForPotentialNetworkLoads(t);
+  assert_equals(iframe.contentWindow.location.search, "?2", "must stay on ?2");
+  assert_equals(iframe.contentWindow.location.hash, "#3", "must stay on ?2");
+}, "traversals in the same (forward) direction: coalesced");
+</script>

--- a/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/resources/helpers.mjs
+++ b/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/resources/helpers.mjs
@@ -1,0 +1,52 @@
+export function createIframe(t) {
+  return new Promise((resolve, reject) => {
+    const iframe = document.createElement("iframe");
+    iframe.onload = () => resolve(iframe);
+    iframe.onerror = () => reject(new Error("Could not load iframe"));
+    iframe.src = "/common/blank.html";
+
+    t.add_cleanup(() => iframe.remove());
+    document.body.append(iframe);
+  });
+}
+
+export function delay(t, ms) {
+  return new Promise(resolve => t.step_timeout(resolve, ms));
+}
+
+export function waitForLoad(obj) {
+  return new Promise(resolve => {
+    obj.addEventListener("load", resolve, { once: true });
+  });
+}
+
+export function waitForHashchange(obj) {
+  return new Promise(resolve => {
+    obj.addEventListener("hashchange", resolve, { once: true });
+  });
+}
+
+export function waitForPopstate(obj) {
+  return new Promise(resolve => {
+    obj.addEventListener("popstate", resolve, { once: true });
+  });
+}
+
+// This is used when we want to end the test by asserting some load doesn't
+// happen, but we're not sure how long to wait. We could just wait a long-ish
+// time (e.g. a second), but that makes the tests slow. Instead, assume that
+// network loads take roughly the same time. Then, you can use this function to
+// wait a small multiple of the duration of a separate iframe load; this should
+// be long enough to catch any problems.
+export async function waitForPotentialNetworkLoads(t) {
+  const before = performance.now();
+
+  // Sometimes we're doing something, like a traversal, which cancels our first
+  // attempt at iframe loading. In that case we bail out after 100 ms and try
+  // again. (Better ideas welcome...)
+  await Promise.race([createIframe(t), delay(t, 100)]);
+  await createIframe(t);
+
+  const after = performance.now();
+  await delay(t, after - before);
+}

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/001-expected.txt
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/001-expected.txt
@@ -1,0 +1,51 @@
+WARNING: This test should always be loaded in a new tab/window, to avoid browsers attempting to recover the state of frames, and history length. Do not reload the test.
+
+Running test...
+
+PASS history.length should update when loading pages in an iframe
+PASS history.length should update when setting location.hash
+PASS history.pushState must exist
+PASS history.pushState must exist within iframes
+PASS initial history.state should be null
+PASS history.length should update when pushing a state
+PASS history.state should update after a state is pushed
+PASS history.length should not decrease after going back
+PASS traversing history must traverse pushed states
+PASS traversing history must also traverse hash changes
+PASS pushState must not be allowed to create invalid URLs
+PASS pushState must not be allowed to create cross-origin URLs
+PASS pushState must not be allowed to create cross-origin URLs (about:blank)
+PASS pushState must not be allowed to create cross-origin URLs (data:URI)
+PASS security errors are expected to be thrown in the context of the document that owns the history object
+PASS location.hash must be allowed to change (part 1)
+PASS location.hash must be allowed to change (part 2)
+PASS pushState must not alter location.hash when no URL is provided
+PASS pushState must remove all history after the current state
+PASS pushState must be able to set location.hash
+FAIL pushState must remove any tasks queued by the history traversal task source assert_equals: expected "test4" but got "test"
+PASS pushState must not fire hashchange events
+PASS pushState must be able to set location.pathname
+PASS pushState must be able to set absolute URLs to the same host
+PASS pushState must not be able to use a function as data
+PASS pushState must not be able to use a DOM node as data
+PASS pushState must be able to use an error object as data
+PASS security errors are expected to be thrown in the context of the document that owns the history object (2)
+PASS pushState must be able to make structured clones of complex objects
+PASS history.state should also reference a clone of the original object
+PASS history.state should be a clone of the original object, not a reference to it
+PASS popstate event should fire when navigation occurs
+PASS popstate event should pass the state data
+PASS state data should cope with circular object references
+PASS state data should be a clone of the original object, not a reference to it
+PASS history.state should also reference a clone of the original object (2)
+PASS history.state should be a clone of the original object, not a reference to it (2)
+PASS history.state should be identical to the object passed to the event handler unless history.state is updated
+PASS pushState should not actually load the new URL
+PASS reloading a pushed state should actually load the new URL
+
+
+
+
+
+
+

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/001.html
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/001.html
@@ -1,0 +1,340 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UseUIProcessForBackForwardItemLoading=true ] -->
+<!doctype html>
+<html>
+    <head>
+        <title>history.pushState tests</title>
+        <script type="text/javascript" src="/resources/testharness.js"></script>
+        <script type="text/javascript" src="/resources/testharnessreport.js"></script>
+        <script type="text/javascript">
+//does not test for firing of popstate onload, because this was dropped from the specification on 25 March 2011
+//covers history.state after load, in accordance with the specification draft from 25 March 2011
+//history.state before load is tested in 006 and 007
+//does not test for structured cloning of FileList, File or Blob interfaces, as these require manual file selection
+
+//**This test assumes that assignments to location.hash will be synchronous - this is how all browsers implement it.
+//The spec (as of 25 March 2011) disagrees.**//
+
+var histlength, atstep = 0, lasttimer;
+setup({explicit_done:true}); //tests should take under 6 seconds + execution time
+
+window.onload = function () {
+    if( location.protocol == 'file:' ) {
+        document.getElementsByTagName('p')[0].innerHTML = 'ERROR: This test cannot be run from file: (URL resolving will not work). It must be loaded over HTTP.';
+        return;
+    } else if( location.protocol == 'https:' ) {
+        document.getElementsByTagName('p')[0].innerHTML += '<br>WARNING: Browsers may intentionally fail to update history.length when pages are loaded over HTTPS, as a privacy restriction. If possible, load this page over HTTP.';
+    }
+    //use a timeout, because some browsers intentionally do not add history entries for URL changes in the onload thread
+    setTimeout(testinit,100);
+};
+function testinit() {
+    atstep = 1;
+    histlength = history.length;
+    iframe = document.getElementsByTagName('iframe')[0].src = 'resources/blank2.html';
+    //reportload will now be called by the onload handler for the iframe
+}
+function reportload() {
+    var iframe = document.getElementsByTagName('iframe')[0], hashchng = false;
+    var canvassup = false, cloneobj;
+
+    function tests1() {
+        //Firefox may fail when reloading, because it recovers iframe state, and therefore does not see the need to alter history length
+        test(function () { assert_equals( history.length, histlength + 1, 'make sure that you loaded the test in a new tab/window' ); }, 'history.length should update when loading pages in an iframe');
+        histlength = history.length;
+        iframe.contentWindow.location.hash = 'test'; //should be synchronous **SEE COMMENT AT TOP OF FILE
+        test(function () {
+            assert_equals( history.length, histlength + 1, 'make sure that you loaded the test in a new tab/window' );
+        }, 'history.length should update when setting location.hash');
+        test(function () { assert_true( !!history.pushState, 'critical test; ignore any failures after this' ); }, 'history.pushState must exist'); //assert_own_property does not allow prototype inheritance
+        test(function () { assert_true( !!iframe.contentWindow.history.pushState, 'critical test; ignore any failures after this' ); }, 'history.pushState must exist within iframes');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state, null );
+        }, 'initial history.state should be null');
+        test(function () {
+            histlength = history.length;
+            iframe.contentWindow.history.pushState('','');
+            assert_equals( history.length, histlength + 1 );
+        }, 'history.length should update when pushing a state');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state, '' );
+        }, 'history.state should update after a state is pushed');
+        histlength = history.length;
+        iframe.contentWindow.addEventListener("popstate", tests2, {once: true});
+        history.back();
+    }
+    function tests2() {
+        test(function () {
+            assert_equals( history.length, histlength );
+        }, 'history.length should not decrease after going back');
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test' );
+        }, 'traversing history must traverse pushed states');
+        iframe.contentWindow.addEventListener("hashchange", tests3, {once: true});
+        history.go(-1);
+    }
+    function tests3() {
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), '', '(this could cause other failures later on)' );
+        }, 'traversing history must also traverse hash changes');
+
+        iframe.contentWindow.addEventListener("hashchange", tests4, {once: true});
+        //Safari 5.0.3 fails here - it navigates *this* document to the *iframe's* location, instead of just navigating the iframe
+        history.go(2);
+    }
+    async function tests4() {
+        test(function () {
+            //Firefox 4 beta 11 has a messed up error object, which does not have the right error type or .SECURITY_ERR property
+            assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','//exa mple'); });
+        }, 'pushState must not be allowed to create invalid URLs');
+        test(function () {
+            assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','http://www.example.com/'); });
+        }, 'pushState must not be allowed to create cross-origin URLs');
+        test(function () {
+            assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','about:blank'); });
+        }, 'pushState must not be allowed to create cross-origin URLs (about:blank)');
+        test(function () {
+            assert_throws_dom('SECURITY_ERR',function () { history.pushState('','','data:text/html,'); });
+        }, 'pushState must not be allowed to create cross-origin URLs (data:URI)');
+        test(function () {
+            assert_throws_dom('SECURITY_ERR', iframe.contentWindow.DOMException, function () { iframe.contentWindow.history.pushState('','','http://www.example.com/'); });
+        }, 'security errors are expected to be thrown in the context of the document that owns the history object');
+        let hashchange =
+          new Promise(function (resolve) {
+            iframe.contentWindow.addEventListener("hashchange", resolve, {once: true});
+          });
+
+        test(function () {
+            iframe.contentWindow.location.hash = 'test2';
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test2', 'location.hash did not change when told to' );
+        }, 'location.hash must be allowed to change (part 1)');
+        await hashchange;
+        history.go(-1);
+        iframe.contentWindow.addEventListener("hashchange", tests5, {once: true});
+    }
+    function tests5() {
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test', 'location.hash did not change when going back' );
+        }, 'location.hash must be allowed to change (part 2)');
+        test(function () {
+            iframe.contentWindow.history.pushState('','');
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test', 'location.hash changed when an unrelated state was pushed' );
+        }, 'pushState must not alter location.hash when no URL is provided');
+        history.go(1); //should do nothing, since the pushState should have removed the forward history
+        setTimeout(tests6,50); //.go is queued to end of thread
+    }
+    function tests6() {
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test' );
+        }, 'pushState must remove all history after the current state');
+        test(function () {
+            iframe.contentWindow.history.pushState('','','#test3');
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test3' );
+        }, 'pushState must be able to set location.hash');
+        //begin setup for "remove any tasks queued by the history traversal task source"
+        iframe.contentWindow.location.hash = '#test4';
+        iframe.contentWindow.history.go(-1); //must be queued
+        try {
+            //must remove the queued navigation in the same browsing context
+            iframe.contentWindow.history.pushState('','');
+        } catch(unsuperr) {}
+        //allow the browser to mistakenly run the .go if it is going to
+        //do not put two .go commands in the same thread, in case the browser mistakenly calculates the history position when
+        //calling .go instead of when executing the traversal task - that could give a false PASS in the next test otherwise
+        setTimeout(tests7,50);
+    }
+    function tests7() {
+        iframe.contentWindow.history.go(-1); //must be queued, but should not be removed this time
+        iframe.contentWindow.addEventListener("popstate", tests8, {once: true});
+    }
+    function tests8() {
+        test(function () {
+            assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test4' );
+        }, 'pushState must remove any tasks queued by the history traversal task source');
+        //end "remove any tasks queued by the history traversal task source"
+        window.addEventListener('hashchange',function () { hashchng = true; },false);
+        try {
+            //push a state that changes the hash
+            iframe.contentWindow.history.pushState('','',iframe.contentWindow.location.pathname+'#test5');
+        } catch(unsuperr) {}
+        setTimeout(tests9,50); //allow the hashchange event to process, if the browser has mistakenly fired it
+    }
+    function tests9() {
+        test(function () {
+            assert_false( hashchng );
+        }, 'pushState must not fire hashchange events');
+        test(function () {
+            iframe.contentWindow.history.pushState('','','/testing_ignore_me_404');
+            assert_equals( iframe.contentWindow.location.pathname, '/testing_ignore_me_404' );
+        }, 'pushState must be able to set location.pathname');
+        test(function () {
+            var newURL = location.href.replace(/\/[^\/]*$/)+'/testing_ignore_me_404/';
+            iframe.contentWindow.history.pushState('','',newURL);
+            assert_equals( iframe.contentWindow.location.href, newURL );
+        }, 'pushState must be able to set absolute URLs to the same host');
+        test(function () {
+            assert_throws_dom( 'DATA_CLONE_ERR', function () {
+                history.pushState({dummy:function () {}},'');
+            } );
+        }, 'pushState must not be able to use a function as data');
+        test(function () {
+            assert_throws_dom( 'DATA_CLONE_ERR', function () {
+                history.pushState({dummy:window},'');
+            } );
+        }, 'pushState must not be able to use a DOM node as data');
+        test(function () {
+            try { a.b = c; } catch(errdata) {
+                history.pushState({dummy:errdata},'');
+                assert_equals(ReferenceError.prototype, Object.getPrototypeOf(history.state.dummy));
+            }
+        }, 'pushState must be able to use an error object as data');
+        test(function () {
+            assert_throws_dom('DATA_CLONE_ERR', iframe.contentWindow.DOMException, function () {
+                iframe.contentWindow.history.pushState(document,'');
+            });
+        }, 'security errors are expected to be thrown in the context of the document that owns the history object (2)');
+        cloneobj = {
+            nulldata: null,
+            udefdata: window.undefined,
+            booldata: true,
+            numdata: 1,
+            strdata: 'string data',
+            boolobj: new Boolean(true),
+            numobj: new Number(1),
+            strobj: new String('string data'),
+            datedata: new Date(),
+            regdata: /a/g,
+            arrdata: [1]
+        };
+        cloneobj.regdata.lastIndex = 1;
+        cloneobj.looped = cloneobj;
+        //test the ImageData type, if the browser supports it
+        var canvas = document.createElement('canvas');
+        if( canvas.getContext && ( canvas = canvas.getContext('2d') ) && canvas.createImageData ) {
+            canvassup = true;
+            cloneobj.imgdata = canvas.createImageData(1,1);
+        }
+        test(function () {
+            try {
+                iframe.contentWindow.history.pushState(cloneobj,'new title');
+            } catch(e) {
+                cloneobj.looped = null;
+                //try again because this object is needed for future tests
+                iframe.contentWindow.history.pushState(cloneobj,'new title');
+                //rethrow so the browser gets a FAIL for not coping with the circular reference; "internal structured cloning algorithm" step 1
+                throw(e);
+            }
+        }, 'pushState must be able to make structured clones of complex objects');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state && iframe.contentWindow.history.state.strdata, 'string data' );
+        }, 'history.state should also reference a clone of the original object');
+        test(function () {
+            assert_not_equals( cloneobj, iframe.contentWindow.history.state );
+        }, 'history.state should be a clone of the original object, not a reference to it');
+        /*
+        behaviour is not defined per spec, and no known implementations do this
+        test(function () {
+            assert_equals( iframe.contentDocument.title, 'new title', 'not required for specification conformance' );
+        }, 'pushState MIGHT set the document title');
+        */
+        history.go(-1);
+        iframe.contentWindow.addEventListener("popstate", tests10, {once: true});
+    }
+    function tests10() {
+        var eventtime = setTimeout(function () { tests11(false); },500); //should be cleared by the event handler long before it has a chance to fire
+        iframe.contentWindow.addEventListener('popstate',function (e) { clearTimeout(eventtime); tests11(true,e); },false);
+        history.forward();
+    }
+    function tests11(hasFired,ev) {
+        test(function () {
+            assert_true( hasFired );
+        }, 'popstate event should fire when navigation occurs');
+        test(function () {
+            assert_true( !!ev && typeof(ev.state) != 'undefined', 'state information was not passed' );
+            assert_true( !!ev.state, 'state information does not contain the expected value - browser is probably stuck in the wrong history position' );
+            assert_equals( ev.state.nulldata, null, 'state null data was not correct' );
+            assert_equals( ev.state.udefdata, window.undefined, 'state undefined data was not correct' );
+            assert_true( ev.state.booldata, 'state boolean data was not correct' );
+            assert_equals( ev.state.numdata, 1, 'state numeric data was not correct' );
+            assert_equals( ev.state.strdata, 'string data', 'state string data was not correct' );
+            assert_true( !!ev.state.datedata.getTime, 'state date data was not correct' );
+            assert_own_property( ev.state, 'regdata', 'state regex data was not correct' );
+            assert_equals( ev.state.regdata.source, 'a', 'state regex pattern data was not correct' );
+            assert_true( ev.state.regdata.global, 'state regex flag data was not correct' );
+            assert_equals( ev.state.regdata.lastIndex, 0, 'state regex lastIndex data was not correct' );
+            assert_equals( ev.state.arrdata.length, 1, 'state array data was not correct' );
+            assert_true( ev.state.boolobj.valueOf(), 'state boolean data was not correct' );
+            assert_equals( ev.state.numobj.valueOf(), 1, 'state numeric data was not correct' );
+            assert_equals( ev.state.strobj.valueOf(), 'string data', 'state string data was not correct' );
+            if( canvassup ) {
+                assert_equals( ev.state.imgdata.width, 1, 'state ImageData was not correct' );
+            }
+        }, 'popstate event should pass the state data');
+        test(function () {
+            assert_equals( ev.state.looped, ev.state );
+        }, 'state data should cope with circular object references');
+        test(function () {
+            assert_not_equals( cloneobj, ev.state );
+        }, 'state data should be a clone of the original object, not a reference to it');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state && iframe.contentWindow.history.state.strdata, 'string data' );
+        }, 'history.state should also reference a clone of the original object (2)');
+        test(function () {
+            assert_not_equals( cloneobj, iframe.contentWindow.history.state );
+        }, 'history.state should be a clone of the original object, not a reference to it (2)');
+        test(function () {
+            assert_equals( iframe.contentWindow.history.state, ev.state );
+        }, 'history.state should be identical to the object passed to the event handler unless history.state is updated');
+        try {
+            iframe.contentWindow.persistval = true;
+            iframe.contentWindow.history.pushState('','', location.href.replace(/\/[^\/]*$/,'/resources/blank3.html') );
+        } catch(unsuperr) {}
+        //it's already cached, so this should be very fast if the browser mistakenly loads it
+        //it should not need to load at all, since it's just a pushed state
+        setTimeout(tests12,1000);
+    }
+    function tests12() {
+        test(function () {
+            assert_true( iframe.contentWindow.persistval && !iframe.contentWindow.forreal );
+        }, 'pushState should not actually load the new URL');
+        atstep = 3;
+        iframe.contentWindow.location.reload(); //load the real URL
+        lasttimer = setTimeout(function () { tests13(false); },3000); //should be cleared by the onload handler long before it has a chance to fire
+    }
+    function tests13(passed) {
+        test(function () {
+            assert_true( passed, 'expected a load event to fire when reloading the URL from cache, gave up waiting after 3 seconds' );
+        }, 'reloading a pushed state should actually load the new URL');
+        //try to make browsers behave when reloading so that the correct URL is recovered - does not always work
+        iframe.contentWindow.location.href = location.href.replace(/\/[^\/]*$/,'/resources/blank.html');
+        done();
+    }
+
+    if( atstep == 1 ) {
+        //blank2 has loaded
+        atstep = 2;
+        //use a timeout, because some browsers intentionally do not add history entries for URL changes in an onload thread
+        setTimeout(tests1,100);
+    } else if( atstep == 3 ) {
+        //blank3 should now have loaded after the .reload() command
+        atstep = 4;
+        clearTimeout(lasttimer);
+        tests13(true);
+    }
+}
+
+
+
+        </script>
+    </head>
+    <body>
+
+        <noscript><p>Enable JavaScript and reload</p></noscript>
+        <p>WARNING: This test should always be loaded in a new tab/window, to avoid browsers attempting to recover the state of frames, and history length. Do not reload the test.</p>
+        <div id="log">Running test...</div>
+        <p><iframe onload="reportload();" src="resources/blank.html"></iframe></p>
+        <p><iframe src="resources/blank.html"></iframe></p>
+        <p><iframe src="resources/blank2.html"></iframe></p>
+        <p><iframe src="blank3.html"></iframe></p>
+
+    </body>
+</html>

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank.html
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Dummy page 1</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank2.html
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank2.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Dummy page 2</title>
+  </head>
+  <body>
+    <script type="text/javascript">
+if( self == top || !parent.reportload ) {
+  document.write("<p>FAIL. Browser got confused when navigating forwards, and navigated the whole window to the iframe's location, instead of just navigating the iframe. It is not possible to run the testsuite.<\/p>");
+}
+    </script>
+  </body>
+</html>

--- a/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank3.html
+++ b/LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank3.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Dummy page 3</title>
+    <script type="text/javascript">
+var forreal = true;
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3682,6 +3682,7 @@ fast/zooming/ios [ Skip ]
 http/tests/site-isolation [ Skip ]
 http/tests/contentextensions/cross-origin-content-rules.html [ Skip ]
 http/tests/gamepad/initial-gamepads-skips-empty-slot.html [ Skip ]
+http/wpt/site-isolation [ Skip ]
 
 # Tests behavior specific to MediaSessionManagerCocoa
 media/audio-session-category.html [ Skip ]

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -61,6 +61,7 @@ public:
     Ref<WebBackForwardListFrameItem> mainFrame();
     WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
     WebBackForwardListFrameItem* NODELETE childItemAtIndex(uint64_t);
+    const Vector<Ref<WebBackForwardListFrameItem>>& children() const { return m_children; }
 
     WebBackForwardListItem* NODELETE backForwardListItem() const;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2744,7 +2744,10 @@ RefPtr<API::Navigation> WebPageProxy::goForward()
     if (!forwardItem)
         return nullptr;
 
-    return goToBackForwardItem(protect(forwardItem->navigatedFrameItem()), FrameLoadType::Forward);
+    Ref frameItem = protect(preferences())->useUIProcessForBackForwardItemLoading()
+        ? forwardItem->mainFrameItem()
+        : forwardItem->navigatedFrameItem();
+    return goToBackForwardItem(WTF::move(frameItem), FrameLoadType::Forward);
 }
 
 RefPtr<API::Navigation> WebPageProxy::goBack()
@@ -2754,16 +2757,7 @@ RefPtr<API::Navigation> WebPageProxy::goBack()
     if (!backItem)
         return nullptr;
 
-    Ref frameItem = backItem->mainFrameItem();
-    if (RefPtr currentItem = backForwardList().currentItem()) {
-        if (RefPtr childItem = currentItem->navigatedFrameID() ? frameItem->childItemForFrameID(*currentItem->navigatedFrameID()) : nullptr) {
-            if (childItem.get() != frameItem.ptr())
-                WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "goBack: redirecting from mainFrameItem to child frameItem for navigatedFrameID=%" PRIu64, currentItem->navigatedFrameID()->toUInt64());
-            frameItem = childItem.releaseNonNull();
-        }
-    }
-
-    return goToBackForwardItem(frameItem, FrameLoadType::Back);
+    return goToBackForwardItem(frameItemForLegacyTraversalRouting(*backItem, "goBack"_s), FrameLoadType::Back);
 }
 
 RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListItem& item)
@@ -2854,13 +2848,93 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
     auto transaction = pageLoadState->transaction();
     pageLoadState->setPendingAPIRequest(transaction, { navigation->navigationID(), URL { item->url() } });
 
-    process->markProcessAsRecentlyUsed();
-
     auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item->url()));
-    process->send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(frameItem), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, shouldRestoreFromBackForwardCache, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), webPageIDInProcess(process));
-    process->startResponsivenessTimer();
+
+    if (preferences->useUIProcessForBackForwardItemLoading()) {
+        bool anySent = false;
+        if (RefPtr currentItem = backForwardList().currentItem())
+            anySent = dispatchPerFrameTraversals(protect(currentItem->mainFrameItem()), protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
+        else {
+            sendGoToBackForwardItemForFrame(protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
+            anySent = true;
+        }
+        if (!anySent)
+            WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "goToBackForwardItem: walk dispatched no GoToBackForwardItem messages — back/forward action will be silently dropped");
+    } else {
+        process->markProcessAsRecentlyUsed();
+        process->send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(frameItem), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, shouldRestoreFromBackForwardCache, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), webPageIDInProcess(process));
+        process->startResponsivenessTimer();
+    }
 
     return RefPtr<API::Navigation> { WTF::move(navigation) };
+}
+
+bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
+{
+    bool anySent = false;
+    if (fromFrame.frameState().itemSequenceNumber != toFrame.frameState().itemSequenceNumber) {
+        sendGoToBackForwardItemForFrame(toFrame, navigationID, frameLoadType, shouldRestore, publicSuffix);
+        anySent = true;
+    }
+
+    bool sameDocument = fromFrame.frameState().documentSequenceNumber == toFrame.frameState().documentSequenceNumber;
+    if (!sameDocument)
+        return anySent;
+
+    auto& toChildren = toFrame.children();
+    for (size_t i = 0; i < toChildren.size(); ++i) {
+        Ref toChild = toChildren[i];
+        auto childFrameID = toChild->frameID();
+        if (!childFrameID)
+            continue;
+        // Stored frameIDs can disagree across entries after a process swap; fall back to position, which is stable across history.
+        RefPtr fromChild = fromFrame.childItemForFrameID(*childFrameID);
+        if (!fromChild)
+            fromChild = fromFrame.childItemAtIndex(i);
+        if (!fromChild)
+            continue;
+        if (dispatchPerFrameTraversals(*fromChild, toChild, navigationID, frameLoadType, shouldRestore, publicSuffix))
+            anySent = true;
+    }
+    return anySent;
+}
+
+void WebPageProxy::sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
+{
+    Ref process = processForTheFrameItem(targetFrame);
+    auto suffixCopy = publicSuffix;
+    process->markProcessAsRecentlyUsed();
+    process->send(Messages::WebPage::GoToBackForwardItem({
+        navigationID,
+        targetFrame.copyFrameState(),
+        frameLoadType,
+        ShouldTreatAsContinuingLoad::No,
+        std::nullopt,
+        m_lastNavigationWasAppInitiated,
+        shouldRestore,
+        std::nullopt,
+        WTF::move(suffixCopy),
+        { },
+        WebCore::ProcessSwapDisposition::None
+    }), webPageIDInProcess(process));
+    process->startResponsivenessTimer();
+}
+
+Ref<WebBackForwardListFrameItem> WebPageProxy::frameItemForLegacyTraversalRouting(WebBackForwardListItem& targetItem, ASCIILiteral logTag)
+{
+    Ref frameItem = targetItem.mainFrameItem();
+    if (protect(preferences())->useUIProcessForBackForwardItemLoading())
+        return frameItem;
+    RefPtr currentItem = backForwardList().currentItem();
+    if (!currentItem)
+        return frameItem;
+    auto navigatedFrameID = currentItem->navigatedFrameID();
+    RefPtr childItem = navigatedFrameID ? frameItem->childItemForFrameID(*navigatedFrameID) : nullptr;
+    if (!childItem)
+        return frameItem;
+    if (childItem.get() != frameItem.ptr())
+        WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "%" PUBLIC_LOG_STRING ": redirecting from mainFrameItem to child frameItem for navigatedFrameID=%" PRIu64, logTag.characters(), navigatedFrameID->toUInt64());
+    return childItem.releaseNonNull();
 }
 
 WebProcessProxy& WebPageProxy::processForTheFrameItem(WebBackForwardListFrameItem& frameItem) const
@@ -2972,16 +3046,7 @@ void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frame
     if (!item)
         return;
 
-    Ref frameItem = item->mainFrameItem();
-    if (RefPtr currentItem = backForwardList().currentItem()) {
-        if (RefPtr childItem = currentItem->navigatedFrameID() ? frameItem->childItemForFrameID(*currentItem->navigatedFrameID()) : nullptr) {
-            if (childItem.get() != frameItem.ptr())
-                WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "goToBackForwardItemAtIndex: redirecting from mainFrameItem to child frameItem for navigatedFrameID=%" PRIu64, currentItem->navigatedFrameID()->toUInt64());
-            frameItem = childItem.releaseNonNull();
-        }
-    }
-
-    goToBackForwardItem(frameItem, frameLoadType);
+    goToBackForwardItem(frameItemForLegacyTraversalRouting(*item, "goToBackForwardItemAtIndex"_s), frameLoadType);
 }
 
 bool WebPageProxy::shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem& item)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -150,6 +150,7 @@ class NotificationResources;
 class PlatformSpeechSynthesisUtterance;
 class PlatformSpeechSynthesizer;
 class PrivateClickMeasurement;
+class PublicSuffix;
 class Region;
 class RegistrableDomain;
 class ResourceError;
@@ -246,6 +247,7 @@ enum class SelectionDirection : uint8_t;
 enum class SessionHistoryVisibility : bool;
 enum class ShouldGoToHistoryItem : uint8_t;
 enum class ShouldOpenExternalURLsPolicy : uint8_t;
+enum class ShouldRestoreFromBackForwardCache : uint8_t;
 enum class ShouldSample : bool;
 enum class ShouldTreatAsContinuingLoad : uint8_t;
 enum class TextAnimationRunMode : uint8_t;
@@ -3017,6 +3019,10 @@ private:
     Ref<WebPageProxy> navigationOriginatingPage(const FrameInfoData&);
 
     RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListFrameItem&, WebCore::FrameLoadType);
+
+    bool dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);
+    void sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);
+    Ref<WebBackForwardListFrameItem> frameItemForLegacyTraversalRouting(WebBackForwardListItem& targetItem, ASCIILiteral logTag);
 
     void updateActivityState(OptionSet<WebCore::ActivityState> flagsToUpdate);
     void updateThrottleState();


### PR DESCRIPTION
#### 0b955f563b10927ce5da920f28f5a1d6a625478f
<pre>
[Site Isolation] Replace navigatedFrameID heuristic with per-frame walk in UIProcess back/forward routing
<a href="https://bugs.webkit.org/show_bug.cgi?id=317090">https://bugs.webkit.org/show_bug.cgi?id=317090</a>
<a href="https://rdar.apple.com/179641336">rdar://179641336</a>

Reviewed by Sihui Liu.

WebPageProxy::goBack/goForward/goToBackForwardItemAtIndex selected the frame to
traverse from currentItem-&gt;navigatedFrameID(). That field names the iframe whose
forward-target the entry undoes, not the iframe a caller wants to traverse, so
it produces direction-asymmetric breakage: back happens to coincide with the
caller&apos;s intent in many cases, forward does not.

Replace the heuristic under useUIProcessForBackForwardItemLoading with a tree
walk in WebPageProxy::goToBackForwardItem. UIProcess walks the (current, target)
frame-item trees pair-wise; for each frame whose itemSequenceNumber differs it
dispatches a per-frame GoToBackForwardItem to that frame&apos;s process with that
frame&apos;s FrameState. Recursion only crosses same-document boundaries (matching
documentSequenceNumber); cross-document subtrees stop the recursion and rely on
the existing frameStateForBackForwardChildFrame pull at commit time. There is
no longer a &quot;primary&quot; frame chosen by heuristic — every frame whose state
differs is dispatched independently.

The three call sites (goBack, goForward, goToBackForwardItemAtIndex) now pass
the entry&apos;s mainFrameItem under the flag. With the flag off they keep the
original navigatedFrameID-based selection, so legacy behavior is unchanged.

The non-flag path is also unchanged: a single GoToBackForwardItem with the full
children-tree FrameState is sent to the primary process as today.

markProcessAsRecentlyUsed() and startResponsivenessTimer() are called per
destination process inside sendGoToBackForwardItemForFrame, since the walk
dispatches to multiple processes.

The legacy navigatedFrameID-based child redirection used by goBack and
goToBackForwardItemAtIndex is extracted into a shared helper
frameItemForLegacyTraversalRouting, which becomes a no-op once the flag is on.

dispatchPerFrameTraversals returns whether any GoToBackForwardItem message was
dispatched during the walk. The entry point in goToBackForwardItem logs an
error if a back/forward action would otherwise be silently dropped.

Test coverage adds two regression tests under http/wpt/site-isolation/, pinned
with webkit-test-runner [ SiteIsolationEnabled=true
UseUIProcessForBackForwardItemLoading=true ] so the path is exercised regardless
of the runner&apos;s default flags. These mirror two of the imported WPT cluster
tests that fail on origin/main with both flags on and pass after this patch.

* LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal-expected.txt: Added.
* LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html: Added.
* LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/resources/helpers.mjs: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/001-expected.txt: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/001.html: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank.html: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank2.html: Added.
* LayoutTests/http/wpt/site-isolation/the-history-interface/resources/blank3.html: Added.
* LayoutTests/platform/glib/TestExpectations: Skip http/wpt/site-isolation, matching the existing skip for http/tests/site-isolation since site isolation drawing is not implemented on the GLib ports.
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::children const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goForward):
(WebKit::WebPageProxy::goBack):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::dispatchPerFrameTraversals):
(WebKit::WebPageProxy::sendGoToBackForwardItemForFrame):
(WebKit::WebPageProxy::frameItemForLegacyTraversalRouting):
(WebKit::WebPageProxy::goToBackForwardItemAtIndex):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/315516@main">https://commits.webkit.org/315516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb740e9b4d0b6dbba671decd46743d09922aeda4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126998 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80f327a1-d58d-4023-9401-d970ec59c0c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131854 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77bc4727-7462-4ca1-9295-fd0008023cc6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172245 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112358 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12df1500-394f-4014-b8ee-529b3f3792e0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27342 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181242 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33952 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140310 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42864 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140148 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37704 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43553 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107485 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35419 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115318 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42063 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6604 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41456 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41711 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41599 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->