### PR TITLE
CoreIPCNSURLRequest decodes the attribution enum from the wrong NSNumber

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -216,7 +216,7 @@ CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
 
     RetainPtr<id> attribution = dict.get()[@"attribution"];
     if ([attribution isKindOfClass:[NSNumber class]]) {
-        auto val = [allowedProtocolTypes unsignedCharValue];
+        auto val = [attribution unsignedCharValue];
         if (isValidEnum<NSURLRequestAttribution>(val))
             m_data.attribution = static_cast<NSURLRequestAttribution>(val);
     }

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1850,6 +1850,17 @@ TEST(IPCSerialization, NSURLRequestNSURLProtocolProperties)
     runTestNS({ request.get() });
 }
 
+TEST(IPCSerialization, NSURLRequestAttribution)
+{
+    WebKit::CoreIPCNSURLRequestData requestData;
+    requestData.url = WebKit::CoreIPCURL([NSURL URLWithString:@"https://webkit.org/"]);
+    requestData.attribution = WebKit::NSURLRequestAttribution::User;
+
+    RetainPtr request = dynamic_objc_cast<NSURLRequest>(WebKit::CoreIPCNSURLRequest(WTF::move(requestData)).toID().get());
+    RetainPtr reconstructed = dynamic_objc_cast<NSURLRequest>(WebKit::CoreIPCNSURLRequest(request.get()).toID().get());
+    EXPECT_EQ([reconstructed attribution], NSURLRequestAttributionUser);
+}
+
 #endif // PLATFORM(COCOA) && HAVE(WK_SECURE_CODING_NSURLREQUEST)
 
 #if USE(AVFOUNDATION) && PLATFORM(MAC)


### PR DESCRIPTION
#### 32f57407f9537ac13b4a18a2593583a2dd40bc56
<pre>
CoreIPCNSURLRequest decodes the attribution enum from the wrong NSNumber
<a href="https://bugs.webkit.org/show_bug.cgi?id=317414">https://bugs.webkit.org/show_bug.cgi?id=317414</a>
<a href="https://rdar.apple.com/180044065">rdar://180044065</a>

Reviewed by Sihui Liu.

The attribution block guards on the &quot;attribution&quot; object but read its numeric value from the sibling
local `allowedProtocolTypes` (the variable from the immediately preceding block) instead of
`attribution`. As a result the decoded NSURLRequest carried the allowedProtocolTypes value as its
NSURLRequestAttribution, or dropped attribution entirely when that value was out of range. Every
other enum-decode block reads from its own object; read from `attribution` here too.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::CoreIPCNSURLRequest):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, NSURLRequestAttribution)):

Canonical link: <a href="https://commits.webkit.org/315712@main">https://commits.webkit.org/315712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e50fe475a2f4411c9d2e59e58828a4b2056976cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126848 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df981837-d3f8-4b7e-8f46-8f4c90f1c1de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131725 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92690 "8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba43377c-a293-4c6c-879e-0b199f42c661) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112228 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33aae893-c257-4fda-9635-a61d804af356) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33168 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31875 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27192 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181092 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140180 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42714 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140021 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43403 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107309 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25880 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35297 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115168 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41912 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6477 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41306 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41561 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->