### PR TITLE
AuthenticationExtensionsClientOutputs::fromCBOR() compares a nested-map iterator against the outer map's end()

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
@@ -35,6 +35,12 @@
 
 namespace WebCore {
 
+static bool booleanValue(const cbor::CBORValue::MapValue& map, ASCIILiteral key)
+{
+    auto iterator = map.find(cbor::CBORValue(key));
+    return iterator != map.end() && iterator->second.isBool() && iterator->second.getBool();
+}
+
 std::optional<AuthenticationExtensionsClientOutputs> AuthenticationExtensionsClientOutputs::fromCBOR(const Vector<uint8_t>& buffer)
 {
     std::optional<cbor::CBORValue> decodedValue = cbor::CBORReader::read(buffer);
@@ -49,9 +55,7 @@ std::optional<AuthenticationExtensionsClientOutputs> AuthenticationExtensionsCli
     it = decodedMap.find(cbor::CBORValue("credProps"));
     if (it != decodedMap.end() && it->second.isMap()) {
         CredentialPropertiesOutput credProps;
-        it = it->second.getMap().find(cbor::CBORValue("rk"));
-        if (it != decodedMap.end() && it->second.isBool())
-            credProps.rk = it->second.getBool();
+        credProps.rk = booleanValue(it->second.getMap(), "rk"_s);
         clientOutputs.credProps = credProps;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
@@ -33,12 +33,14 @@
 
 #include "FidoTestData.h"
 #include <JavaScriptCore/ArrayBuffer.h>
+#include <WebCore/AuthenticationExtensionsClientOutputs.h>
 #include <WebCore/AuthenticatorAttachment.h>
 #include <WebCore/AuthenticatorTransport.h>
 #include <WebCore/BufferSource.h>
 #include <WebCore/CBORReader.h>
 #include <WebCore/CBORValue.h>
 #include <WebCore/CBORWriter.h>
+#include <WebCore/CredentialPropertiesOutput.h>
 #include <WebCore/DeviceResponseConverter.h>
 #include <WebCore/FidoConstants.h>
 #include <WebCore/U2fResponseConverter.h>
@@ -666,6 +668,36 @@ TEST(CTAPResponseTest, TestReadMakeCredentialResponseWithHmacSecret)
     ASSERT_TRUE(extensions.prf);
     ASSERT_TRUE(extensions.prf->enabled);
     EXPECT_TRUE(*extensions.prf->enabled);
+}
+
+static Vector<uint8_t> encodeExtensionOutputs(cbor::CBORValue::MapValue&& map)
+{
+    auto encoded = cbor::CBORWriter::write(cbor::CBORValue(WTF::move(map)));
+    return encoded.value();
+}
+
+static Vector<uint8_t> encodeCredPropsExtensionOutputs(cbor::CBORValue::MapValue&& credPropsMap)
+{
+    cbor::CBORValue::MapValue root;
+    root[cbor::CBORValue("credProps")] = cbor::CBORValue(WTF::move(credPropsMap));
+    return encodeExtensionOutputs(WTF::move(root));
+}
+
+TEST(CTAPResponseTest, TestExtensionOutputsCredPropsWithoutRk)
+{
+    {
+        auto outputs = AuthenticationExtensionsClientOutputs::fromCBOR(encodeCredPropsExtensionOutputs({ }));
+        ASSERT_TRUE(outputs);
+        EXPECT_TRUE(outputs->credProps.has_value());
+    }
+
+    {
+        cbor::CBORValue::MapValue credProps;
+        credProps[cbor::CBORValue("unknownKey")] = cbor::CBORValue(true);
+        auto outputs = AuthenticationExtensionsClientOutputs::fromCBOR(encodeCredPropsExtensionOutputs(WTF::move(credProps)));
+        ASSERT_TRUE(outputs);
+        EXPECT_TRUE(outputs->credProps.has_value());
+    }
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 97990a2481e5152757431ac3175afd85a7284283
<pre>
AuthenticationExtensionsClientOutputs::fromCBOR() compares a nested-map iterator against the outer map&apos;s end()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317240">https://bugs.webkit.org/show_bug.cgi?id=317240</a>
<a href="https://rdar.apple.com/179858461">rdar://179858461</a>

Reviewed by Pascoe and Darin Adler.

In the credProps branch the iterator returned by find() on the nested credProps map was compared
against decodedMap.end() (the outer map). Comparing iterators from different containers is undefined
behavior, and since the nested map&apos;s end() is essentially never equal to the outer map&apos;s end(), a
credProps map lacking an &quot;rk&quot; key passed the guard and dereferenced a past-the-end iterator. Use a
separate iterator compared against the credProps map&apos;s own end(), as the largeBlob branch already
does.

Test: Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp:
(WebCore::AuthenticationExtensionsClientOutputs::fromCBOR):
* Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp:
(TestWebKitAPI::encodeExtensionOutputs):
(TestWebKitAPI::encodeCredPropsExtensionOutputs):
(TestWebKitAPI::TEST(CTAPResponseTest, TestExtensionOutputsCredPropsWithoutRk)):

Canonical link: <a href="https://commits.webkit.org/315510@main">https://commits.webkit.org/315510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47b96c5ee25104cb9ab48f89a84b0eaaa004a26f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126877 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b48679c-a4d5-40d3-b3de-9c4dc2816053) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131751 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/775856a3-97f0-4ee8-964c-5f38f9245ca2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112254 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8891278-8975-4311-ac7c-6bf15c11db9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33192 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31900 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27221 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143182 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181121 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140204 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42743 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140045 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37701 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43432 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107352 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35320 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115197 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41941 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6501 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41590 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41478 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->