### PR TITLE
Improve log efficiency in UserActivity::Impl

### DIFF
--- a/Source/WebCore/platform/LogMessages.in
+++ b/Source/WebCore/platform/LogMessages.in
@@ -205,4 +205,6 @@ SubResourceLoaderWillSendRequestInternalResourceLoadCancelledTooManyRedirects, "
 SubResourceLoaderWillSendRequestInternalResourceLoadCompleted, "[pageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 " SubResourceLoader::willSendRequestInternal: resource load completed", (uint64_t, uint64_t, uint64_t), DEFAULT, ResourceLoading
 SubResourceLoaderWillSendRequestInternalResourceLoadFinished, "[pageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 " SubResourceLoader::willSendRequestInternal: resource load finished; calling completion handler", (uint64_t, uint64_t, uint64_t), DEFAULT, ResourceLoading
 SubResourceLoaderWillSendRequestInternalTerminalStateCallingCompletionHandler, "[pageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 " SubResourceLoader::willSendRequestInternal: reached terminal state; calling completion handler", (uint64_t, uint64_t, uint64_t), DEFAULT, ResourceLoading
+UserActivityImplBeginActivity, "UserActivity::Impl::beginActivity: description=%" PUBLIC_LOG_STRING, (CString), DEFAULT, ActivityState
+UserActivityImplEndActivity, "UserActivity::Impl::endActivity: description=%" PUBLIC_LOG_STRING, (CString), DEFAULT, ActivityState
 WebCoreTestLog, "WebCore log message for testing (%u)", (unsigned), DEFAULT, Testing

--- a/Source/WebCore/platform/mac/UserActivityMac.mm
+++ b/Source/WebCore/platform/mac/UserActivityMac.mm
@@ -27,6 +27,7 @@
 #import "UserActivity.h"
 
 #import "Logging.h"
+#import <wtf/text/CString.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ UserActivity::Impl::Impl(ASCIILiteral descriptionLiteral)
 void UserActivity::Impl::beginActivity()
 {
     if (!m_activity) {
-        RELEASE_LOG(ActivityState, "%p - UserActivity::Impl::beginActivity: description=%" PUBLIC_LOG_STRING, this, [m_description UTF8String]);
+        RELEASE_LOG_FORWARDABLE(ActivityState, UserActivityImplBeginActivity, CString([m_description UTF8String]));
         NSActivityOptions options = (NSActivityUserInitiatedAllowingIdleSystemSleep | NSActivityLatencyCritical) & ~(NSActivitySuddenTerminationDisabled | NSActivityAutomaticTerminationDisabled);
         m_activity = [[NSProcessInfo processInfo] beginActivityWithOptions:options reason:m_description.get()];
     }
@@ -48,7 +49,7 @@ void UserActivity::Impl::beginActivity()
 
 void UserActivity::Impl::endActivity()
 {
-    RELEASE_LOG(ActivityState, "%p - UserActivity::Impl::endActivity: description=%" PUBLIC_LOG_STRING, this, [m_description UTF8String]);
+    RELEASE_LOG_FORWARDABLE(ActivityState, UserActivityImplEndActivity, CString([m_description UTF8String]));
     [[NSProcessInfo processInfo] endActivity:m_activity.get()];
     m_activity.clear();
 }


### PR DESCRIPTION
#### de9b867d2f8a9b6e6da2dd2600aa9a4cf557c716
<pre>
Improve log efficiency in UserActivity::Impl
<a href="https://bugs.webkit.org/show_bug.cgi?id=317419">https://bugs.webkit.org/show_bug.cgi?id=317419</a>

Reviewed by Rupin Mittal (OOPS\!).

This allows the log message to be forwarded from the WebContent process
to the UIProcess via IPC without sending the format string, improving
log efficiency.

Canonical link: <a href="https://commits.webkit.org/315486@main">https://commits.webkit.org/315486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9012b4c8758f42645b86d79262a716fb61a1e1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126857 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131732 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e364ddbf-b15f-4e99-914b-dba8b1db1cfe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34192 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28c2a0eb-3216-411a-93ac-4064221784de) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27201 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181101 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140187 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42723 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140028 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43412 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107326 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25782 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35307 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115177 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41921 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6489 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41315 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41458 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->