### PR TITLE
[Fullscreen] Element Video resizing causes video to shift partly out of window or become smaller than window

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2687,7 +2687,11 @@ static CGFloat liveResizeMinimumWidthDifference()
     auto endLiveResizeHysteresis = 500_ms;
     bool didEndLiveResizeImmediately = false;
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    if ([self _shouldForceEndLiveResize]) {
+    if ([self _shouldForceEndLiveResize]
+#if ENABLE(FULLSCREEN_API)
+        && ![_fullScreenWindowController isFullScreen]
+#endif
+    ) {
         endLiveResizeHysteresis = 0_ms;
         didEndLiveResizeImmediately = true;
     }
@@ -3798,6 +3802,16 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 {
     if (_liveResizeSnapshotState)
         [self _removeLiveSnapshotState];
+
+    _perProcessState.transactionIDForEndLiveResize = std::nullopt;
+    _perProcessState.waitingForEndLiveResizePresentationUpdate = NO;
+
+#if ENABLE(FULLSCREEN_API)
+    if ([_fullScreenWindowController isFullScreen]) {
+        [self _endLiveResizeDefault];
+        return;
+    }
+#endif
 
     if (RefPtr drawingArea = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->drawingArea()))
         _perProcessState.transactionIDForEndLiveResize = drawingArea->nextMainFrameLayerTreeTransactionID();


### PR DESCRIPTION
#### b2b580981c464483f2228f4da9b9981178424a7b
<pre>
[Fullscreen] Element Video resizing causes video to shift partly out of window or become smaller than window
<a href="https://bugs.webkit.org/show_bug.cgi?id=317417">https://bugs.webkit.org/show_bug.cgi?id=317417</a>
<a href="https://rdar.apple.com/179974251">rdar://179974251</a>

Reviewed by Abrar Rahman Protyasha.

The introduction of responsive live resizing on visionOS from 312437@main triggers additional
relayouts that conflict with the WKFullScreenViewController.viewDidLayoutSubviews when entering
element fullscreen. This causes issues where, while the fullscreen controller tries to layout
its subviews, the web view is also committing additional updates to the layer tree.

In general, the responsive live resize behavior is not needed for element fullscreen, so this
patch applies three changes:
1. We separate the logic behind _endLiveResize for the general case (without responsive relayout)
and the responsive relayout case. This also addresses the concerns raised in
<a href="https://bugs.webkit.org/show_bug.cgi?id=317000">https://bugs.webkit.org/show_bug.cgi?id=317000</a>

2. We guard the `endLiveResizeHysteresis` change in `_rescheduleEndLiveResizeTimer` if we are
in fullscreen. This prevents us from triggering resize relayouts while resizing the fullscreen
window.

3. We also guard the `_endLiveResizeWithResponsiveRelayout` path if we are in fullscreen. This
prevents us from setting the liveResizeSnapshotState and the transactionIDForEndLiveResize
during fullscreen, which can cause issues with the rest of the layer tree commit flow.

The combination of these 3 changes result in us defaulting to the general, non-responsive live
resize relayout machinery when we are in fullscreen, which is pre-existing behavior.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _rescheduleEndLiveResizeTimer]):
Add a guard to setting endLiveResizeHysteresis to 0ms if we are in fullscreen

(-[WKWebView _endLiveResizeWithResponsiveRelayout]):
(-[WKWebView _endLiveResizeDefault]):
Separate the &quot;default live resize&quot; logic from the &quot;responsive live resize&quot; logic
_endLiveResizeWithResponsiveRelayout also calls _endLiveResizeDefault when we are
in fullscreen

(-[WKWebView _endLiveResize]):
Update calls to use the helper functions as explained above

Canonical link: <a href="https://commits.webkit.org/315642@main">https://commits.webkit.org/315642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3b27188e54835eac0afa5e7b72c72e1e59d93a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43562 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178999 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172599 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112690 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27696 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181598 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43218 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140471 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37801 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43907 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/35742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42417 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42065 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/41953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->