### PR TITLE
RTCPacketOptions::serializableData has the SRTP auth key ternary branches swapped

### DIFF
--- a/Source/WebKit/Shared/RTCPacketOptions.cpp
+++ b/Source/WebKit/Shared/RTCPacketOptions.cpp
@@ -33,6 +33,8 @@
 
 namespace WebKit {
 
+#if !PLATFORM(COCOA)
+
 static_assert(static_cast<webrtc::DiffServCodePoint>(RTCPacketOptions::DifferentiatedServicesCodePoint::NoChange) == webrtc::DSCP_NO_CHANGE);
 static_assert(static_cast<webrtc::DiffServCodePoint>(RTCPacketOptions::DifferentiatedServicesCodePoint::Default) == webrtc::DSCP_DEFAULT);
 static_assert(static_cast<webrtc::DiffServCodePoint>(RTCPacketOptions::DifferentiatedServicesCodePoint::CS0) == webrtc::DSCP_CS0);
@@ -109,10 +111,14 @@ static RTCPacketOptions::DifferentiatedServicesCodePoint NODELETE toDifferentiat
     return RTCPacketOptions::DifferentiatedServicesCodePoint::Default;
 }
 
+#endif // !PLATFORM(COCOA)
+
 RTCPacketOptions::RTCPacketOptions(const SerializableData& data)
 {
-    options.dscp = static_cast<webrtc::DiffServCodePoint>(data.dscp);
     options.packet_id = data.packetId;
+
+#if !PLATFORM(COCOA)
+    options.dscp = static_cast<webrtc::DiffServCodePoint>(data.dscp);
 
     webrtc::PacketTimeUpdateParams params;
     params.rtp_sendtime_extension_id = data.rtpSendtimeExtensionId;
@@ -122,17 +128,20 @@ RTCPacketOptions::RTCPacketOptions(const SerializableData& data)
     params.srtp_packet_index = data.srtpPacketIndex;
 
     options.packet_time_params = WTF::move(params);
+#endif
 }
 
 auto RTCPacketOptions::serializableData() const -> SerializableData
 {
     return {
-        toDifferentiatedServicesCodePoint(options.dscp),
         safeCast<int32_t>(options.packet_id),
+#if !PLATFORM(COCOA)
+        toDifferentiatedServicesCodePoint(options.dscp),
         options.packet_time_params.rtp_sendtime_extension_id,
         static_cast<int64_t>(options.packet_time_params.srtp_auth_tag_len),
-        options.packet_time_params.srtp_auth_tag_len > 0  ? std::span<const char> { } : std::span<const char> { options.packet_time_params.srtp_auth_key },
+        options.packet_time_params.srtp_auth_tag_len > 0  ? std::span<const char> { options.packet_time_params.srtp_auth_key } : std::span<const char> { },
         options.packet_time_params.srtp_packet_index
+#endif
     };
 }
 

--- a/Source/WebKit/Shared/RTCPacketOptions.h
+++ b/Source/WebKit/Shared/RTCPacketOptions.h
@@ -64,12 +64,14 @@ struct RTCPacketOptions {
     };
 
     struct SerializableData {
-        DifferentiatedServicesCodePoint dscp;
         int32_t packetId;
+#if !PLATFORM(COCOA)
+        DifferentiatedServicesCodePoint dscp;
         int rtpSendtimeExtensionId;
         int64_t srtpAuthTagLength;
         std::span<const char> srtpAuthKey;
         int64_t srtpPacketIndex;
+#endif
     };
 
     explicit RTCPacketOptions(const webrtc::AsyncSocketPacketOptions& options)

--- a/Source/WebKit/Shared/RTCPacketOptions.serialization.in
+++ b/Source/WebKit/Shared/RTCPacketOptions.serialization.in
@@ -22,6 +22,7 @@
 
 #if USE(LIBWEBRTC)
 
+#if !PLATFORM(COCOA)
 [Nested] enum class WebKit::RTCPacketOptions::DifferentiatedServicesCodePoint : int8_t {
     NoChange,
     CS0,
@@ -46,14 +47,17 @@
     CS6,
     CS7
 };
+#endif
 
 [Nested] struct WebKit::RTCPacketOptions::SerializableData {
-    WebKit::RTCPacketOptions::DifferentiatedServicesCodePoint dscp;
     int32_t packetId;
+#if !PLATFORM(COCOA)
+    WebKit::RTCPacketOptions::DifferentiatedServicesCodePoint dscp;
     int rtpSendtimeExtensionId;
     int64_t srtpAuthTagLength;
     std::span<const char> srtpAuthKey;
     int64_t srtpPacketIndex;
+#endif
 };
 
 struct WebKit::RTCPacketOptions {


### PR DESCRIPTION
#### 9de1add22c90b99c1770c024c121cbe72e1eab4a
<pre>
RTCPacketOptions::serializableData has the SRTP auth key ternary branches swapped
<a href="https://bugs.webkit.org/show_bug.cgi?id=317426">https://bugs.webkit.org/show_bug.cgi?id=317426</a>
<a href="https://rdar.apple.com/180051570">rdar://180051570</a>

Reviewed by Youenn Fablet.

Fixed the swapped ternary in RTCPacketOptions::serializableData.

Also compile out all fields but packet_id on Cocoa platforms, as they are not used.

* Source/WebKit/Shared/RTCPacketOptions.cpp:
(WebKit::RTCPacketOptions::RTCPacketOptions):
(WebKit::RTCPacketOptions::serializableData const):
* Source/WebKit/Shared/RTCPacketOptions.h:
* Source/WebKit/Shared/RTCPacketOptions.serialization.in:

Canonical link: <a href="https://commits.webkit.org/316287@main">https://commits.webkit.org/316287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4589cf2223ee4c921ee28c455835593f353cca67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa5f08bb-40c8-42c4-b2e7-1cc957ab200d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132406 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93292 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aaefee54-d495-4c60-968b-2901fcf1509a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112908 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c09a1445-d92b-470d-a731-214a48801a1a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34231 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32548 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27949 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181850 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140859 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43470 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140690 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44159 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29199 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108454 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26095 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35959 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115924 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42670 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7299 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42062 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->