### PR TITLE
Web Inspector: [SI] add per-frame FrameDOMStorageAgent (enable/disable)

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/DOMStorage.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOMStorage.json
@@ -2,7 +2,7 @@
     "domain": "DOMStorage",
     "description": "Query and modify DOM storage.",
     "debuggableTypes": ["itml", "web-page"],
-    "targetTypes": ["itml", "page"],
+    "targetTypes": ["itml", "frame", "page"],
     "types": [
         {
             "id": "StorageId",

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1961,6 +1961,7 @@ inspector/agents/frame/FrameCSSAgent.cpp @header:RenderStyleGetters
 inspector/agents/frame/FrameConsoleAgent.cpp
 inspector/agents/frame/FrameDOMAgent.cpp
 inspector/agents/frame/FrameDOMAgentStubs.cpp
+inspector/agents/frame/FrameDOMStorageAgent.cpp
 inspector/agents/frame/FrameDebuggerAgent.cpp
 inspector/agents/frame/FrameWorkerAgent.cpp
 inspector/agents/page/PageAuditAgent.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2707,6 +2707,7 @@
 		5E2C43741BCF0D750001E2BC /* JSRTCRtpSender.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E2C43701BCF0D690001E2BC /* JSRTCRtpSender.h */; };
 		5E2C43741BCF0D750001E2BE /* JSRTCRtpParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E2C43701BCF0D690001E2BE /* JSRTCRtpParameters.h */; };
 		5E3DD8092F903C9A00250DF5 /* FrameDOMAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E3DD8062F903C9A00250DF5 /* FrameDOMAgent.h */; };
+		5E3DD80C2F903C9A00250DF5 /* FrameDOMStorageAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E3DD80A2F903C9A00250DF5 /* FrameDOMStorageAgent.h */; };
 		5E5E2B141CFC3E75000C0D85 /* RTCRtpTransceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E5E2B111CFC3E4B000C0D85 /* RTCRtpTransceiver.h */; };
 		5EA725D31ACABD4700EAD17B /* MediaDevices.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EA725CE1ACABCD900EAD17B /* MediaDevices.h */; };
 		5EA725D61ACABD5700EAD17B /* NavigatorMediaDevices.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EA725CB1ACABCB500EAD17B /* NavigatorMediaDevices.h */; };
@@ -13748,6 +13749,8 @@
 		5E3DD8062F903C9A00250DF5 /* FrameDOMAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameDOMAgent.h; sourceTree = "<group>"; };
 		5E3DD8072F903C9A00250DF5 /* FrameDOMAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameDOMAgent.cpp; sourceTree = "<group>"; };
 		5E3DD8082F903C9A00250DF5 /* FrameDOMAgentStubs.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameDOMAgentStubs.cpp; sourceTree = "<group>"; };
+		5E3DD80A2F903C9A00250DF5 /* FrameDOMStorageAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameDOMStorageAgent.h; sourceTree = "<group>"; };
+		5E3DD80B2F903C9A00250DF5 /* FrameDOMStorageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameDOMStorageAgent.cpp; sourceTree = "<group>"; };
 		5E5E2B101CFC3E4B000C0D85 /* RTCRtpTransceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RTCRtpTransceiver.cpp; sourceTree = "<group>"; };
 		5E5E2B111CFC3E4B000C0D85 /* RTCRtpTransceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtpTransceiver.h; sourceTree = "<group>"; };
 		5E5E2B121CFC3E4B000C0D85 /* RTCRtpTransceiver.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RTCRtpTransceiver.idl; sourceTree = "<group>"; };
@@ -41540,6 +41543,8 @@
 				5E3DD8072F903C9A00250DF5 /* FrameDOMAgent.cpp */,
 				5E3DD8062F903C9A00250DF5 /* FrameDOMAgent.h */,
 				5E3DD8082F903C9A00250DF5 /* FrameDOMAgentStubs.cpp */,
+				5E3DD80B2F903C9A00250DF5 /* FrameDOMStorageAgent.cpp */,
+				5E3DD80A2F903C9A00250DF5 /* FrameDOMStorageAgent.h */,
 				5EAA0A2B2F47C803009CAB0D /* FrameRuntimeAgent.cpp */,
 				5EAA0A2A2F47C803009CAB0D /* FrameRuntimeAgent.h */,
 				5EAA1A372F4FC900009CAB0D /* FrameWorkerAgent.cpp */,
@@ -45534,6 +45539,7 @@
 				974A862314B7ADBB003FDC76 /* FrameDestructionObserver.h in Headers */,
 				46014ACC28333F65004C0B84 /* FrameDestructionObserverInlines.h in Headers */,
 				5E3DD8092F903C9A00250DF5 /* FrameDOMAgent.h in Headers */,
+				5E3DD80C2F903C9A00250DF5 /* FrameDOMStorageAgent.h in Headers */,
 				0F11781822E3C47F008BD570 /* FrameIdentifier.h in Headers */,
 				9B46C04B2DC4A867002E22C4 /* FrameInlines.h in Headers */,
 				F30EE46B2E721BA800935B60 /* FrameInspectorController.h in Headers */,

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -35,6 +35,7 @@
 #include "FrameCSSAgent.h"
 #include "FrameConsoleAgent.h"
 #include "FrameDOMAgent.h"
+#include "FrameDOMStorageAgent.h"
 #include "FrameDebugger.h"
 #include "FrameDebuggerAgent.h"
 #include "FrameInlines.h"
@@ -151,6 +152,7 @@ void FrameInspectorController::createLazyAgents()
     auto context = frameAgentContext();
     m_agents.append(makeUniqueRef<FrameDebuggerAgent>(context));
     m_agents.append(makeUniqueRef<FrameDOMAgent>(context));
+    m_agents.append(makeUniqueRef<FrameDOMStorageAgent>(context));
     m_agents.append(makeUniqueRef<FrameRuntimeAgent>(context));
     m_agents.append(makeUniqueRef<FrameCSSAgent>(context));
     m_agents.append(makeUniqueRef<FrameWorkerAgent>(context));

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -61,6 +61,7 @@ class InspectorTimelineAgent;
 class InspectorWorkerAgent;
 class FrameCSSAgent;
 class FrameDOMAgent;
+class FrameDOMStorageAgent;
 class FrameDebuggerAgent;
 class FrameRuntimeAgent;
 class PageCanvasAgent;
@@ -84,6 +85,7 @@ class WebHeapAgent;
 #define DEFINE_INSPECTOR_AGENT_DOMDebugger(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorDOMDebuggerAgent, DOMDebuggerAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_DOMDebugger_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageDOMDebuggerAgent, PageDOMDebuggerAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_DOMStorage(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorDOMStorageAgent, DOMStorageAgent, Getter, Setter)
+#define DEFINE_INSPECTOR_AGENT_DOMStorage_Frame(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, FrameDOMStorageAgent, FrameDOMStorageAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Debugger_Web(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, WebDebuggerAgent, WebDebuggerAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Debugger_Frame(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, FrameDebuggerAgent, FrameDebuggerAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Debugger_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageDebuggerAgent, PageDebuggerAgent, Getter, Setter)
@@ -142,6 +144,7 @@ class WebHeapAgent;
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, DOMDebugger) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, DOMDebugger_Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, DOMStorage) \
+    DEFINE_ENABLED_INSPECTOR_AGENT(macro, DOMStorage_Frame) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Heap_Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, LayerTree) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Memory) \

--- a/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameDOMStorageAgent.h"
+
+#include "InstrumentingAgents.h"
+#include "LocalFrame.h"
+#include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameDOMStorageAgent);
+
+FrameDOMStorageAgent::FrameDOMStorageAgent(FrameAgentContext& context)
+    : InspectorAgentBase("DOMStorage"_s, context)
+    , m_frontendDispatcher(makeUniqueRef<Inspector::DOMStorageFrontendDispatcher>(context.frontendRouter))
+    , m_backendDispatcher(Inspector::DOMStorageBackendDispatcher::create(Ref { context.backendDispatcher }, this))
+    , m_inspectedFrame(context.inspectedFrame)
+{
+}
+
+FrameDOMStorageAgent::~FrameDOMStorageAgent() = default;
+
+void FrameDOMStorageAgent::didCreateFrontendAndBackend()
+{
+}
+
+void FrameDOMStorageAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
+{
+    disable();
+}
+
+Inspector::CommandResult<void> FrameDOMStorageAgent::enable()
+{
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledFrameDOMStorageAgent() == this)
+        return { };
+
+    agents->setEnabledFrameDOMStorageAgent(this);
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMStorageAgent::disable()
+{
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledFrameDOMStorageAgent() != this)
+        return { };
+
+    agents->setEnabledFrameDOMStorageAgent(nullptr);
+
+    return { };
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOMStorage::Item>>> FrameDOMStorageAgent::getDOMStorageItems(Ref<JSON::Object>&&)
+{
+    // FIXME: <rdar://179249711>: Implement DOMStorage commands for frame targets.
+    return makeUnexpected("DOMStorage commands are not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMStorageAgent::setDOMStorageItem(Ref<JSON::Object>&&, const String&, const String&)
+{
+    // FIXME: <rdar://179249711>: Implement DOMStorage commands for frame targets.
+    return makeUnexpected("DOMStorage commands are not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMStorageAgent::removeDOMStorageItem(Ref<JSON::Object>&&, const String&)
+{
+    // FIXME: <rdar://179249711>: Implement DOMStorage commands for frame targets.
+    return makeUnexpected("DOMStorage commands are not yet implemented for frame targets"_s);
+}
+
+Inspector::CommandResult<void> FrameDOMStorageAgent::clearDOMStorageItems(Ref<JSON::Object>&&)
+{
+    // FIXME: <rdar://179249711>: Implement DOMStorage commands for frame targets.
+    return makeUnexpected("DOMStorage commands are not yet implemented for frame targets"_s);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorWebAgentBase.h"
+#include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
+#include <wtf/text/WTFString.h>
+
+namespace Inspector {
+class DOMStorageFrontendDispatcher;
+}
+
+namespace WebCore {
+
+class LocalFrame;
+
+// FrameDOMStorageAgent is the per-frame DOMStorage agent for Site Isolation. Each
+// LocalFrame owns one, and it only ever serves its own frame's storage areas (which
+// are the only ones reachable in this frame's process). This deliberately replaces the
+// page-level InspectorDOMStorageAgent's origin-based frame-tree lookup, which cannot
+// reach cross-origin (out-of-process RemoteFrame) storage under Site Isolation.
+class FrameDOMStorageAgent final : public InspectorAgentBase, public Inspector::DOMStorageBackendDispatcherHandler, public CanMakeCheckedPtr<FrameDOMStorageAgent> {
+    WTF_MAKE_NONCOPYABLE(FrameDOMStorageAgent);
+    WTF_MAKE_TZONE_ALLOCATED(FrameDOMStorageAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameDOMStorageAgent);
+public:
+    explicit FrameDOMStorageAgent(FrameAgentContext&);
+    ~FrameDOMStorageAgent();
+
+    // InspectorAgentBase
+    void didCreateFrontendAndBackend() override;
+    void willDestroyFrontendAndBackend(Inspector::DisconnectReason) override;
+
+    // DOMStorageBackendDispatcherHandler
+    Inspector::CommandResult<void> enable() override;
+    Inspector::CommandResult<void> disable() override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOMStorage::Item>>> getDOMStorageItems(Ref<JSON::Object>&& storageId) override;
+    Inspector::CommandResult<void> setDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key, const String& value) override;
+    Inspector::CommandResult<void> removeDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key) override;
+    Inspector::CommandResult<void> clearDOMStorageItems(Ref<JSON::Object>&& storageId) override;
+
+private:
+    const UniqueRef<Inspector::DOMStorageFrontendDispatcher> m_frontendDispatcher;
+    const Ref<Inspector::DOMStorageBackendDispatcher> m_backendDispatcher;
+
+    WeakRef<LocalFrame> m_inspectedFrame;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### e1679b539c6174f7b2628eda2b25fb21cba830be
<pre>
Web Inspector: [SI] add per-frame FrameDOMStorageAgent (enable/disable)
<a href="https://bugs.webkit.org/show_bug.cgi?id=316799">https://bugs.webkit.org/show_bug.cgi?id=316799</a>
<a href="https://rdar.apple.com/179249922">rdar://179249922</a>

Reviewed by BJ Burg.

Introduce FrameDOMStorageAgent, the per-frame DOMStorage agent for Site
Isolation. Each LocalFrame&apos;s FrameInspectorController creates one, and
it registers itself as the enabled per-frame DOMStorage agent on its
frame&apos;s InstrumentingAgents.

This patch is enablement only: enable/disable are functional, and the
DOMStorage domain now advertises the &quot;frame&quot; target type so a frame
target exposes DOMStorageAgent to the frontend. The storage commands are
present as &quot;Not supported on frame targets&quot; stubs and are implemented in
a follow-up.

enable() is idempotent: unlike the page-level InspectorDOMStorageAgent
(which errors on a redundant enable), a repeat enable for the same agent
is treated as a no-op, matching the sibling Frame* agents (e.g.
FrameCSSAgent).

* Source/JavaScriptCore/inspector/protocol/DOMStorage.json:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::createLazyAgents):
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp: Added.
(WebCore::FrameDOMStorageAgent::FrameDOMStorageAgent):
(WebCore::m_inspectedFrame):
(WebCore::FrameDOMStorageAgent::didCreateFrontendAndBackend):
(WebCore::FrameDOMStorageAgent::willDestroyFrontendAndBackend):
(WebCore::FrameDOMStorageAgent::enable):
(WebCore::FrameDOMStorageAgent::disable):
(WebCore::FrameDOMStorageAgent::getDOMStorageItems):
(WebCore::FrameDOMStorageAgent::setDOMStorageItem):
(WebCore::FrameDOMStorageAgent::removeDOMStorageItem):
(WebCore::FrameDOMStorageAgent::clearDOMStorageItems):
* Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h: Added.

Canonical link: <a href="https://commits.webkit.org/316491@main">https://commits.webkit.org/316491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/729cec1912d0cda22124ea61d379d20225701546

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181970 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130069 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bbd1e13-8b12-4f4c-9743-2b069712e1e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46102 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35568473-d5c0-40c0-a388-7bf0041739d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175471 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114654 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d4eea40-0f69-4042-8512-159394354c5e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30570 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3238 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184503 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33774 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37181 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46103 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142836 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46781 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111586 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26177 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37863 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205191 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45298 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9158 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54785 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44698 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44930 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44757 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->