### PR TITLE
[GFC] Items have incorrect position within the grid's border box.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008-expected.html
@@ -1,3 +1,6 @@
 <!DOCTYPE html>
-<p>Test passes if there is a filled green square.</p>
-<div style="width: 100px; height: 100px; background: green;"></div>
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the grid item (red outline), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; width: 200px; height: 200px; outline: 1px solid black;">
+  <div style="position: absolute; left: 25px; top: 25px; width: 150px; height: 150px; outline: 1px solid red;"></div>
+  <div style="position: absolute; left: 25px; top: 25px; width: 100px; height: 100px; background: green; outline: 1px solid blue;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
-<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
-<p>Test passes if there is a filled green square.</p>
-<div style="position: relative; display: grid; width: 150px; height: 150px; padding: 25px; grid-template-columns: 150px; grid-template-rows: 150px;">
-  <div style="grid-column: 1/2; grid-row: 1/2;">
-    <div style="position: absolute; width: 50%; height: 50%; background: green;"></div>
+<link rel="match" href="positioned-grid-descendant-containing-block-008-expected.html">
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the grid item (red outline), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; display: grid; width: 150px; height: 150px; padding: 25px; grid-template-columns: 150px; grid-template-rows: 150px; outline: 1px solid black;">
+  <div style="grid-column: 1/2; grid-row: 1/2; outline: 1px solid red;">
+    <div style="position: absolute; width: 50%; height: 50%; background: green; outline: 1px solid blue;"></div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009-expected.html
@@ -1,3 +1,6 @@
 <!DOCTYPE html>
-<p>Test passes if there is a filled green square.</p>
-<div style="width: 100px; height: 100px; background: green;"></div>
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the grid area (red outline matches the grid item), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; width: 240px; height: 240px; outline: 1px solid black;">
+  <div style="position: absolute; left: 20px; top: 20px; width: 200px; height: 200px; outline: 1px solid red;"></div>
+  <div style="position: absolute; left: 20px; top: 20px; width: 100px; height: 100px; background: green; outline: 1px solid blue;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
-<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
-<p>Test passes if there is a filled green square.</p>
-<div style="position: relative; display: grid; width: 200px; height: 200px; padding: 20px; grid-template-columns: 200px; grid-template-rows: 200px;">
-  <div style="grid-column: 1/2; grid-row: 1/2;">
-    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green;"></div>
+<link rel="match" href="positioned-grid-descendant-containing-block-009-expected.html">
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the grid area (red outline matches the grid item), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; display: grid; width: 200px; height: 200px; padding: 20px; grid-template-columns: 200px; grid-template-rows: 200px; outline: 1px solid black;">
+  <div style="grid-column: 1/2; grid-row: 1/2; outline: 1px solid red;">
+    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green; outline: 1px solid blue;"></div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010-expected.html
@@ -1,3 +1,6 @@
 <!DOCTYPE html>
-<p>Test passes if there is a filled green square.</p>
-<div style="width: 100px; height: 100px; background: green;"></div>
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the first grid area (red outline matches the grid item), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; width: 440px; height: 440px; outline: 1px solid black;">
+  <div style="position: absolute; left: 20px; top: 20px; width: 200px; height: 200px; outline: 1px solid red;"></div>
+  <div style="position: absolute; left: 20px; top: 20px; width: 100px; height: 100px; background: green; outline: 1px solid blue;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
-<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
-<p>Test passes if there is a filled green square.</p>
-<div style="position: relative; display: grid; width: 400px; height: 400px; padding: 20px; grid-template-columns: 200px 200px; grid-template-rows: 200px 200px;">
-  <div style="grid-column: 1/2; grid-row: 1/2;">
-    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green;"></div>
+<link rel="match" href="positioned-grid-descendant-containing-block-010-expected.html">
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the first grid area (red outline matches the grid item), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; display: grid; width: 400px; height: 400px; padding: 20px; grid-template-columns: 200px 200px; grid-template-rows: 200px 200px; outline: 1px solid black;">
+  <div style="grid-column: 1/2; grid-row: 1/2; outline: 1px solid red;">
+    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green; outline: 1px solid blue;"></div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012-expected.html
@@ -1,3 +1,6 @@
 <!DOCTYPE html>
-<p>Test passes if there is a filled green square.</p>
-<div style="width: 100px; height: 100px; background: green;"></div>
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the grid item (red outline), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; width: 200px; height: 200px; outline: 1px solid black;">
+  <div style="position: absolute; left: 25px; top: 25px; width: 150px; height: 150px; outline: 1px solid red;"></div>
+  <div style="position: absolute; left: 25px; top: 25px; width: 100px; height: 100px; background: green; outline: 1px solid blue;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
-<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
-<p>Test passes if there is a filled green square.</p>
-<div style="position: relative; display: grid; width: 150px; padding: 25px; grid-template-columns: 150px; grid-template-rows: 150px;">
-  <div style="grid-column: 1/2; grid-row: 1/2;">
-    <div style="position: absolute; width: 50%; height: 50%; background: green;"></div>
+<link rel="match" href="positioned-grid-descendant-containing-block-012-expected.html">
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the grid item (red outline), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; display: grid; width: 150px; padding: 25px; grid-template-columns: 150px; grid-template-rows: 150px; outline: 1px solid black;">
+  <div style="grid-column: 1/2; grid-row: 1/2; outline: 1px solid red;">
+    <div style="position: absolute; width: 50%; height: 50%; background: green; outline: 1px solid blue;"></div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013-expected.html
@@ -1,3 +1,6 @@
 <!DOCTYPE html>
-<p>Test passes if there is a filled green square.</p>
-<div style="width: 100px; height: 100px; background: green;"></div>
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the first grid area (red outline matches the grid item), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; width: 440px; height: 440px; outline: 1px solid black;">
+  <div style="position: absolute; left: 20px; top: 20px; width: 200px; height: 200px; outline: 1px solid red;"></div>
+  <div style="position: absolute; left: 20px; top: 20px; width: 100px; height: 100px; background: green; outline: 1px solid blue;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos">
-<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
-<p>Test passes if there is a filled green square.</p>
-<div style="position: relative; display: grid; width: 400px; padding: 20px; grid-template-columns: 200px 200px; grid-template-rows: 200px 200px;">
-  <div style="grid-column: 1/2; grid-row: 1/2;">
-    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green;"></div>
+<link rel="match" href="positioned-grid-descendant-containing-block-013-expected.html">
+<p>Test passes if the green abspos box (blue outline) sits at the top-left of the first grid area (red outline matches the grid item), inset by the grid container's padding (black outline).</p>
+<div style="position: relative; display: grid; width: 400px; padding: 20px; grid-template-columns: 200px 200px; grid-template-rows: 200px 200px; outline: 1px solid black;">
+  <div style="grid-column: 1/2; grid-row: 1/2; outline: 1px solid red;">
+    <div style="position: absolute; grid-column: 1/2; grid-row: 1/2; width: 50%; height: 50%; background: green; outline: 1px solid blue;"></div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-001-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is inside the black border at the top-left of the grid content area.</p>
+<div style="width: 100px; height: 100px; border: 10px solid black;">
+    <div style="width: 50px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-001-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is inside the black border at the top-left of the grid content area.</p>
+<div style="width: 100px; height: 100px; border: 10px solid black;">
+    <div style="width: 50px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-001.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/">
+<link rel="match" href="grid-item-border-padding-001-ref.html">
+<style>
+.grid {
+    display: grid;
+    width: 100px;
+    height: 100px;
+    grid-template-columns: 100px;
+    grid-template-rows: 100px;
+    border: 10px solid black;
+}
+.item {
+    width: 50px;
+    height: 50px;
+    grid-row: 1/2;
+    background-color: green;
+}
+</style>
+<p>Test passes if the green box is inside the black border at the top-left of the grid content area.</p>
+<div class="grid">
+    <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-002-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is inset by the padding from the outline.</p>
+<div style="width: 100px; height: 100px; padding: 10px; outline: 1px solid black;">
+    <div style="width: 50px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-002-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is inset by the padding from the outline.</p>
+<div style="width: 100px; height: 100px; padding: 10px; outline: 1px solid black;">
+    <div style="width: 50px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-002.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/">
+<link rel="match" href="grid-item-border-padding-002-ref.html">
+<style>
+.grid {
+    display: grid;
+    width: 100px;
+    height: 100px;
+    grid-template-columns: 100px;
+    grid-template-rows: 100px;
+    padding: 10px;
+    outline: 1px solid black;
+}
+.item {
+    width: 50px;
+    height: 50px;
+    grid-row: 1/2;
+    background-color: green;
+}
+</style>
+<p>Test passes if the green box is inset by the padding from the outline.</p>
+<div class="grid">
+    <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-003-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is inset by border and padding.</p>
+<div style="width: 100px; height: 100px; border: 5px solid black; padding: 10px;">
+    <div style="width: 50px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-003-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is inset by border and padding.</p>
+<div style="width: 100px; height: 100px; border: 5px solid black; padding: 10px;">
+    <div style="width: 50px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-003.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/">
+<link rel="match" href="grid-item-border-padding-003-ref.html">
+<style>
+.grid {
+    display: grid;
+    width: 100px;
+    height: 100px;
+    grid-template-columns: 100px;
+    grid-template-rows: 100px;
+    border: 5px solid black;
+    padding: 10px;
+}
+.item {
+    width: 50px;
+    height: 50px;
+    grid-row: 1/2;
+    background-color: green;
+}
+</style>
+<p>Test passes if the green box is inset by border and padding.</p>
+<div class="grid">
+    <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-004-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is correctly inset by asymmetric border and padding.</p>
+<div style="width: 100px; height: 100px; border-width: 5px 10px 15px 20px; border-style: solid; border-color: black; padding: 5px 10px 15px 20px;">
+    <div style="width: 50px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-004-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-004-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is correctly inset by asymmetric border and padding.</p>
+<div style="width: 100px; height: 100px; border-width: 5px 10px 15px 20px; border-style: solid; border-color: black; padding: 5px 10px 15px 20px;">
+    <div style="width: 50px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-004.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/">
+<link rel="match" href="grid-item-border-padding-004-ref.html">
+<style>
+.grid {
+    display: grid;
+    width: 100px;
+    height: 100px;
+    grid-template-columns: 100px;
+    grid-template-rows: 100px;
+    border-width: 5px 10px 15px 20px;
+    border-style: solid;
+    border-color: black;
+    padding: 5px 10px 15px 20px;
+}
+.item {
+    width: 50px;
+    height: 50px;
+    grid-row: 1/2;
+    background-color: green;
+}
+</style>
+<p>Test passes if the green box is correctly inset by asymmetric border and padding.</p>
+<div class="grid">
+    <div class="item"></div>
+</div>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -151,13 +151,16 @@ static inline Layout::GridLayoutConstraints constraintsForGridContent(const Layo
 
 void GridLayout::updateGridItemRenderers()
 {
+    CheckedRef layoutState = this->layoutState();
+    auto& gridBoxGeometry = layoutState->geometryForBox(gridBox());
+    auto contentBoxOffset = LayoutPoint(gridBoxGeometry.contentBoxLeft(), gridBoxGeometry.contentBoxTop());
+
     for (CheckedRef layoutBox : formattingContextBoxes(gridBox())) {
         CheckedRef renderer = downcast<RenderBox>(*layoutBox->rendererForIntegration());
-        CheckedRef layoutState = this->layoutState();
         auto& gridItemGeometry = layoutState->geometryForBox(layoutBox);
         auto borderBoxRect = Layout::BoxGeometry::borderBoxRect(gridItemGeometry);
 
-        renderer->setLocation(borderBoxRect.topLeft());
+        renderer->setLocation(contentBoxOffset + borderBoxRect.topLeft());
         renderer->setWidth(borderBoxRect.width());
         renderer->setHeight(borderBoxRect.height());
 


### PR DESCRIPTION
#### 7f1da39fa5e890a99e1d24511132c32848d503ef
<pre>
[GFC] Items have incorrect position within the grid&apos;s border box.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317420">https://bugs.webkit.org/show_bug.cgi?id=317420</a>
<a href="https://rdar.apple.com/180047102">rdar://180047102</a>

Reviewed by Alan Baradlay.

Grid items were positioned relative to the grid container&apos;s border box
instead of its content box. Offset by contentBoxLeft/contentBoxTop from
the grid box geometry so that border and padding are accounted for.

Update five abspos reftests so the previously-asserted positions
match the new (and cross-browser) behavior. With grid items now
correctly inset by the grid&apos;s padding, the static position of an abspos
descendant of a grid item also shifts by that padding -- which is what
Chrome and Firefox already render. The tests are reworded with outlines
on the grid container, grid item, and abspos box so the layout is
visually obvious, and their -expected.html files are rewritten as
self-contained references with matching outlines.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-001.html: Added.
   Border only

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-002.html: Added.
   Padding only

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-003.html: Added.
   Border + padding

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-border-padding-004.html: Added.
   Asymmetric border + padding

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-008.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-009.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-010.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-012.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendant-containing-block-013.html:
   Add outlines on the grid container, grid item, and abspos box so the
   layout is visually obvious; rewrite each -expected.html as a
   self-contained reference using absolutely-positioned rectangles at
   the spec-correct coordinates.

Canonical link: <a href="https://commits.webkit.org/315509@main">https://commits.webkit.org/315509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/751aa9d34f05767d193b119abe5fc08562520630

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126974 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c08512c-cdc3-47cc-9346-cbd719e29978) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131832 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a90c9be9-4e8a-470e-9a1a-de15feae463b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172221 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112336 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7536d332-ed64-495b-b37a-087bf8fb006c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27318 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181218 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140287 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140127 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37700 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43529 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107460 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35398 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115294 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42039 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6585 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41432 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->