### PR TITLE
[css-ui] outline-offset computed value should be snapped as a line width

### DIFF
--- a/LayoutTests/fast/borders/hidpi-outline-hairline-painting-expected.html
+++ b/LayoutTests/fast/borders/hidpi-outline-hairline-painting-expected.html
@@ -12,24 +12,24 @@
 </style>
 </head>
 <body>
-<div style="border-style: solid; top: 9.5px; left: 9.5px;"></div>
-<div style="border-style: solid; top: 9.5px; left: 24.5px;"></div>
+<div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 9px;"></div>
+<div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 24px;"></div>
 <div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 39px;"></div>
 <div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 54px;"></div>
 <div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 69px;"></div>
 <div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 84px;"></div>
 <div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 99px;"></div>
-<div style="border-style: solid; width: 7px; height: 7px; top: 8.5px; left: 113.5px;"></div>
-<div style="border-style: solid; width: 7px; height: 7px; top: 8.5px; left: 128.5px;"></div>
+<div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 114px;"></div>
+<div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 129px;"></div>
 <div style="border-style: solid; border-width: 1px; width: 7px; height: 7px; top: 8px; left: 143px;"></div>
 <div style="border-style: solid; border-width: 1px; width: 7px; height: 7px; top: 8px; left: 158px;"></div>
 
-<div style="border-style: double; top: 23.5px; left: 8.5px; width: 7px; height: 7px;"></div>
-<div style="border-style: double; top: 23.5px; left: 23.5px; width: 7px; height: 7px;"></div>
+<div style="border-style: double; top: 24px; left: 9px; width: 6px; height: 6px;"></div>
+<div style="border-style: double; top: 24px; left: 24px; width: 6px; height: 6px;"></div>
 <div style="border-style: double; border-width: 1px; top: 23px; left: 38px; width: 7px; height: 7px;"></div>
 <div style="border-style: double; border-width: 1px; top: 23px; left: 53px; width: 7px; height: 7px;"></div>
 <div style="border-style: double; border-width: 1px; top: 23px; left: 68px; width: 7px; height: 7px;"></div>
-<div style="border-style: double; border-width: 1px; top: 22.5px; left: 82.5px; width: 8px; height: 8px;"></div>
-<div style="border-style: double; border-width: 1px; top: 22.5px; left: 97.5px; width: 8px; height: 8px;"></div>
+<div style="border-style: double; border-width: 1px; top: 23px; left: 83px; width: 7px; height: 7px;"></div>
+<div style="border-style: double; border-width: 1px; top: 23px; left: 98px; width: 7px; height: 7px;"></div>
 </body>
 </html>

--- a/LayoutTests/fast/css/outline-offset-used-value-zoom-rounding-expected.txt
+++ b/LayoutTests/fast/css/outline-offset-used-value-zoom-rounding-expected.txt
@@ -1,0 +1,10 @@
+
+PASS used outline-offset of 1px at zoom 1 is snapped as a line width
+PASS used outline-offset of -1px at zoom 1 is snapped as a line width
+PASS used outline-offset of 1px at zoom 1.5 is snapped as a line width
+PASS used outline-offset of 3px at zoom 1.5 is snapped as a line width
+PASS used outline-offset of -3px at zoom 1.5 is snapped as a line width
+PASS used outline-offset of 1px at zoom 0.5 is snapped as a line width
+PASS used outline-offset of -1px at zoom 0.5 is snapped as a line width
+PASS used outline-offset of 0px at zoom 0.5 is snapped as a line width
+

--- a/LayoutTests/fast/css/outline-offset-used-value-zoom-rounding.html
+++ b/LayoutTests/fast/css/outline-offset-used-value-zoom-rounding.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>The used value of outline-offset is snapped as a line width after zoom</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#propdef-outline-offset">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12906">
+<meta name="assert" content="Applying zoom to outline-offset re-snaps the result to an integer number of device pixels, the same way outline-width does. Uses internals to read the used value, which is not otherwise web-exposed.">
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id="target"></div>
+
+<script>
+const target = document.getElementById("target");
+
+// https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width, applied to the
+// magnitude so that the sign of a negative outline-offset is preserved. Expectations are
+// derived from this rather than hard-coded so that they hold at any device scale factor.
+function snap(value) {
+  const devicePixel = 1 / window.devicePixelRatio;
+  const sign = value < 0 ? -1 : 1;
+  const magnitude = Math.abs(value);
+  if (magnitude > 0 && magnitude < devicePixel)
+    return sign * devicePixel;
+  return sign * Math.floor(magnitude * window.devicePixelRatio) / window.devicePixelRatio;
+}
+
+function usedOutlineOffset(offset, zoom) {
+  target.style.outlineOffset = offset;
+  target.style.zoom = zoom;
+  return internals.usedOutlineOffset(target);
+}
+
+// [outline-offset, zoom, unsnapped used value]
+const tests = [
+  // Without zoom the used value is the computed value, which is already snapped.
+  ["1px", 1, 1],
+  ["-1px", 1, -1],
+  // A magnitude that is not an integer number of device pixels after zoom rounds toward zero.
+  ["1px", 1.5, 1.5],
+  ["3px", 1.5, 4.5],
+  ["-3px", 1.5, -4.5],
+  // A magnitude below 1 device pixel after zoom rounds away from zero, never to zero.
+  ["1px", 0.5, 0.5],
+  ["-1px", 0.5, -0.5],
+  // Zero stays zero.
+  ["0px", 0.5, 0],
+];
+
+for (const [offset, zoom, unsnapped] of tests) {
+  test(() => {
+    assert_implements(window.internals, "internals is required to read the used value");
+    assert_equals(usedOutlineOffset(offset, zoom), snap(unsnapped));
+  }, `used outline-offset of ${offset} at zoom ${zoom} is snapped as a line width`);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/outline-offset-rounding.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/outline-offset-rounding.tentative-expected.txt
@@ -1,22 +1,32 @@
 
 PASS 0px
 PASS -0px
-FAIL 0.1px assert_equals: expected "1px" but got "0.1px"
-FAIL -0.1px assert_equals: expected "-1px" but got "-0.1px"
-FAIL 0.25px assert_equals: expected "1px" but got "0.25px"
-FAIL -0.25px assert_equals: expected "-1px" but got "-0.25px"
-FAIL 0.5px assert_equals: expected "1px" but got "0.5px"
-FAIL -0.5px assert_equals: expected "-1px" but got "-0.5px"
-FAIL 0.9px assert_equals: expected "1px" but got "0.9px"
-FAIL -0.9px assert_equals: expected "-1px" but got "-0.9px"
+PASS 0px snaps the same way as outline-width
+PASS 0.1px
+PASS -0.1px
+PASS 0.1px snaps the same way as outline-width
+PASS 0.25px
+PASS -0.25px
+PASS 0.25px snaps the same way as outline-width
+PASS 0.5px
+PASS -0.5px
+PASS 0.5px snaps the same way as outline-width
+PASS 0.9px
+PASS -0.9px
+PASS 0.9px snaps the same way as outline-width
 PASS 1px
 PASS -1px
-FAIL 1.25px assert_equals: expected "1px" but got "1.25px"
-FAIL -1.25px assert_equals: expected "-1px" but got "-1.25px"
-FAIL 1.5px assert_equals: expected "1px" but got "1.5px"
-FAIL -1.5px assert_equals: expected "-1px" but got "-1.5px"
+PASS 1px snaps the same way as outline-width
+PASS 1.25px
+PASS -1.25px
+PASS 1.25px snaps the same way as outline-width
+PASS 1.5px
+PASS -1.5px
+PASS 1.5px snaps the same way as outline-width
 PASS 2px
 PASS -2px
-FAIL 2.75px assert_equals: expected "2px" but got "2.75px"
-FAIL -2.75px assert_equals: expected "-2px" but got "-2.75px"
+PASS 2px snaps the same way as outline-width
+PASS 2.75px
+PASS -2.75px
+PASS 2.75px snaps the same way as outline-width
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/outline-offset-rounding.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/outline-offset-rounding.tentative.html
@@ -1,37 +1,60 @@
 <!doctype html>
 <title>outline-offset gets snapped like outline-width</title>
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12906">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#snap-as-a-line-width">
+<meta name="assert" content="The computed value of outline-offset is snapped to an integer number of device pixels, the same way outline-width and border-width are, with the sign preserved.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
-  const values = [
-    { input: "0px", expected: "0px" },
-    { input: "0.1px", expected: "1px" },
-    { input: "0.25px", expected: "1px" },
-    { input: "0.5px", expected: "1px" },
-    { input: "0.9px", expected: "1px" },
-    { input: "1px", expected: "1px" },
-    { input: "1.25px", expected: "1px" },
-    { input: "1.5px", expected: "1px" },
-    { input: "2px", expected: "2px" },
-    { input: "2.75px", expected: "2px" },
-  ];
+  // https://drafts.csswg.org/css-values-4/#snap-as-a-line-width, extended to negative values:
+  // `outline-offset` snaps its magnitude and keeps its sign.
+  //
+  // Expectations are derived from `devicePixelRatio` rather than hard-coded, so that this test
+  // is also meaningful where 1 device pixel is not 1 CSS pixel.
+  function snapAsLineWidth(cssPixels) {
+    const dppx = window.devicePixelRatio;
+    const magnitude = Math.abs(cssPixels);
 
-  for (const {input, expected} of values) {
+    // 1. If the length is an integer number of device pixels, do nothing.
+    // 2. If the length is greater than zero, but less than 1 device pixel, round up to 1 device pixel.
+    // 3. Otherwise round down to the nearest integer number of device pixels.
+    // Steps 1 and 3 are both handled by the flooring below.
+    if (!magnitude)
+      return 0;
+    if (magnitude < 1 / dppx)
+      return Math.sign(cssPixels) / dppx;
+    return Math.sign(cssPixels) * Math.floor(magnitude * dppx) / dppx;
+  }
+
+  const magnitudes = ["0px", "0.1px", "0.25px", "0.5px", "0.9px", "1px", "1.25px", "1.5px", "2px", "2.75px"];
+
+  // A device pixel can be an unrepresentable fraction of a CSS pixel (e.g. 1/3 at 3dppx), so
+  // compare numbers rather than serializations. Serialization is covered separately.
+  const epsilon = 1 / 1024;
+
+  for (const magnitude of magnitudes) {
+    for (const input of [magnitude, "-" + magnitude]) {
+      test(function() {
+        const div = document.createElement("div");
+        div.style.outlineOffset = input;
+        document.body.appendChild(div);
+        const expected = snapAsLineWidth(parseFloat(input));
+        assert_approx_equals(parseFloat(getComputedStyle(div).outlineOffset), expected, epsilon,
+                             `${input} should snap to ${expected}px at ${window.devicePixelRatio}dppx`);
+      }, input);
+    }
+
+    // The CSSWG resolution is that `outline-offset` rounds the same way `outline-width` does, so
+    // cross-check the two against each other. This holds at any device pixel ratio and, unlike
+    // the subtests above, also covers the serialization of the computed value.
     test(function() {
       const div = document.createElement("div");
-      div.style.outlineOffset = input;
+      div.style.outline = `solid ${magnitude} blue`;
+      div.style.outlineOffset = magnitude;
       document.body.appendChild(div);
-      assert_equals(getComputedStyle(div).outlineOffset, expected);
-    }, input)
-
-    let negExpected = input == "0px" ? "0px" : "-" + expected;
-    test(function() {
-      const div = document.createElement("div");
-      div.style.outlineOffset = "-" + input;
-      document.body.appendChild(div);
-      assert_equals(getComputedStyle(div).outlineOffset, negExpected);
-    }, "-" + input)
+      const style = getComputedStyle(div);
+      assert_equals(style.outlineOffset, style.outlineWidth);
+    }, `${magnitude} snaps the same way as outline-width`);
   }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/animation/outline-offset-interpolation-rounding.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/animation/outline-offset-interpolation-rounding.tentative-expected.txt
@@ -1,0 +1,9 @@
+
+PASS outline-offset from 0px to 10px at 0.25 is snapped as a line width
+PASS outline-offset from 0px to -10px at 0.25 is snapped as a line width
+PASS outline-offset from 10px to 0px at 0.75 is snapped as a line width
+PASS outline-offset from 0px to 1px at 0.5 is snapped as a line width
+PASS outline-offset from 0px to -1px at 0.5 is snapped as a line width
+PASS outline-offset from 0px to 10px at 0 is snapped as a line width
+PASS outline-offset inset does not interpolate with a length
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/animation/outline-offset-interpolation-rounding.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/animation/outline-offset-interpolation-rounding.tentative.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Blended outline-offset values are snapped as a line width</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#propdef-outline-offset">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12906">
+<meta name="assert" content="A blended outline-offset is snapped to an integer number of device pixels the same way outline-width is, and the inset keyword does not interpolate with a length.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="target"></div>
+<script>
+const target = document.getElementById("target");
+
+// https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width, applied to the
+// magnitude so that the sign of a negative outline-offset is preserved. Expectations are
+// derived from this rather than hard-coded so that they hold at any device scale factor.
+function snap(value) {
+  const devicePixel = 1 / window.devicePixelRatio;
+  const sign = value < 0 ? -1 : 1;
+  const magnitude = Math.abs(value);
+  if (magnitude > 0 && magnitude < devicePixel)
+    return sign * devicePixel;
+  return sign * Math.floor(magnitude * window.devicePixelRatio) / window.devicePixelRatio;
+}
+
+function offsetAt(from, to, progress) {
+  const animation = target.animate({ outlineOffset: [from, to] }, 1000);
+  animation.pause();
+  animation.currentTime = progress * 1000;
+  const offset = getComputedStyle(target).outlineOffset;
+  animation.cancel();
+  return offset;
+}
+
+// [from, to, progress, unsnapped value the progress lands on]
+const tests = [
+  ["0px", "10px", 0.25, 2.5],
+  ["0px", "-10px", 0.25, -2.5],
+  ["10px", "0px", 0.75, 2.5],
+  // A magnitude below 1 device pixel must round away from zero, never to zero.
+  ["0px", "1px", 0.5, 0.5],
+  ["0px", "-1px", 0.5, -0.5],
+  // Zero stays zero.
+  ["0px", "10px", 0, 0],
+];
+
+for (const [from, to, progress, unsnapped] of tests) {
+  test(() => {
+    assert_equals(offsetAt(from, to, progress), `${snap(unsnapped)}px`);
+  }, `outline-offset from ${from} to ${to} at ${progress} is snapped as a line width`);
+}
+
+test(() => {
+  // `inset` is a css-ui-4 addition; skip where it is not supported, since an unsupported
+  // keyframe value is dropped and the animation interpolates the underlying value instead.
+  assert_implements_optional(CSS.supports("outline-offset", "inset"),
+                             "outline-offset: inset is not supported");
+  assert_equals(offsetAt("inset", "10px", 0.25), "inset");
+  assert_equals(offsetAt("inset", "10px", 0.75), "10px");
+}, "outline-offset inset does not interpolate with a length");
+</script>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3442,6 +3442,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StylePrimitiveNumericTypes+Rounding.h
     style/values/primitives/StylePrimitiveNumericTypes.h
     style/values/primitives/StyleRatio.h
+    style/values/primitives/StyleSnapLengthAsBorderWidth.h
     style/values/primitives/StyleString.h
     style/values/primitives/StyleURL.h
     style/values/primitives/StyleUnevaluatedCalculation.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3516,6 +3516,7 @@ style/values/non-standard/StyleWebKitLocale.cpp
 style/values/non-standard/StyleWebKitOverflowScrolling.cpp
 style/values/non-standard/StyleWebKitTextStrokeWidth.cpp
 style/values/non-standard/StyleWebKitTouchCallout.cpp
+style/values/outline/StyleOutlineOffset.cpp @header:RenderStyleGetters
 style/values/overflow/StyleBlockEllipsis.cpp
 style/values/overflow/StyleScrollbarGutter.cpp
 style/values/overflow/StyleOverflowClipMargin.cpp
@@ -3526,6 +3527,7 @@ style/values/primitives/StyleLengthResolution.cpp @header:RenderStyleGetters @co
 style/values/primitives/StylePosition.cpp
 style/values/primitives/StylePrimitiveData.cpp
 style/values/primitives/StyleRatio.cpp
+style/values/primitives/StyleSnapLengthAsBorderWidth.cpp
 style/values/primitives/StyleString.cpp
 style/values/primitives/StyleURL.cpp
 style/values/primitives/StyleUnevaluatedCalculation.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5144,6 +5144,7 @@
 		BC22AB362E3ABBDC009AC0C3 /* StyleOpacity.h in Headers */ = {isa = PBXBuildFile; fileRef = BC22AB332E3A9B8E009AC0C3 /* StyleOpacity.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC23875B2D84982100698102 /* CSSRatio.h in Headers */ = {isa = PBXBuildFile; fileRef = BC23875A2D84982100698102 /* CSSRatio.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2387602D84A59400698102 /* StyleRatio.h in Headers */ = {isa = PBXBuildFile; fileRef = BC23875F2D84A59400698102 /* StyleRatio.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		28A097C7302E767800E50E45 /* StyleSnapLengthAsBorderWidth.h in Headers */ = {isa = PBXBuildFile; fileRef = 28A097C5302E767800E50E45 /* StyleSnapLengthAsBorderWidth.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2387EB2D88D3BA00698102 /* CSSStyleProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2387E92D88D3BA00698102 /* CSSStyleProperties.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2388132D89D94800698102 /* CSSFontFaceDescriptors.h in Headers */ = {isa = PBXBuildFile; fileRef = BC23880B2D88EFDA00698102 /* CSSFontFaceDescriptors.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC23888A2D8C72D900698102 /* CSSPageDescriptors.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2388882D8C72D900698102 /* CSSPageDescriptors.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -13140,6 +13141,7 @@
 		52B84CA048CEC33FFD5367B8 /* VolumeMuted-RTL.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "VolumeMuted-RTL.svg"; sourceTree = "<group>"; };
 		52D2ED227687272BB8AC7430 /* UnifiedSource77-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource77-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		52D4C867EF1213EBE219805C /* StyleOutlineOffset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleOutlineOffset.h; sourceTree = "<group>"; };
+		28650B482FE3F8420024E0CD /* StyleOutlineOffset.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleOutlineOffset.cpp; sourceTree = "<group>"; };
 		52D5A18D1C54590300DE34A3 /* VideoLayerManagerObjC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoLayerManagerObjC.mm; sourceTree = "<group>"; };
 		52D5A18E1C54590300DE34A3 /* VideoLayerManagerObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLayerManagerObjC.h; sourceTree = "<group>"; };
 		52D5A1A41C57488900DE34A3 /* VideoPresentationModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoPresentationModel.h; sourceTree = "<group>"; };
@@ -19295,6 +19297,7 @@
 		BC23875D2D849E6E00698102 /* CSSPropertyParserConsumer+Ratio.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+Ratio.h"; sourceTree = "<group>"; };
 		BC23875E2D849E7400698102 /* CSSPropertyParserConsumer+Ratio.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CSSPropertyParserConsumer+Ratio.cpp"; sourceTree = "<group>"; };
 		BC23875F2D84A59400698102 /* StyleRatio.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleRatio.h; sourceTree = "<group>"; };
+		28A097C5302E767800E50E45 /* StyleSnapLengthAsBorderWidth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleSnapLengthAsBorderWidth.h; sourceTree = "<group>"; };
 		BC2387E82D88D3BA00698102 /* CSSStyleProperties.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSStyleProperties.cpp; sourceTree = "<group>"; };
 		BC2387E92D88D3BA00698102 /* CSSStyleProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSStyleProperties.h; sourceTree = "<group>"; };
 		BC2387EA2D88D3BA00698102 /* CSSStyleProperties.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = CSSStyleProperties.idl; sourceTree = "<group>"; };
@@ -20609,6 +20612,7 @@
 		BCD9EFF12E198C0500D1C3DF /* StyleContainIntrinsicSize.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleContainIntrinsicSize.cpp; sourceTree = "<group>"; };
 		BCD9F0062E1AEC5700D1C3DF /* StyleGridTrackBreadth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleGridTrackBreadth.h; sourceTree = "<group>"; };
 		BCD9F05B2E1C297600D1C3DF /* StyleRatio.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleRatio.cpp; sourceTree = "<group>"; };
+		28A097C6302E767800E50E45 /* StyleSnapLengthAsBorderWidth.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleSnapLengthAsBorderWidth.cpp; sourceTree = "<group>"; };
 		BCD9F05C2E1C2A9600D1C3DF /* CSSRatio.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSRatio.cpp; sourceTree = "<group>"; };
 		BCD9F1012E1E0DA800D1C3DF /* StyleClip.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleClip.h; sourceTree = "<group>"; };
 		BCD9F1022E1E0DA800D1C3DF /* StyleClip.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleClip.cpp; sourceTree = "<group>"; };
@@ -32399,6 +32403,7 @@
 		74A67DA5B4E1E1FC14532479 /* outline */ = {
 			isa = PBXGroup;
 			children = (
+				28650B482FE3F8420024E0CD /* StyleOutlineOffset.cpp */,
 				52D4C867EF1213EBE219805C /* StyleOutlineOffset.h */,
 			);
 			path = outline;
@@ -39211,6 +39216,8 @@
 				BCB271EE2CC0156E00265123 /* StylePrimitiveNumericTypes.h */,
 				BCD9F05B2E1C297600D1C3DF /* StyleRatio.cpp */,
 				BC23875F2D84A59400698102 /* StyleRatio.h */,
+				28A097C6302E767800E50E45 /* StyleSnapLengthAsBorderWidth.cpp */,
+				28A097C5302E767800E50E45 /* StyleSnapLengthAsBorderWidth.h */,
 				BC66AF5A2F7D8E4000345E91 /* StyleString.cpp */,
 				BC66AF592F7D8D3B00345E91 /* StyleString.h */,
 				BC38D4F22D480063004BE2FF /* StyleUnevaluatedCalculation.cpp */,
@@ -49224,6 +49231,7 @@
 				83C05A5B1A686212007E5DEA /* StylePropertyShorthandFunctions.h in Headers */,
 				5A574F29131DB96D00471B88 /* StyleQuotes.h in Headers */,
 				BC2387602D84A59400698102 /* StyleRatio.h in Headers */,
+				28A097C7302E767800E50E45 /* StyleSnapLengthAsBorderWidth.h in Headers */,
 				BCEA07332CC6C395000AC148 /* StyleRayFunction.h in Headers */,
 				BCB2720C2CC1F1DB00265123 /* StyleRectFunction.h in Headers */,
 				E461802D1C8DD2900026C02C /* StyleRelations.h in Headers */,

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -786,8 +786,8 @@ Path AccessibilityRenderObject::elementPath() const
         if (!rectsSpanMultipleLines(rects, style->writingMode().isHorizontal()))
             return { };
 
-        auto outlineOffset = Style::evaluate<float>(style->usedOutlineOffset(), style->usedZoomForLength());
         float deviceScaleFactor = protect(renderText->document())->deviceScaleFactor();
+        auto outlineOffset = Style::evaluate<float>(style->usedOutlineOffset(), style->usedZoomForLength(), deviceScaleFactor);
         Vector<FloatRect> pixelSnappedRects;
         for (auto rect : rects) {
             rect.inflate(outlineOffset);

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -95,7 +95,7 @@ void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRec
 
     auto zoom = styleToUse->usedZoomForLength();
     auto outlineWidth = Style::evaluate<LayoutUnit>(styleToUse->usedOutlineWidth(), zoom, deviceScaleFactor(renderer));
-    auto outlineOffset = Style::evaluate<LayoutUnit>(styleToUse->usedOutlineOffset(), zoom);
+    auto outlineOffset = Style::evaluate<LayoutUnit>(styleToUse->usedOutlineOffset(), zoom, deviceScaleFactor(renderer));
 
     auto outerRect = paintRect;
     outerRect.inflate(outlineOffset + outlineWidth);
@@ -204,7 +204,7 @@ void OutlinePainter::paintOutlineWithLineRects(const RenderInline& renderer, con
     auto zoom = styleToUse->usedZoomForLength();
     auto deviceScaleFactor = WebCore::deviceScaleFactor(renderer);
 
-    auto outlineOffset = Style::evaluate<float>(styleToUse->usedOutlineOffset(), zoom);
+    auto outlineOffset = Style::evaluate<float>(styleToUse->usedOutlineOffset(), zoom, deviceScaleFactor);
     auto outlineWidth = Style::evaluate<float>(styleToUse->usedOutlineWidth(), zoom, deviceScaleFactor);
 
     Vector<FloatRect> pixelSnappedRects;
@@ -279,7 +279,7 @@ void OutlinePainter::paintFocusRing(const RenderElement& renderer, const Vector<
     auto deviceScaleFactor = WebCore::deviceScaleFactor(renderer);
     auto zoom = style->usedZoomForLength();
 
-    auto outlineOffset = Style::evaluate<float>(style->usedOutlineOffset(), zoom);
+    auto outlineOffset = Style::evaluate<float>(style->usedOutlineOffset(), zoom, deviceScaleFactor);
 
     Vector<FloatRect> pixelSnappedFocusRingRects;
     for (auto rect : focusRingRects) {

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1632,7 +1632,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 });
             };
             auto outlineRightInsetExtent = [&] -> LayoutUnit {
-                auto offset = Style::evaluate<LayoutUnit>(outlineStyle->usedOutlineOffset(), outlineZoom);
+                auto offset = Style::evaluate<LayoutUnit>(outlineStyle->usedOutlineOffset(), outlineZoom, deviceScaleFactor);
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowRightInsetExtent = [&] {
@@ -1676,7 +1676,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 });
             };
             auto outlineBottomInsetExtent = [&] -> LayoutUnit {
-                auto offset = Style::evaluate<LayoutUnit>(outlineStyle->usedOutlineOffset(), outlineZoom);
+                auto offset = Style::evaluate<LayoutUnit>(outlineStyle->usedOutlineOffset(), outlineZoom, deviceScaleFactor);
                 return offset < 0 ? -offset : 0_lu;
             };
             auto boxShadowBottomInsetExtent = [&]() -> LayoutUnit {

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -144,7 +144,7 @@ static void drawFocusRingForPathForVectorBasedControls(const RenderObject& box, 
     // macOS controls have never honored outline offset.
 #if PLATFORM(IOS_FAMILY)
     auto deviceScaleFactor = box.style().deviceScaleFactor();
-    auto outlineOffset = floorToDevicePixel(Style::evaluate<float>(box.style().usedOutlineOffset(), box.style().usedZoomForLength()), deviceScaleFactor);
+    auto outlineOffset = Style::evaluate<float>(box.style().usedOutlineOffset(), box.style().usedZoomForLength(), deviceScaleFactor);
 
     if (outlineOffset > 0) {
         const auto center = rect.center();

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -591,7 +591,7 @@ Style::LineWidth ComputedStyle::usedColumnRuleWidth() const
     return columnRuleWidth();
 }
 
-Style::Length<> ComputedStyle::usedOutlineOffset() const
+Style::UsedOutlineOffset ComputedStyle::usedOutlineOffset() const
 {
     auto& outline = this->outline();
     if (outline.outlineOffset.isInset())
@@ -611,7 +611,7 @@ Style::LineWidth ComputedStyle::usedOutlineWidth() const
 
 float ComputedStyle::usedOutlineSize(Style::ZoomFactor zoom, float deviceScaleFactor) const
 {
-    return std::max(0.0f, Style::evaluate<float>(usedOutlineWidth(), zoom, deviceScaleFactor) + Style::evaluate<float>(usedOutlineOffset(), zoom));
+    return std::max(0.0f, Style::evaluate<float>(usedOutlineWidth(), zoom, deviceScaleFactor) + Style::evaluate<float>(usedOutlineOffset(), zoom, deviceScaleFactor));
 }
 
 // MARK: - Derived Values

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -167,7 +167,7 @@ public:
 
     Style::LineWidth NODELETE usedColumnRuleWidth() const;
 
-    WEBCORE_EXPORT Style::Length<> usedOutlineOffset() const;
+    WEBCORE_EXPORT Style::UsedOutlineOffset usedOutlineOffset() const;
     Style::LineWidth usedOutlineWidth() const;
     float usedOutlineSize(Style::ZoomFactor, float deviceScaleFactor) const; // used value combining `outline-width` and `outline-offset`
 

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -374,6 +374,7 @@ struct Transform;
 struct TransformOrigin;
 struct Transition;
 struct Translate;
+struct UsedOutlineOffset;
 struct VerticalAlign;
 struct ViewTimeline;
 struct ViewTransitionClasses;

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -37,39 +37,12 @@
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+Serialization.h"
+#include "StyleSnapLengthAsBorderWidth.h"
 
 namespace WebCore {
 namespace Style {
 
 // MARK: - Conversion
-
-static float snapLengthAsBorderWidth(float length, float deviceScaleFactor)
-{
-    // https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width
-
-    // 1. Assert: `length` is non-negative.
-    // NOTE: Not asserted, but checked in step 3.
-
-    // 2. If `length` is an integer number of device pixels, do nothing.
-    // NOTE: Handled by step 4 without explicitly checking here.
-
-    // 3. If `length` is greater than zero, but less than 1 device pixel, round `length` up to 1 device pixel.
-    if (auto singleDevicePixelLength = 1.0f / deviceScaleFactor; length > 0.0f && length < singleDevicePixelLength)
-        return singleDevicePixelLength;
-
-    // 4. If `length` is greater than 1 device pixel, round it down to the nearest integer number of device pixels.
-    return std::floor(length * deviceScaleFactor) / deviceScaleFactor;
-}
-
-LineWidth::Length LineWidth::snapLengthAsBorderWidth(float length, float deviceScaleFactor)
-{
-    return LineWidth::Length { Style::snapLengthAsBorderWidth(length, deviceScaleFactor) };
-}
-
-LineWidth::Length LineWidth::snapLengthAsBorderWidth(LineWidth::Length length, float deviceScaleFactor)
-{
-    return LineWidth::Length { Style::snapLengthAsBorderWidth(length.unresolvedValue(), deviceScaleFactor) };
-}
 
 auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSValue& value) -> LineWidth
 {
@@ -87,7 +60,7 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
         }
     }
 
-    return LineWidth::snapLengthAsBorderWidth(toStyleFromCSSValue<LineWidth::Length>(state, value), state.style().deviceScaleFactor());
+    return snapLengthAsBorderWidth(toStyleFromCSSValue<LineWidth::Length>(state, value), state.style().deviceScaleFactor());
 }
 
 // MARK: - Blending
@@ -96,7 +69,7 @@ auto Blending<LineWidth>::blend(const LineWidth& a, const LineWidth& b, const St
 {
     auto blendedValue = Style::blend(a.value, b.value, aStyle, bStyle, context);
     if (RefPtr document = context.client.document())
-        return LineWidth::snapLengthAsBorderWidth(blendedValue, document->deviceScaleFactor());
+        return snapLengthAsBorderWidth(blendedValue, document->deviceScaleFactor());
     return blendedValue;
 }
 

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -50,9 +50,6 @@ struct LineWidth {
     constexpr LineWidth(CSS::Keyword::Medium) : value { 3 } { }
     constexpr LineWidth(CSS::Keyword::Thick) : value { 5 } { }
 
-    static Length snapLengthAsBorderWidth(float, float deviceScaleFactor);
-    static Length snapLengthAsBorderWidth(Length, float deviceScaleFactor);
-
     constexpr auto unresolvedValue() const { return value.unresolvedValue(); }
 
     constexpr bool isZero() const { return value.isZero(); }

--- a/Source/WebCore/style/values/outline/StyleOutlineOffset.cpp
+++ b/Source/WebCore/style/values/outline/StyleOutlineOffset.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleOutlineOffset.h"
+
+#include "CSSKeywordValue.h"
+#include "Document.h"
+#include "StyleBuilderState.h"
+#include "StyleComputedStyle+GettersInlines.h"
+#include "StyleInterpolationClient.h"
+#include "StyleInterpolationContext.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StyleSnapLengthAsBorderWidth.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<OutlineOffset>::operator()(BuilderState& state, const CSSValue& value) -> OutlineOffset
+{
+    if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value)) {
+        if (keywordValue->valueID() == CSSValueInset)
+            return CSS::Keyword::Inset { };
+    }
+
+    return snapSignedLengthAsBorderWidth(toStyleFromCSSValue<Length<>>(state, value), state.style().deviceScaleFactor());
+}
+
+// MARK: - Blending
+
+auto Blending<OutlineOffset>::canBlend(const OutlineOffset& a, const OutlineOffset& b) -> bool
+{
+    if (a.isInset() || b.isInset())
+        return false;
+    return Style::canBlend(*a.tryLength(), *b.tryLength());
+}
+
+auto Blending<OutlineOffset>::blend(const OutlineOffset& a, const OutlineOffset& b, const Style::ComputedStyle& aStyle, const Style::ComputedStyle& bStyle, const Interpolation::Context& context) -> OutlineOffset
+{
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1);
+        return context.progress ? b : a;
+    }
+
+    auto blendedValue = Style::blend(*a.tryLength(), *b.tryLength(), aStyle, bStyle, context);
+    if (RefPtr document = context.client.document())
+        return snapSignedLengthAsBorderWidth(blendedValue, document->deviceScaleFactor());
+    return blendedValue;
+}
+
+// MARK: - Evaluation
+
+auto Evaluation<UsedOutlineOffset, float>::operator()(const UsedOutlineOffset& value, ZoomFactor zoom, float deviceScaleFactor) -> float
+{
+    return snapSignedLengthAsBorderWidth(evaluate<float>(value.value, zoom), deviceScaleFactor);
+}
+
+auto Evaluation<UsedOutlineOffset, LayoutUnit>::operator()(const UsedOutlineOffset& value, ZoomFactor zoom, float deviceScaleFactor) -> LayoutUnit
+{
+    // NOTE: Using `evaluate<float>`, not `evaluate<LayoutUnit>`, as snapSignedLengthAsBorderWidth takes a `float`.
+    return LayoutUnit { snapSignedLengthAsBorderWidth(evaluate<float>(value.value, zoom), deviceScaleFactor) };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/outline/StyleOutlineOffset.h
+++ b/Source/WebCore/style/values/outline/StyleOutlineOffset.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/LayoutUnit.h>
 #include <WebCore/StylePrimitiveNumeric.h>
 #include <WebCore/StyleValueTypes.h>
 
@@ -37,6 +38,40 @@ struct OutlineOffset : ValueOrKeyword<Length<>, CSS::Keyword::Inset> {
 
     bool isInset() const { return isKeyword(); }
     std::optional<Length<>> tryLength() const { return tryValue(); }
+};
+
+// The used value of `outline-offset`: either the specified <length> or, for the `inset` keyword,
+// the negated used `outline-width`. Like a line width, it is snapped to an integer number of
+// device pixels when evaluated, but unlike a line width it may be negative.
+struct UsedOutlineOffset {
+    Length<> value;
+
+    constexpr UsedOutlineOffset(Length<> length) : value { length } { }
+    constexpr UsedOutlineOffset(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : value { literal } { }
+
+    constexpr auto unresolvedValue() const { return value.unresolvedValue(); }
+
+    constexpr bool operator==(const UsedOutlineOffset&) const = default;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<OutlineOffset> { OutlineOffset operator()(BuilderState&, const CSSValue&); };
+
+// MARK: - Blending
+
+template<> struct Blending<OutlineOffset> {
+    auto canBlend(const OutlineOffset&, const OutlineOffset&) -> bool;
+    auto blend(const OutlineOffset&, const OutlineOffset&, const Style::ComputedStyle&, const Style::ComputedStyle&, const Interpolation::Context&) -> OutlineOffset;
+};
+
+// MARK: - Evaluation
+
+template<> struct Evaluation<UsedOutlineOffset, float> {
+    WEBCORE_EXPORT auto operator()(const UsedOutlineOffset&, ZoomFactor, float deviceScaleFactor) -> float;
+};
+template<> struct Evaluation<UsedOutlineOffset, LayoutUnit> {
+    auto operator()(const UsedOutlineOffset&, ZoomFactor, float deviceScaleFactor) -> LayoutUnit;
 };
 
 } // namespace WebCore::Style

--- a/Source/WebCore/style/values/primitives/StyleSnapLengthAsBorderWidth.cpp
+++ b/Source/WebCore/style/values/primitives/StyleSnapLengthAsBorderWidth.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleSnapLengthAsBorderWidth.h"
+
+#include <cmath>
+
+namespace WebCore {
+namespace Style {
+
+float snapLengthAsBorderWidth(float length, float deviceScaleFactor)
+{
+    // https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width
+
+    // 1. Assert: `length` is non-negative.
+    // NOTE: Not asserted, but checked in step 3.
+
+    // 2. If `length` is an integer number of device pixels, do nothing.
+    // NOTE: Handled by step 4 without explicitly checking here.
+
+    // 3. If `length` is greater than zero, but less than 1 device pixel, round `length` up to 1 device pixel.
+    if (auto singleDevicePixelLength = 1.0f / deviceScaleFactor; length > 0.0f && length < singleDevicePixelLength)
+        return singleDevicePixelLength;
+
+    // 4. If `length` is greater than 1 device pixel, round it down to the nearest integer number of device pixels.
+    return std::floor(length * deviceScaleFactor) / deviceScaleFactor;
+}
+
+Length<CSS::Nonnegative> snapLengthAsBorderWidth(Length<CSS::Nonnegative> length, float deviceScaleFactor)
+{
+    return Length<CSS::Nonnegative> { snapLengthAsBorderWidth(length.unresolvedValue(), deviceScaleFactor) };
+}
+
+float snapSignedLengthAsBorderWidth(float length, float deviceScaleFactor)
+{
+    if (length >= 0.0f)
+        return snapLengthAsBorderWidth(length, deviceScaleFactor);
+    return -snapLengthAsBorderWidth(-length, deviceScaleFactor);
+}
+
+Length<> snapSignedLengthAsBorderWidth(Length<> length, float deviceScaleFactor)
+{
+    return Length<> { snapSignedLengthAsBorderWidth(length.unresolvedValue(), deviceScaleFactor) };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleSnapLengthAsBorderWidth.h
+++ b/Source/WebCore/style/values/primitives/StyleSnapLengthAsBorderWidth.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumeric.h>
+
+namespace WebCore {
+namespace Style {
+
+// Snaps a non-negative length, in CSS pixels, to an integer number of device pixels.
+// https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width
+float snapLengthAsBorderWidth(float, float deviceScaleFactor);
+Length<CSS::Nonnegative> snapLengthAsBorderWidth(Length<CSS::Nonnegative>, float deviceScaleFactor);
+
+// As above, but for lengths that may be negative, such as `outline-offset`. The magnitude is
+// snapped and the sign restored, so a magnitude smaller than 1 device pixel rounds away from
+// zero and a larger magnitude rounds toward zero.
+float snapSignedLengthAsBorderWidth(float, float deviceScaleFactor);
+Length<> snapSignedLengthAsBorderWidth(Length<>, float deviceScaleFactor);
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1642,7 +1642,7 @@ float Internals::usedOutlineOffset(Element& element)
     auto* style = element.computedStyle();
     if (!style)
         return 0;
-    return Style::evaluate<float>(style->usedOutlineOffset(), style->usedZoomForLength());
+    return Style::evaluate<float>(style->usedOutlineOffset(), style->usedZoomForLength(), style->deviceScaleFactor());
 }
 
 Node& Internals::ensureUserAgentShadowRoot(Element& host)


### PR DESCRIPTION
#### 3adec8e64df0536e4d34c37902714552fbc0057d
<pre>
[css-ui] outline-offset computed value should be snapped as a line width
<a href="https://bugs.webkit.org/show_bug.cgi?id=317427">https://bugs.webkit.org/show_bug.cgi?id=317427</a>
<a href="https://rdar.apple.com/180054053">rdar://180054053</a>

Reviewed by Sam Weinig and Darin Adler.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The CSSWG resolved that `outline-offset` should be snapped to an integer number of
device pixels the same way `outline-width` and `border-width` are
(w3c/csswg-drafts#12906). WebKit used the raw, unsnapped length, so
getComputedStyle().outlineOffset returned values like &quot;0.1px&quot; instead of &quot;1px&quot;.

Move &quot;snap a length as a border width&quot;
(<a href="https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width)">https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width)</a> out of
`LineWidth` into its own file, exposing the `float` overload directly and adding
signed overloads for lengths that may be negative, which snap the magnitude and
restore the sign: zero is unchanged, a magnitude below 1 device pixel rounds away
from zero, a larger magnitude rounds toward zero.

`outline-offset` now snaps in the same three places `outline-width` does:

 - `CSSValueConversion&lt;OutlineOffset&gt;` snaps the computed value.
 - `Blending&lt;OutlineOffset&gt;` re-snaps blended values, keeping animations on device
   pixels. It also has to supply `canBlend()`, since a full specialization replaces
   the generic `ValueOrKeyword` one, which is what makes `inset` interpolate
   discretely against a length rather than blending as an empty value.
 - `Evaluation&lt;UsedOutlineOffset&gt;` re-snaps after zoom is applied, keeping the used
   value on device pixels at any page zoom. `ComputedStyle::usedOutlineOffset()`
   returns `Style::UsedOutlineOffset` so that evaluating it requires a device scale
   factor, and its callers pass one.

The manual `floorToDevicePixel()` in RenderThemeCocoa is subsumed by that used-value
snapping. It is not quite equivalent: for a magnitude below one device pixel, `floor`
gave 0 while snapping rounds away from zero to 1 device pixel, so an iOS focus ring
at a zoom below 1 now scales by the offset instead of ignoring it. That is the
behavior `outline-width` already has.

`inset` resolves to the negated used `outline-width`, and snapping both after zoom
makes them cancel exactly, which they previously did not at fractional zoom.

* LayoutTests/fast/borders/hidpi-outline-hairline-painting-expected.html: Rebaselined.
This reference was authored against unsnapped offsets, and at the 2x device scale factor
this test runs at, snapping the offset changes the painted outline geometry.
* LayoutTests/fast/css/outline-offset-used-value-zoom-rounding-expected.txt: Added.
* LayoutTests/fast/css/outline-offset-used-value-zoom-rounding.html: Added. Covers the
used value after zoom, which needs `internals` since it is not web-exposed.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/outline-offset-rounding.tentative.html:
The test as imported hard-codes expectations that assume 1 device pixel is 1 CSS pixel, so its
sub-pixel sub-tests reported FAIL at any other device scale factor even though the engine was
behaving as specified. Derive the expectations from window.devicePixelRatio instead, and add
sub-tests that cross-check outline-offset against outline-width for the same input, which is a
direct statement of the CSSWG resolution and holds at any device scale factor. Verified all 30
sub-tests pass at 1x, 2x and 3x. To be upstreamed.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/outline-offset-rounding.tentative-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/animation/outline-offset-interpolation-rounding.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/animation/outline-offset-interpolation-rounding.tentative.html: Added.
Covers snapping of blended values, deriving expectations from window.devicePixelRatio so they hold
at any device scale factor. The `inset` sub-test is gated on CSS.supports(), since Chromium and
Gecko do not implement it yet and drop the keyframe. To be upstreamed.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::elementPath const):
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::OutlinePainter::paintOutline const):
(WebCore::OutlinePainter::paintOutlineWithLineRects const):
(WebCore::OutlinePainter::paintFocusRing const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintAfterLayoutIfNeeded):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::drawFocusRingForPathForVectorBasedControls):
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::usedOutlineOffset const):
(WebCore::Style::ComputedStyle::usedOutlineSize const):
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
(WebCore::Style::snapLengthAsBorderWidth): Deleted.
(WebCore::Style::LineWidth::snapLengthAsBorderWidth): Deleted.
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:
* Source/WebCore/style/values/outline/StyleOutlineOffset.cpp:
(WebCore::Style::CSSValueConversion&lt;OutlineOffset&gt;::operator()):
(WebCore::Style::Blending&lt;OutlineOffset&gt;::canBlend):
(WebCore::Style::Blending&lt;OutlineOffset&gt;::blend):
(WebCore::Style::Evaluation&lt;UsedOutlineOffset, float&gt;::operator()):
(WebCore::Style::Evaluation&lt;UsedOutlineOffset, LayoutUnit&gt;::operator()):
* Source/WebCore/style/values/outline/StyleOutlineOffset.h:
* Source/WebCore/style/values/primitives/StyleSnapLengthAsBorderWidth.cpp: Added.
(WebCore::Style::snapLengthAsBorderWidth):
(WebCore::Style::snapSignedLengthAsBorderWidth):
* Source/WebCore/style/values/primitives/StyleSnapLengthAsBorderWidth.h: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::usedOutlineOffset):

Canonical link: <a href="https://commits.webkit.org/319236@main">https://commits.webkit.org/319236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9090c747f1c8ce38edf3053618b5710ce3ab3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180761 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145084 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae28d4e3-28f6-4e5d-9efa-beb3be2fc940) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141010 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/97716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10528cbb-a6ea-4635-8ba6-e826ca6b4c99) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121462 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4107158-ab15-4d88-9c1e-41b668d24bf0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43344 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41622 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41295 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2135 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192909 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150389 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40274 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55060 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150106 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44700 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127326 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122612 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53577 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16288 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52959 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53024 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->