### PR TITLE
Distinguish between mutation observer callbacks in normal vs. non-normal worlds

### DIFF
--- a/Source/WebCore/dom/MutationCallback.h
+++ b/Source/WebCore/dom/MutationCallback.h
@@ -55,6 +55,11 @@ public:
 
     virtual CallbackResult<void> invoke(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;
+
+    // Non-inlined wrappers around invoke() to distinguish between mutation observers that fire
+    // on page-installed script vs. work from injected scripts.
+    NEVER_INLINE CallbackResult<void> invokeInNonNormalWorld(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&);
+    NEVER_INLINE CallbackResult<void> invokeInAutoFillWorld(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -34,10 +34,13 @@
 #include "MutationObserver.h"
 
 #include "ContextDestructionObserverInlines.h"
+#include "DOMWrapperWorld.h"
 #include "Document.h"
 #include "GCReachableRef.h"
 #include "HTMLSlotElement.h"
 #include "InspectorInstrumentation.h"
+#include "JSDOMGlobalObject.h"
+#include "JSMutationCallback.h"
 #include "MutationCallback.h"
 #include "MutationObserverRegistration.h"
 #include "MutationRecord.h"
@@ -46,6 +49,7 @@
 #include <ranges>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/NoTailCalls.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -64,7 +68,16 @@ Ref<MutationObserver> MutationObserver::create(Ref<MutationCallback>&& callback)
 MutationObserver::MutationObserver(Ref<MutationCallback>&& callback)
     : m_callback(WTF::move(callback))
     , m_priority(s_observerPriority++)
+    , m_isInNonNormalWorld(false)
+    , m_isAutoFillWorld(false)
 {
+    if (auto* jsCallback = dynamicDowncast<JSMutationCallback>(m_callback.get())) {
+        if (auto* globalObject = jsCallback->callbackData()->globalObject()) {
+            auto& world = globalObject->world();
+            m_isInNonNormalWorld = !world.isNormal();
+            m_isAutoFillWorld = world.allowAutofill();
+        }
+    }
 }
 
 MutationObserver::~MutationObserver()
@@ -218,7 +231,12 @@ void MutationObserver::deliver()
             return;
 
         InspectorInstrumentation::willFireObserverCallback(*context, "MutationObserver"_s);
-        m_callback->invoke(*this, records, *this);
+        if (!m_isInNonNormalWorld) [[likely]]
+            m_callback->invoke(*this, records, *this);
+        else if (m_isAutoFillWorld)
+            m_callback->invokeInAutoFillWorld(*this, records, *this);
+        else
+            m_callback->invokeInNonNormalWorld(*this, records, *this);
         InspectorInstrumentation::didFireObserverCallback(*context);
     }
 }
@@ -265,6 +283,18 @@ void MutationObserver::notifyMutationObservers(WindowEventLoop& eventLoop)
         for (auto& slot : slotList)
             slot->dispatchSlotChangeEvent();
     }
+}
+
+NEVER_INLINE CallbackResult<void> MutationCallback::invokeInNonNormalWorld(MutationObserver& thisObject, const Vector<Ref<MutationRecord>>& records, MutationObserver& observer)
+{
+    NO_TAIL_CALLS();
+    return invoke(thisObject, records, observer);
+}
+
+NEVER_INLINE CallbackResult<void> MutationCallback::invokeInAutoFillWorld(MutationObserver& thisObject, const Vector<Ref<MutationRecord>>& records, MutationObserver& observer)
+{
+    NO_TAIL_CALLS();
+    return invoke(thisObject, records, observer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -109,7 +109,9 @@ private:
     Vector<Ref<MutationRecord>> m_records;
     HashSet<GCReachableRef<Node>> m_pendingTargets;
     WeakHashSet<MutationObserverRegistration> m_registrations;
-    unsigned m_priority;
+    unsigned m_priority : 30;
+    unsigned m_isInNonNormalWorld : 1;
+    unsigned m_isAutoFillWorld : 1;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d84afd125019bd63f20d7fb42e95fe0fec7de2a5
<pre>
Distinguish between mutation observer callbacks in normal vs. non-normal worlds
<a href="https://bugs.webkit.org/show_bug.cgi?id=317431">https://bugs.webkit.org/show_bug.cgi?id=317431</a>
<a href="https://rdar.apple.com/179843353">rdar://179843353</a>

Reviewed by Chris Dumez.

We have been getting WebContent hang traces where it seems like the page is spending an excessive
amount of time hanging the main thread in mutation observer callbacks. However, we can&apos;t tell if
those callbacks are associated with mutation observers installed by the page vs. mutation observers
installed by injected scripts. Add some non-inlined call frames to the mutation observer firing
chain to help make our native backtraces in the hang traces more useful.

* Source/WebCore/dom/MutationCallback.h:
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::MutationObserver):
(WebCore::MutationObserver::deliver):
(WebCore::MutationCallback::invokeInNonNormalWorld):
(WebCore::MutationCallback::invokeInAutoFillWorld):
* Source/WebCore/dom/MutationObserver.h:

Canonical link: <a href="https://commits.webkit.org/315512@main">https://commits.webkit.org/315512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ef5981a8ab865bb8a5b58448f8f1eb0473e9296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126892 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/232025f8-9256-4f3c-8104-6f1b2ccc8bbf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131765 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c73c7f3c-324d-44b4-a433-8c8204e7aa17) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172139 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afb5d04c-07d6-4f1e-8726-945914310cf9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27236 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181136 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140219 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42758 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37703 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43447 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107367 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35334 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115212 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41956 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6516 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41350 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41605 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->