### PR TITLE
[

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1069,7 +1069,11 @@ void EmptyFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem&, Completion
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void EmptyFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int, FrameLoadType)
+void EmptyFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int)
+{
+}
+
+void EmptyFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta(int)
 {
 }
 

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -164,7 +164,8 @@ private:
     ShouldGoToHistoryItem NODELETE shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const final;
     bool NODELETE supportsAsyncShouldGoToHistoryItem() const final;
     void NODELETE shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const final;
-    void NODELETE dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType) final;
+    void NODELETE dispatchGoToBackForwardItemAtIndex(int steps) final;
+    void NODELETE dispatchEnqueueHistoryTraversalDelta(int delta) final;
 
     void NODELETE saveViewStateToItem(HistoryItem&) final;
     bool NODELETE canCachePage() const final;

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -236,7 +236,8 @@ public:
     virtual ShouldGoToHistoryItem shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const = 0;
     virtual bool supportsAsyncShouldGoToHistoryItem() const = 0;
     virtual void shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const = 0;
-    virtual void dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType) = 0;
+    virtual void dispatchGoToBackForwardItemAtIndex(int steps) = 0;
+    virtual void dispatchEnqueueHistoryTraversalDelta(int delta) = 0;
 
     virtual bool shouldFallBack(const ResourceError&) const = 0;
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -323,7 +323,7 @@ public:
 
         if (page->settings().useUIProcessForBackForwardItemLoading()) {
             localFrame->loader().setPendingAsyncBackForwardNavigation();
-            localFrame->loader().client().dispatchGoToBackForwardItemAtIndex(m_steps, FrameLoadType::IndexedBackForward);
+            localFrame->loader().client().dispatchGoToBackForwardItemAtIndex(m_steps);
             return;
         }
 
@@ -819,14 +819,22 @@ void NavigationScheduler::scheduleHistoryNavigation(Frame& originatingFrame, int
 
     if (steps) {
         if (Ref top = m_frame->tree().top(); top.ptr() != m_frame.ptr()) {
-            if (RefPtr localTop = dynamicDowncast<LocalFrame>(top.get())) {
-                if (RefPtr localOriginating = dynamicDowncast<LocalFrame>(originatingFrame); localOriginating && !localOriginating->loader().isComplete())
-                    localOriginating->loader().completed();
-                if (m_redirect)
-                    cancel();
+            RefPtr localTop = dynamicDowncast<LocalFrame>(top.get());
+            RefPtr localOriginating = dynamicDowncast<LocalFrame>(originatingFrame);
+            if (localOriginating && !localOriginating->loader().isComplete())
+                localOriginating->loader().completed();
+            if (m_redirect)
+                cancel();
+
+            if (localTop) {
                 protect(localTop->navigationScheduler())->scheduleHistoryNavigation(originatingFrame, steps);
                 return;
             }
+            ASSERT(localOriginating);
+            if (!localOriginating)
+                return;
+            localOriginating->loader().client().dispatchEnqueueHistoryTraversalDelta(steps);
+            return;
         }
     }
 

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -149,6 +149,14 @@ void WebBackForwardListFrameItem::updateFrameID(FrameIdentifier newFrameID)
     m_frameState->frameID = newFrameID;
 }
 
+void WebBackForwardListFrameItem::clearFrameIDIfMatches(FrameIdentifier frameID)
+{
+    if (m_frameState->frameID == frameID)
+        m_frameState->frameID = std::nullopt;
+    for (auto& child : m_children)
+        child->clearFrameIDIfMatches(frameID);
+}
+
 Ref<FrameState> WebBackForwardListFrameItem::copyFrameState()
 {
     Ref frameState = protect(this->frameState())->copy();

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -69,6 +69,7 @@ public:
     void clearChildren() { m_children.clear(); }
 
     void NODELETE updateFrameID(WebCore::FrameIdentifier);
+    void NODELETE clearFrameIDIfMatches(WebCore::FrameIdentifier);
 
     void NODELETE setWasRestoredFromSession();
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -219,4 +219,11 @@ void WebBackForwardListItem::updateFrameID(FrameIdentifier oldFrameID, FrameIden
         m_navigatedFrameID = newFrameID;
 }
 
+void WebBackForwardListItem::clearFrameID(FrameIdentifier frameID)
+{
+    m_mainFrameItem->clearFrameIDIfMatches(frameID);
+    if (m_navigatedFrameID && *m_navigatedFrameID == frameID)
+        m_navigatedFrameID = std::nullopt;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -105,6 +105,7 @@ public:
     EnhancedSecurity enhancedSecurity() const { return m_enhancedSecurity; }
 
     void updateFrameID(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
+    void clearFrameID(WebCore::FrameIdentifier);
 
 private:
     WebBackForwardListItem(Ref<FrameState>&&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, BrowsingContextGroup*);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -859,6 +859,12 @@ void WebBackForwardList::updateFrameIdentifier(FrameIdentifier oldFrameID, Frame
         entry->updateFrameID(oldFrameID, newFrameID);
 }
 
+void WebBackForwardList::clearFrameIdentifier(FrameIdentifier frameID)
+{
+    for (auto& entry : m_entries)
+        entry->clearFrameID(frameID);
+}
+
 void WebBackForwardList::replaceFrameStateForChild(WebBackForwardListItem& item, WebCore::FrameIdentifier frameID, Ref<FrameState>&& newFrameState)
 {
     RefPtr targetFrameItem = item.mainFrameItem().childItemForFrameID(frameID);

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -104,6 +104,7 @@ public:
 
     FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier, uint64_t);
     void updateFrameIdentifier(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
+    void clearFrameIdentifier(WebCore::FrameIdentifier);
 
     void replaceFrameStateForChild(WebBackForwardListItem&, WebCore::FrameIdentifier, Ref<FrameState>&& newFrameState);
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -153,8 +153,10 @@ WebFrameProxy::WebFrameProxy(WebPageProxy& page, FrameProcess& process, FrameIde
 
 WebFrameProxy::~WebFrameProxy()
 {
-    if (RefPtr page = m_page.get())
+    if (RefPtr page = m_page.get()) {
         page->inspectorController().willDestroyFrame(*this);
+        page->frameWasDestroyed(m_frameID);
+    }
 
     WebProcessPool::statistics().wkFrameCount--;
 #if PLATFORM(GTK)
@@ -208,8 +210,10 @@ void WebFrameProxy::webProcessWillShutDown()
     for (auto& childFrame : std::exchange(m_childFrames, { }))
         childFrame->webProcessWillShutDown();
 
-    if (RefPtr page = m_page.get())
+    if (RefPtr page = m_page.get()) {
         page->inspectorController().willDestroyFrame(*this);
+        page->frameWasDestroyed(m_frameID);
+    }
 
     m_page = nullptr;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2873,10 +2873,27 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
     return RefPtr<API::Navigation> { WTF::move(navigation) };
 }
 
+// HTML spec replaces an iframe's initial about:blank entry on the frame's first real navigation; WebKit's BF list keeps the stale state in older entries, so dispatching a traversal into one would regress the live iframe.
+static bool isStaleInitialAboutBlankIframeTarget(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame)
+{
+    auto& toURL = toFrame.frameState().urlString;
+    if (!toURL.isEmpty() && toURL != "about:blank"_s)
+        return false;
+    auto& fromURL = fromFrame.frameState().urlString;
+    if (fromURL.isEmpty() || fromURL == "about:blank"_s)
+        return false;
+    auto toFrameID = toFrame.frameID();
+    if (!toFrameID)
+        return false;
+    RefPtr toLiveFrame = WebFrameProxy::webFrame(*toFrameID);
+    return toLiveFrame && !toLiveFrame->isMainFrame();
+}
+
 bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
 {
     bool anySent = false;
-    if (fromFrame.frameState().itemSequenceNumber != toFrame.frameState().itemSequenceNumber)
+    if (fromFrame.frameState().itemSequenceNumber != toFrame.frameState().itemSequenceNumber
+        && !isStaleInitialAboutBlankIframeTarget(fromFrame, toFrame))
         anySent = sendGoToBackForwardItemForFrame(toFrame, navigationID, frameLoadType, shouldRestore, publicSuffix);
 
     bool sameDocument = fromFrame.frameState().documentSequenceNumber == toFrame.frameState().documentSequenceNumber;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -303,6 +303,7 @@
 #include <ranges>
 #include <stdio.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/CoroutineUtilities.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/FileSystem.h>
@@ -312,6 +313,7 @@
 #include <wtf/Scope.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
 #include <wtf/URLParser.h>
@@ -887,6 +889,63 @@ static Ref<BrowsingContextGroup> getOrCreateBrowsingContextGroup(const API::Page
     return BrowsingContextGroup::create();
 }
 
+class WebPageProxy::SessionHistoryTraversalQueue final : public CanMakeCheckedPtr<WebPageProxy::SessionHistoryTraversalQueue> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SessionHistoryTraversalQueue);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SessionHistoryTraversalQueue);
+public:
+    explicit SessionHistoryTraversalQueue(WebPageProxy& page)
+        : m_pageProxy(page)
+        , m_flushTimer(RunLoop::mainSingleton(), "WebPageProxy::SessionHistoryTraversalQueue::FlushTimer"_s, this, &SessionHistoryTraversalQueue::flush)
+    {
+    }
+
+    ~SessionHistoryTraversalQueue()
+    {
+        m_flushTimer.stop();
+    }
+
+    void enqueueDelta(int32_t delta)
+    {
+        if (m_hasPending) {
+            auto sum = WTF::CheckedInt32 { m_pendingDelta } + delta;
+            if (sum.hasOverflowed()) {
+                cancel();
+                return;
+            }
+            m_pendingDelta = sum.value();
+        } else {
+            m_pendingDelta = delta;
+            m_hasPending = true;
+            m_flushTimer.startOneShot(0_s);
+        }
+    }
+
+    void cancel()
+    {
+        m_flushTimer.stop();
+        m_pendingDelta = 0;
+        m_hasPending = false;
+    }
+
+private:
+    void flush()
+    {
+        int32_t delta = std::exchange(m_pendingDelta, 0);
+        m_hasPending = false;
+
+        if (!delta)
+            return;
+
+        Ref pageProxy = m_pageProxy.get();
+        pageProxy->goToBackForwardItemAtIndex(delta);
+    }
+
+    WeakRef<WebPageProxy> m_pageProxy;
+    int32_t m_pendingDelta { 0 };
+    RunLoop::Timer m_flushTimer;
+    bool m_hasPending { false };
+};
+
 WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref<API::PageConfiguration>&& configuration)
     : m_internals(makeUniqueRefWithoutRefCountedCheck<Internals>(*this, configuration->processInheritedFromOpener()))
     , m_identifier(Identifier::generate())
@@ -905,6 +964,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #endif
     , m_navigationState(makeUniqueRefWithoutRefCountedCheck<WebNavigationState>(*this))
     , m_generatePageLoadTimingTimer(RunLoop::mainSingleton(), "WebPageProxy::GeneratePageLoadTimingTimer"_s, this, &WebPageProxy::didEndNetworkRequestsForPageLoadTimingTimerFired)
+    , m_sessionHistoryTraversalQueue(makeUniqueRefWithoutRefCountedCheck<SessionHistoryTraversalQueue>(*this))
 #if PLATFORM(COCOA)
     , m_textIndicatorFadeTimer(RunLoop::mainSingleton(), "WebPageProxy::TextIndicatorFadeTimer"_s, this, &WebPageProxy::startTextIndicatorFadeOut)
 #endif
@@ -1886,6 +1946,8 @@ void WebPageProxy::close()
     WEBPAGEPROXY_RELEASE_LOG(Loading, "close:");
 
     m_isClosed = true;
+
+    m_sessionHistoryTraversalQueue->cancel();
 
     // Make sure we do this before we clear the UIClient so that we can ask the UIClient
     // to release the wake locks.
@@ -3067,7 +3129,7 @@ void WebPageProxy::shouldGoToBackForwardListItemSync(BackForwardItemIdentifier i
     shouldGoToBackForwardListItem(itemID, false, WTF::move(completionHandler));
 }
 
-void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frameLoadType)
+void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "goToBackForwardItemAtIndex: steps=%d", steps);
 
@@ -3075,7 +3137,12 @@ void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frame
     if (!item)
         return;
 
-    goToBackForwardItem(frameItemForLegacyTraversalRouting(*item, "goToBackForwardItemAtIndex"_s), frameLoadType);
+    goToBackForwardItem(frameItemForLegacyTraversalRouting(*item, "goToBackForwardItemAtIndex"_s), FrameLoadType::IndexedBackForward);
+}
+
+void WebPageProxy::enqueueHistoryTraversalDelta(int32_t delta)
+{
+    m_sessionHistoryTraversalQueue->enqueueDelta(delta);
 }
 
 bool WebPageProxy::shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem& item)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7607,6 +7607,11 @@ void WebPageProxy::didDestroyFrame(IPC::Connection& connection, FrameIdentifier 
     });
 }
 
+void WebPageProxy::frameWasDestroyed(FrameIdentifier frameID)
+{
+    backForwardList().clearFrameIdentifier(frameID);
+}
+
 void WebPageProxy::disconnectFramesFromPage()
 {
     if (RefPtr mainFrame = std::exchange(m_mainFrame, nullptr))

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2695,6 +2695,8 @@ public:
     void didDestroyFrame(IPC::Connection&, WebCore::FrameIdentifier);
     void disconnectFramesFromPage();
 
+    void frameWasDestroyed(WebCore::FrameIdentifier);
+
     void didCommitLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, String&& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool wasPrivateRelayed, String&& proxyName, const WebCore::ResourceResponseSource, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, WebCore::DocumentSecurityPolicy&&, HashSet<WebCore::SecurityOriginData>&& cspOriginsThatUpgradeInsecureNavigations, const UserData&, WebCore::RestoredFromBackForwardCache, RefPtr<FrameState>&& redirectReplaceFrameState);
 
     void didCreateSleepDisabler(IPC::Connection&, WebCore::SleepDisablerIdentifier, const String& reason, bool display);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1007,7 +1007,8 @@ public:
     void didChangeBackForwardList(WebBackForwardListItem* addedItem, Vector<Ref<WebBackForwardListItem>>&& removed);
     void shouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier, bool inBackForwardCache, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
     void shouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
-    void goToBackForwardItemAtIndex(int32_t steps, WebCore::FrameLoadType);
+    void goToBackForwardItemAtIndex(int32_t steps);
+    void enqueueHistoryTraversalDelta(int32_t delta);
 
     bool shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem&);
 
@@ -3753,6 +3754,9 @@ private:
     std::unique_ptr<WebPageLoadTiming> m_pageLoadTimingPendingCommit;
     HashSet<WebCore::FrameIdentifier> m_framesWithSubresourceLoadingForPageLoadTiming;
     RunLoop::Timer m_generatePageLoadTimingTimer;
+
+    class SessionHistoryTraversalQueue;
+    const UniqueRef<SessionHistoryTraversalQueue> m_sessionHistoryTraversalQueue;
 
 #if PLATFORM(COCOA)
     RunLoop::Timer m_textIndicatorFadeTimer;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -238,7 +238,8 @@ messages -> WebPageProxy {
     # BackForward messages
     ShouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier itemID, bool inBackForwardCache) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem)
     ShouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier itemID) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem) Synchronous
-    GoToBackForwardItemAtIndex(int32_t steps, enum:uint8_t WebCore::FrameLoadType frameLoadType)
+    GoToBackForwardItemAtIndex(int32_t steps)
+    EnqueueHistoryTraversalDelta(int32_t delta)
 
     # Undo/Redo messages
     RegisterEditCommandForUndo(WebKit::WebUndoStepID commandID, String label) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1343,9 +1343,6 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
     bool siteIsolationEnabled = protect(pageConfiguration->preferences())->siteIsolationEnabled();
     if (siteIsolationEnabled) {
         Ref<WebPreferences> preferences = pageConfiguration->preferences();
-        // FIXME: we should enable UseUIProcessForBackForwardItemLoading not only here but also in test infrastructure
-        // when site isolation is enabled, but doing that causes a lot of test failures that we need to investigate.
-        // https://bugs.webkit.org/show_bug.cgi?id=316588
         preferences->setUseUIProcessForBackForwardItemLoading(true);
         preferences->setMultiProcessBackForwardCacheEnabled(true);
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1477,13 +1477,22 @@ void WebLocalFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem& item, Co
     webPage->sendWithAsyncReply(Messages::WebPageProxy::ShouldGoToBackForwardListItem(item.itemID(), item.isInBackForwardCache()), WTF::move(completionHandler));
 }
 
-void WebLocalFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType frameLoadType)
+void WebLocalFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int steps)
 {
     RefPtr webPage = m_frame->page();
     if (!webPage)
         return;
 
-    webPage->send(Messages::WebPageProxy::GoToBackForwardItemAtIndex(steps, frameLoadType));
+    webPage->send(Messages::WebPageProxy::GoToBackForwardItemAtIndex(steps));
+}
+
+void WebLocalFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta(int delta)
+{
+    RefPtr webPage = m_frame->page();
+    if (!webPage)
+        return;
+
+    webPage->send(Messages::WebPageProxy::EnqueueHistoryTraversalDelta(delta));
 }
 
 bool WebLocalFrameLoaderClient::shouldFallBack(const ResourceError& error) const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -178,7 +178,8 @@ private:
     bool supportsAsyncShouldGoToHistoryItem() const final;
     void shouldGoToHistoryItemAsync(WebCore::HistoryItem&, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&) const final;
 
-    void dispatchGoToBackForwardItemAtIndex(int steps, WebCore::FrameLoadType) final;
+    void dispatchGoToBackForwardItemAtIndex(int steps) final;
+    void dispatchEnqueueHistoryTraversalDelta(int delta) final;
 
     void didFinishServiceWorkerPageRegistration(bool success) final;
     

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -163,7 +163,8 @@ private:
     bool supportsAsyncShouldGoToHistoryItem() const final;
     void shouldGoToHistoryItemAsync(WebCore::HistoryItem&, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&) const final;
 
-    void dispatchGoToBackForwardItemAtIndex(int steps, WebCore::FrameLoadType) final;
+    void dispatchGoToBackForwardItemAtIndex(int steps) final;
+    void dispatchEnqueueHistoryTraversalDelta(int delta) final;
 
     void loadStorageAccessQuirksIfNeeded() final { }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1123,9 +1123,12 @@ void WebFrameLoaderClient::shouldGoToHistoryItemAsync(WebCore::HistoryItem&, Com
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void WebFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int, WebCore::FrameLoadType)
+void WebFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int)
 {
-    // Not needed in WebKitLegacy — single process, useUIProcessForBackForwardItemLoading is never enabled.
+}
+
+void WebFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta(int)
+{
 }
 
 bool WebFrameLoaderClient::shouldFallBack(const WebCore::ResourceError& error) const

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9869,4 +9869,56 @@ TEST(SiteIsolation, UserGesture)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "did not throw");
 }
 
+TEST(SiteIsolation, CrossProcessHistoryTraversalCoalesce)
+{
+    constexpr auto pageWithIframes = "<iframe src='https://webkit.org/x'></iframe><iframe src='https://apple.com/x'></iframe>"_s;
+    constexpr auto iframeBody = "x"_s;
+
+    HTTPServer server({
+        { "/a"_s, { pageWithIframes } },
+        { "/b"_s, { pageWithIframes } },
+        { "/c"_s, { pageWithIframes } },
+        { "/x"_s, { iframeBody } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)2);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)0);
+
+    auto childFrames = [webView mainFrame].childFrames;
+    EXPECT_EQ(childFrames.count, 2u);
+    pid_t mainPid = [[webView mainFrame] info]._processIdentifier;
+    pid_t pidWk = childFrames[0].info._processIdentifier;
+    pid_t pidAp = childFrames[1].info._processIdentifier;
+    EXPECT_NE(pidWk, mainPid);
+    EXPECT_NE(pidAp, mainPid);
+    EXPECT_NE(pidWk, pidAp);
+
+    __block unsigned didFinishCount = 0;
+    __block bool firstFinished = false;
+    navigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+        ++didFinishCount;
+        firstFinished = true;
+    };
+
+    [webView evaluateJavaScript:@"history.back()" inFrame:childFrames[0].info completionHandler:nil];
+    [webView evaluateJavaScript:@"history.back()" inFrame:childFrames[1].info completionHandler:nil];
+
+    TestWebKitAPI::Util::run(&firstFinished);
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    EXPECT_EQ(didFinishCount, 1u);
+    EXPECT_WK_STREQ(@"https://example.com/a", [[webView URL] absoluteString]);
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)0);
+    EXPECT_EQ([webView backForwardList].forwardList.count, (NSUInteger)2);
+}
+
 }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2106,7 +2106,22 @@ TestOptions TestController::testOptionsForTest(const TestCommand& command) const
     merge(features, featureDefaultsFromTestHeaderForTest(command, TestOptions::keyTypeMapping()));
     merge(features, featureFromAdditionalHeaderOption(command, TestOptions::keyTypeMapping()));
     merge(features, platformSpecificFeatureOverridesDefaultsForTest(command));
+
+    auto siteIsolationIt = features.boolWebPreferenceFeatures.find("SiteIsolationEnabled");
+    if (siteIsolationIt != features.boolWebPreferenceFeatures.end() && siteIsolationIt->second)
+        merge(features, featuresImpliedBySiteIsolation());
+
     return TestOptions { features };
+}
+
+// Mirror WebProcessPool::createWebPage, which unconditionally enables this under Site
+// Isolation. Merged last so it matches that override and survives WebKitTestRunner's
+// per-test preference reset; a test cannot run Site Isolation with it off, as in production.
+TestFeatures TestController::featuresImpliedBySiteIsolation() const
+{
+    TestFeatures implied;
+    implied.boolWebPreferenceFeatures.insert_or_assign("UseUIProcessForBackForwardItemLoading", true);
+    return implied;
 }
 
 void TestController::updateWebViewSizeForTest(const TestInvocation& test)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -544,6 +544,7 @@ private:
     TestOptions testOptionsForTest(const TestCommand&) const;
     TestFeatures platformSpecificFeatureDefaultsForTest(const TestCommand&) const;
     TestFeatures platformSpecificFeatureOverridesDefaultsForTest(const TestCommand&) const;
+    TestFeatures featuresImpliedBySiteIsolation() const;
 
     void updateWebViewSizeForTest(const TestInvocation&);
     void updateWindowScaleForTest(PlatformWebView*, const TestInvocation&);


### PR DESCRIPTION
#### 3dd07c1e4e5b2f9f909f7a6035b9d0ffd8f2dc6d
<pre>
[NavigationScheduler] history.back/forward/go(n) coalescing across processes via UIProcess session history traversal queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=317229">https://bugs.webkit.org/show_bug.cgi?id=317229</a>

Reviewed by NOBODY (OOPS!).

Follow-up to <a href="https://bugs.webkit.org/show_bug.cgi?id=317077.">https://bugs.webkit.org/show_bug.cgi?id=317077.</a>

Per HTML&apos;s &quot;traverse the history by a delta&quot; algorithm, history.back/
forward/go(n) appends a task to the top-level traversable&apos;s session
history traversal queue. The previous fix (bug 317077) implemented
per-WebProcess coalescing by forwarding to the top frame&apos;s
NavigationScheduler when reachable in this WebProcess. Under Site
Isolation, when the top frame is a RemoteFrame (a cross-site iframe
initiates the traversal), the queue lives above any single WebProcess
and the originating scheduler can&apos;t see traversals from other
processes targeting the same traversable.

Symptom: two cross-site iframes in different WebProcesses each call
history.back() in the same task; both navigations execute and the
user sees an extra intermediate document load that the spec says
should not occur.

Introduce SessionHistoryTraversalQueue, owned by WebPageProxy
(top-level traversable proxy). The queue accumulates pending delta
across all WebProcesses targeting this page and flushes on a 0-delay
timer, calling goToBackForwardItemAtIndex with the net delta (no-op
when delta == 0, matching &quot;going nowhere&quot;). NavigationScheduler&apos;s
existing per-WebProcess aggregation in scheduleHistoryNavigation now
gains a second branch: when the top frame is in another process
(top frame downcasts to RemoteFrame), forward via a new
LocalFrameLoaderClient hook (dispatchEnqueueHistoryTraversalDelta)
that posts WebPageProxy::EnqueueHistoryTraversalDelta to the
UIProcess. The originating frame&apos;s pending m_redirect and
in-progress load are completed/cancelled the same way the LocalFrame
top branch does in 317077, so an iframe&apos;s pending
ScheduledLocationChange doesn&apos;t race the queued traversal.

Trust model note: EnqueueHistoryTraversalDelta accepts an int32_t
delta from any WebProcess and forwards it to
goToBackForwardItemAtIndex on flush. This is the same trust boundary
as the existing GoToBackForwardItemAtIndex IPC; Site Isolation does
not introduce a new attack vector here. The eventual
WebBackForwardList lookup clamps to the available range, so an
out-of-range delta degrades to a no-op rather than memory unsafety.

This is the observable-coalescing approximation; the spec-faithful
&quot;sequential apply + synchronous queue jumping&quot; is left for a future
epic. The class name (SessionHistoryTraversalQueue) leaves room for
that evolution.

Out of scope here: spec-correct top-level reload semantics for
history.go(0), which remains implemented as a per-frame reload —
tracked alongside bug 317077.

Drive-by cleanup carried in this follow-up: drop the unused
FrameLoadType parameter from both this new IPC and the sibling
GoToBackForwardItemAtIndex IPC (introduced for 317077). Both call
sites in NavigationScheduler always pass IndexedBackForward and the
UIProcess methods always forward the same constant; the parameter
was dead weight. The FrameLoaderClient hooks
(dispatchGoToBackForwardItemAtIndex, dispatchEnqueueHistoryTraversalDelta)
are simplified to match.

Test plan: SiteIsolation.CrossProcessHistoryTraversalCoalesce builds
a 3-entry main-frame history (a, b, c) where each page hosts two
cross-site iframes (webkit.org and apple.com) in distinct
WebProcesses. main-frame postMessage triggers both iframes to call
history.back() in the same JS turn; the two
EnqueueHistoryTraversalDelta IPCs land in the same UIProcess flush
window and combine into one goToBackForwardItem(-2), so main goes
c-&gt;a in a single navigation (BFList: backList=0, forwardList=2). The
test is sensitive: temporarily disabling the new RemoteFrame branch
in NavigationScheduler causes the BFList state assertions to fail.
The bug 317077 API tests (WKBackForwardList.* synchronous coalescing
suite) and the SI history regression set under SiteIsolation.* do
not regress.

* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta):
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleHistoryNavigation):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::SessionHistoryTraversalQueue::SessionHistoryTraversalQueue):
(WebKit::WebPageProxy::SessionHistoryTraversalQueue::enqueueDelta):
(WebKit::WebPageProxy::SessionHistoryTraversalQueue::cancel):
(WebKit::WebPageProxy::SessionHistoryTraversalQueue::flush):
(WebKit::WebPageProxy::WebPageProxy):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::enqueueHistoryTraversalDelta):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchEnqueueHistoryTraversalDelta):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TEST(SiteIsolation, CrossProcessHistoryTraversalCoalesce)):
</pre>
----------------------------------------------------------------------
#### 48087a146e3f1113f4aba1109f48dca16c9bc635
<pre>
[Site Isolation] Clear orphan frameIDs in BF list when WebFrameProxy is destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=317814">https://bugs.webkit.org/show_bug.cgi?id=317814</a>
<a href="https://rdar.apple.com/180584464">rdar://180584464</a>

Reviewed by NOBODY (OOPS!).

Follow-up to <a href="https://bugs.webkit.org/show_bug.cgi?id=317799">https://bugs.webkit.org/show_bug.cgi?id=317799</a>, which added a
defensive skip at the per-frame walk-as-replacement dispatch site. This is the
underlying fix at the source.

The BF list (WebBackForwardListFrameItem::m_frameState-&gt;frameID) was never
cleared when an iframe is removed. WebFrameProxy::~WebFrameProxy() only
removed itself from the static allFrames() map; no BF entry&apos;s stored frameID
was touched. Tolerable in the legacy non-BFCache path — every back/forward
rebuilt frames from scratch — but with multi-process BFCache under Site
Isolation reusing the WebPageProxy frame tree, the BF tree&apos;s frameIDs and
the live frame graph are coupled, and orphan frameIDs surface at the
dispatch site.

When a WebFrameProxy is destroyed (or its hosting WebProcess shuts down),
walk the page&apos;s BF list entries and null out any matching frameIDs. The new
API mirrors the existing updateFrameID / updateFrameIdentifier pattern, with
one deliberate divergence: WebBackForwardListFrameItem::clearFrameIDIfMatches
walks the entire frame subtree and clears every match (vs. updateFrameID&apos;s
single childItemForFrameID lookup). &quot;Clear&quot; carries no information-loss risk
from over-applying, while leaving any sibling orphan in place would defeat
the fix.

The cleanup is driven from two call sites:
- WebFrameProxy&apos;s destructor calls page-&gt;frameWasDestroyed(m_frameID) before
  the allFrames() map removal.
- WebFrameProxy::webProcessWillShutDown() (the recursive teardown path used
  when the frame&apos;s hosting WebProcess terminates) calls
  page-&gt;frameWasDestroyed(m_frameID) before nulling m_page. Without this, a
  process kill would leave orphans on the surviving WebPageProxy&apos;s BF list,
  because the eventual destructor sees m_page already null and skips
  cleanup.

Cross-process BCG, SuspendedPage, and BFCache eviction paths can still leave
orphan frameIDs in BF entries on a different WebPageProxy&apos;s list. That
fan-out cleanup is a separate follow-up; the defensive dispatch-site guard
from <a href="https://bugs.webkit.org/show_bug.cgi?id=317799">https://bugs.webkit.org/show_bug.cgi?id=317799</a> stays as defense-in-depth
until covered.

Covered by existing tests. With the defensive guard from
<a href="https://bugs.webkit.org/show_bug.cgi?id=317799">https://bugs.webkit.org/show_bug.cgi?id=317799</a> temporarily disabled,
http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html
still passes 4/4 (defensive guard hit count under proper fix: 0).

* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::clearFrameIDIfMatches):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::clearFrameID):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::clearFrameIdentifier):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::~WebFrameProxy):
(WebKit::WebFrameProxy::webProcessWillShutDown):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::frameWasDestroyed):
</pre>
----------------------------------------------------------------------
#### 511a92da6e0ade61496e374ed328bbc213e55d76
<pre>
[Site Isolation] Per-frame back/forward walk regresses iframe to stale initial about:blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=317458">https://bugs.webkit.org/show_bug.cgi?id=317458</a>
<a href="https://rdar.apple.com/180077264">rdar://180077264</a>

Reviewed by NOBODY (OOPS!).

Under UseUIProcessForBackForwardItemLoading, WebPageProxy::dispatchPerFrameTraversals
walks the (current, target) BF frame trees and dispatches a per-frame
GoToBackForwardItem whenever itemSequenceNumber differs. When the target entry
holds the stale &quot;initial about:blank&quot; state for an iframe whose live document has
since loaded a real URL, the walk dispatches a navigation back to about:blank and
regresses the live iframe.

The HTML spec (<a href="https://html.spec.whatwg.org/#initialise-the-document-object)">https://html.spec.whatwg.org/#initialise-the-document-object)</a>
requires the iframe&apos;s initial about:blank entry to be replaced by the iframe&apos;s
first real navigation, but WebKit&apos;s BF list does not propagate that replacement
to non-current entries. The legacy navigatedFrameID-heuristic routing path
masked the issue by never dispatching a per-frame iframe traversal in the first
place; the walk-as-replacement (<a href="https://bugs.webkit.org/show_bug.cgi?id=317090)">https://bugs.webkit.org/show_bug.cgi?id=317090)</a>
exposes it because it compares each frame&apos;s state pair-wise.

Reproduction is the imported WPT
imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/history-traversal-navigate-parent-while-child-loading.html
which performs a parent pushState() while an iframe is mid-initial-navigation,
then asserts on history.back() that the iframe URL is preserved. Without the
fix, the iframe regresses:

  FAIL pushState() in parent while child is doing initial navigation, then go back
  assert_equals: expected &quot;<a href="http://web-platform.test">http://web-platform.test</a>:8800/common/blank.html&quot; but got &quot;about:blank&quot;

This regression surfaces only when UseUIProcessForBackForwardItemLoading is
enabled under SiteIsolationEnabled, the configuration that PR #67459
(<a href="https://bugs.webkit.org/show_bug.cgi?id=316588)">https://bugs.webkit.org/show_bug.cgi?id=316588)</a> re-enables in the test harness.

Fix: introduce a walk-side guard isStaleInitialAboutBlankIframeTarget that
returns true when the target frame&apos;s URL is empty or about:blank, the from
frame&apos;s URL is a real document, and the live frame is a non-main child frame.
dispatchPerFrameTraversals consults the guard before dispatching, so traversals
into the stale entries are skipped while all other traversals — including
legitimate main-frame about:blank navigations and any traversal where the target
already matches the from URL — are unchanged.

A spec-level fix would be to propagate the initial about:blank replacement to
older BF entries when an iframe completes its first real navigation; that is
not attempted here because it touches BackForwardClient / HistoryController
across processes and is out of scope for the regression.

Covered by existing test:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/history-traversal-navigate-parent-while-child-loading.html

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::isStaleInitialAboutBlankIframeTarget):
(WebKit::WebPageProxy::dispatchPerFrameTraversals):
</pre>
----------------------------------------------------------------------
#### d2d7e0a7d6f463b2bacc27e213bd2cb45c8addf5
<pre>
[Site Isolation] Re-enable UseUIProcessForBackForwardItemLoading auto-couple in test harness
<a href="https://bugs.webkit.org/show_bug.cgi?id=316588">https://bugs.webkit.org/show_bug.cgi?id=316588</a>
<a href="https://rdar.apple.com/179043211">rdar://179043211</a>

Reviewed by NOBODY (OOPS!).

Bug 314648 originally coupled UseUIProcessForBackForwardItemLoading to
SiteIsolationEnabled in the test harness via
TestController::featuresImpliedBySiteIsolation, mirroring the production
coupling in WebProcessPool::createWebPage. Several imported wpt history
tests timed out only in Release under that auto-couple, so <a href="https://commits.webkit.org/314862@main">314862@main</a>
reverted the test-harness side and left only the production coupling.

The underlying issues that caused those timeouts have since been fixed
and landed:
- bug 317090 (<a href="https://commits.webkit.org/315516@main">315516@main</a>) replaces the navigatedFrameID heuristic with
  a per-frame tree walk in UIProcess back/forward routing, so iframe
  traversals are no longer misrouted to the main frame under the flag.
- bug 317044 (<a href="https://commits.webkit.org/315779@main">315779@main</a>) propagates iframe client-redirect URL updates
  from the WebProcess to UIProcess authoritatively, so subtest #3 of
  cross-document-traversal-cross-document-traversal.html no longer
  reports an empty location.search.
- the dead-frame skip (bug 317799, <a href="https://commits.webkit.org/315925@main">315925@main</a>) prevents the walk from
  dispatching GoToBackForwardItem to BF tree slots whose iframe has been
  removed from the DOM, which was the actual cause of the cluster
  timeouts (the dead-frame dispatch fell back to the main frame at the
  WebProcess receiver and navigated the test page itself to the dead
  iframe&apos;s URL).

With those in place, re-add featuresImpliedBySiteIsolation and replace
the path-pattern hook (which auto-enabled the flag for seven specific
WPT cluster paths) with the broad SiteIsolationEnabled → flag coupling
that <a href="https://commits.webkit.org/314862@main">314862@main</a> reverted. The path-pattern hook is removed entirely.
The production-side FIXME in WebProcessPool::createWebPage is dropped
since the test infrastructure now mirrors production again.

Covered by existing tests (the imported WPT cluster under SI auto-enable
plus the SiteIsolation API test suite).

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage): Drop the resolved 316588 FIXME.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::siteIsolationImpliedFeaturesForTest): Deleted.
(WTR::TestController::testOptionsForTest const): Merge featuresImpliedBySiteIsolation in place of the path hook.
(WTR::TestController::featuresImpliedBySiteIsolation const):
* Tools/WebKitTestRunner/TestController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dd07c1e4e5b2f9f909f7a6035b9d0ffd8f2dc6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170517 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128230 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86f3ef13-bbd8-41cb-b439-052a65c92192) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44076 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132978 "Found 2 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93766 "3 flakes 19 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3d6c937-d9e2-4e4e-8659-f4f384c27214) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173476 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36157 "Found 3 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153414 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.BackNavigationOverCrossSiteIframeWithoutBFCache, TestWebKitAPI.SiteIsolation.ProcessTerminationReason (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113475 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f826cdd9-fd9a-4c99-b4ba-db6bed1652b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34774 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33120 "Found 3 new API test failures: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce, TestWebKitAPI.SiteIsolation.BackNavigationOverCrossSiteIframeWithoutBFCache, TestWebKitAPI.SiteIsolation.ProcessTerminationReason (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28575 "Hash 3dd07c1e for PR 67459 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145235 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.BackNavigationOverCrossSiteIframeWithoutBFCache, TestWebKitAPI.SiteIsolation.ProcessTerminationReason (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32808 "Found 3 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182477 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35275 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37298 "Found 3 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141430 "Found 2 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44098 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141247 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44787 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29794 "Found 3 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109294 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36513 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116676 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43297 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7896 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42702 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42833 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->