### PR TITLE
[libWebRTC][GStreamer] Missing video in WebRTC playback when decoding on playback pipeline

### DIFF
--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -102,6 +102,8 @@ public:
 
     virtual IntSize presentationSize() const = 0;
     virtual uint32_t pixelFormat() const = 0;
+    virtual bool isEncoded() const { return false; }
+    virtual bool hasSameEncodedFormat(const VideoFrame&) const { return false; }
 
     virtual bool isRemoteProxy() const { return false; }
     virtual bool isLibWebRTC() const { return false; }

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -498,6 +498,8 @@ VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const
     , m_sample(sample)
     , m_presentationSize(options.presentationSize)
 {
+    ASSERT(m_sample);
+
     ensureVideoFrameDebugCategoryInitialized();
     setMemoryTypeFromCaps();
 
@@ -866,6 +868,38 @@ VideoFrameContentHint VideoFrameGStreamer::contentHint() const
 {
     auto buffer = gst_sample_get_buffer(m_sample.get());
     return webkitGstBufferGetContentHint(buffer);
+}
+
+bool VideoFrameGStreamer::isEncoded() const
+{
+    GstCaps* caps = gst_sample_get_caps(m_sample.get());
+    if (!caps)
+        return false;
+
+    const GstStructure* structure = gst_caps_get_structure(caps, 0);
+    if (!structure)
+        return false;
+
+    return gstStructureGetName(structure) != "video/x-raw"_s;
+}
+
+bool VideoFrameGStreamer::hasSameEncodedFormat(const VideoFrame& other) const
+{
+    if (!other.isGStreamer())
+        return false;
+
+    GstCaps* thisCaps = gst_sample_get_caps(m_sample.get());
+    GstCaps* otherCaps = gst_sample_get_caps(static_cast<const VideoFrameGStreamer&>(other).m_sample.get());
+
+    if (!thisCaps && !otherCaps)
+        return true;
+
+    if (!thisCaps || !otherCaps)
+        return false;
+
+    ASSERT(thisCaps && otherCaps);
+
+    return gst_caps_is_equal(thisCaps, otherCaps);
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -110,6 +110,9 @@ public:
 
     VideoFrameContentHint contentHint() const;
 
+    bool isEncoded() const final;
+    bool hasSameEncodedFormat(const VideoFrame&) const final;
+
 private:
     VideoFrameGStreamer(GRefPtr<GstSample>&&, const CreateOptions&, PlatformVideoColorSpace&&);
     VideoFrameGStreamer(const GRefPtr<GstSample>&, const CreateOptions&, PlatformVideoColorSpace&&);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -362,32 +362,60 @@ void RealtimeMediaSource::videoFrameAvailable(VideoFrame& videoFrame, VideoFrame
 #endif
     }();
 
-    for (auto& [key, value] : m_videoFrameObservers) {
-        if (auto* adaptor = value.get()) {
-            if (adaptor->frameDecimation > 1 && ++adaptor->frameDecimationCounter % adaptor->frameDecimation)
-                continue;
+    // videoFrameObservers needs to be passed as parameter because if m_videoFrameObservers
+    // is used, that confuses the thread safety static analysis, which can't deduce that
+    // the lock has been taken by the outer scope of the videoFrameAvailable() method.
+    auto deliverFrame = [&] (Ref<VideoFrame>&& frame, VideoFrameTimeMetadata&& frameMetadata,
+        HashMap<VideoFrameObserver*, std::unique_ptr<VideoFrameAdaptor>>& videoFrameObservers) {
+        for (auto& [key, value] : videoFrameObservers) {
+            if (auto* adaptor = value.get()) {
+                if (adaptor->frameDecimation > 1 && ++adaptor->frameDecimationCounter % adaptor->frameDecimation)
+                    continue;
 
-            adaptor->frameDecimation = adaptor->frameRate ? static_cast<size_t>(observedFrameRate() / adaptor->frameRate) : 1;
-            if (!adaptor->frameDecimation)
-                adaptor->frameDecimation = 1;
+                adaptor->frameDecimation = adaptor->frameRate ? static_cast<size_t>(observedFrameRate() / adaptor->frameRate) : 1;
+                if (!adaptor->frameDecimation)
+                    adaptor->frameDecimation = 1;
 
-            if (!adaptor->size.isZero()) {
-                auto actualSize = expandedIntSize(currentVideoFrame->presentationSize());
-                auto adaptorSize = adaptor->size;
-                if (shouldSwapAdaptorSize)
-                    adaptorSize = adaptorSize.transposedSize();
-                auto desiredSize = computeResizedVideoFrameSize(adaptorSize, actualSize);
+                if (!adaptor->size.isZero()) {
+                    auto actualSize = expandedIntSize(frame->presentationSize());
+                    auto adaptorSize = adaptor->size;
+                    if (shouldSwapAdaptorSize)
+                        adaptorSize = adaptorSize.transposedSize();
+                    auto desiredSize = computeResizedVideoFrameSize(adaptorSize, actualSize);
 
-                if (desiredSize != actualSize) {
-                    if (auto newVideoFrame = adaptVideoFrame(*adaptor, currentVideoFrame, desiredSize)) {
-                        key->videoFrameAvailable(*newVideoFrame, metadata);
-                        continue;
+                    if (desiredSize != actualSize) {
+                        if (auto newVideoFrame = adaptVideoFrame(*adaptor, frame, desiredSize)) {
+                            key->videoFrameAvailable(*newVideoFrame, frameMetadata);
+                            continue;
+                        }
                     }
                 }
             }
+            key->videoFrameAvailable(frame, frameMetadata);
         }
-        key->videoFrameAvailable(currentVideoFrame, metadata);
+    };
+
+    // Store encoded (H.264, vp9, etc.) video frames to avoid missing the headers when the first observer starts listening.
+    if (m_videoFrameObservers.isEmpty() && currentVideoFrame->isEncoded()) {
+        // If the encoded format has changed, empty the pending frames, because there's no point on delivering them anymore.
+        if (!m_pendingVideoFrames.isEmpty() && !(protect(m_pendingVideoFrames.last().frame)->hasSameEncodedFormat(currentVideoFrame)))
+            m_pendingVideoFrames.clear();
+
+        if (m_pendingVideoFrames.size() < maxPendingVideoFramesBeforeAddTrack)
+            m_pendingVideoFrames.append(PendingVideoFrame { WTF::move(currentVideoFrame), WTF::move(metadata) });
+        else
+            ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource: Dropping video frame (queue is full) ", m_pendingVideoFrames.size(), " frames");
+        return;
     }
+
+    if (!m_pendingVideoFrames.isEmpty()) {
+        ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER, "RealtimeMediaSource: Delivering ", m_pendingVideoFrames.size(), " queued frame(s) (observer ready)");
+        for (auto& pending : m_pendingVideoFrames)
+            deliverFrame(WTF::move(pending.frame), WTF::move(pending.metadata), m_videoFrameObservers);
+        m_pendingVideoFrames.clear();
+    }
+
+    deliverFrame(WTF::move(currentVideoFrame), WTF::move(metadata), m_videoFrameObservers);
 }
 
 void RealtimeMediaSource::audioSamplesAvailable(const MediaTime& time, const PlatformAudioData& audioData, const AudioStreamDescription& description, size_t numberOfFrames)
@@ -428,6 +456,12 @@ void RealtimeMediaSource::stop()
     ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER);
 
     m_isProducingData = false;
+
+    {
+        Locker locker { m_videoFrameObserversLock };
+        m_pendingVideoFrames.clear();
+    }
+
     stopProducingData();
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -399,6 +399,13 @@ private:
     mutable Lock m_videoFrameObserversLock;
     HashMap<VideoFrameObserver*, std::unique_ptr<VideoFrameAdaptor>> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
 
+    struct PendingVideoFrame {
+        Ref<VideoFrame> frame;
+        VideoFrameTimeMetadata metadata;
+    };
+    static constexpr size_t maxPendingVideoFramesBeforeAddTrack = 30;
+    Vector<PendingVideoFrame> m_pendingVideoFrames WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);
+
     CaptureDevice m_device;
 
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 48ba671f2f85b586706f412bfb2d2479e5575b32
<pre>
[libWebRTC][GStreamer] Missing video in WebRTC playback when decoding on playback pipeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=317111">https://bugs.webkit.org/show_bug.cgi?id=317111</a>

Reviewed by Xabier Rodriguez-Calvar.

LibWebRTC has a dedicated Decoder component that is supposed to decode video
frames and supply them like that to its observers. Under those assumptions,
missing some of those decoded frames (eg: because no observer is listening yet)
isn&apos;t very problematic in this expected case.

However, in order to facilitate hardware decoding, the libWebRTC Decoder
implementation provided by the GStreamer port emits encoded frames (that is,
doesn&apos;t decode at all) unders some circumstances, with the hope that those
encoded frames end up reaching the playback pipeline and being decoded there.

In such a case, missing video frames because no observer has been registered
(a circumstance that has been reported by at least one downstream setup but
that can&apos;t be reproduced reliably) can be problematic. Missing the first
&quot;frames&quot; (buffers) of an encoded video means that the video headers (eg:
SPS/PPS for H.264) are missed that&apos;s a condition the actual video decoder
can&apos;t recover from.

This patch provides a mechanism to keep undelivered buffers when they come
in an encoded format and there&apos;s no registered observer to deliver them to,
and redeliver them when the first observer is registered. This solves the
problem detected in the mentioned downstream setup.

If a format change is detected or if RealtimeMediaSource is stopping, the
list of pending frames is emtied, since there&apos;s no point anymore on
delivering them.

Co-authored by: Ganesh prasad Sahu &lt;GaneshPrasad_Sahu@comcast.com&gt;

* Source/WebCore/platform/VideoFrame.h:
(WebCore::VideoFrame::isEncoded const): Added generic implementation to know if a VideoFrame has an encoded format or not. Defaults to false.
(WebCore::VideoFrame::hasSameEncodedFormat const): Compares if format of one sample is the same as the one from another. Defaults to false.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::VideoFrameGStreamer): Added assertion to ensure m_sample is not null.
(WebCore::VideoFrameGStreamer::isEncoded const): Specific implementation, only true when the caps are other than video/x-raw.
(WebCore::VideoFrameGStreamer::hasSameEncodedFormat const): Format comparison is implemented by comparing caps.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h: Added isEncoded() declaration.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::videoFrameAvailable): Added code to hoard decoded frames when there&apos;s no observer, and redeliver then later. The frame delivery code is reused from the regular case, so it has been factored into a lambda. If a format change is detected, the pending frames are emptied, because there&apos;s no point on redelivering them (only the ones with the new format are relevant).
(WebCore::RealtimeMediaSource::stop): Empty the pending frames, since there&apos;s no point in delivering them when we&apos;re stopping the whole RealtimeMediaSource.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h: Added PendingVideoFrame struct to hold the pending frames and metadata, a Vector of pending frames, and the constant that defines the maximum number of frames that can be kept waiting redelivery.

Canonical link: <a href="https://commits.webkit.org/315815@main">https://commits.webkit.org/315815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/723982203eb7e9cd5172080dc4eb1dfec9734670

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179521 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132646 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173118 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113148 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28217 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182118 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34907 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141099 "Found 1 new test failure: fast/flexbox/002.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43739 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140924 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37947 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44428 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108802 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36191 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116308 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42938 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7561 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->