### PR TITLE
SecureCoding::applyProcessCreationParameters dereferences a null unique_ptr

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
@@ -76,7 +76,7 @@ void applyProcessCreationParameters(AuxiliaryProcessCreationParameters&& paramet
     RELEASE_ASSERT(!exemptClassNames);
 
     if (parameters.classNamesExemptFromSecureCodingCrash)
-        *exemptClassNames = WTF::move(*parameters.classNamesExemptFromSecureCodingCrash);
+        exemptClassNames = WTF::move(parameters.classNamesExemptFromSecureCodingCrash);
 }
 
 } // namespace SecureCoding

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift
@@ -55,6 +55,16 @@ struct WebPageNavigationTests {
     }
 
     @Test
+    func secureCodingExemptClassesAppliedToAuxiliaryProcess() async throws {
+        UserDefaults.standard.register(defaults: [
+            "WebKitCrashOnSecureCodingWithExemptClassesKey": ["NSURLRequest", "NSError"]
+        ])
+
+        let page = WebPage()
+        try await page.load(html: "<body></body>").wait()
+    }
+
+    @Test
     func failedNavigationProducesExpectedNavigationError() async throws {
         let page = WebPage()
 


### PR DESCRIPTION
#### df1c872b25dd48cdfab23126f83b62eaf369030d
<pre>
SecureCoding::applyProcessCreationParameters dereferences a null unique_ptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=317432">https://bugs.webkit.org/show_bug.cgi?id=317432</a>
<a href="https://rdar.apple.com/180061163">rdar://180061163</a>

Reviewed by Richard Robinson.

exemptClassNames is a reference to the process-global std::unique_ptr&lt;HashSet&lt;String&gt;&gt;, which
RELEASE_ASSERT(!exemptClassNames) has just proven to be null. The code then evaluated
`*exemptClassNames = WTF::move(*parameters....)`, calling unique_ptr::operator* on the null pointer.
Move the whole unique_ptr instead of dereferencing both sides.

* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm:
(WebKit::SecureCoding::applyProcessCreationParameters):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageNavigationTests.swift:
(WebPageNavigationTests.secureCodingExemptClassesAppliedToAuxiliaryProcess):

Canonical link: <a href="https://commits.webkit.org/315546@main">https://commits.webkit.org/315546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38a0f85f17def7ef29fe97cf95b1d09247b6e8d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126981 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24a2f489-e00b-44c0-bccf-29975dd7cf04) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131840 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2a049d1-d5ca-4460-ba68-6cb9c830aa4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112344 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd9c4e33-f36f-4475-a92c-c44ab074936e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33294 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31984 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181225 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140294 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42847 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140133 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43536 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28503 "Found 1 new test failure: storage/indexeddb/modern/request-dispatch-untrusted-event-private.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107468 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25805 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35402 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115301 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42046 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6593 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41439 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41582 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->