### PR TITLE
[Smart Lists] Apple-*-list should be constants

### DIFF
--- a/Source/WebCore/editing/ChangeListTypeCommand.cpp
+++ b/Source/WebCore/editing/ChangeListTypeCommand.cpp
@@ -32,6 +32,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "FrameSelection.h"
 #include "HTMLElement.h"
+#include "HTMLInterchange.h"
 #include "HTMLOListElement.h"
 #include "HTMLUListElement.h"
 #include "LocalFrameInlines.h"
@@ -83,12 +84,12 @@ static void removeSourceListAttributes(const HTMLElement& listToReplace, HTMLEle
     list.removeInlineStyleProperty(CSSPropertyListStyleType);
 
     Ref classList = list.classList();
-    bool sourceHasClassNameForSmartList = classList->contains("Apple-decimal-list"_s) || classList->contains("Apple-disc-list"_s) || classList->contains("Apple-dash-list"_s);
+    bool sourceHasClassNameForSmartList = classList->contains(AppleDecimalListClass) || classList->contains(AppleDiscListClass) || classList->contains(AppleDashListClass);
 
     if (sourceHasClassNameForSmartList) {
-        FixedVector<AtomString> classNamesToRemove { "Apple-dash-list"_s, (convertToUnorderedList ? "Apple-decimal-list"_s : "Apple-disc-list"_s) };
+        FixedVector<AtomString> classNamesToRemove { AppleDashListClass, (convertToUnorderedList ? AppleDecimalListClass : AppleDiscListClass) };
         classList->remove(classNamesToRemove);
-        classList->add(convertToUnorderedList ? "Apple-disc-list"_s : "Apple-decimal-list"_s);
+        classList->add(convertToUnorderedList ? AppleDiscListClass : AppleDecimalListClass);
     }
 
     RefPtr existingInlineStyle = listToReplace.inlineStyle();

--- a/Source/WebCore/editing/HTMLInterchange.h
+++ b/Source/WebCore/editing/HTMLInterchange.h
@@ -40,6 +40,10 @@ constexpr auto ApplePasteAsQuotation = "Apple-paste-as-quotation"_s;
 constexpr auto AppleStyleSpanClass = "Apple-style-span"_s;
 constexpr auto AppleTabSpanClass = "Apple-tab-span"_s;
 
+constexpr auto AppleDashListClass = "Apple-dash-list"_s;
+constexpr auto AppleDecimalListClass = "Apple-decimal-list"_s;
+constexpr auto AppleDiscListClass = "Apple-disc-list"_s;
+
 // Controls whether a special BR which is removed upon paste in ReplaceSelectionCommand needs to be inserted
 // and making sequence of spaces not collapsible by inserting non-breaking spaces.
 // See https://trac.webkit.org/r8087 and https://trac.webkit.org/r8096.

--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -36,6 +36,7 @@
 #include <WebCore/ElementInlines.h>
 #include <WebCore/FontAttributes.h>
 #include <WebCore/HTMLElement.h>
+#include <WebCore/HTMLInterchange.h>
 #include <WebCore/HTMLNames.h>
 #include <WebCore/MutableStyleProperties.h>
 #include <WebCore/RenderElement.h>
@@ -188,14 +189,14 @@ static AtomString classNameForSmartList(const TextList& textList)
 {
     if (textList.ordered) {
         ASSERT(textList.styleType.isDecimal());
-        return "Apple-decimal-list"_s;
+        return AppleDecimalListClass;
     }
 
     if (textList.styleType.isDisc())
-        return "Apple-disc-list"_s;
+        return AppleDiscListClass;
 
     ASSERT(textList.styleType.isString());
-    return "Apple-dash-list"_s;
+    return AppleDashListClass;
 }
 
 static AtomString startingOrdinalForList(const StyledElement& element, const TextList& textList)


### PR DESCRIPTION
#### b526e2556718425a177f3996106d75ca7828399f
<pre>
[Smart Lists] Apple-*-list should be constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=317434">https://bugs.webkit.org/show_bug.cgi?id=317434</a>
<a href="https://rdar.apple.com/180061726">rdar://180061726</a>

Reviewed by Abrar Rahman Protyasha, Richard Robinson, and Aditya Keerthi.

As `Apple-*-list` is used mutliple times in different
files, they should be constants instead.

* Source/WebCore/editing/ChangeListTypeCommand.cpp:
(WebCore::removeSourceListAttributes):
* Source/WebCore/editing/HTMLInterchange.h:
* Source/WebCore/editing/TextListParser.cpp:
(WebCore::classNameForSmartList):

Canonical link: <a href="https://commits.webkit.org/315580@main">https://commits.webkit.org/315580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae24df6cdac7216c9d965d1b55ca8bf635f4fe19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126950 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9aaacd3-4793-4d9c-b98c-8184f5afd1a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131812 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92762 "8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/024d846b-aa6a-4801-b06a-d4b5c542c252) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112316 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5b20d72-8175-4464-a92e-47a2f34506ae) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31958 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27294 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181194 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140266 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42816 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140107 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43505 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107426 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25814 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35378 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115270 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42015 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6567 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41408 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41663 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41551 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->