### PR TITLE
Inherited policy should not re-apply a meta-delivered sandbox directive

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/meta-element.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/meta-element.sub-expected.txt
@@ -2,5 +2,5 @@
 
 PASS Document shouldn't be sandboxed by <meta>
 PASS Worker shouldn't be sandboxed by inheriting <meta>
-FAIL Worker shouldn't be sandboxed when created <iframe> inheriting parent's CSP with sandbox <meta> null is not an object (evaluating 'iframeDocument.createElement')
+PASS Worker shouldn't be sandboxed when created <iframe> inheriting parent's CSP with sandbox <meta>
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -144,6 +144,7 @@ void ContentSecurityPolicy::copyStateFrom(const ContentSecurityPolicy* other, Sh
     if (m_hasAPIPolicy)
         return;
     ASSERT(m_policies.isEmpty());
+    m_sandboxFlags = other->m_sandboxFlags;
     for (auto& policy : other->m_policies)
         didReceiveHeader(policy->header(), policy->headerType(), ContentSecurityPolicy::PolicyFrom::Inherited, String { });
     m_referrer = shouldMakeIsolatedCopy == ShouldMakeIsolatedCopy::Yes ? other->m_referrer.isolatedCopy() : other->m_referrer;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -487,7 +487,8 @@ void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecu
             if (auto directive = parseDirective(std::span { directiveBegin, buffer.position() })) {
                 ASSERT(!directive->name.isEmpty());
                 if (policyFrom == ContentSecurityPolicy::PolicyFrom::Inherited) {
-                    if (equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::upgradeInsecureRequests))
+                    if (equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::upgradeInsecureRequests)
+                        || equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::sandbox))
                         continue;
                 } else if (policyFrom == ContentSecurityPolicy::PolicyFrom::HTTPEquivMeta) {
                     if (equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::sandbox)


### PR DESCRIPTION
#### 08a2933c1c9bfd9a1e0a51700620bebc2a87ad96
<pre>
Inherited policy should not re-apply a meta-delivered sandbox directive
<a href="https://bugs.webkit.org/show_bug.cgi?id=317436">https://bugs.webkit.org/show_bug.cgi?id=317436</a>
<a href="https://rdar.apple.com/180062669">rdar://180062669</a>

Reviewed by Ryan Reno.

`sandbox` is required to be removed from CSP delivered via &lt;meta http-equiv&gt; before enforcement:
<a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy</a>

We ignored the directive for the meta-hosting document, but preserved it in the serialized policy.
When inherited by about:blank, it was reparsed and enforced, incorrectly giving the child an opaque
origin.

Drop the sandbox directive when reparsing an inherited policy. So a header-delivered sandbox is
still inherited, carry the parent&apos;s already-resolved sandbox flags forward in copyStateFrom(),
mirroring upgrade-insecure-requests.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/sandbox/meta-element.sub-expected.txt:
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::parse):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::copyStateFrom):

Canonical link: <a href="https://commits.webkit.org/315702@main">https://commits.webkit.org/315702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a65fc8cc9836c765c5e394959035c356b82ff71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178633 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126989 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb09510d-f8ab-4c09-badf-82bfd0313b0d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131844 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92784 "2 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd8ea1ea-8fff-402c-8f1e-1557a60abcd9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112348 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e4acdb5-6603-43c1-9b79-2c4e3284b5e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33530 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31990 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27333 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143520 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181233 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140301 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42855 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140139 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43544 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107476 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25871 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35412 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115309 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42054 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6665 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41447 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41702 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41590 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->