### PR TITLE
Support writing ISOBoxes as well as reading/parsing

### DIFF
--- a/Source/JavaScriptCore/runtime/DataView.h
+++ b/Source/JavaScriptCore/runtime/DataView.h
@@ -40,7 +40,7 @@ public:
     JSArrayBufferView* wrapImpl(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject);
     
     template<typename T>
-    T get(size_t offset, bool littleEndian, bool* status = nullptr)
+    T get(size_t offset, bool littleEndian, bool* status = nullptr) const
     {
         if (status) {
             if (offset + sizeof(T) > byteLength()) {
@@ -56,7 +56,7 @@ public:
     }
     
     template<typename T>
-    T read(size_t& offset, bool littleEndian, bool* status = nullptr)
+    T read(size_t& offset, bool littleEndian, bool* status = nullptr) const
     {
         T result = this->template get<T>(offset, littleEndian, status);
         if (!status || *status)

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -32,7 +32,6 @@
 #include "ISOProtectionSystemSpecificHeaderBox.h"
 #include "NotImplemented.h"
 #include "SharedBuffer.h"
-#include <JavaScriptCore/DataView.h>
 #include <wtf/JSONValues.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/Base64.h>
@@ -130,7 +129,7 @@ std::optional<Vector<std::unique_ptr<ISOProtectionSystemSpecificHeaderBox>>> Ini
     unsigned offset = 0;
     Vector<std::unique_ptr<ISOProtectionSystemSpecificHeaderBox>> psshBoxes;
 
-    auto view = JSC::DataView::create(buffer.tryCreateArrayBuffer(), offset, buffer.size());
+    auto view = buffer.span();
     while (auto optionalBoxType = ISOBox::peekBox(view, offset)) {
         auto& boxTypeName = optionalBoxType.value().first;
         auto& boxSize = optionalBoxType.value().second;
@@ -166,11 +165,7 @@ RefPtr<SharedBuffer> InitDataRegistry::extractFairPlayPsshFromCenc(const SharedB
     if (buffer.size() >= kCencMaxBoxSize)
         return nullptr;
 
-    auto arrayBuffer = buffer.tryCreateArrayBuffer();
-    if (!arrayBuffer)
-        return nullptr;
-
-    auto view = JSC::DataView::create(WTF::move(arrayBuffer), 0, buffer.size());
+    auto view = buffer.span();
     unsigned offset = 0;
     while (auto optionalBoxType = ISOBox::peekBox(view, offset)) {
         auto& [boxTypeName, boxSize] = optionalBoxType.value();

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -135,7 +135,7 @@ static SchemeAndKeyResult extractSchemeAndKeyIdFromSinf(const SharedBuffer& buff
         std::optional<FourCC> scheme;
         std::optional<Vector<uint8_t>> keyID;
 
-        auto view = JSC::DataView::create(buffer->tryCreateArrayBuffer(), offset, buffer->size());
+        auto view = buffer->span();
         while (auto optionalBoxType = ISOBox::peekBox(view, offset)) {
             auto& boxTypeName = optionalBoxType.value().first;
             auto& boxSize = optionalBoxType.value().second;

--- a/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
@@ -27,17 +27,18 @@
 #include "ISOFairPlayStreamingPsshBox.h"
 
 #include <JavaScriptCore/DataView.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
-const Vector<uint8_t>& ISOFairPlayStreamingPsshBox::fairPlaySystemID()
+const ISOFairPlayStreamingPsshBox::SystemID& ISOFairPlayStreamingPsshBox::fairPlaySystemID()
 {
-    static NeverDestroyed<Vector<uint8_t>> systemID = Vector<uint8_t>({ 0x94, 0xCE, 0x86, 0xFB, 0x07, 0xFF, 0x4F, 0x43, 0xAD, 0xB8, 0x93, 0xD2, 0xFA, 0x96, 0x8C, 0xA2 });
+    static NeverDestroyed<SystemID> systemID { SystemID { { 0x94, 0xCE, 0x86, 0xFB, 0x07, 0xFF, 0x4F, 0x43, 0xAD, 0xB8, 0x93, 0xD2, 0xFA, 0x96, 0x8C, 0xA2 } } };
     return systemID;
 }
 
-bool ISOFairPlayStreamingInfoBox::parse(JSC::DataView& view, unsigned& offset)
+bool ISOFairPlayStreamingInfoBox::parse(const ByteView& view, unsigned& offset)
 {
     if (!ISOFullBox::parse(view, offset))
         return false;
@@ -45,10 +46,18 @@ bool ISOFairPlayStreamingInfoBox::parse(JSC::DataView& view, unsigned& offset)
     return checkedRead<uint32_t>(m_scheme, view, offset, BigEndian);
 }
 
-bool ISOFairPlayStreamingKeyRequestInfoBox::parse(JSC::DataView& view, unsigned& offset)
+bool ISOFairPlayStreamingInfoBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOFullBox::pack(view, offset))
+        return false;
+
+    return checkedWrite<uint32_t>(m_scheme.value, view, offset, BigEndian);
+}
+
+bool ISOFairPlayStreamingKeyRequestInfoBox::parse(const ByteView& view, unsigned& offset)
 {
     unsigned localOffset = offset;
-    if (!ISOBox::parse(view, localOffset))
+    if (!ISOFullBox::parse(view, localOffset))
         return false;
 
     CheckedUint64 remaining = m_size;
@@ -59,23 +68,23 @@ bool ISOFairPlayStreamingKeyRequestInfoBox::parse(JSC::DataView& view, unsigned&
     if (remaining < m_keyID.capacity())
         return false;
 
-    auto buffer = view.possiblySharedBuffer();
-    if (!buffer)
-        return false;
-
-    auto keyID = buffer->slice(localOffset, localOffset + m_keyID.capacity());
-    localOffset += m_keyID.capacity();
-
     m_keyID.resize(m_keyID.capacity());
-    if (keyID->byteLength() < m_keyID.capacity())
+    if (!checkedReadSequence<uint8_t>(m_keyID, view, localOffset, BigEndian))
         return false;
-    memcpySpan(m_keyID.mutableSpan(), keyID->span().first(m_keyID.capacity()));
 
     offset = localOffset;
     return true;
 }
 
-bool ISOFairPlayStreamingKeyAssetIdBox::parse(JSC::DataView& view, unsigned& offset)
+bool ISOFairPlayStreamingKeyRequestInfoBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOFullBox::pack(view, offset))
+        return false;
+
+    return checkedWriteSequence<uint8_t>(m_keyID, view, offset, BigEndian);
+}
+
+bool ISOFairPlayStreamingKeyAssetIdBox::parse(const ByteView& view, unsigned& offset)
 {
     unsigned localOffset = offset;
     if (!ISOBox::parse(view, localOffset))
@@ -87,26 +96,34 @@ bool ISOFairPlayStreamingKeyAssetIdBox::parse(JSC::DataView& view, unsigned& off
         return true;
     }
 
-    auto buffer = view.possiblySharedBuffer();
-    if (!buffer)
-        return false;
-
     size_t dataSize;
     if (!WTF::safeSub(m_size, localOffset - offset, dataSize))
         return false;
 
-    auto parsedData = buffer->slice(localOffset, localOffset + dataSize);
-    localOffset += dataSize;
+    size_t remainingInView;
+    if (!WTF::safeSub(view.size(), localOffset, remainingInView))
+        return false;
+
+    if (remainingInView < dataSize)
+        return false;
 
     m_data.resize(dataSize);
-    if (parsedData->byteLength() < dataSize)
+    if (!checkedReadSequence<uint8_t>(m_data, view, localOffset, BigEndian))
         return false;
-    memcpySpan(m_data.mutableSpan(), parsedData->span().first(dataSize));
+
     offset = localOffset;
     return true;
 }
 
-bool ISOFairPlayStreamingKeyContextBox::parse(JSC::DataView& view, unsigned& offset)
+bool ISOFairPlayStreamingKeyAssetIdBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    return checkedWriteSequence<uint8_t>(m_data, view, offset, BigEndian);
+}
+
+bool ISOFairPlayStreamingKeyContextBox::parse(const ByteView& view, unsigned& offset)
 {
     unsigned localOffset = offset;
     if (!ISOBox::parse(view, localOffset))
@@ -118,26 +135,34 @@ bool ISOFairPlayStreamingKeyContextBox::parse(JSC::DataView& view, unsigned& off
         return true;
     }
 
-    auto buffer = view.possiblySharedBuffer();
-    if (!buffer)
-        return false;
-
     size_t dataSize;
     if (!WTF::safeSub(m_size, localOffset - offset, dataSize))
         return false;
 
-    auto parsedData = buffer->slice(localOffset, localOffset + dataSize);
-    localOffset += dataSize;
+    size_t remainingInView;
+    if (!WTF::safeSub(view.size(), localOffset, remainingInView))
+        return false;
+
+    if (remainingInView < dataSize)
+        return false;
 
     m_data.resize(dataSize);
-    if (parsedData->byteLength() < dataSize)
+    if (!checkedReadSequence<uint8_t>(m_data, view, localOffset, BigEndian))
         return false;
-    memcpySpan(m_data.mutableSpan(), parsedData->span().first(dataSize));
+
     offset = localOffset;
     return true;
 }
 
-bool ISOFairPlayStreamingKeyVersionListBox::parse(JSC::DataView& view, unsigned& offset)
+bool ISOFairPlayStreamingKeyContextBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    return checkedWriteSequence<uint8_t>(m_data, view, offset, BigEndian);
+}
+
+bool ISOFairPlayStreamingKeyVersionListBox::parse(const ByteView& view, unsigned& offset)
 {
     unsigned localOffset = offset;
     if (!ISOBox::parse(view, localOffset))
@@ -161,10 +186,43 @@ bool ISOFairPlayStreamingKeyVersionListBox::parse(JSC::DataView& view, unsigned&
     } while (true);
 
     offset = localOffset;
-    return true; 
+    return true;
 }
 
-bool ISOFairPlayStreamingKeyRequestBox::parse(JSC::DataView& view, unsigned& offset)
+bool ISOFairPlayStreamingKeyVersionListBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    return checkedWriteSequence<uint32_t>(m_versions, view, offset, BigEndian);
+}
+
+void ISOFairPlayStreamingKeyRequestBox::updateSize()
+{
+    m_requestInfo.updateSize();
+    if (m_assetID)
+        m_assetID->updateSize();
+    if (m_context)
+        m_context->updateSize();
+    if (m_versionList)
+        m_versionList->updateSize();
+    ISOBox::updateSize();
+}
+
+uint64_t ISOFairPlayStreamingKeyRequestBox::partialSize() const
+{
+    auto size = ISOBox::partialSize();
+    size += m_requestInfo.requiredSize();
+    if (m_assetID)
+        size += m_assetID->requiredSize();
+    if (m_context)
+        size += m_context->requiredSize();
+    if (m_versionList)
+        size += m_versionList->requiredSize();
+    return size;
+}
+
+bool ISOFairPlayStreamingKeyRequestBox::parse(const ByteView& view, unsigned& offset)
 {
     unsigned localOffset = offset;
     if (!ISOBox::parse(view, localOffset))
@@ -220,10 +278,30 @@ bool ISOFairPlayStreamingKeyRequestBox::parse(JSC::DataView& view, unsigned& off
     }   
     
     offset = localOffset;
-    return true; 
+    return true;
 }
 
-bool ISOFairPlayStreamingInitDataBox::parse(JSC::DataView& view, unsigned& offset)
+bool ISOFairPlayStreamingKeyRequestBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    if (!m_requestInfo.write(view, offset))
+        return false;
+
+    if (m_assetID && !m_assetID->write(view, offset))
+        return false;
+
+    if (m_context && !m_context->write(view, offset))
+        return false;
+
+    if (m_versionList && !m_versionList->write(view, offset))
+        return false;
+
+    return true;
+}
+
+bool ISOFairPlayStreamingInitDataBox::parse(const ByteView& view, unsigned& offset)
 {
     unsigned localOffset = offset;
     if (!ISOBox::parse(view, localOffset))
@@ -244,44 +322,145 @@ bool ISOFairPlayStreamingInitDataBox::parse(JSC::DataView& view, unsigned& offse
     return true;
 }
 
-bool ISOFairPlayStreamingPsshBox::parse(JSC::DataView& view, unsigned& offset)
+bool ISOFairPlayStreamingPsshBox::parseData(const ByteView& view, unsigned& offset, uint64_t size)
 {
-    if (!ISOProtectionSystemSpecificHeaderBox::parse(view, offset))
+    if (!m_initDataBox.read(view, offset))
         return false;
-
-    // Back up the offset by exactly the size of m_data:
-    offset -= m_data.size();
-
-    return m_initDataBox.read(view, offset);
+    ASSERT_UNUSED(size, m_initDataBox.size() == size);
+    return true;
 }
 
-ISOFairPlayStreamingInfoBox::ISOFairPlayStreamingInfoBox() = default;
+bool ISOFairPlayStreamingInitDataBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    if (!m_info.write(view, offset))
+        return false;
+
+    for (auto& request : m_requests) {
+        if (!request.write(view, offset))
+            return false;
+    }
+
+    return true;
+}
+
+void ISOFairPlayStreamingInitDataBox::updateSize()
+{
+    m_info.updateSize();
+    for (auto& request : m_requests)
+        request.updateSize();
+    ISOBox::updateSize();
+}
+
+uint64_t ISOFairPlayStreamingInitDataBox::partialSize() const
+{
+    auto size = ISOBox::partialSize();
+    size += m_info.requiredSize();
+    for (auto& request : m_requests)
+        size += request.requiredSize();
+    return size;
+}
+
+uint64_t ISOFairPlayStreamingPsshBox::dataSize() const
+{
+    return m_initDataBox.size();
+}
+
+bool ISOFairPlayStreamingPsshBox::writeData(MutableByteView& view, unsigned& offset) const
+{
+    return m_initDataBox.write(view, offset);
+}
+
+void ISOFairPlayStreamingPsshBox::updateSize()
+{
+    m_initDataBox.updateSize();
+    ISOBox::updateSize();
+}
+
+uint64_t ISOFairPlayStreamingPsshBox::partialSize() const
+{
+    // ISOProtectionSystemSpecificHeaderBox::partialSize() adds its base size
+    // to the size of m_data. However, as we've overridden parseData(), it should
+    // be the case that m_data is empty. Assert so, and just in case, subtract out
+    // its size from our super classes' partial size.
+    ASSERT(!m_data.size());
+    return ISOProtectionSystemSpecificHeaderBox::partialSize()
+        - m_data.size()
+        + m_initDataBox.requiredSize();
+}
+
+ISOFairPlayStreamingInfoBox::ISOFairPlayStreamingInfoBox()
+    : ISOFullBox(boxTypeName(), 0, 0)
+{
+}
+
 ISOFairPlayStreamingInfoBox::ISOFairPlayStreamingInfoBox(const ISOFairPlayStreamingInfoBox&) = default;
+ISOFairPlayStreamingInfoBox::ISOFairPlayStreamingInfoBox(ISOFairPlayStreamingInfoBox&&) = default;
 ISOFairPlayStreamingInfoBox::~ISOFairPlayStreamingInfoBox() = default;
 
-ISOFairPlayStreamingKeyRequestInfoBox::ISOFairPlayStreamingKeyRequestInfoBox() = default;
+ISOFairPlayStreamingKeyRequestInfoBox::ISOFairPlayStreamingKeyRequestInfoBox()
+    : ISOFullBox(boxTypeName(), 0, 0)
+{
+    // The key ID is a fixed-width field, so a default-constructed box has to start out with one:
+    // parse() requires capacity() bytes to be present, and a box written without them would not
+    // be readable back. Match the length parse() expects rather than hard-coding it here.
+    m_keyID.fill(0, m_keyID.capacity());
+}
+
+ISOFairPlayStreamingKeyRequestInfoBox::ISOFairPlayStreamingKeyRequestInfoBox(const ISOFairPlayStreamingKeyRequestInfoBox&) = default;
+ISOFairPlayStreamingKeyRequestInfoBox::ISOFairPlayStreamingKeyRequestInfoBox(ISOFairPlayStreamingKeyRequestInfoBox&&) = default;
 ISOFairPlayStreamingKeyRequestInfoBox::~ISOFairPlayStreamingKeyRequestInfoBox() = default;
 
-ISOFairPlayStreamingKeyAssetIdBox::ISOFairPlayStreamingKeyAssetIdBox() = default;
+ISOFairPlayStreamingKeyAssetIdBox::ISOFairPlayStreamingKeyAssetIdBox()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOFairPlayStreamingKeyAssetIdBox::ISOFairPlayStreamingKeyAssetIdBox(const ISOFairPlayStreamingKeyAssetIdBox&) = default;
+ISOFairPlayStreamingKeyAssetIdBox::ISOFairPlayStreamingKeyAssetIdBox(ISOFairPlayStreamingKeyAssetIdBox&&) = default;
 ISOFairPlayStreamingKeyAssetIdBox::~ISOFairPlayStreamingKeyAssetIdBox() = default;
 
-ISOFairPlayStreamingKeyContextBox::ISOFairPlayStreamingKeyContextBox() = default;
+ISOFairPlayStreamingKeyContextBox::ISOFairPlayStreamingKeyContextBox()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOFairPlayStreamingKeyContextBox::ISOFairPlayStreamingKeyContextBox(const ISOFairPlayStreamingKeyContextBox&) = default;
+ISOFairPlayStreamingKeyContextBox::ISOFairPlayStreamingKeyContextBox(ISOFairPlayStreamingKeyContextBox&&) = default;
 ISOFairPlayStreamingKeyContextBox::~ISOFairPlayStreamingKeyContextBox() = default;
 
-ISOFairPlayStreamingKeyVersionListBox::ISOFairPlayStreamingKeyVersionListBox() = default;
+ISOFairPlayStreamingKeyVersionListBox::ISOFairPlayStreamingKeyVersionListBox()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOFairPlayStreamingKeyVersionListBox::ISOFairPlayStreamingKeyVersionListBox(const ISOFairPlayStreamingKeyVersionListBox&) = default;
+ISOFairPlayStreamingKeyVersionListBox::ISOFairPlayStreamingKeyVersionListBox(ISOFairPlayStreamingKeyVersionListBox&&) = default;
 ISOFairPlayStreamingKeyVersionListBox::~ISOFairPlayStreamingKeyVersionListBox() = default;
 
-ISOFairPlayStreamingKeyRequestBox::ISOFairPlayStreamingKeyRequestBox() = default;
+ISOFairPlayStreamingKeyRequestBox::ISOFairPlayStreamingKeyRequestBox()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOFairPlayStreamingKeyRequestBox::ISOFairPlayStreamingKeyRequestBox(const ISOFairPlayStreamingKeyRequestBox&) = default;
+ISOFairPlayStreamingKeyRequestBox::ISOFairPlayStreamingKeyRequestBox(ISOFairPlayStreamingKeyRequestBox&&) = default;
 ISOFairPlayStreamingKeyRequestBox::~ISOFairPlayStreamingKeyRequestBox() = default;
 
-ISOFairPlayStreamingInitDataBox::ISOFairPlayStreamingInitDataBox() = default;
+ISOFairPlayStreamingInitDataBox::ISOFairPlayStreamingInitDataBox()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOFairPlayStreamingInitDataBox::~ISOFairPlayStreamingInitDataBox() = default;
 
-ISOFairPlayStreamingPsshBox::ISOFairPlayStreamingPsshBox() = default;
+ISOFairPlayStreamingPsshBox::ISOFairPlayStreamingPsshBox()
+    : ISOProtectionSystemSpecificHeaderBox(fairPlaySystemID())
+{
+}
+
 ISOFairPlayStreamingPsshBox::~ISOFairPlayStreamingPsshBox() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.h
+++ b/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.h
@@ -38,27 +38,37 @@ public:
 
     static FourCC boxTypeName() { return std::span { "fpsi" }; }
 
+    void setScheme(FourCC scheme) { m_scheme = scheme; }
     FourCC scheme() const { return m_scheme; }
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const final;
 
 private:
+    uint64_t partialSize() const final { return ISOFullBox::partialSize() + sizeof(uint32_t); }
+
     FourCC m_scheme;
 };
 
 class ISOFairPlayStreamingKeyRequestInfoBox final : public ISOFullBox {
 public:
     WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestInfoBox();
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestInfoBox(const ISOFairPlayStreamingKeyRequestInfoBox&);
+    ISOFairPlayStreamingKeyRequestInfoBox(ISOFairPlayStreamingKeyRequestInfoBox&&);
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyRequestInfoBox();
 
     static FourCC boxTypeName() { return std::span { "fkri" }; }
 
     using KeyID = Vector<uint8_t, 16>;
+    void setKeyID(KeyID keyID) { m_keyID = keyID; }
     const KeyID& keyID() const LIFETIME_BOUND { return m_keyID; }
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const final;
 
 private:
+    uint64_t partialSize() const final { return ISOFullBox::partialSize() + m_keyID.size(); }
+
     KeyID m_keyID;
 };
 
@@ -66,7 +76,7 @@ class ISOFairPlayStreamingKeyAssetIdBox final : public ISOBox {
 public:
     WEBCORE_EXPORT ISOFairPlayStreamingKeyAssetIdBox();
     WEBCORE_EXPORT ISOFairPlayStreamingKeyAssetIdBox(const ISOFairPlayStreamingKeyAssetIdBox&);
-    ISOFairPlayStreamingKeyAssetIdBox(ISOFairPlayStreamingKeyAssetIdBox&&) = default;
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyAssetIdBox(ISOFairPlayStreamingKeyAssetIdBox&&);
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyAssetIdBox();
 
     ISOFairPlayStreamingKeyAssetIdBox& operator=(const ISOFairPlayStreamingKeyAssetIdBox&) = default;
@@ -74,10 +84,14 @@ public:
 
     static FourCC boxTypeName() { return std::span { "fkai" }; }
     const Vector<uint8_t>& data() const LIFETIME_BOUND { return m_data; }
+    Vector<uint8_t>& data() LIFETIME_BOUND { return m_data; }
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const final;
 
 private:
+    uint64_t partialSize() const final { return ISOBox::partialSize() + m_data.size(); }
+
     Vector<uint8_t> m_data;
 };
 
@@ -85,7 +99,7 @@ class ISOFairPlayStreamingKeyContextBox final : public ISOBox {
 public:
     WEBCORE_EXPORT ISOFairPlayStreamingKeyContextBox();
     WEBCORE_EXPORT ISOFairPlayStreamingKeyContextBox(const ISOFairPlayStreamingKeyContextBox&);
-    ISOFairPlayStreamingKeyContextBox(ISOFairPlayStreamingKeyContextBox&&) = default;
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyContextBox(ISOFairPlayStreamingKeyContextBox&&);
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyContextBox();
 
     ISOFairPlayStreamingKeyContextBox& operator=(const ISOFairPlayStreamingKeyContextBox&) = default;
@@ -93,10 +107,14 @@ public:
 
     static FourCC boxTypeName() { return std::span { "fkcx" }; }
     const Vector<uint8_t>& data() const LIFETIME_BOUND { return m_data; }
+    Vector<uint8_t>& data() LIFETIME_BOUND { return m_data; }
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const final;
 
 private:
+    uint64_t partialSize() const final { return ISOBox::partialSize() + m_data.size(); }
+
     Vector<uint8_t> m_data;
 };
 
@@ -104,36 +122,51 @@ class ISOFairPlayStreamingKeyVersionListBox final : public ISOBox {
 public:
     WEBCORE_EXPORT ISOFairPlayStreamingKeyVersionListBox();
     WEBCORE_EXPORT ISOFairPlayStreamingKeyVersionListBox(const ISOFairPlayStreamingKeyVersionListBox&);
-    ISOFairPlayStreamingKeyVersionListBox(ISOFairPlayStreamingKeyVersionListBox&&) = default;
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyVersionListBox(ISOFairPlayStreamingKeyVersionListBox&&);
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyVersionListBox();
 
     ISOFairPlayStreamingKeyVersionListBox& operator=(const ISOFairPlayStreamingKeyVersionListBox&) = default;
     ISOFairPlayStreamingKeyVersionListBox& operator=(ISOFairPlayStreamingKeyVersionListBox&&) = default;
 
     static FourCC boxTypeName() { return std::span { "fkvl" }; }
-    const Vector<uint8_t> versions() const { return m_versions; }
+    const Vector<uint32_t>& versions() const LIFETIME_BOUND { return m_versions; }
+    Vector<uint32_t>& versions() LIFETIME_BOUND { return m_versions; }
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const final;
 
 private:
-    Vector<uint8_t> m_versions;
+    uint64_t partialSize() const final { return ISOBox::partialSize() + m_versions.size() * sizeof(uint32_t); }
+
+    Vector<uint32_t> m_versions;
 };
 
 class ISOFairPlayStreamingKeyRequestBox final : public ISOBox {
 public:
     WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestBox();
     WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestBox(const ISOFairPlayStreamingKeyRequestBox&);
-    ISOFairPlayStreamingKeyRequestBox(ISOFairPlayStreamingKeyRequestBox&&) = default;
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestBox(ISOFairPlayStreamingKeyRequestBox&&);
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyRequestBox();
 
     static FourCC boxTypeName() { return std::span { "fpsk" }; }
 
     const ISOFairPlayStreamingKeyRequestInfoBox& requestInfo() const LIFETIME_BOUND { return m_requestInfo; }
-    const std::optional<ISOFairPlayStreamingKeyAssetIdBox>& assetID() const LIFETIME_BOUND { return m_assetID; }
-    const std::optional<ISOFairPlayStreamingKeyContextBox>& content() const LIFETIME_BOUND { return m_context; }
-    const std::optional<ISOFairPlayStreamingKeyVersionListBox>& versionList() const LIFETIME_BOUND { return m_versionList; }
+    ISOFairPlayStreamingKeyRequestInfoBox& requestInfo() LIFETIME_BOUND { return m_requestInfo; }
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
+    const std::optional<ISOFairPlayStreamingKeyAssetIdBox>& assetID() const LIFETIME_BOUND { return m_assetID; }
+    void setAssetID(std::optional<ISOFairPlayStreamingKeyAssetIdBox>&& assetID) { m_assetID = WTF::move(assetID); }
+
+    const std::optional<ISOFairPlayStreamingKeyContextBox>& content() const LIFETIME_BOUND { return m_context; }
+    void setContent(std::optional<ISOFairPlayStreamingKeyContextBox>&& content)  { m_context = WTF::move(content); }
+
+    const std::optional<ISOFairPlayStreamingKeyVersionListBox>& versionList() const LIFETIME_BOUND { return m_versionList; }
+    void setVersionList(std::optional<ISOFairPlayStreamingKeyVersionListBox>&& versionList)  { m_versionList = WTF::move(versionList); }
+
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const final;
+
+    WEBCORE_EXPORT void updateSize() final;
+    uint64_t partialSize() const final;
 
 private:
     ISOFairPlayStreamingKeyRequestInfoBox m_requestInfo;
@@ -150,9 +183,16 @@ public:
     static FourCC boxTypeName() { return std::span { "fpsd" }; }
 
     const ISOFairPlayStreamingInfoBox& info() const LIFETIME_BOUND { return m_info; }
-    const Vector<ISOFairPlayStreamingKeyRequestBox>& requests() const LIFETIME_BOUND { return m_requests; }
+    ISOFairPlayStreamingInfoBox& info() LIFETIME_BOUND { return m_info; }
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
+    const Vector<ISOFairPlayStreamingKeyRequestBox>& requests() const LIFETIME_BOUND { return m_requests; }
+    void setRequests(Vector<ISOFairPlayStreamingKeyRequestBox>&& requests) { m_requests = WTF::move(requests); }
+
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const final;
+
+    void updateSize() final;
+    uint64_t partialSize() const final;
 
 private:
     ISOFairPlayStreamingInfoBox m_info;
@@ -164,11 +204,17 @@ public:
     WEBCORE_EXPORT ISOFairPlayStreamingPsshBox();
     WEBCORE_EXPORT ~ISOFairPlayStreamingPsshBox();
 
-    static const Vector<uint8_t>& fairPlaySystemID();
+    WEBCORE_EXPORT static const SystemID& fairPlaySystemID();
 
-    const ISOFairPlayStreamingInitDataBox& initDataBox() LIFETIME_BOUND { return m_initDataBox; }
+    const ISOFairPlayStreamingInitDataBox& initDataBox() const LIFETIME_BOUND { return m_initDataBox; }
+    ISOFairPlayStreamingInitDataBox& initDataBox() LIFETIME_BOUND { return m_initDataBox; }
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
+    uint64_t dataSize() const final;
+    bool parseData(const ByteView&, unsigned& offset, uint64_t size) final;
+    bool writeData(MutableByteView&, unsigned& offset) const final;
+
+    WEBCORE_EXPORT void updateSize() final;
+    uint64_t partialSize() const final;
 
 private:
     ISOFairPlayStreamingInitDataBox m_initDataBox;

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -534,8 +534,7 @@ void InbandTextTrackPrivateAVF::processVTTSample(CMSampleBufferRef sampleBuffer,
     }
 
     while (true) {
-        RefPtr buffer = ArrayBuffer::create(m_sampleInputBuffer);
-        Ref view = JSC::DataView::create(WTF::move(buffer), 0, buffer->byteLength());
+        auto view = m_sampleInputBuffer.span();
 
         auto peekResult = ISOBox::peekBox(view, 0);
         if (!peekResult)
@@ -545,7 +544,7 @@ void InbandTextTrackPrivateAVF::processVTTSample(CMSampleBufferRef sampleBuffer,
         auto boxLength = peekResult.value().second;
         ALWAYS_LOG(LOGIDENTIFIER, "chunk type = '", type, "', size = ", boxLength);
 
-        if (boxLength > view->byteLength()) {
+        if (boxLength > view.size()) {
             ERROR_LOG(LOGIDENTIFIER, "ISO box larger than buffer length!");
             break;
         }

--- a/Source/WebCore/platform/graphics/iso/ISOBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOBox.cpp
@@ -26,32 +26,38 @@
 #include "config.h"
 #include "ISOBox.h"
 
-#include <JavaScriptCore/DataView.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/TZoneMallocInlines.h>
-
-using JSC::DataView;
+#include "SharedBuffer.h"
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ISOBox);
 
 ISOBox::ISOBox() = default;
+ISOBox::ISOBox(FourCC boxType)
+    : m_boxType { boxType }
+{
+}
+
 ISOBox::~ISOBox() = default;
 ISOBox::ISOBox(const ISOBox&) = default;
+ISOBox::ISOBox(ISOBox&&) = default;
 
 // A box's size field and the cursor these parsers walk it with are both 32-bit, so a larger view
 // cannot be walked at all: its remaining length would not even be representable.
-static bool isWalkableView(const DataView& view)
+static bool isWalkableView(const ISOBox::ByteView& view)
 {
-    return isInBounds<unsigned>(view.byteLength());
+    return isInBounds<unsigned>(view.size());
 }
 
-ISOBox::PeekResult ISOBox::peekBox(DataView& view, unsigned offset)
+ISOBox::PeekResult ISOBox::peekBox(const ByteView& view, unsigned offset)
 {
     if (!isWalkableView(view))
         return std::nullopt;
 
-    unsigned maximumPossibleSize = view.byteLength() - offset;
+    unsigned maximumPossibleSize = view.size() - offset;
+
     uint64_t size = 0;
     if (!checkedRead<uint32_t>(size, view, offset, BigEndian))
         return std::nullopt;
@@ -71,28 +77,77 @@ ISOBox::PeekResult ISOBox::peekBox(DataView& view, unsigned offset)
     return std::make_pair(type, size);
 }
 
-bool ISOBox::read(DataView& view)
+bool ISOBox::read(const ByteView& view)
 {
     unsigned localOffset { 0 };
-    return parse(view, localOffset);
+    if (!parse(view, localOffset))
+        return false;
+
+    return localOffset <= m_size;
 }
 
-bool ISOBox::read(DataView& view, unsigned& offset)
+bool ISOBox::read(const ByteView& view, unsigned& offset)
 {
+    if (!isWalkableView(view))
+        return false;
+
     unsigned localOffset = offset;
     if (!parse(view, localOffset))
+        return false;
+
+    unsigned consumed;
+    if (!WTF::safeSub(localOffset, offset, consumed) || consumed > m_size)
         return false;
 
     offset += m_size;
     return true;
 }
 
-bool ISOBox::parse(DataView& view, unsigned& offset)
+bool ISOBox::write(MutableByteView& view, unsigned& offset) const
 {
     if (!isWalkableView(view))
         return false;
 
-    unsigned maximumPossibleSize = view.byteLength() - offset;
+    unsigned localOffset = offset;
+    if (!pack(view, localOffset))
+        return false;
+
+    unsigned consumed;
+    if (!WTF::safeSub(localOffset, offset, consumed) || consumed > m_size)
+        return false;
+
+    offset += m_size;
+    return true;
+}
+
+void ISOBox::updateSize()
+{
+    m_size = requiredSize();
+}
+
+uint64_t ISOBox::partialSize() const
+{
+    uint64_t size = 8;
+    if (m_boxType == std::span { "uuid" })
+        size += 16;
+    return size;
+}
+
+uint64_t ISOBox::requiredSize() const
+{
+    auto partialSize = this->partialSize();
+    if (partialSize > std::numeric_limits<uint32_t>::max())
+        partialSize += 4;
+    return partialSize;
+}
+
+bool ISOBox::parse(const ByteView& view, unsigned& offset)
+{
+    if (!isWalkableView(view))
+        return false;
+
+    unsigned maximumPossibleSize = view.size() - offset;
+
     if (!checkedRead<uint32_t>(m_size, view, offset, BigEndian))
         return false;
 
@@ -108,22 +163,65 @@ bool ISOBox::parse(DataView& view, unsigned& offset)
         m_size = maximumPossibleSize;
 
     if (m_boxType == std::span { "uuid" }) {
-        struct ExtendedType {
-            uint8_t value[16];
-        } extendedTypeStruct;
-        if (!checkedRead<ExtendedType>(extendedTypeStruct, view, offset, BigEndian))
+        ExtendedType extendedType;
+        if (!checkedRead<ExtendedType>(extendedType, view, offset, BigEndian))
             return false;
 
-        m_extendedType = Vector<uint8_t>(std::span { extendedTypeStruct.value });
+        m_extendedType = WTF::move(extendedType);
     }
 
     return true;
 }
 
-ISOFullBox::ISOFullBox() = default;
-ISOFullBox::ISOFullBox(const ISOFullBox&) = default;
+bool ISOBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    uint32_t firstSize = 1u;
+    if (m_size <= std::numeric_limits<uint32_t>::max())
+        firstSize = m_size;
 
-bool ISOFullBox::parse(DataView& view, unsigned& offset)
+    if (!checkedWrite<uint32_t>(firstSize, view, offset, BigEndian))
+        return false;
+
+    if (!checkedWrite<uint32_t>(m_boxType.value, view, offset, BigEndian))
+        return false;
+
+    if (firstSize == 1 && !checkedWrite<uint64_t>(m_size, view, offset, BigEndian))
+        return false;
+
+    if (m_boxType == std::span { "uuid" }) {
+        ASSERT(m_extendedType);
+        if (!m_extendedType)
+            return false;
+
+        if (!checkedWriteSequence<uint8_t>(*m_extendedType, view, offset, BigEndian))
+            return false;
+    }
+
+    return true;
+}
+
+Ref<SharedBuffer> ISOBox::serialize() const
+{
+    auto buffer = Vector<uint8_t>(m_size);
+    MutableByteView view = buffer.mutableSpan();
+    unsigned offset = 0;
+    if (!write(view, offset))
+        return SharedBuffer::create();
+
+    return SharedBuffer::create(WTF::move(buffer));
+}
+
+ISOFullBox::ISOFullBox() = default;
+ISOFullBox::ISOFullBox(FourCC boxType, uint8_t version, uint32_t flags)
+    : ISOBox(boxType)
+    , m_version { version }
+    , m_flags { flags }
+{
+}
+ISOFullBox::ISOFullBox(const ISOFullBox&) = default;
+ISOFullBox::ISOFullBox(ISOFullBox&&) = default;
+
+bool ISOFullBox::parse(const ByteView& view, unsigned& offset)
 {
     if (!ISOBox::parse(view, offset))
         return false;
@@ -131,7 +229,19 @@ bool ISOFullBox::parse(DataView& view, unsigned& offset)
     return parseVersionAndFlags(view, offset);
 }
 
-bool ISOFullBox::parseVersionAndFlags(DataView& view, unsigned& offset)
+bool ISOFullBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    uint32_t versionAndFlags = (m_version << 24) + m_flags;
+    if (!checkedWrite<uint32_t>(versionAndFlags, view, offset, BigEndian))
+        return false;
+
+    return true;
+}
+
+bool ISOFullBox::parseVersionAndFlags(const ByteView& view, unsigned& offset)
 {
     uint32_t versionAndFlags = 0;
     if (!checkedRead<uint32_t>(versionAndFlags, view, offset, BigEndian))

--- a/Source/WebCore/platform/graphics/iso/ISOBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOBox.h
@@ -26,76 +26,132 @@
 #pragma once
 
 #include <WebCore/FourCC.h>
+#include <wtf/FlipBytes.h>
 #include <wtf/Forward.h>
 #include <wtf/StdIntExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/TypeCasts.h>
 
-namespace JSC {
-class DataView;
-}
-
 namespace WebCore {
+
+class SharedBuffer;
 
 class ISOBox {
     WTF_MAKE_TZONE_ALLOCATED(ISOBox);
 public:
     WEBCORE_EXPORT ISOBox();
+    WEBCORE_EXPORT ISOBox(FourCC boxType);
     WEBCORE_EXPORT ISOBox(const ISOBox&);
-    ISOBox(ISOBox&&) = default;
+    WEBCORE_EXPORT ISOBox(ISOBox&&);
     WEBCORE_EXPORT virtual ~ISOBox();
 
     ISOBox& operator=(const ISOBox&) = default;
     ISOBox& operator=(ISOBox&&) = default;
 
+    using ByteView = std::span<const uint8_t>;
+    using MutableByteView = std::span<uint8_t>;
+
     using PeekResult = std::optional<std::pair<FourCC, uint64_t>>;
-    static PeekResult peekBox(JSC::DataView&, unsigned offset);
+    static PeekResult peekBox(const ByteView&, unsigned offset);
     static constexpr size_t minimumBoxSize() { return 2 * sizeof(uint32_t); }
 
-    WEBCORE_EXPORT bool read(JSC::DataView&);
-    bool read(JSC::DataView&, unsigned& offset);
+    WEBCORE_EXPORT bool read(const ByteView&);
+    bool read(const ByteView&, unsigned& offset);
+    bool write(MutableByteView&, unsigned& offset) const;
+
+    WEBCORE_EXPORT Ref<SharedBuffer> serialize() const;
 
     uint64_t size() const { return m_size; }
     FourCC boxType() const { return m_boxType; }
-    const Vector<uint8_t>& extendedType() const LIFETIME_BOUND { return m_extendedType; }
+    using ExtendedType = std::array<uint8_t, 16>;
+    const std::optional<ExtendedType>& extendedType() const LIFETIME_BOUND { return m_extendedType; }
+
+    WEBCORE_EXPORT virtual void updateSize();
+    virtual uint64_t partialSize() const;
+    WEBCORE_EXPORT virtual uint64_t requiredSize() const;
 
 protected:
-    virtual bool parse(JSC::DataView&, unsigned& offset);
+    virtual bool parse(const ByteView&, unsigned& offset);
+    virtual bool pack(MutableByteView&, unsigned& offset) const;
 
     enum Endianness { BigEndian, LittleEndian };
 
-    template<typename T, typename R, typename V>
-    static bool checkedRead(R& returnValue, V& view, unsigned& offset, Endianness endianness)
+    template<typename T, typename R>
+    static bool checkedRead(R& returnValue, const ByteView& view, unsigned& offset, Endianness endianness)
     {
-        bool readStatus = false;
-        size_t actualOffset = offset;
-        T value = view.template read<T>(actualOffset, endianness == LittleEndian, &readStatus);
-        RELEASE_ASSERT(isInBounds<uint32_t>(actualOffset));
-        offset = actualOffset;
-        if (!readStatus)
+        if (offset + sizeof(T) > view.size())
             return false;
 
-        returnValue = value;
+        T value;
+        memcpySpan(asMutableByteSpan(value), view.subspan(offset, sizeof(T)));
+        returnValue = flipBytesIfLittleEndian(value, endianness == LittleEndian);
+        offset += sizeof(T);
+        RELEASE_ASSERT(isInBounds<uint32_t>(offset));
+
+        return true;
+    }
+
+    template<typename T, typename S>
+    static bool checkedReadSequence(S& returnValue, const ByteView& view, unsigned& offset, Endianness endianness)
+    {
+        unsigned actualOffset = offset;
+        for (auto& value : returnValue) {
+            if (!checkedRead<T>(value, view, actualOffset, endianness))
+                return false;
+        }
+        offset = actualOffset;
+        return true;
+    }
+
+    template<typename T, typename R>
+    static bool checkedWrite(const R& value, MutableByteView& view, unsigned& offset, Endianness endianness)
+    {
+        if (offset + sizeof(T) > view.size())
+            return false;
+
+        T flipped = flipBytesIfLittleEndian(static_cast<T>(value), endianness == LittleEndian);
+        memcpySpan(view.subspan(offset, sizeof(T)), asByteSpan(flipped));
+        offset += sizeof(T);
+        RELEASE_ASSERT(isInBounds<uint32_t>(offset));
+        return true;
+    }
+
+    template<typename T, typename S>
+    static bool checkedWriteSequence(const S& sequence, MutableByteView& view, unsigned& offset, Endianness endianness)
+    {
+        unsigned actualOffset = offset;
+        for (auto& value : sequence) {
+            if (!checkedWrite<T>(value, view, actualOffset, endianness))
+                return false;
+        }
+        offset = actualOffset;
         return true;
     }
 
     uint64_t m_size { 0 };
     FourCC m_boxType;
-    Vector<uint8_t> m_extendedType;
+    std::optional<ExtendedType> m_extendedType;
 };
 
 class ISOFullBox : public ISOBox {
 public:
     WEBCORE_EXPORT ISOFullBox();
+    WEBCORE_EXPORT ISOFullBox(FourCC boxType, uint8_t version, uint32_t flags);
     WEBCORE_EXPORT ISOFullBox(const ISOFullBox&);
-    ISOFullBox(ISOFullBox&&) = default;
+    WEBCORE_EXPORT ISOFullBox(ISOFullBox&&);
 
     uint8_t version() const { return m_version; }
+    void setVersion(uint8_t version) { m_version = version; }
+
     uint32_t flags() const { return m_flags; }
+    void setFlags(uint32_t flags) { m_flags = flags; }
 
 protected:
-    bool parse(JSC::DataView&, unsigned& offset) override;
-    bool parseVersionAndFlags(JSC::DataView&, unsigned& offset);
+    uint64_t partialSize() const override { return ISOBox::partialSize() + 4; }
+    bool parse(const ByteView&, unsigned& offset) override;
+    bool parseVersionAndFlags(const ByteView&, unsigned& offset);
+    bool pack(MutableByteView&, unsigned& offset) const override;
 
     uint8_t m_version { 0 };
     uint32_t m_flags { 0 };

--- a/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.cpp
@@ -26,21 +26,29 @@
 #include "config.h"
 #include "ISOOriginalFormatBox.h"
 
-#include <JavaScriptCore/DataView.h>
-
-using JSC::DataView;
-
 namespace WebCore {
 
-ISOOriginalFormatBox::ISOOriginalFormatBox() = default;
+ISOOriginalFormatBox::ISOOriginalFormatBox()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOOriginalFormatBox::~ISOOriginalFormatBox() = default;
 
-bool ISOOriginalFormatBox::parse(DataView& view, unsigned& offset)
+bool ISOOriginalFormatBox::parse(const ByteView& view, unsigned& offset)
 {
     if (!ISOBox::parse(view, offset))
         return false;
 
-    return checkedRead<uint32_t>(m_dataFormat, view, offset, BigEndian);
+    return checkedRead<uint32_t>(m_dataFormat.value, view, offset, BigEndian);
+}
+
+bool ISOOriginalFormatBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    return checkedWrite<uint32_t>(m_dataFormat.value, view, offset, BigEndian);
 }
 
 }

--- a/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h
@@ -29,18 +29,20 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT ISOOriginalFormatBox final : public ISOBox {
+class ISOOriginalFormatBox final : public ISOBox {
 public:
-    ISOOriginalFormatBox();
-    ~ISOOriginalFormatBox();
+    WEBCORE_EXPORT ISOOriginalFormatBox();
+    WEBCORE_EXPORT virtual ~ISOOriginalFormatBox();
 
     static FourCC boxTypeName() { return std::span { "frma" }; }
 
     FourCC dataFormat() const { return m_dataFormat; }
 
-    bool parse(JSC::DataView&, unsigned& offset) override;
+    bool parse(const ByteView&, unsigned& offset) final;
+    bool pack(MutableByteView&, unsigned& offset) const final;
 
 private:
+    uint64_t partialSize() const final { return ISOBox::partialSize() + 4; }
     FourCC m_dataFormat;
 };
 

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.cpp
@@ -28,16 +28,17 @@
 
 #include "ISOSchemeInformationBox.h"
 #include "ISOSchemeTypeBox.h"
-#include <JavaScriptCore/DataView.h>
-
-using JSC::DataView;
 
 namespace WebCore {
 
-ISOProtectionSchemeInfoBox::ISOProtectionSchemeInfoBox() = default;
+ISOProtectionSchemeInfoBox::ISOProtectionSchemeInfoBox()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOProtectionSchemeInfoBox::~ISOProtectionSchemeInfoBox() = default;
 
-bool ISOProtectionSchemeInfoBox::parse(DataView& view, unsigned& offset)
+bool ISOProtectionSchemeInfoBox::parse(const ByteView& view, unsigned& offset)
 {
     unsigned localOffset = offset;
     if (!ISOBox::parse(view, localOffset))
@@ -81,6 +82,44 @@ bool ISOProtectionSchemeInfoBox::parse(DataView& view, unsigned& offset)
 
     offset = localOffset;
     return true;
+}
+
+bool ISOProtectionSchemeInfoBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    if (!m_originalFormatBox.write(view, offset))
+        return false;
+
+    if (m_schemeTypeBox && !m_schemeTypeBox->write(view, offset))
+        return false;
+
+    if (m_schemeInformationBox && !m_schemeInformationBox->write(view, offset))
+        return false;
+
+    return true;
+}
+
+void ISOProtectionSchemeInfoBox::updateSize()
+{
+    m_originalFormatBox.updateSize();
+    if (m_schemeTypeBox)
+        m_schemeTypeBox->updateSize();
+    if (m_schemeInformationBox)
+        m_schemeInformationBox->updateSize();
+    ISOBox::updateSize();
+}
+
+uint64_t ISOProtectionSchemeInfoBox::partialSize() const
+{
+    auto size = ISOBox::partialSize();
+    size += m_originalFormatBox.requiredSize();
+    if (m_schemeTypeBox)
+        size += m_schemeTypeBox->requiredSize();
+    if (m_schemeInformationBox)
+        size += m_schemeInformationBox->requiredSize();
+    return size;
 }
 
 }

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h
@@ -43,7 +43,11 @@ public:
     const ISOSchemeTypeBox* schemeTypeBox() const LIFETIME_BOUND { return m_schemeTypeBox.get(); }
     const ISOSchemeInformationBox* schemeInformationBox() const LIFETIME_BOUND { return m_schemeInformationBox.get(); }
 
-    bool parse(JSC::DataView&, unsigned& offset) override;
+    bool parse(const ByteView&, unsigned& offset) final;
+    bool pack(MutableByteView&, unsigned& offset) const final;
+
+    void updateSize() final;
+    uint64_t partialSize() const final;
 
 private:
     ISOOriginalFormatBox m_originalFormatBox;

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp
@@ -28,80 +28,166 @@
 #include "config.h"
 #include "ISOProtectionSystemSpecificHeaderBox.h"
 
-#include <JavaScriptCore/DataView.h>
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
-
-using JSC::DataView;
 
 namespace WebCore {
 
-ISOProtectionSystemSpecificHeaderBox::ISOProtectionSystemSpecificHeaderBox() = default;
+auto ISOProtectionSystemSpecificHeaderBox::commonSystemID() -> const SystemID& {
+    static NeverDestroyed<SystemID> systemID = SystemID({ 0x10, 0x77, 0xef, 0xec, 0xc0, 0xb2, 0x4d, 0x02, 0xac, 0xe3, 0x3c, 0x1e, 0x52, 0xe2, 0xfb, 0x4b });
+    return systemID;
+}
+
+ISOProtectionSystemSpecificHeaderBox::ISOProtectionSystemSpecificHeaderBox()
+    : ISOFullBox(boxTypeName(), 0, 0)
+    , m_systemID { }
+{
+}
+
+ISOProtectionSystemSpecificHeaderBox::ISOProtectionSystemSpecificHeaderBox(const ISOProtectionSystemSpecificHeaderBox&) = default;
+ISOProtectionSystemSpecificHeaderBox::ISOProtectionSystemSpecificHeaderBox(ISOProtectionSystemSpecificHeaderBox&&) = default;
+
+ISOProtectionSystemSpecificHeaderBox::ISOProtectionSystemSpecificHeaderBox(SystemID systemID)
+    : ISOFullBox(boxTypeName(), 0, 0)
+    , m_systemID { systemID }
+{
+}
+
 ISOProtectionSystemSpecificHeaderBox::~ISOProtectionSystemSpecificHeaderBox() = default;
 
-std::optional<Vector<uint8_t>> ISOProtectionSystemSpecificHeaderBox::peekSystemID(JSC::DataView& view, unsigned offset)
+auto ISOProtectionSystemSpecificHeaderBox::peekSystemID(ByteView& view, unsigned offset) -> std::optional<SystemID>
 {
     auto peekResult = ISOBox::peekBox(view, offset);
     if (!peekResult || peekResult.value().first != boxTypeName())
         return std::nullopt;
 
     ISOProtectionSystemSpecificHeaderBox psshBox;
-    psshBox.parse(view, offset);
+    // checkedReadSequence() populates elements as it goes and only bails on the one that
+    // fails, so a partially parsed box would otherwise report a half-populated systemID
+    // that callers would treat as authoritative.
+    if (!psshBox.parse(view, offset))
+        return std::nullopt;
+
     return psshBox.systemID();
 }
 
-bool ISOProtectionSystemSpecificHeaderBox::parse(DataView& view, unsigned& offset)
+bool ISOProtectionSystemSpecificHeaderBox::parse(const ByteView& view, unsigned& offset)
 {
+    auto startOffset = offset;
     if (!ISOFullBox::parse(view, offset))
         return false;
 
+    auto endOffset = checkedSum<uint64_t>(startOffset, m_size);
+    if (endOffset.hasOverflowed())
+        return false;
+
+    auto remainingInBox = [&]() -> std::optional<uint64_t> {
+        uint64_t remaining;
+        if (!WTF::safeSub(endOffset.value(), offset, remaining))
+            return std::nullopt;
+        return remaining;
+    };
+
+    if (!remainingInBox())
+        return false;
+
     // ISO/IEC 23001-7-2016 Section 8.1.1
-    auto buffer = view.possiblySharedBuffer();
-    if (!buffer)
+    if (!checkedReadSequence<uint8_t>(m_systemID, view, offset, BigEndian))
         return false;
-    auto systemID = buffer->slice(offset, offset + 16);
-    offset += 16;
-
-    m_systemID.resize(16);
-    if (systemID->byteLength() < 16)
-        return false;
-
-    memcpySpan(m_systemID.mutableSpan(), systemID->span().first(16));
 
     if (m_version) {
         uint32_t keyIDCount = 0;
         if (!checkedRead<uint32_t>(keyIDCount, view, offset, BigEndian))
             return false;
-        if (buffer->byteLength() - offset < keyIDCount * 16)
+
+        auto remaining = remainingInBox();
+        if (!remaining || keyIDCount > *remaining / sizeof(KeyID))
             return false;
-        if (!m_keyIDs.tryReserveCapacity(keyIDCount))
-            return false;
-        m_keyIDs.resize(keyIDCount);
-        for (unsigned keyID = 0; keyID < keyIDCount; keyID++) {
-            auto& currentKeyID = m_keyIDs[keyID];
-            currentKeyID.resize(16);
-            auto parsedKeyID = buffer->slice(offset, offset + 16);
-            offset += 16;
-            if (parsedKeyID->byteLength() < 16)
-                continue;
-            memcpySpan(currentKeyID.mutableSpan(), parsedKeyID->span().first(16));
+
+        m_keyIDs.clear();
+        while (keyIDCount--) {
+            KeyID keyID;
+            if (!checkedReadSequence<uint8_t>(keyID, view, offset, BigEndian))
+                return false;
+            m_keyIDs.append(WTF::move(keyID));
         }
     }
 
     uint32_t dataSize = 0;
     if (!checkedRead<uint32_t>(dataSize, view, offset, BigEndian))
         return false;
-    if (buffer->byteLength() - offset < dataSize)
-        return false;
-    auto parsedData = buffer->slice(offset, offset + dataSize);
-    offset += dataSize;
 
-    m_data.resize(dataSize);
-    if (parsedData->byteLength() < dataSize)
+    auto remaining = remainingInBox();
+    if (!remaining || *remaining < dataSize)
         return false;
 
-    memcpySpan(m_data.mutableSpan(), parsedData->span().first(dataSize));
+    return parseData(view, offset, dataSize);
+}
 
-    return true;
+bool ISOProtectionSystemSpecificHeaderBox::parseData(const ByteView& view, unsigned& offset, uint64_t size)
+{
+    uint64_t remainingInView;
+    if (!WTF::safeSub(view.size(), offset, remainingInView))
+        return false;
+
+    if (remainingInView < size)
+        return false;
+
+    m_data.resize(size);
+    return checkedReadSequence<uint8_t>(m_data, view, offset, BigEndian);
+}
+
+bool ISOProtectionSystemSpecificHeaderBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOFullBox::pack(view, offset))
+        return false;
+
+    if (!checkedWriteSequence<uint8_t>(m_systemID, view, offset, BigEndian))
+        return false;
+
+    if (m_version) {
+        if (!checkedWrite<uint32_t>(m_keyIDs.size(), view, offset, BigEndian))
+            return false;
+        for (auto& keyID : m_keyIDs) {
+            if (!checkedWriteSequence<uint8_t>(keyID, view, offset, BigEndian))
+                return false;
+        }
+    }
+
+    if (!checkedWrite<uint32_t>(dataSize(), view, offset, BigEndian))
+        return false;
+
+    return writeData(view, offset);
+}
+
+bool ISOProtectionSystemSpecificHeaderBox::writeData(MutableByteView& view, unsigned& offset) const
+{
+    return checkedWriteSequence<uint8_t>(m_data, view, offset, BigEndian);
+}
+
+uint64_t ISOProtectionSystemSpecificHeaderBox::partialSize() const
+{
+    uint64_t size = ISOFullBox::partialSize();
+
+    // unsigned int(8)[16] SystemID;
+    size += 16;
+
+    if (version() > 0) {
+        // unsigned int(32) KID_count;
+        size += 4;
+        // {
+        // unsigned int(8)[16] KID;
+        // } [KID_count];
+        size += 16 * m_keyIDs.size();
+    }
+
+    // unsigned int(32) DataSize;
+    size += 4;
+    // unsigned int(8)[DataSize] Data;
+    size += m_data.size();
+
+    return size;
 }
 
 }

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h
@@ -31,25 +31,37 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT ISOProtectionSystemSpecificHeaderBox : public ISOFullBox {
+class ISOProtectionSystemSpecificHeaderBox : public ISOFullBox {
 public:
-    using KeyID = Vector<uint8_t>;
+    using KeyID = std::array<uint8_t, 16>;
+    using SystemID = std::array<uint8_t, 16>;
 
-    ISOProtectionSystemSpecificHeaderBox();
-    ~ISOProtectionSystemSpecificHeaderBox();
+    WEBCORE_EXPORT static const SystemID& commonSystemID();
+
+    WEBCORE_EXPORT ISOProtectionSystemSpecificHeaderBox();
+    WEBCORE_EXPORT ISOProtectionSystemSpecificHeaderBox(const ISOProtectionSystemSpecificHeaderBox&);
+    WEBCORE_EXPORT ISOProtectionSystemSpecificHeaderBox(ISOProtectionSystemSpecificHeaderBox&&);
+    WEBCORE_EXPORT ISOProtectionSystemSpecificHeaderBox(SystemID);
+    WEBCORE_EXPORT virtual ~ISOProtectionSystemSpecificHeaderBox();
 
     static FourCC boxTypeName() { return std::span { "pssh" }; }
 
-    static std::optional<Vector<uint8_t>> peekSystemID(JSC::DataView&, unsigned offset);
+    WEBCORE_EXPORT static std::optional<SystemID> peekSystemID(ByteView&, unsigned offset);
 
-    const Vector<uint8_t>& systemID() const LIFETIME_BOUND { return m_systemID; }
+    const SystemID& systemID() const LIFETIME_BOUND { return m_systemID; }
     const Vector<KeyID>& keyIDs() const LIFETIME_BOUND { return m_keyIDs; }
     const Vector<uint8_t>& data() const LIFETIME_BOUND { return m_data; }
 
-    bool parse(JSC::DataView&, unsigned& offset) override;
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) override;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const override;
 
 protected:
-    Vector<uint8_t> m_systemID;
+    virtual uint64_t dataSize() const { return m_data.size(); }
+    virtual bool parseData(const ByteView&, unsigned& offset, uint64_t size);
+    virtual bool writeData(MutableByteView&, unsigned& offset) const;
+    uint64_t partialSize() const override;
+
+    SystemID m_systemID;
     Vector<KeyID> m_keyIDs;
     Vector<uint8_t> m_data;
 };

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp
@@ -27,16 +27,17 @@
 #include "ISOSchemeInformationBox.h"
 
 #include "ISOTrackEncryptionBox.h"
-#include <JavaScriptCore/DataView.h>
-
-using JSC::DataView;
 
 namespace WebCore {
 
-ISOSchemeInformationBox::ISOSchemeInformationBox() = default;
+ISOSchemeInformationBox::ISOSchemeInformationBox()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOSchemeInformationBox::~ISOSchemeInformationBox() = default;
 
-bool ISOSchemeInformationBox::parse(DataView& view, unsigned& offset)
+bool ISOSchemeInformationBox::parse(const ByteView& view, unsigned& offset)
 {
     unsigned localOffset = offset;
     if (!ISOBox::parse(view, localOffset))
@@ -58,6 +59,32 @@ bool ISOSchemeInformationBox::parse(DataView& view, unsigned& offset)
     }
 
     return true;
+}
+
+bool ISOSchemeInformationBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOBox::pack(view, offset))
+        return false;
+
+    if (m_schemeSpecificData)
+        return m_schemeSpecificData->write(view, offset);
+
+    return true;
+}
+
+void ISOSchemeInformationBox::updateSize()
+{
+    if (m_schemeSpecificData)
+        m_schemeSpecificData->updateSize();
+    ISOBox::updateSize();
+}
+
+uint64_t ISOSchemeInformationBox::partialSize() const
+{
+    auto size = ISOBox::partialSize();
+    if (m_schemeSpecificData)
+        size += m_schemeSpecificData->requiredSize();
+    return size;
 }
 
 }

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h
@@ -38,7 +38,11 @@ public:
 
     const ISOBox* schemeSpecificData() const LIFETIME_BOUND { return m_schemeSpecificData.get(); }
 
-    bool parse(JSC::DataView&, unsigned& offset) override;
+    bool parse(const ByteView&, unsigned& offset) final;
+    bool pack(MutableByteView&, unsigned& offset) const final;
+
+    void updateSize() final;
+    uint64_t partialSize() const final;
 
 private:
     std::unique_ptr<ISOBox> m_schemeSpecificData;

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.cpp
@@ -26,16 +26,15 @@
 #include "config.h"
 #include "ISOSchemeTypeBox.h"
 
-#include <JavaScriptCore/DataView.h>
-
-using JSC::DataView;
-
 namespace WebCore {
 
-ISOSchemeTypeBox::ISOSchemeTypeBox() = default;
+ISOSchemeTypeBox::ISOSchemeTypeBox()
+    : ISOFullBox(boxTypeName(), 0, 0)
+{
+}
 ISOSchemeTypeBox::~ISOSchemeTypeBox() = default;
 
-bool ISOSchemeTypeBox::parse(DataView& view, unsigned& offset)
+bool ISOSchemeTypeBox::parse(const ByteView& view, unsigned& offset)
 {
     if (!ISOFullBox::parse(view, offset))
         return false;
@@ -47,6 +46,17 @@ bool ISOSchemeTypeBox::parse(DataView& view, unsigned& offset)
         return false;
 
     return true;
+}
+
+bool ISOSchemeTypeBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    if (!ISOFullBox::pack(view, offset))
+        return false;
+
+    if (!checkedWrite<uint32_t>(m_schemeType.value, view, offset, BigEndian))
+        return false;
+
+    return checkedWrite<uint32_t>(m_schemeVersion, view, offset, BigEndian);
 }
 
 }

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h
@@ -29,19 +29,22 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT ISOSchemeTypeBox final : public ISOFullBox {
+class ISOSchemeTypeBox final : public ISOFullBox {
 public:
-    ISOSchemeTypeBox();
-    ~ISOSchemeTypeBox();
+    WEBCORE_EXPORT ISOSchemeTypeBox();
+    WEBCORE_EXPORT virtual ~ISOSchemeTypeBox();
 
     static FourCC boxTypeName() { return std::span { "schm" }; }
 
     FourCC schemeType() const { return m_schemeType; }
     uint32_t schemeVersion() const { return m_schemeVersion; }
 
-    bool parse(JSC::DataView&, unsigned& offset) override;
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool pack(MutableByteView&, unsigned& offset) const final;
 
 private:
+    uint64_t partialSize() const final { return ISOFullBox::partialSize() + 8; }
+
     FourCC m_schemeType;
     uint32_t m_schemeVersion { 0 };
 };

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
@@ -27,17 +27,19 @@
 #include "ISOTrackEncryptionBox.h"
 
 #include "BitReader.h"
-#include <JavaScriptCore/DataView.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
-
-using JSC::DataView;
 
 namespace WebCore {
 
-ISOTrackEncryptionBox::ISOTrackEncryptionBox() = default;
+ISOTrackEncryptionBox::ISOTrackEncryptionBox()
+    : ISOFullBox(boxTypeName(), 0, 0)
+{
+}
+
 ISOTrackEncryptionBox::~ISOTrackEncryptionBox() = default;
 
-bool ISOTrackEncryptionBox::parse(DataView& view, unsigned& offset)
+bool ISOTrackEncryptionBox::parse(const ByteView& view, unsigned& offset)
 {
     // ISO/IEC 23001-7-2015 Section 8.2.2
     if (!ISOFullBox::parse(view, offset))
@@ -46,7 +48,7 @@ bool ISOTrackEncryptionBox::parse(DataView& view, unsigned& offset)
     return parsePayload(view, offset);
 }
 
-bool ISOTrackEncryptionBox::parsePayload(DataView& view, unsigned& offset)
+bool ISOTrackEncryptionBox::parsePayload(const ByteView& view, unsigned& offset)
 {
     // unsigned int(8) reserved = 0;
     offset += 1;
@@ -69,18 +71,13 @@ bool ISOTrackEncryptionBox::parsePayload(DataView& view, unsigned& offset)
     if (!checkedRead<int8_t>(m_defaultPerSampleIVSize, view, offset, BigEndian))
         return false;
 
-    auto buffer = view.possiblySharedBuffer();
-    if (!buffer)
+    size_t remaining;
+    if (!WTF::safeSub(view.size(), offset, remaining) || remaining < 16)
         return false;
-
-    auto keyIDBuffer = buffer->slice(offset, offset + 16);
-    offset += 16;
 
     m_defaultKID.resize(16);
-    if (keyIDBuffer->byteLength() < 16)
+    if (!checkedReadSequence<uint8_t>(m_defaultKID, view, offset, BigEndian))
         return false;
-
-    memcpySpan(m_defaultKID.mutableSpan(), keyIDBuffer->span().first(16));
 
     if (m_defaultIsProtected == 1 && !m_defaultPerSampleIVSize) {
         int8_t defaultConstantIVSize = 0;
@@ -99,6 +96,63 @@ bool ISOTrackEncryptionBox::parsePayload(DataView& view, unsigned& offset)
     }
 
     return true;
+}
+
+bool ISOTrackEncryptionBox::pack(MutableByteView& view, unsigned& offset) const
+{
+    // ISO/IEC 23001-7-2015 Section 8.2.2
+    if (!ISOFullBox::pack(view, offset))
+        return false;
+
+    // unsigned int(8) reserved = 0;
+    if (!checkedWrite<int8_t>(0, view, offset, BigEndian))
+        return false;
+
+    if (!m_version) {
+        // unsigned int(8) reserved = 0;
+        if (!checkedWrite<int8_t>(0, view, offset, BigEndian))
+            return false;
+    } else {
+        int8_t cryptAndSkip = (m_defaultCryptByteBlock.value_or(0) << 4) | (m_defaultSkipByteBlock.value_or(0) & 0xF);
+        if (!checkedWrite<int8_t>(cryptAndSkip, view, offset, BigEndian))
+            return false;
+    }
+
+    if (!checkedWrite<int8_t>(m_defaultIsProtected, view, offset, BigEndian))
+        return false;
+
+    if (!checkedWrite<int8_t>(m_defaultPerSampleIVSize, view, offset, BigEndian))
+        return false;
+
+    if (m_defaultKID.size() != 16)
+        return false;
+
+    if (!checkedWriteSequence<uint8_t>(m_defaultKID, view, offset, BigEndian))
+        return false;
+
+    if (m_defaultIsProtected == 1 && !m_defaultPerSampleIVSize) {
+        if (m_defaultConstantIV.size() > std::numeric_limits<int8_t>::max())
+            return false;
+
+        if (!checkedWrite<int8_t>(static_cast<int8_t>(m_defaultConstantIV.size()), view, offset, BigEndian))
+            return false;
+
+        if (!checkedWriteSequence<uint8_t>(m_defaultConstantIV, view, offset, BigEndian))
+            return false;
+    }
+
+    return true;
+}
+
+uint64_t ISOTrackEncryptionBox::partialSize() const
+{
+    // reserved(1) + reserved-or-crypt/skip(1) + isProtected(1) + perSampleIVSize(1) + KID(16)
+    uint64_t size = ISOFullBox::partialSize() + 20;
+
+    if (m_defaultIsProtected == 1 && !m_defaultPerSampleIVSize)
+        size += 1 + m_defaultConstantIV.size();
+
+    return size;
 }
 
 bool ISOTrackEncryptionBox::parseWithoutTypeAndSize(std::span<const uint8_t> data)

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
@@ -46,10 +46,12 @@ public:
 
     bool parseWithoutTypeAndSize(std::span<const uint8_t>);
 
-    bool parse(JSC::DataView&, unsigned& offset) override;
+    bool parse(const ByteView&, unsigned& offset) final;
+    bool pack(MutableByteView&, unsigned& offset) const final;
 
 private:
-    bool parsePayload(JSC::DataView&, unsigned& offset);
+    uint64_t partialSize() const final;
+    bool parsePayload(const ByteView&, unsigned& offset);
     std::optional<int8_t> m_defaultCryptByteBlock;
     std::optional<int8_t> m_defaultSkipByteBlock;
     int8_t m_defaultIsProtected { 0 };

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp
@@ -27,12 +27,9 @@
 #include "ISOVTTCue.h"
 
 #include "Logging.h"
-#include <JavaScriptCore/DataView.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/JSONValues.h>
 #include <wtf/URL.h>
-
-using JSC::DataView;
 
 namespace WebCore {
 
@@ -41,7 +38,7 @@ public:
     const String& NODELETE contents() { return m_contents; }
 
 private:
-    bool parse(JSC::DataView& view, unsigned& offset) override
+    bool parse(const ByteView& view, unsigned& offset) override
     {
         unsigned localOffset = offset;
         if (!ISOBox::parse(view, localOffset))
@@ -53,7 +50,7 @@ private:
             return true;
         }
 
-        auto bytesRemaining = view.byteLength() - localOffset;
+        auto bytesRemaining = view.size() - localOffset;
         if (characterCount > bytesRemaining)
             return false;
 
@@ -80,13 +77,15 @@ static FourCC NODELETE vttCurrentTimeBoxType() { return std::span { "ctim" }; }
 static FourCC NODELETE vttCueSourceIDBoxType() { return std::span { "vsid" }; }
 
 ISOWebVTTCue::ISOWebVTTCue(const MediaTime& presentationTime, const MediaTime& duration)
-    : m_presentationTime(presentationTime)
+    : ISOBox(boxTypeName())
+    , m_presentationTime(presentationTime)
     , m_duration(duration)
 {
 }
 
 ISOWebVTTCue::ISOWebVTTCue(const MediaTime& presentationTime, const MediaTime& duration, String&& cueID, String&& cueText, String&& settings, String&& sourceID, String&& originalStartTime)
-    : m_presentationTime(presentationTime)
+    : ISOBox(boxTypeName())
+    , m_presentationTime(presentationTime)
     , m_duration(duration)
     , m_sourceID(WTF::move(sourceID))
     , m_identifier(WTF::move(cueID))
@@ -96,11 +95,15 @@ ISOWebVTTCue::ISOWebVTTCue(const MediaTime& presentationTime, const MediaTime& d
 {
 }
 
-ISOWebVTTCue::ISOWebVTTCue() = default;
+ISOWebVTTCue::ISOWebVTTCue()
+    : ISOBox(boxTypeName())
+{
+}
+
 ISOWebVTTCue::ISOWebVTTCue(ISOWebVTTCue&&) = default;
 ISOWebVTTCue::~ISOWebVTTCue() = default;
 
-bool ISOWebVTTCue::parse(DataView& view, unsigned& offset)
+bool ISOWebVTTCue::parse(const ByteView& view, unsigned& offset)
 {
     if (!ISOBox::parse(view, offset))
         return false;

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
@@ -61,7 +61,7 @@ public:
 
     String toJSONString() const;
 
-    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) override;
+    WEBCORE_EXPORT bool parse(const ByteView&, unsigned& offset) override;
 
     ISOWebVTTCue isolatedCopy() const &;
     ISOWebVTTCue isolatedCopy() &&;

--- a/Tools/TestWebKitAPI/Tests/WebCore/ISOBox.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ISOBox.cpp
@@ -28,15 +28,52 @@
 #include "Helpers/Test.h"
 #include <JavaScriptCore/DataView.h>
 #include <WebCore/ISOFairPlayStreamingPsshBox.h>
+#include <WebCore/ISOOriginalFormatBox.h>
 #include <WebCore/ISOProtectionSchemeInfoBox.h>
+#include <WebCore/ISOProtectionSystemSpecificHeaderBox.h>
 #include <WebCore/ISOSchemeInformationBox.h>
 #include <WebCore/ISOSchemeTypeBox.h>
 #include <WebCore/ISOTrackEncryptionBox.h>
+#include <WebCore/ISOVTTCue.h>
+#include <WebCore/SharedBuffer.h>
 #include <wtf/text/Base64.h>
 
 using namespace WebCore;
 
 namespace TestWebKitAPI {
+
+// Reads `box` out of `bytes`, then serializes it back out and returns the result. A
+// correctly implemented box writes byte-for-byte what it read, so callers can assert
+// equality against the original input. Returns an empty Vector if either step fails.
+//
+// `box` must not have been read into already: some boxes refuse a second read rather than
+// overwrite sub-boxes they have already parsed.
+static Vector<uint8_t> readThenSerialize(ISOBox& box, const Vector<uint8_t>& bytes)
+{
+    if (!box.read(bytes.span()))
+        return { };
+
+    auto serialized = box.serialize();
+    return { serialized->span() };
+}
+
+// Computes `box`'s size from its own fields, serializes it, and returns the bytes. Unlike
+// readThenSerialize(), nothing here is inherited from parsed input: updateSize() has to derive
+// the size from the box's partialSize() overrides alone, and serialize() allocates from that.
+static Vector<uint8_t> updateSizeThenSerialize(ISOBox& box)
+{
+    box.updateSize();
+    auto serialized = box.serialize();
+    return { serialized->span() };
+}
+
+static Vector<uint8_t> decodeBase64(ASCIILiteral literal)
+{
+    auto decoded = base64Decode(StringView { literal });
+    if (!decoded)
+        return { };
+    return WTF::move(*decoded);
+}
 
 static constexpr auto base64EncodedSinfWithKeyID3 = "AAAAYXNpbmYAAAAMZnJtYW1wNGEAAAAUc2NobQAAAABjYmNzAAEAAAAAADlzY2hpAAAAMXRlbmMBAAAAAAABAAAAAAAAAAAAAAAAAAAAAAMQ1fvWuC7ZPk75iuQJMe4ztw=="_s;
 
@@ -46,7 +83,7 @@ TEST(ISOBox, ISOProtectionSchemeInfoBox)
     ASSERT_TRUE(sinfArray);
     ASSERT_EQ(97UL, sinfArray->size());
 
-    auto view = JSC::DataView::create(ArrayBuffer::create(*sinfArray), 0, sinfArray->size());
+    auto view = sinfArray->span();
 
     ISOProtectionSchemeInfoBox sinfBox;
     ASSERT_TRUE(sinfBox.read(view));
@@ -82,7 +119,7 @@ TEST(ISOBox, ISOFairPlayStreamingPsshBox)
     ASSERT_TRUE(psshArray);
     ASSERT_EQ(176UL, psshArray->size());
 
-    auto view = JSC::DataView::create(ArrayBuffer::create(*psshArray), 0, psshArray->size());
+    auto view = psshArray->span();
 
     ISOFairPlayStreamingPsshBox psshBox;
 
@@ -94,19 +131,699 @@ TEST(ISOBox, ISOFairPlayStreamingPsshBox)
     auto requests = psshBox.initDataBox().requests();
     ASSERT_EQ(2UL, requests.size());
 
-    Vector<uint8_t, 16> expectedFirstKeyID = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    Vector<uint8_t, 16> expectedFirstKeyID = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
     ASSERT_EQ(requests[0].requestInfo().keyID(), expectedFirstKeyID);
 
     Vector<uint8_t> expectedFirstAssetID = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF1 };
     ASSERT_TRUE(requests[0].assetID());
     ASSERT_EQ(requests[0].assetID().value().data(), expectedFirstAssetID);
 
-    Vector<uint8_t, 16> expectedSecondKeyID = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    Vector<uint8_t, 16> expectedSecondKeyID = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2 };
     ASSERT_EQ(requests[1].requestInfo().keyID(), expectedSecondKeyID);
 
     Vector<uint8_t> expectedSecondAssetID = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF2 };
     ASSERT_TRUE(requests[1].assetID());
     ASSERT_EQ(requests[1].assetID().value().data(), expectedSecondAssetID);
+}
+
+// MARK: - Round-trip tests
+//
+// Serializing a box that was just read must reproduce the original bytes exactly.
+
+TEST(ISOBox, ProtectionSchemeInfoBox_Roundtrip)
+{
+    auto sinfArray = decodeBase64(base64EncodedSinfWithKeyID3);
+    ASSERT_EQ(97UL, sinfArray.size());
+
+    ISOProtectionSchemeInfoBox sinfBox;
+    EXPECT_EQ(sinfArray, readThenSerialize(sinfBox, sinfArray));
+}
+
+TEST(ISOBox, FairPlayStreamingPsshBox_Roundtrip)
+{
+    auto psshArray = decodeBase64(base64EncodedPsshWithAssetId);
+    ASSERT_EQ(176UL, psshArray.size());
+
+    ISOFairPlayStreamingPsshBox psshBox;
+    EXPECT_EQ(psshArray, readThenSerialize(psshBox, psshArray));
+}
+
+// Byte equality alone would also be satisfied by a writer that echoed the bytes it parsed,
+// which is what ISOFairPlayStreamingPsshBox used to do via the base class's m_data. Now that
+// it serializes through m_initDataBox, re-parse the output and check the sub-box tree came
+// back, so a regression to byte-echoing is caught.
+TEST(ISOBox, FairPlayStreamingPsshBox_RoundtripReconstructsSubBoxes)
+{
+    auto psshArray = decodeBase64(base64EncodedPsshWithAssetId);
+    ASSERT_EQ(176UL, psshArray.size());
+
+    ISOFairPlayStreamingPsshBox original;
+    auto serialized = readThenSerialize(original, psshArray);
+    ASSERT_EQ(psshArray, serialized);
+
+    ISOFairPlayStreamingPsshBox reparsed;
+    auto reparsedView = serialized.span();
+    ASSERT_TRUE(reparsed.read(reparsedView));
+
+    EXPECT_EQ(ISOFairPlayStreamingPsshBox::fairPlaySystemID(), reparsed.systemID());
+    EXPECT_EQ(FourCC('cenc'), reparsed.initDataBox().info().scheme());
+
+    auto& requests = reparsed.initDataBox().requests();
+    ASSERT_EQ(2UL, requests.size());
+
+    Vector<uint8_t, 16> expectedFirstKeyID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+    EXPECT_EQ(expectedFirstKeyID, requests[0].requestInfo().keyID());
+    Vector<uint8_t> expectedFirstAssetID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF1 };
+    ASSERT_TRUE(requests[0].assetID());
+    EXPECT_EQ(expectedFirstAssetID, requests[0].assetID()->data());
+
+    Vector<uint8_t, 16> expectedSecondKeyID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2 };
+    EXPECT_EQ(expectedSecondKeyID, requests[1].requestInfo().keyID());
+    Vector<uint8_t> expectedSecondAssetID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF2 };
+    ASSERT_TRUE(requests[1].assetID());
+    EXPECT_EQ(expectedSecondAssetID, requests[1].assetID()->data());
+}
+
+// serialize() allocates from m_size, so the size a box computes for itself has to agree with
+// the size it parsed. Recomputing it must be a no-op for a well-formed box, and the box must
+// still serialize identically afterwards.
+TEST(ISOBox, FairPlayStreamingPsshBox_UpdateSizeIsStable)
+{
+    auto psshArray = decodeBase64(base64EncodedPsshWithAssetId);
+    ASSERT_EQ(176UL, psshArray.size());
+
+    ISOFairPlayStreamingPsshBox psshBox;
+    auto view = psshArray.span();
+    ASSERT_TRUE(psshBox.read(view));
+    ASSERT_EQ(176U, psshBox.size());
+
+    psshBox.updateSize();
+    EXPECT_EQ(176U, psshBox.size());
+
+    auto serialized = psshBox.serialize();
+    EXPECT_EQ(psshArray, Vector<uint8_t> { serialized->span() });
+}
+
+// MARK: - Individual box types
+
+TEST(ISOBox, OriginalFormatBox)
+{
+    Vector<uint8_t> bytes { 0x00, 0x00, 0x00, 0x0C, 'f', 'r', 'm', 'a', 'm', 'p', '4', 'a' };
+
+    auto view = bytes.span();
+    ISOOriginalFormatBox frma;
+    ASSERT_TRUE(frma.read(view));
+    EXPECT_EQ(FourCC('mp4a'), frma.dataFormat());
+    EXPECT_EQ(12U, frma.size());
+
+    EXPECT_EQ(bytes, readThenSerialize(frma, bytes));
+}
+
+TEST(ISOBox, SchemeTypeBox)
+{
+    Vector<uint8_t> bytes {
+        0x00, 0x00, 0x00, 0x14, 's', 'c', 'h', 'm',
+        0x00, 0x00, 0x00, 0x00,
+        'c', 'b', 'c', 's',
+        0x00, 0x01, 0x00, 0x00,
+    };
+
+    auto view = bytes.span();
+    ISOSchemeTypeBox schm;
+    ASSERT_TRUE(schm.read(view));
+    EXPECT_EQ(FourCC('cbcs'), schm.schemeType());
+    EXPECT_EQ(0x10000U, schm.schemeVersion());
+
+    EXPECT_EQ(bytes, readThenSerialize(schm, bytes));
+}
+
+// The version 1 'tenc' payload carries a crypt/skip byte pattern, which the version 0
+// payload does not. The sinf fixture above only exercises a constant-IV box, so cover
+// the pattern-encryption path explicitly.
+TEST(ISOBox, TrackEncryptionBox_V1PatternEncryption)
+{
+    Vector<uint8_t> bytes {
+        0x00, 0x00, 0x00, 0x20, 't', 'e', 'n', 'c',
+        0x01, 0x00, 0x00, 0x00, // version 1, flags 0
+        0x00, // reserved
+        0x19, // cryptByteBlock = 1, skipByteBlock = 9
+        0x01, // defaultIsProtected
+        0x08, // defaultPerSampleIVSize (non-zero, so no constant IV)
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+    };
+
+    auto view = bytes.span();
+    ISOTrackEncryptionBox tenc;
+    ASSERT_TRUE(tenc.read(view));
+
+    ASSERT_TRUE(tenc.defaultCryptByteBlock());
+    EXPECT_EQ(1, *tenc.defaultCryptByteBlock());
+    ASSERT_TRUE(tenc.defaultSkipByteBlock());
+    EXPECT_EQ(9, *tenc.defaultSkipByteBlock());
+    EXPECT_EQ(1, tenc.defaultIsProtected());
+    EXPECT_EQ(8, tenc.defaultPerSampleIVSize());
+
+    Vector<uint8_t> expectedKID { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+    EXPECT_EQ(expectedKID, tenc.defaultKID());
+    EXPECT_TRUE(tenc.defaultConstantIV().isEmpty());
+
+    EXPECT_EQ(bytes, readThenSerialize(tenc, bytes));
+}
+
+// A version 1 'pssh' carries an explicit key ID list ahead of its data payload; a
+// version 0 'pssh' does not.
+static constexpr auto base64EncodedPsshV1WithKeyIDs = "AAAASHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAIAAAAAAAAAAAAAAAAAAACqAAAAAAAAAAAAAAAAAAAAuwAAAAREQVRB"_s;
+
+TEST(ISOBox, ProtectionSystemSpecificHeaderBox_V1KeyIDs)
+{
+    auto psshArray = decodeBase64(base64EncodedPsshV1WithKeyIDs);
+    ASSERT_EQ(72UL, psshArray.size());
+
+    auto view = psshArray.span();
+    ISOProtectionSystemSpecificHeaderBox pssh;
+    ASSERT_TRUE(pssh.read(view));
+
+    EXPECT_EQ(ISOProtectionSystemSpecificHeaderBox::commonSystemID(), pssh.systemID());
+
+    auto& keyIDs = pssh.keyIDs();
+    ASSERT_EQ(2UL, keyIDs.size());
+    EXPECT_EQ(0xAA, keyIDs[0][15]);
+    EXPECT_EQ(0xBB, keyIDs[1][15]);
+
+    Vector<uint8_t> expectedData { 'D', 'A', 'T', 'A' };
+    EXPECT_EQ(expectedData, pssh.data());
+
+    EXPECT_EQ(psshArray, readThenSerialize(pssh, psshArray));
+}
+
+// 'vttc' and its string sub-boxes had no coverage at all.
+static constexpr auto base64EncodedWebVTTCue = "AAAAPnZ0dGMAAAANaWRlbmN1ZS0xAAAAFHN0dGdhbGlnbjpjZW50ZXIAAAAVcGF5bEhlbGxvLCB3b3JsZCE="_s;
+
+TEST(ISOBox, WebVTTCue)
+{
+    auto cueArray = decodeBase64(base64EncodedWebVTTCue);
+    ASSERT_EQ(62UL, cueArray.size());
+
+    auto view = cueArray.span();
+    ISOWebVTTCue cue;
+    ASSERT_TRUE(cue.read(view));
+
+    EXPECT_STREQ("cue-1", cue.id().utf8().data());
+    EXPECT_STREQ("align:center", cue.settings().utf8().data());
+    EXPECT_STREQ("Hello, world!", cue.cueText().utf8().data());
+    EXPECT_TRUE(cue.sourceID().isEmpty());
+    EXPECT_TRUE(cue.originalStartTime().isEmpty());
+}
+
+// 'fkvl' carries 32-bit key versions. Storing them in a byte vector silently truncated any
+// value above 255, and made partialSize() report one byte per version where parse consumes
+// four.
+TEST(ISOBox, FairPlayStreamingKeyRequestBox_VersionList)
+{
+    auto bytes = decodeBase64("AAAAOGZwc2sAAAAcZmtyaQAAAAABAgMEBQYHCAkKCwwNDg8QAAAAFGZrdmwAAAABAAASNN6tvu8="_s);
+    ASSERT_EQ(56UL, bytes.size());
+
+    auto view = bytes.span();
+    ISOFairPlayStreamingKeyRequestBox fpsk;
+    ASSERT_TRUE(fpsk.read(view));
+
+    Vector<uint8_t> expectedKeyID { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+    EXPECT_EQ(expectedKeyID, fpsk.requestInfo().keyID());
+
+    ASSERT_TRUE(fpsk.versionList());
+    Vector<uint32_t> expectedVersions { 1U, 0x1234U, 0xDEADBEEFU };
+    EXPECT_EQ(expectedVersions, fpsk.versionList()->versions());
+
+    // The versions are 32-bit, so the writer has to emit four bytes each; writing them as a
+    // byte sequence would narrow each one and leave the rest of the reserved space zero-filled.
+    // Note this needs a fresh box: parse() rejects a second read once an optional sub-box is
+    // already present.
+    ISOFairPlayStreamingKeyRequestBox roundtripped;
+    EXPECT_EQ(bytes, readThenSerialize(roundtripped, bytes));
+}
+
+// A version 0 'tenc' whose defaultPerSampleIVSize is zero carries a trailing constant IV,
+// which the sinf fixture above does exercise but only as part of a larger tree. Cover the
+// standalone read/write of that trailing field.
+//
+// Note the writer also refuses a constant IV longer than 127 bytes, since the length is
+// encoded as a single signed byte; that guard is not reachable through the public API today
+// because there is no setter for the IV, so it is not covered here.
+TEST(ISOBox, TrackEncryptionBox_V0ConstantIV)
+{
+    Vector<uint8_t> bytes {
+        0x00, 0x00, 0x00, 0x23, 't', 'e', 'n', 'c',
+        0x00, 0x00, 0x00, 0x00, // version 0, flags 0
+        0x00, // reserved
+        0x00, // reserved
+        0x01, // defaultIsProtected
+        0x00, // defaultPerSampleIVSize == 0, so a constant IV follows
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        0x02, 0xAA, 0xBB, // constant IV: length byte + 2 bytes
+    };
+
+    auto view = bytes.span();
+    ISOTrackEncryptionBox tenc;
+    ASSERT_TRUE(tenc.read(view));
+
+    EXPECT_EQ(1, tenc.defaultIsProtected());
+    EXPECT_EQ(0, tenc.defaultPerSampleIVSize());
+    EXPECT_FALSE(tenc.defaultCryptByteBlock());
+    EXPECT_FALSE(tenc.defaultSkipByteBlock());
+
+    Vector<uint8_t> expectedIV { 0xAA, 0xBB };
+    EXPECT_EQ(expectedIV, tenc.defaultConstantIV());
+
+    EXPECT_EQ(bytes, readThenSerialize(tenc, bytes));
+}
+
+// MARK: - Construct-from-scratch round-trips
+//
+// A parse-then-serialize test inherits m_size from its input, so it never exercises a box's
+// own size computation. Building a box programmatically does: updateSize() has to derive the
+// size from partialSize() alone, and serialize() then allocates from it. This is the shape
+// CDMPrivateFairPlayStreaming uses to synthesize a PSSH from a set of key IDs.
+
+TEST(ISOBox, FairPlayStreamingPsshBox_ConstructedRoundtrip)
+{
+    ISOFairPlayStreamingKeyRequestInfoBox::KeyID firstKeyID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+    ISOFairPlayStreamingKeyRequestInfoBox::KeyID secondKeyID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2 };
+
+    ISOFairPlayStreamingPsshBox pssh;
+    // A default-constructed box is already a well-formed empty 'pssh' carrying the FairPlay
+    // system ID, so callers only supply the init data.
+    EXPECT_EQ(FourCC('pssh'), pssh.boxType());
+    EXPECT_EQ(ISOFairPlayStreamingPsshBox::fairPlaySystemID(), pssh.systemID());
+
+    pssh.initDataBox().info().setScheme(FourCC('cbcs'));
+
+    Vector<ISOFairPlayStreamingKeyRequestBox> requests;
+    for (auto& keyID : { firstKeyID, secondKeyID }) {
+        ISOFairPlayStreamingKeyRequestBox request;
+        request.requestInfo().setKeyID(keyID);
+        requests.append(WTF::move(request));
+    }
+    pssh.initDataBox().setRequests(WTF::move(requests));
+
+    pssh.updateSize();
+
+    // 'pssh' version/flags + systemID + DataSize (32) wrapping an 'fpsd' of 96: its own header
+    // (8) plus an 'fpsi' of 16 and two 'fpsk' of 36, each an 8-byte header over a 28-byte
+    // 'fkri'. Every one of those contributions comes from a partialSize() override.
+    EXPECT_EQ(128U, pssh.size());
+
+    auto serialized = pssh.serialize();
+    auto bytes = Vector<uint8_t> { serialized->span() };
+    ASSERT_EQ(128UL, bytes.size());
+
+    ISOFairPlayStreamingPsshBox reparsed;
+    auto view = bytes.span();
+    ASSERT_TRUE(reparsed.read(view));
+
+    EXPECT_EQ(FourCC('pssh'), reparsed.boxType());
+    EXPECT_EQ(ISOFairPlayStreamingPsshBox::fairPlaySystemID(), reparsed.systemID());
+    EXPECT_EQ(FourCC('cbcs'), reparsed.initDataBox().info().scheme());
+
+    auto& reparsedRequests = reparsed.initDataBox().requests();
+    ASSERT_EQ(2UL, reparsedRequests.size());
+    EXPECT_EQ(firstKeyID, reparsedRequests[0].requestInfo().keyID());
+    EXPECT_EQ(secondKeyID, reparsedRequests[1].requestInfo().keyID());
+
+    // Nothing set these, so they must not appear in the output.
+    EXPECT_FALSE(reparsedRequests[0].assetID());
+    EXPECT_FALSE(reparsedRequests[0].versionList());
+    EXPECT_FALSE(reparsedRequests[1].assetID());
+    EXPECT_FALSE(reparsedRequests[1].versionList());
+}
+
+// The leaf payload boxes expose non-const accessors so a caller can fill them in. Each one is
+// checked standalone as well as through the tree below, because a size mismatch anywhere in the
+// tree fails the whole serialization: testing the leaves alone says which box got it wrong.
+
+TEST(ISOBox, FairPlayStreamingKeyAssetIdBox_ConstructedRoundtrip)
+{
+    Vector<uint8_t> assetIDData { 0xF1, 0xF2, 0xF3, 0xF4, 0xF5 };
+
+    ISOFairPlayStreamingKeyAssetIdBox fkai;
+    EXPECT_EQ(FourCC('fkai'), fkai.boxType());
+    fkai.data() = assetIDData;
+
+    auto bytes = updateSizeThenSerialize(fkai);
+    Vector<uint8_t> expected {
+        0x00, 0x00, 0x00, 0x0D, 'f', 'k', 'a', 'i',
+        0xF1, 0xF2, 0xF3, 0xF4, 0xF5,
+    };
+    EXPECT_EQ(expected, bytes);
+
+    ISOFairPlayStreamingKeyAssetIdBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+    EXPECT_EQ(assetIDData, reparsed.data());
+}
+
+TEST(ISOBox, FairPlayStreamingKeyContextBox_ConstructedRoundtrip)
+{
+    Vector<uint8_t> contextData { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4 };
+
+    ISOFairPlayStreamingKeyContextBox fkcx;
+    EXPECT_EQ(FourCC('fkcx'), fkcx.boxType());
+    fkcx.data() = contextData;
+
+    auto bytes = updateSizeThenSerialize(fkcx);
+    Vector<uint8_t> expected {
+        0x00, 0x00, 0x00, 0x0D, 'f', 'k', 'c', 'x',
+        0xC0, 0xC1, 0xC2, 0xC3, 0xC4,
+    };
+    EXPECT_EQ(expected, bytes);
+
+    ISOFairPlayStreamingKeyContextBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+    EXPECT_EQ(contextData, reparsed.data());
+}
+
+// The version values are 32-bit, so four bytes have to be reserved and written per entry. A
+// byte-wide size or write would put the box's declared size and its payload out of step.
+TEST(ISOBox, FairPlayStreamingKeyVersionListBox_ConstructedRoundtrip)
+{
+    Vector<uint32_t> versions { 1U, 0x1234U, 0xDEADBEEFU };
+
+    ISOFairPlayStreamingKeyVersionListBox fkvl;
+    EXPECT_EQ(FourCC('fkvl'), fkvl.boxType());
+    fkvl.versions() = versions;
+
+    auto bytes = updateSizeThenSerialize(fkvl);
+    Vector<uint8_t> expected {
+        0x00, 0x00, 0x00, 0x14, 'f', 'k', 'v', 'l',
+        0x00, 0x00, 0x00, 0x01,
+        0x00, 0x00, 0x12, 0x34,
+        0xDE, 0xAD, 0xBE, 0xEF,
+    };
+    EXPECT_EQ(expected, bytes);
+
+    ISOFairPlayStreamingKeyVersionListBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+    EXPECT_EQ(versions, reparsed.versions());
+}
+
+// An empty payload is legal and must not be confused with a truncated one: 'fkai' and 'fkcx'
+// both special-case a box whose declared size covers only its header.
+TEST(ISOBox, FairPlayStreamingKeyAssetIdBox_ConstructedEmpty)
+{
+    ISOFairPlayStreamingKeyAssetIdBox fkai;
+    auto bytes = updateSizeThenSerialize(fkai);
+
+    Vector<uint8_t> expected { 0x00, 0x00, 0x00, 0x08, 'f', 'k', 'a', 'i' };
+    EXPECT_EQ(expected, bytes);
+
+    ISOFairPlayStreamingKeyAssetIdBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+    EXPECT_TRUE(reparsed.data().isEmpty());
+}
+
+// 'fkri' carries a fixed-width key ID, and parse() requires those bytes to be present, so a
+// default-constructed box starts out with a zero-filled one. Without that, a request built from
+// scratch and never given a key ID would serialize to bytes it could not read back.
+TEST(ISOBox, FairPlayStreamingKeyRequestInfoBox_DefaultKeyIDIsZeroFilled)
+{
+    ISOFairPlayStreamingKeyRequestInfoBox fkri;
+    EXPECT_EQ(FourCC('fkri'), fkri.boxType());
+
+    Vector<uint8_t, 16> expectedKeyID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    EXPECT_EQ(expectedKeyID, fkri.keyID());
+
+    auto bytes = updateSizeThenSerialize(fkri);
+    Vector<uint8_t> expected {
+        0x00, 0x00, 0x00, 0x1C, 'f', 'k', 'r', 'i',
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    };
+    EXPECT_EQ(expected, bytes);
+
+    ISOFairPlayStreamingKeyRequestInfoBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+    EXPECT_EQ(expectedKeyID, reparsed.keyID());
+}
+
+// All three optional sub-boxes at once, with the exact bytes spelled out: 'fpsk' writes them in
+// a fixed order (asset ID, context, version list) that a size-only assertion would not pin down.
+TEST(ISOBox, FairPlayStreamingKeyRequestBox_ConstructedWithAllSubBoxes)
+{
+    ISOFairPlayStreamingKeyRequestInfoBox::KeyID keyID { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    Vector<uint8_t> assetIDData { 0xA1, 0xA2, 0xA3, 0xA4 };
+    Vector<uint8_t> contextData { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4 };
+    Vector<uint32_t> versions { 1U, 0xDEADBEEFU };
+
+    ISOFairPlayStreamingKeyRequestBox fpsk;
+    fpsk.requestInfo().setKeyID(keyID);
+
+    ISOFairPlayStreamingKeyAssetIdBox assetID;
+    assetID.data() = assetIDData;
+    fpsk.setAssetID(WTF::move(assetID));
+
+    ISOFairPlayStreamingKeyContextBox context;
+    context.data() = contextData;
+    fpsk.setContent(WTF::move(context));
+
+    ISOFairPlayStreamingKeyVersionListBox versionList;
+    versionList.versions() = versions;
+    fpsk.setVersionList(WTF::move(versionList));
+
+    auto bytes = updateSizeThenSerialize(fpsk);
+
+    // 8-byte 'fpsk' header over a 28-byte 'fkri', a 12-byte 'fkai', a 13-byte 'fkcx' and a
+    // 16-byte 'fkvl'.
+    Vector<uint8_t> expected {
+        0x00, 0x00, 0x00, 0x4D, 'f', 'p', 's', 'k',
+        0x00, 0x00, 0x00, 0x1C, 'f', 'k', 'r', 'i',
+        0x00, 0x00, 0x00, 0x00,
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        0x00, 0x00, 0x00, 0x0C, 'f', 'k', 'a', 'i',
+        0xA1, 0xA2, 0xA3, 0xA4,
+        0x00, 0x00, 0x00, 0x0D, 'f', 'k', 'c', 'x',
+        0xC0, 0xC1, 0xC2, 0xC3, 0xC4,
+        0x00, 0x00, 0x00, 0x10, 'f', 'k', 'v', 'l',
+        0x00, 0x00, 0x00, 0x01, 0xDE, 0xAD, 0xBE, 0xEF,
+    };
+    EXPECT_EQ(expected, bytes);
+    EXPECT_EQ(77U, fpsk.size());
+
+    ISOFairPlayStreamingKeyRequestBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+
+    EXPECT_EQ(keyID, reparsed.requestInfo().keyID());
+    ASSERT_TRUE(reparsed.assetID());
+    EXPECT_EQ(assetIDData, reparsed.assetID()->data());
+    ASSERT_TRUE(reparsed.content());
+    EXPECT_EQ(contextData, reparsed.content()->data());
+    ASSERT_TRUE(reparsed.versionList());
+    EXPECT_EQ(versions, reparsed.versionList()->versions());
+}
+
+// The same request nested in a 'pssh', so every enclosing partialSize() has to account for the
+// optional sub-boxes rather than just the required 'fkri'.
+TEST(ISOBox, FairPlayStreamingPsshBox_ConstructedWithAllSubBoxes)
+{
+    ISOFairPlayStreamingKeyRequestInfoBox::KeyID keyID { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+    Vector<uint8_t> assetIDData { 0xA1, 0xA2, 0xA3, 0xA4 };
+    Vector<uint8_t> contextData { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4 };
+    Vector<uint32_t> versions { 1U, 0xDEADBEEFU };
+
+    ISOFairPlayStreamingKeyRequestBox request;
+    request.requestInfo().setKeyID(keyID);
+
+    ISOFairPlayStreamingKeyAssetIdBox assetID;
+    assetID.data() = assetIDData;
+    request.setAssetID(WTF::move(assetID));
+
+    ISOFairPlayStreamingKeyContextBox context;
+    context.data() = contextData;
+    request.setContent(WTF::move(context));
+
+    ISOFairPlayStreamingKeyVersionListBox versionList;
+    versionList.versions() = versions;
+    request.setVersionList(WTF::move(versionList));
+
+    ISOFairPlayStreamingPsshBox pssh;
+    pssh.initDataBox().info().setScheme(FourCC('cbcs'));
+
+    Vector<ISOFairPlayStreamingKeyRequestBox> requests;
+    requests.append(WTF::move(request));
+    pssh.initDataBox().setRequests(WTF::move(requests));
+
+    auto bytes = updateSizeThenSerialize(pssh);
+
+    // 'pssh' header (32) over an 'fpsd' of 101: its own header (8) plus a 16-byte 'fpsi' and the
+    // 77-byte 'fpsk' checked above.
+    EXPECT_EQ(133U, pssh.size());
+    ASSERT_EQ(133UL, bytes.size());
+
+    ISOFairPlayStreamingPsshBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+
+    EXPECT_EQ(ISOFairPlayStreamingPsshBox::fairPlaySystemID(), reparsed.systemID());
+    EXPECT_EQ(FourCC('cbcs'), reparsed.initDataBox().info().scheme());
+
+    auto& reparsedRequests = reparsed.initDataBox().requests();
+    ASSERT_EQ(1UL, reparsedRequests.size());
+    EXPECT_EQ(keyID, reparsedRequests[0].requestInfo().keyID());
+    ASSERT_TRUE(reparsedRequests[0].assetID());
+    EXPECT_EQ(assetIDData, reparsedRequests[0].assetID()->data());
+    ASSERT_TRUE(reparsedRequests[0].content());
+    EXPECT_EQ(contextData, reparsedRequests[0].content()->data());
+    ASSERT_TRUE(reparsedRequests[0].versionList());
+    EXPECT_EQ(versions, reparsedRequests[0].versionList()->versions());
+}
+
+// Clearing an optional sub-box has to shrink the enclosing boxes, not just leave a hole: this is
+// the reverse of the resize test below, and catches a partialSize() that only ever grows.
+TEST(ISOBox, FairPlayStreamingKeyRequestBox_ClearedOptionalsShrinkBox)
+{
+    ISOFairPlayStreamingKeyRequestBox fpsk;
+
+    ISOFairPlayStreamingKeyContextBox context;
+    context.data() = Vector<uint8_t> { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4 };
+    fpsk.setContent(WTF::move(context));
+
+    fpsk.updateSize();
+    EXPECT_EQ(49U, fpsk.size());
+
+    fpsk.setContent(std::nullopt);
+    auto bytes = updateSizeThenSerialize(fpsk);
+
+    // Back to an 8-byte header over the required 28-byte 'fkri' alone.
+    EXPECT_EQ(36U, fpsk.size());
+    ASSERT_EQ(36UL, bytes.size());
+
+    ISOFairPlayStreamingKeyRequestBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+    EXPECT_FALSE(reparsed.content());
+    EXPECT_FALSE(reparsed.assetID());
+    EXPECT_FALSE(reparsed.versionList());
+}
+
+// Builds the same box the base64 fixture above holds, from scratch, and requires the bytes to
+// match it exactly. The fixture is known-good input for the parser, so this pins the writer and
+// every partialSize() in the tree ('fpsi', 'fkri', 'fkai', 'fpsk', 'fpsd', 'pssh') against it
+// without hand-asserting an expected size at each level.
+TEST(ISOBox, FairPlayStreamingPsshBox_ConstructedMatchesFixture)
+{
+    auto expected = decodeBase64(base64EncodedPsshWithAssetId);
+    ASSERT_EQ(176UL, expected.size());
+
+    auto makeRequest = [](uint8_t keyIDTail, uint8_t assetIDTail) {
+        ISOFairPlayStreamingKeyRequestBox request;
+        request.requestInfo().setKeyID(ISOFairPlayStreamingKeyRequestInfoBox::KeyID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, keyIDTail });
+
+        ISOFairPlayStreamingKeyAssetIdBox assetID;
+        assetID.data() = Vector<uint8_t> { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, assetIDTail };
+        request.setAssetID(WTF::move(assetID));
+
+        return request;
+    };
+
+    ISOFairPlayStreamingPsshBox pssh;
+    pssh.initDataBox().info().setScheme(FourCC('cenc'));
+
+    Vector<ISOFairPlayStreamingKeyRequestBox> requests;
+    requests.append(makeRequest(0x01, 0xF1));
+    requests.append(makeRequest(0x02, 0xF2));
+    pssh.initDataBox().setRequests(WTF::move(requests));
+
+    EXPECT_EQ(expected, updateSizeThenSerialize(pssh));
+    EXPECT_EQ(176U, pssh.size());
+}
+
+// Swapping a parsed box's 16-byte asset ID for a 20-byte one has to grow every enclosing box by
+// the same four bytes. That only happens if each partialSize() measures the box it contains
+// rather than reusing the size it parsed, so this catches a stale size that the fixture tests --
+// where the computed and parsed sizes coincide -- cannot distinguish.
+TEST(ISOBox, FairPlayStreamingPsshBox_ResizedAssetIDUpdatesEnclosingSizes)
+{
+    auto psshArray = decodeBase64(base64EncodedPsshWithAssetId);
+    ASSERT_EQ(176UL, psshArray.size());
+
+    ISOFairPlayStreamingPsshBox pssh;
+    ASSERT_TRUE(pssh.read(psshArray.span()));
+    ASSERT_EQ(176U, pssh.size());
+
+    auto requests = pssh.initDataBox().requests();
+    ASSERT_EQ(2UL, requests.size());
+
+    ISOFairPlayStreamingKeyAssetIdBox widerAssetID;
+    widerAssetID.data() = Vector<uint8_t> { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF9 };
+    requests[0].setAssetID(WTF::move(widerAssetID));
+    pssh.initDataBox().setRequests(WTF::move(requests));
+
+    auto bytes = updateSizeThenSerialize(pssh);
+    EXPECT_EQ(180U, pssh.size());
+    ASSERT_EQ(180UL, bytes.size());
+
+    ISOFairPlayStreamingPsshBox reparsed;
+    ASSERT_TRUE(reparsed.read(bytes.span()));
+
+    auto& reparsedRequests = reparsed.initDataBox().requests();
+    ASSERT_EQ(2UL, reparsedRequests.size());
+
+    Vector<uint8_t> expectedFirstAssetID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF9 };
+    ASSERT_TRUE(reparsedRequests[0].assetID());
+    EXPECT_EQ(expectedFirstAssetID, reparsedRequests[0].assetID()->data());
+
+    // The request that was not touched has to come back byte-for-byte, so the extra four bytes
+    // went into the first asset ID rather than shifting the boxes that follow it.
+    Vector<uint8_t> expectedSecondAssetID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xF2 };
+    ASSERT_TRUE(reparsedRequests[1].assetID());
+    EXPECT_EQ(expectedSecondAssetID, reparsedRequests[1].assetID()->data());
+
+    Vector<uint8_t, 16> expectedSecondKeyID { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2 };
+    EXPECT_EQ(expectedSecondKeyID, reparsedRequests[1].requestInfo().keyID());
+}
+
+// MARK: - Malformed input
+//
+// Every bound in ISOProtectionSystemSpecificHeaderBox::parse is derived from the box's
+// declared size, which ISOBox::parse only clamps down to the bytes left in the view — never
+// up to the size of the box's own header. These cover the resulting arithmetic edges.
+
+// A box declaring a size (8) smaller than its own header must be rejected. Version 0 with a
+// zero dataSize, so no other bound can reject it incidentally: without the size invariant
+// this parses "successfully" while having consumed far more bytes than it claims to occupy.
+TEST(ISOBox, ProtectionSystemSpecificHeaderBox_RejectsSizeSmallerThanHeader)
+{
+    auto bytes = decodeBase64("AAAACHBzc2gAAAAAEHfv7MCyTQKs4zweUuL7SwAAAADMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzA=="_s);
+    ASSERT_FALSE(bytes.isEmpty());
+
+    auto view = bytes.span();
+    ISOProtectionSystemSpecificHeaderBox pssh;
+    EXPECT_FALSE(pssh.read(view));
+}
+
+// keyIDCount == 2^28 makes `keyIDCount * sizeof(KeyID)` wrap to exactly 0 when computed in
+// 32-bit arithmetic, defeating the bound on the key ID list.
+TEST(ISOBox, ProtectionSystemSpecificHeaderBox_RejectsOverflowingKeyIDCount)
+{
+    auto bytes = decodeBase64("AAAAYHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s);
+    ASSERT_FALSE(bytes.isEmpty());
+
+    auto view = bytes.span();
+    ISOProtectionSystemSpecificHeaderBox pssh;
+    EXPECT_FALSE(pssh.read(view));
+    EXPECT_TRUE(pssh.keyIDs().isEmpty());
+}
+
+// A dataSize that reaches past the box's own end but stays inside the view must be rejected;
+// bounding only by the view would let the box absorb the sibling bytes that follow it.
+TEST(ISOBox, ProtectionSystemSpecificHeaderBox_RejectsDataSizePastBoxEnd)
+{
+    auto bytes = decodeBase64("AAAAKHBzc2gAAAAAEHfv7MCyTQKs4zweUuL7SwAAAECqqqqqqqqqqru7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7s="_s);
+    ASSERT_FALSE(bytes.isEmpty());
+
+    auto view = bytes.span();
+    ISOProtectionSystemSpecificHeaderBox pssh;
+    EXPECT_FALSE(pssh.read(view));
+    EXPECT_TRUE(pssh.data().isEmpty());
 }
 
 }


### PR DESCRIPTION
#### 6446fdc8e0be049f61e48d8beb8556ee8e2e1009
<pre>
Support writing ISOBoxes as well as reading/parsing
<a href="https://rdar.apple.com/180057740">rdar://180057740</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317430">https://bugs.webkit.org/show_bug.cgi?id=317430</a>

Reviewed by Jean-Yves Avenard.

ISOBoxes and their subclasses are parsed representations of ISO-BMFF media data. In addition
to reading these boxes from files and memory, we may also want to serialize these boxes to
memory, for features like mp4-file authoring and editing.

Add the ability to write a box (and all its children) to memory. Each box must be able to
calculate its own size, so there is a new pair of methods: `partialSize` and `requiredSize`.
Base ISOBoxes boxes need their subclasses&apos; sizes to be fully calculated, hence the split
between the two functions. Also add a `serialize` and virtual `write` method, and a convenience
template `checkedReadSequence` and `checkedWriteSequence` to support reading and writing
data arrays.

Test: Tools/TestWebKitAPI/Tests/WebCore/ISOBox.cpp

* Source/WebCore/platform/graphics/iso/ISOBox.cpp:
(WebCore::ISOBox::ISOBox):
(WebCore::ISOBox::peekBox):
(WebCore::ISOBox::read):
(WebCore::ISOBox::updateSize):
(WebCore::ISOBox::partialSize const):
(WebCore::ISOBox::requiredSize const):
(WebCore::ISOBox::parse):
(WebCore::ISOBox::write const):
(WebCore::ISOBox::serialize const):
(WebCore::ISOFullBox::ISOFullBox):
(WebCore::ISOFullBox::parse):
(WebCore::ISOFullBox::write const):
(WebCore::ISOFullBox::parseVersionAndFlags):
* Source/WebCore/platform/graphics/iso/ISOBox.h:
(WebCore::ISOBox::checkedRead):
(WebCore::ISOBox::checkedReadSequence):
(WebCore::ISOBox::checkedWrite):
(WebCore::ISOBox::checkedWriteSequence):
(WebCore::ISOFullBox::setVersion):
(WebCore::ISOFullBox::setFlags):
* Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.cpp:
(WebCore::ISOOriginalFormatBox::ISOOriginalFormatBox):
(WebCore::ISOOriginalFormatBox::parse):
* Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h:
* Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.cpp:
(WebCore::ISOProtectionSchemeInfoBox::ISOProtectionSchemeInfoBox):
(WebCore::ISOProtectionSchemeInfoBox::parse):
(WebCore::ISOProtectionSchemeInfoBox::updateSize):
(WebCore::ISOProtectionSchemeInfoBox::partialSize const):
* Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h:
* Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp:
(WebCore::ISOProtectionSystemSpecificHeaderBox::commonSystemID const):
(WebCore::ISOProtectionSystemSpecificHeaderBox::ISOProtectionSystemSpecificHeaderBox):
(WebCore::ISOProtectionSystemSpecificHeaderBox::peekSystemID):
(WebCore::ISOProtectionSystemSpecificHeaderBox::parse):
(WebCore::ISOProtectionSystemSpecificHeaderBox::parseData):
(WebCore::ISOProtectionSystemSpecificHeaderBox::write const):
(WebCore::ISOProtectionSystemSpecificHeaderBox::writeData const):
(WebCore::ISOProtectionSystemSpecificHeaderBox::partialSize const):
* Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h:
* Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp:
(WebCore::ISOSchemeInformationBox::ISOSchemeInformationBox):
(WebCore::ISOSchemeInformationBox::parse):
(WebCore::ISOSchemeInformationBox::updateSize):
(WebCore::ISOSchemeInformationBox::partialSize const):
* Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h:
* Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.cpp:
(WebCore::ISOSchemeTypeBox::ISOSchemeTypeBox):
(WebCore::ISOSchemeTypeBox::parse):
* Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h:
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp:
(WebCore::ISOTrackEncryptionBox::ISOTrackEncryptionBox):
(WebCore::ISOTrackEncryptionBox::parse):
(WebCore::ISOTrackEncryptionBox::parsePayload):
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h:
* Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp:
(WebCore::ISOWebVTTCue::ISOWebVTTCue):
* Source/WebCore/platform/graphics/iso/ISOVTTCue.h:
* Tools/TestWebKitAPI/Tests/WebCore/ISOBox.cpp:
(TestWebKitAPI::TEST(ISOBox, ISOFairPlayStreamingPsshBox)):
(TestWebKitAPI::serializeBox):
(TestWebKitAPI::TEST(ISOBox, FairPlay_KeyRequestInfoBox_Write)):
(TestWebKitAPI::TEST(ISOBox, FairPlay_KeyRequestInfoBox_Roundtrip)):
(TestWebKitAPI::TEST(ISOBox, FairPlay_InfoBox_Write)):
(TestWebKitAPI::TEST(ISOBox, FairPlay_InfoBox_Roundtrip)):
(TestWebKitAPI::TEST(ISOBox, FairPlay_KeyAssetIdBox_ParseAndRewrite)):
(TestWebKitAPI::TEST(ISOBox, FairPlay_KeyRequestBox_WriteWithFkriOnly)):
(TestWebKitAPI::TEST(ISOBox, FairPlay_KeyRequestBox_RoundtripWithAssetId)):
(TestWebKitAPI::TEST(ISOBox, FairPlay_InitDataBox_WriteAndRoundtrip)):
(TestWebKitAPI::TEST(ISOBox, FairPlay_PsshBox_ParseWriteParseRoundtrip)):
(TestWebKitAPI::TEST(ISOBox, PsshBox_V1_PartialSizeIncludesSystemIDAndDataSize)):

Canonical link: <a href="https://commits.webkit.org/319410@main">https://commits.webkit.org/319410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/774c34b5f6427b4834307054f535e912a8922626

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191574 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145677 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141540 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121980 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43894 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42165 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3946 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10763 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41817 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2730 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42627 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193502 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54967 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40435 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55654 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38440 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150641 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45224 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127935 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123535 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54170 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16816 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53552 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53790 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53617 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->