### PR TITLE
Web Inspector: [SI] implement DOMStorage storage commands on FrameDOMStorageAgent

### DIFF
--- a/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp
@@ -26,8 +26,16 @@
 #include "config.h"
 #include "FrameDOMStorageAgent.h"
 
+#include "DOMException.h"
+#include "Document.h"
+#include "DocumentPage.h"
 #include "InstrumentingAgents.h"
 #include "LocalFrame.h"
+#include "LocalFrameInlines.h"
+#include "Page.h"
+#include "SecurityOrigin.h"
+#include "StorageArea.h"
+#include "StorageNamespaceProvider.h"
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <wtf/JSONValues.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -79,28 +87,110 @@ Inspector::CommandResult<void> FrameDOMStorageAgent::disable()
     return { };
 }
 
-Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOMStorage::Item>>> FrameDOMStorageAgent::getDOMStorageItems(Ref<JSON::Object>&&)
+Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::DOMStorage::Item>>> FrameDOMStorageAgent::getDOMStorageItems(Ref<JSON::Object>&& storageId)
 {
-    // FIXME: <rdar://179249711>: Implement DOMStorage commands for frame targets.
-    return makeUnexpected("DOMStorage commands are not yet implemented for frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr<LocalFrame> frame;
+    RefPtr storageArea = findStorageArea(errorString, storageId, frame);
+    if (!storageArea)
+        return makeUnexpected(errorString);
+
+    auto storageItems = JSON::ArrayOf<JSON::ArrayOf<String>>::create();
+    for (unsigned i = 0; i < storageArea->length(); ++i) {
+        String key = storageArea->key(i);
+        String value = storageArea->item(key);
+
+        auto entry = JSON::ArrayOf<String>::create();
+        entry->addItem(key);
+        entry->addItem(value);
+        storageItems->addItem(WTF::move(entry));
+    }
+    return storageItems;
 }
 
-Inspector::CommandResult<void> FrameDOMStorageAgent::setDOMStorageItem(Ref<JSON::Object>&&, const String&, const String&)
+Inspector::CommandResult<void> FrameDOMStorageAgent::setDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key, const String& value)
 {
-    // FIXME: <rdar://179249711>: Implement DOMStorage commands for frame targets.
-    return makeUnexpected("DOMStorage commands are not yet implemented for frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr<LocalFrame> frame;
+    RefPtr storageArea = findStorageArea(errorString, storageId, frame);
+    if (!storageArea)
+        return makeUnexpected(errorString);
+
+    bool quotaException = false;
+    storageArea->setItem(*frame, key, value, quotaException);
+    if (quotaException)
+        return makeUnexpected(DOMException::name(ExceptionCode::QuotaExceededError));
+
+    return { };
 }
 
-Inspector::CommandResult<void> FrameDOMStorageAgent::removeDOMStorageItem(Ref<JSON::Object>&&, const String&)
+Inspector::CommandResult<void> FrameDOMStorageAgent::removeDOMStorageItem(Ref<JSON::Object>&& storageId, const String& key)
 {
-    // FIXME: <rdar://179249711>: Implement DOMStorage commands for frame targets.
-    return makeUnexpected("DOMStorage commands are not yet implemented for frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr<LocalFrame> frame;
+    RefPtr storageArea = findStorageArea(errorString, storageId, frame);
+    if (!storageArea)
+        return makeUnexpected(errorString);
+
+    storageArea->removeItem(*frame, key);
+
+    return { };
 }
 
-Inspector::CommandResult<void> FrameDOMStorageAgent::clearDOMStorageItems(Ref<JSON::Object>&&)
+Inspector::CommandResult<void> FrameDOMStorageAgent::clearDOMStorageItems(Ref<JSON::Object>&& storageId)
 {
-    // FIXME: <rdar://179249711>: Implement DOMStorage commands for frame targets.
-    return makeUnexpected("DOMStorage commands are not yet implemented for frame targets"_s);
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr<LocalFrame> frame;
+    RefPtr storageArea = findStorageArea(errorString, storageId, frame);
+    if (!storageArea)
+        return makeUnexpected(errorString);
+
+    storageArea->clear(*frame);
+
+    return { };
+}
+
+RefPtr<StorageArea> FrameDOMStorageAgent::findStorageArea(Inspector::Protocol::ErrorString& errorString, const JSON::Object& storageId, RefPtr<LocalFrame>& targetFrame)
+{
+    auto securityOrigin = storageId.getString("securityOrigin"_s);
+    if (!securityOrigin) {
+        errorString = "Missing securityOrigin in given storageId"_s;
+        return nullptr;
+    }
+
+    auto isLocalStorage = storageId.getBoolean("isLocalStorage"_s);
+    if (!isLocalStorage) {
+        errorString = "Missing isLocalStorage in given storageId"_s;
+        return nullptr;
+    }
+
+    RefPtr frame = m_inspectedFrame.get();
+    RefPtr page = frame ? frame->page() : nullptr;
+    RefPtr document = frame ? frame->document() : nullptr;
+    if (!frame || !page || !document) {
+        errorString = "Frame or page not available"_s;
+        return nullptr;
+    }
+
+    // The frame agent only operates on its own frame's storage, so securityOrigin is not used
+    // to locate the area (unlike the page-level agent's origin search). It is still validated
+    // as a precondition: a mismatch means the storageId was routed to the wrong frame or is
+    // stale after a navigation, and proceeding would mutate a different origin's storage. Fail
+    // so the frontend can re-resolve, rather than silently acting on the wrong origin.
+    if (protect(document->securityOrigin())->toRawString() != securityOrigin) {
+        errorString = "Given securityOrigin does not match the inspected frame's origin"_s;
+        return nullptr;
+    }
+
+    targetFrame = WTF::move(frame);
+
+    if (*isLocalStorage)
+        return page->storageNamespaceProvider().localStorageArea(*document);
+    return page->storageNamespaceProvider().sessionStorageArea(*document);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h
@@ -39,6 +39,7 @@ class DOMStorageFrontendDispatcher;
 namespace WebCore {
 
 class LocalFrame;
+class StorageArea;
 
 // FrameDOMStorageAgent is the per-frame DOMStorage agent for Site Isolation. Each
 // LocalFrame owns one, and it only ever serves its own frame's storage areas (which
@@ -66,6 +67,8 @@ public:
     Inspector::CommandResult<void> clearDOMStorageItems(Ref<JSON::Object>&& storageId) override;
 
 private:
+    RefPtr<StorageArea> findStorageArea(Inspector::Protocol::ErrorString&, const JSON::Object& storageId, RefPtr<LocalFrame>& targetFrame);
+
     const UniqueRef<Inspector::DOMStorageFrontendDispatcher> m_frontendDispatcher;
     const Ref<Inspector::DOMStorageBackendDispatcher> m_backendDispatcher;
 


### PR DESCRIPTION
#### 766b2065d561c89048a43428f23826a0463bd75c
<pre>
Web Inspector: [SI] implement DOMStorage storage commands on FrameDOMStorageAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=316800">https://bugs.webkit.org/show_bug.cgi?id=316800</a>
<a href="https://rdar.apple.com/179249711">rdar://179249711</a>

Reviewed by BJ Burg.

Implement getDOMStorageItems, setDOMStorageItem, removeDOMStorageItem,
and clearDOMStorageItems on FrameDOMStorageAgent, replacing the stubs.

Unlike the page-level InspectorDOMStorageAgent, which searches the frame
tree by security origin (and so cannot reach cross-origin out-of-process
frames), the frame agent resolves its storage area directly from its own
m_inspectedFrame&apos;s document via the page&apos;s StorageNamespaceProvider.
securityOrigin is therefore not needed to locate the area; a mismatch
against the frame&apos;s own origin is asserted (debug only) but the command
still proceeds on this frame&apos;s storage.

* Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.cpp:
(WebCore::FrameDOMStorageAgent::getDOMStorageItems):
(WebCore::FrameDOMStorageAgent::setDOMStorageItem):
(WebCore::FrameDOMStorageAgent::removeDOMStorageItem):
(WebCore::FrameDOMStorageAgent::clearDOMStorageItems):
(WebCore::FrameDOMStorageAgent::findStorageArea): Resolve the StorageArea
from the inspected frame&apos;s document, no origin-based frame-tree lookup.
* Source/WebCore/inspector/agents/frame/FrameDOMStorageAgent.h:

Canonical link: <a href="https://commits.webkit.org/316501@main">https://commits.webkit.org/316501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1896f40e113b0421b0cfc2b8b1858f930c61b249

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172535 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46453 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181992 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130091 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/174400 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47746 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46124 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/181992 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130091 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/175493 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47746 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181992 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47746 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46124 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/30592 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47746 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/184525 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37209 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46124 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/184525 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46125 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/184525 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46803 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111631 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26184 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46803 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118556 "Built successfully") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39884 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44720 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44779 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->