### PR TITLE
Crash at WebKit: IPC::Encoder::grow after a call to browser.storage.local.get()

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionConstants.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionConstants.h
@@ -44,9 +44,10 @@ static constexpr size_t webExtensionDeclarativeNetRequestMaximumNumberOfDynamicA
 // MARK: Storage
 static constexpr size_t webExtensionUnlimitedStorageQuotaBytes = std::numeric_limits<size_t>::max();
 
-static constexpr size_t webExtensionStorageAreaLocalQuotaBytes = 5 * 1024 * 1024;
+static constexpr size_t webExtensionStorageAreaLocalQuotaBytes = 10 * 1024 * 1024;
 static constexpr size_t webExtensionStorageAreaSessionQuotaBytes = 10 * 1024 * 1024;
 static constexpr size_t webExtensionStorageAreaSyncQuotaBytes = 100 * 1024;
+static constexpr size_t webExtensionStorageAreaMaximumBytesPerCall = 995 * 1024 * 1024;
 
 static constexpr size_t webExtensionStorageAreaSyncQuotaBytesPerItem = 8 * 1024;
 

--- a/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
+++ b/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
@@ -57,18 +57,27 @@ void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifi
     auto callingAPIName = makeString("browser.storage."_s, toAPIString(dataType), ".get()"_s);
 
     Ref storage = storageForType(dataType);
-    storage->getValuesForKeys(keys, [callingAPIName, completionHandler = WTF::move(completionHandler)](HashMap<String, String> values, const String& errorMessage) mutable {
+    storage->getValuesForKeys(keys, [callingAPIName, dataType, completionHandler = WTF::move(completionHandler)](HashMap<String, String> values, const String& errorMessage) mutable {
         if (!errorMessage.isEmpty())
             completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
         else {
             Ref jsonObject = JSON::Object::create();
-            for (auto entry : values)
+            for (auto& entry : values)
                 jsonObject->setString(entry.key, entry.value);
 
+            size_t size = 0;
             Vector<String> serializedJSONStrings;
             serializeToMultipleJSONStrings(jsonObject, [&](String&& jsonChunk) {
+                size += jsonChunk.sizeInBytes();
                 serializedJSONStrings.append(WTF::move(jsonChunk));
             });
+
+            if (size > webExtensionStorageAreaMaximumBytesPerCall) {
+                ASSERT_UNUSED(dataType, dataType == WebExtensionDataType::Local);
+                completionHandler(toWebExtensionError(callingAPIName, nullString(), "it exceeded maximum data size allowed per call"_s));
+                return;
+            }
+
             completionHandler(serializedJSONStrings);
         }
     });

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -195,6 +195,11 @@ void WebExtensionAPIStorageArea::set(WebPageProxyIdentifier webPageProxyIdentifi
         return;
     }
 
+    if (storageSizeOf(serializedData) > webExtensionStorageAreaMaximumBytesPerCall) {
+        *outExceptionString = toErrorString(nullString(), nullString(), @"it exceeded maximum data size allowed per call").createNSString().autorelease();
+        return;
+    }
+
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSet(webPageProxyIdentifier, m_type, encodeJSONString(serializedData)), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result)
             callback->reportError(result.error().createNSString().get());

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm
@@ -54,6 +54,22 @@ static auto *storageManifest = @{
     } ],
 };
 
+static auto *unlimitedStorageManifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"Storage Test",
+    @"description": @"Storage Test",
+    @"version": @"1",
+
+    @"permissions": @[ @"unlimitedStorage" ],
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+};
+
 TEST(WKWebExtensionAPIStorage, Errors)
 {
     auto *backgroundScript = Util::constructScript(@[
@@ -637,6 +653,23 @@ TEST(WKWebExtensionAPIStorage, StorageFromSubframe)
     [manager.get().defaultTab.webView loadRequest:urlRequestMain];
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPIStorage, SetExceedsMaximumDataSize)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // 5120 keys × 200 KB ≈ 1GB of data, exceeding the 950 MB per-call limit.
+        @"const value = 'x'.repeat(200 * 1024)",
+        @"const data = {}",
+        @"for (let i = 0; i < 5120; i++)",
+        @"    data[`key${i}`] = value",
+
+        @"browser.test.assertThrows(() => browser.storage.local.set(data), /exceeded maximum data size allowed per call/i)",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(unlimitedStorageManifest, @{ @"background.js": backgroundScript });
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### ea232f38603949069f5757d9b3b9210dc3eb94db
<pre>
Crash at WebKit: IPC::Encoder::grow after a call to browser.storage.local.get()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317433">https://bugs.webkit.org/show_bug.cgi?id=317433</a>
<a href="https://rdar.apple.com/177578845">rdar://177578845</a>

Reviewed by Timothy Hatcher.

Extensions can declare an unlimited use of storage and at the moment, we don&apos;t restrict the amount
of data they can set or get at once. This can cause issues, especially on iOS, where we have tighter
memory constraints, leading to crashes in both the Web and UI process when an extension tries to set
or get large amounts of data. This patch makes it so that we cap out at 995 MB, a bit under 1GB
which is where we occasionally crash on iOS. Larger than 1GB is a constant crash on iOS. I haven&apos;t
observed any crashes on macOS but to be consistent across platforms, the limit is introduced on macOS
as well.

I filed this WECG issue proposing limits for these calls:
<a href="https://github.com/w3c/webextensions/issues/1028">https://github.com/w3c/webextensions/issues/1028</a>

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm

* Source/WebKit/Shared/Extensions/WebExtensionConstants.h:
Add a new constant for the maximum amount of data that can be set or retrieved at once from a call
to local storage.

Also, bump the local storage quota for extensions that don&apos;t use unlimited storage as the increased
quota was agreed upon in the WECG: <a href="https://github.com/w3c/webextensions/issues/351.">https://github.com/w3c/webextensions/issues/351.</a>

* Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp:
(WebKit::WebExtensionContext::storageGet):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::set):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, SetExceedsMaximumDataSize)):
Add a new test to ensure that setting larger than 1GB of data throws an error. I attempted to write
a test for get() as well but it was a constant timeout. Verified manually that we throw an error in
this case as well.

Canonical link: <a href="https://commits.webkit.org/315539@main">https://commits.webkit.org/315539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9882aa541dbfce921aa57bd0142852796c894435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169369 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/43291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/178725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171235 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/43398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/42919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/178725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172328 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/43398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/178725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/43398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/42919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/27425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/43398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181325 "Failed to checkout and rebase branch from PR 67469") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34035 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/42919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/181325 "Failed to checkout and rebase branch from PR 67469") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/42947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/181325 "Failed to checkout and rebase branch from PR 67469") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/43636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107666 "Build is in progress. Recent messages:") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25799 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/43636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/42146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/41539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/41794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/41682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->