### PR TITLE
Fix flaky privateClickMeasurement/database-disabled-in-ephemeral-session.html

### DIFF
--- a/LayoutTests/http/tests/privateClickMeasurement/database-disabled-in-ephemeral-session.html
+++ b/LayoutTests/http/tests/privateClickMeasurement/database-disabled-in-ephemeral-session.html
@@ -17,8 +17,10 @@
 
     prepareTest();
 
-    if (window.testRunner)
+    if (window.testRunner) {
+        testRunner.setPrivateClickMeasurementAppBundleIDForTesting("com.apple.WebKit.WebKitTestRunner");
         testRunner.setPrivateClickMeasurementAttributionReportURLsForTesting("http://127.0.0.1:8000/privateClickMeasurement/resources/conversionReport.py?nonce=" + nonce, "http://localhost:8000/privateClickMeasurement/resources/conversionReport.py?nonce=" + nonce);
+    }
 
     function activateElement(elementID) {
         var element = document.getElementById(elementID);


### PR DESCRIPTION
#### 19aa2b984fdf414d15845ac2a2fa694e3336c932
<pre>
Fix flaky privateClickMeasurement/database-disabled-in-ephemeral-session.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=317441">https://bugs.webkit.org/show_bug.cgi?id=317441</a>

Reviewed by NOBODY (OOPS\!).

The test was flaky because the application bundle identifier in the
output could vary depending on WebContent process reuse. The fix
explicitly sets the app bundle ID via the Network process testing
API, making the test deterministic.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19aa2b984fdf414d15845ac2a2fa694e3336c932

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126929 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e03897be-8cc8-4cf6-9776-e7587213f686) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131797 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92746 "1 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ec2a91a-c316-4c08-b9eb-d25091056537) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112301 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bc7a703-0073-4036-8e05-c08671c8f616) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33292 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31940 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27273 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181173 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140250 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140091 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43484 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107404 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35362 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41994 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6541 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41387 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41642 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41530 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->