### PR TITLE
CoreIPCNSURLCredential attribute type guard is always true

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
@@ -81,7 +81,7 @@ CoreIPCNSURLCredential::CoreIPCNSURLCredential(NSURLCredential *credential)
                 break;
             }
             id value = [attributes objectForKey:key];
-            if (![value isKindOfClass:NSString.class] || ![value isKindOfClass:NSNumber.class] || ![value isKindOfClass:NSDate.class]) {
+            if (![value isKindOfClass:NSString.class] && ![value isKindOfClass:NSNumber.class] && ![value isKindOfClass:NSDate.class]) {
                 ASSERT_NOT_REACHED();
                 break;
             }

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -2046,6 +2046,21 @@ TEST(IPCSerialization, NSURLCredentialKerberosFlags)
     EXPECT_FALSE(decoded->flags->isEmpty());
 }
 
+TEST(IPCSerialization, NSURLCredentialAttributes)
+{
+    RetainPtr credential = adoptNS([[NSURLCredential alloc] _initWithWebKitPropertyListData:@{
+        @"type": @(kURLCredentialInternetPassword),
+        @"persistence": @(kCFURLCredentialPersistenceForSession),
+        @"attributes": @{ @"name": @"value" },
+    }]);
+
+    IPC::Encoder encoder(IPC::MessageName::IPCTester_AsyncPing, 0);
+    encoder << WebKit::CoreIPCNSURLCredential { credential.get() };
+    auto decoder = IPC::Decoder::create(encoder.span(), encoder.releaseAttachments());
+    auto decoded = decoder->decode<WebKit::CoreIPCNSURLCredentialData>();
+    EXPECT_EQ(decoded->attributes->size(), 1u);
+}
+
 #endif // HAVE(WK_SECURE_CODING_NSURLCREDENTIAL)
 
 @interface PKPaymentMerchantSession ()


### PR DESCRIPTION
#### 3ad9e87e41ee56322c335a1dfbd0ccf794e57f7f
<pre>
CoreIPCNSURLCredential attribute type guard is always true
<a href="https://bugs.webkit.org/show_bug.cgi?id=317444">https://bugs.webkit.org/show_bug.cgi?id=317444</a>
<a href="https://rdar.apple.com/180069344">rdar://180069344</a>

Reviewed by Sihui Liu.

The guard meant to reject an attribute value that is none of NSString, NSNumber or NSDate was
written with ||. Since a value can be at most one of those classes, at least two of the negated
checks are always true, so the expression is always true. The body therefore fired on the very first
attribute regardless of its type, terminating the loop and dropping every credential attribute from
the IPC encoding. Use &amp;&amp; so the guard rejects only values that are none of the three classes.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm:
(WebKit::CoreIPCNSURLCredential::CoreIPCNSURLCredential):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, NSURLCredentialAttributes)):

Canonical link: <a href="https://commits.webkit.org/315792@main">https://commits.webkit.org/315792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d90e6956fb38dbfe1d7eb8b9afb14aa73316487

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127607 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9107ab0e-7148-4dac-bdd0-d04229ed2f69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132409 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dfbace8-169a-4cde-a7dd-26855a81d36a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172854 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112911 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71e89ebd-1e5e-4aa3-9107-2bf73c49b634) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32550 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27952 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144734 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181853 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140863 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43473 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140694 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44162 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108457 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25922 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35956 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115927 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42673 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7297 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42320 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42208 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->