### PR TITLE
Revert 312304@main, which used a stale HashMap iterator in LegacyRenderSVGResourceFilter::applyResource

### DIFF
--- a/LayoutTests/svg/filters/feImage-reentrant-filter-remove-crash-expected.txt
+++ b/LayoutTests/svg/filters/feImage-reentrant-filter-remove-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if it does not crash.
+
+

--- a/LayoutTests/svg/filters/feImage-reentrant-filter-remove-crash.html
+++ b/LayoutTests/svg/filters/feImage-reentrant-filter-remove-crash.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>PASS if it does not crash.</p>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="300">
+    <defs>
+        <filter id="f">
+            <feImage href="#target" xlink:href="#target"></feImage>
+            <feDiffuseLighting></feDiffuseLighting>
+        </filter>
+        <g id="target">
+            <rect x="0"   y="0"   width="40" height="40" filter="url(#f)"/>
+            <rect x="50"  y="0"   width="40" height="40" filter="url(#f)"/>
+            <rect x="100" y="0"   width="40" height="40" filter="url(#f)"/>
+            <rect x="0"   y="50"  width="40" height="40" filter="url(#f)"/>
+            <rect x="50"  y="50"  width="40" height="40" filter="url(#f)"/>
+            <rect x="100" y="50"  width="40" height="40" filter="url(#f)"/>
+            <rect x="0"   y="100" width="40" height="40" filter="url(#f)"/>
+            <rect x="50"  y="100" width="40" height="40" filter="url(#f)"/>
+        </g>
+    </defs>
+    <rect x="0" y="0" width="100" height="100" filter="url(#f)"/>
+</svg>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+requestAnimationFrame(() => requestAnimationFrame(() => {
+    document.body.firstElementChild.textContent = "PASS if it does not crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}));
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -97,8 +97,7 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
     }
 
     auto addResult = m_rendererFilterDataMap.set(renderer, makeUnique<FilterData>());
-    auto addedIterator = addResult.iterator;
-    auto filterData = addedIterator->value.get();
+    auto filterData = addResult.iterator->value.get();
 
     Ref filterElement = this->filterElement();
     RefPtr contextElement = dynamicDowncast<SVGElement>(renderer.element());
@@ -106,14 +105,14 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
 
     auto filterRegion = SVGLengthContext::resolveRectangle(contextElement.get(), filterElement.get(), filterElement->filterUnits(), targetBoundingBox);
     if (filterRegion.isEmpty()) {
-        m_rendererFilterDataMap.remove(addedIterator);
+        m_rendererFilterDataMap.remove(renderer);
         return { };
     }
 
     // Determine absolute transformation matrix for filter.
     auto absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
     if (!absoluteTransform.isInvertible()) {
-        m_rendererFilterDataMap.remove(addedIterator);
+        m_rendererFilterDataMap.remove(renderer);
         return { };
     }
 
@@ -138,7 +137,7 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
     }, preferredFilterModes, renderingOptions, *context, RenderingResourceIdentifier::generate());
 
     if (!filterData->filter) {
-        m_rendererFilterDataMap.remove(addedIterator);
+        m_rendererFilterDataMap.remove(renderer);
         return { };
     }
 
@@ -156,7 +155,7 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
 
     filterData->targetSwitcher = GraphicsContextSwitcher::create(*context, filterData->sourceImageRect, colorSpace, filterData->filter, &results);
     if (!filterData->targetSwitcher) {
-        m_rendererFilterDataMap.remove(addedIterator);
+        m_rendererFilterDataMap.remove(renderer);
         return { };
     }
     


### PR DESCRIPTION
#### 5b3364fd97cd3c58f7c0d5571b6ac594c909b049
<pre>
Revert 312304@main, which used a stale HashMap iterator in LegacyRenderSVGResourceFilter::applyResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=317445">https://bugs.webkit.org/show_bug.cgi?id=317445</a>
<a href="https://rdar.apple.com/177698242">rdar://177698242</a>

Reviewed by Simon Fraser.

This reverts the source change from 312304@main, which removed map entries by
the iterator from set() to avoid re-hashing the key. applyResource() can be
re-entered recursively (SVGFilterRenderer::create() paints an feImage&apos;s
referenced subtree, which re-enters with another client and inserts into the
same map), rehashing it and invalidating that iterator, so removing by it is a
use-after-free. Restore removal by key, and add a regression test.

* LayoutTests/svg/filters/feImage-reentrant-filter-remove-crash-expected.txt: Added.
* LayoutTests/svg/filters/feImage-reentrant-filter-remove-crash.html: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::applyResource):

Canonical link: <a href="https://commits.webkit.org/315624@main">https://commits.webkit.org/315624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb9a9ef983c0e69e32b4e807be72d03b7f31078f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127268 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb4dbe8d-394c-4bda-8772-ec1769b252ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171422 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132105 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93039 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65c42293-8dd1-4405-914a-3203725a84a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172515 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112608 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a9d4e2b-1739-48be-b93a-cf4bef46bd42) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32245 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27612 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181514 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140554 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140390 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43823 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108028 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35658 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115588 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42333 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6966 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41726 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41981 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41869 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->