### PR TITLE
[CMake] Use -fstrict-aliasing

### DIFF
--- a/Source/cmake/OptionsIOS.cmake
+++ b/Source/cmake/OptionsIOS.cmake
@@ -200,7 +200,6 @@ add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-Wno-objc-method-access>
 
 add_compile_options(
     "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fno-common>"
-    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fstrict-aliasing>"
 )
 
 if (ENABLE_SANITIZERS)

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -194,8 +194,6 @@ if (COMPILER_IS_GCC_OR_CLANG)
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-gsimple-template-names)
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS("-mllvm -dwarf-linkage-names=Abstract")
 
-    WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-strict-aliasing)
-
     # clang-cl.exe impersonates cl.exe so some clang arguments like -fno-rtti are
     # represented using cl.exe's options and should not be passed as flags, so
     # we do not add -fno-rtti or -fno-exceptions for clang-cl


### PR DESCRIPTION
#### 50a48d720f6cbdea50c6c611d25ca0386fd3d797
<pre>
[CMake] Use -fstrict-aliasing
<a href="https://bugs.webkit.org/show_bug.cgi?id=317449">https://bugs.webkit.org/show_bug.cgi?id=317449</a>
<a href="https://rdar.apple.com/180072685">rdar://180072685</a>

Reviewed by Geoffrey Garen.

The current use seems to be a holdover from 2010 to work around a GCC
4.4 bug. Since that&apos;s well, well below the minimum GCC we can probably
drop it. xcodebuild uses strict aliasing so only non-Darwin-specific
code would carry any risk.

iOS port also no longer needs to explicitly re-enable it.

Canonical link: <a href="https://commits.webkit.org/315506@main">https://commits.webkit.org/315506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9120d466845f9eea4465290702655663a1c24ea9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126946 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e36f2ca-b20c-4345-a7bf-1f6e09cfba6c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42782 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131818 "Found 24 new test failures: fast/gradients/conic-center-outside-box.html fast/gradients/conic-extended-stops.html fast/gradients/conic-from-angle.html fast/gradients/conic-gradient-extended-stops.html fast/gradients/conic-off-center.html fast/gradients/conic-repeating.html fast/gradients/conic-stop-with-offset-zero-in-middle.html fast/gradients/conic-two-hints.html fast/gradients/conic.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-image-computed.sub.html ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fff62f84-8cbf-4512-b1d3-f509a03700db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172193 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112322 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c773a313-6ee9-44f1-9d91-c61415ef6d94) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27290 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/517 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181190 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30489 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140278 "Found 26 new test failures: fast/gradients/conic-center-outside-box.html fast/gradients/conic-extended-stops.html fast/gradients/conic-from-angle.html fast/gradients/conic-gradient-extended-stops.html fast/gradients/conic-off-center.html fast/gradients/conic-repeating.html fast/gradients/conic-stop-with-offset-zero-in-middle.html fast/gradients/conic-two-hints.html fast/gradients/conic.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-image-computed.sub.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42812 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140118 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43501 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107422 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25792 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35374 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201913 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42011 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6563 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54160 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41404 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41659 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41547 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->