### PR TITLE
BorderShape: implement corner-shape dispatch and eliminate redundant pixel snapping in path helpers

### DIFF
--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -71,10 +71,15 @@ static RectEdges<LayoutUnit> applyClosedEdges(const RectEdges<LayoutUnit>& width
     };
 }
 
-static RectCorners<float> cornerCurvaturesFromStyle(const Style::ComputedStyle&)
+static RectCorners<float> cornerCurvaturesFromStyle(const Style::ComputedStyle& style)
 {
-    // TODO: read corner-shape from style.
-    return { 1.0f, 1.0f, 1.0f, 1.0f };
+    auto& border = style.border();
+    return {
+        static_cast<float>(border.topLeftCornerShape().superellipse->value),
+        static_cast<float>(border.topRightCornerShape().superellipse->value),
+        static_cast<float>(border.bottomRightCornerShape().superellipse->value),
+        static_cast<float>(border.bottomLeftCornerShape().superellipse->value),
+    };
 }
 
 BorderShape BorderShape::shapeForBorderRect(const Style::ComputedStyle& style, const LayoutRect& borderRect, RectEdges<bool> closedEdges)
@@ -264,198 +269,193 @@ static void addRoundedRectToPath(const FloatRoundedRect& roundedRect, Path& path
 
 bool BorderShape::hasNonRoundCornerShape() const
 {
-    // TODO: return true when corner-shape rendering is implemented.
-    // Must also check hasNonZeroRadii() since zero radii have no corner to shape.
-    return false;
+    const auto& radii = m_borderRect.radii();
+    return (m_cornerCurvatures.topLeft() != 1.0f && !radii.topLeft().isEmpty())
+        || (m_cornerCurvatures.topRight() != 1.0f && !radii.topRight().isEmpty())
+        || (m_cornerCurvatures.bottomRight() != 1.0f && !radii.bottomRight().isEmpty())
+        || (m_cornerCurvatures.bottomLeft() != 1.0f && !radii.bottomLeft().isEmpty());
 }
 
-Path BorderShape::pathForOuterRoundedRect(float deviceScaleFactor) const
+Path BorderShape::pathForOuterRoundedRect(const FloatRoundedRect& outerSnapped) const
 {
-    auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     Path path;
-    addRoundedRectToPath(pixelSnappedRect, path);
+    addRoundedRectToPath(outerSnapped, path);
     return path;
 }
 
-Path BorderShape::pathForInnerRoundedRect(float deviceScaleFactor) const
+Path BorderShape::pathForInnerRoundedRect(const FloatRoundedRect& innerSnapped) const
 {
-    auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    ASSERT(pixelSnappedRect.isRenderable());
+    ASSERT(innerSnapped.isRenderable());
     Path path;
-    addRoundedRectToPath(pixelSnappedRect, path);
+    addRoundedRectToPath(innerSnapped, path);
     return path;
 }
 
-Path BorderShape::pathForOuterCornerShape(float deviceScaleFactor) const
+Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped) const
 {
-    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     // TODO: implement corner-shape path generation using outerSnapped.
-    UNUSED_PARAM(outerSnapped);
-    return pathForOuterRoundedRect(deviceScaleFactor);
+    return pathForOuterRoundedRect(outerSnapped);
 }
 
-Path BorderShape::pathForInnerCornerShape(float deviceScaleFactor) const
+Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped) const
 {
-    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     // TODO: implement corner-shape path generation using outerSnapped and innerSnapped.
     UNUSED_PARAM(outerSnapped);
-    UNUSED_PARAM(innerSnapped);
-    return pathForInnerRoundedRect(deviceScaleFactor);
+    return pathForInnerRoundedRect(innerSnapped);
 }
 
 Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
 {
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape())
-        return pathForOuterCornerShape(deviceScaleFactor);
-    return pathForOuterRoundedRect(deviceScaleFactor);
+        return pathForOuterCornerShape(outerSnapped);
+    return pathForOuterRoundedRect(outerSnapped);
 }
 
 Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
 {
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape())
-        return pathForInnerCornerShape(deviceScaleFactor);
-    return pathForInnerRoundedRect(deviceScaleFactor);
+        return pathForInnerCornerShape(outerSnapped, innerSnapped);
+    return pathForInnerRoundedRect(innerSnapped);
 }
 
 void BorderShape::addOuterShapeToPath(Path& path, float deviceScaleFactor) const
 {
     if (hasNonRoundCornerShape()) {
         // TODO: addOuterCornerShapeToPath(path, deviceScaleFactor);
-        return;
     }
-    auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    addRoundedRectToPath(pixelSnappedRect, path);
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    addRoundedRectToPath(outerSnapped, path);
 }
 
 void BorderShape::addInnerShapeToPath(Path& path, float deviceScaleFactor) const
 {
     if (hasNonRoundCornerShape()) {
         // TODO: addInnerCornerShapeToPath(path, deviceScaleFactor);
-        return;
     }
-    auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    ASSERT(pixelSnappedRect.isRenderable());
-    addRoundedRectToPath(pixelSnappedRect, path);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    ASSERT(innerSnapped.isRenderable());
+    addRoundedRectToPath(innerSnapped, path);
 }
 
 Path BorderShape::pathForBorderArea(float deviceScaleFactor) const
 {
-    auto pixelSnappedOuterRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    auto pixelSnappedInnerRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
 
-    ASSERT(pixelSnappedInnerRect.isRenderable());
+    ASSERT(innerSnapped.isRenderable());
 
     Path path;
-    addRoundedRectToPath(pixelSnappedOuterRect, path);
-    addRoundedRectToPath(pixelSnappedInnerRect, path);
+    addRoundedRectToPath(outerSnapped, path);
+    addRoundedRectToPath(innerSnapped, path);
     return path;
 }
 
 void BorderShape::clipToOuterShape(GraphicsContext& context, float deviceScaleFactor) const
 {
-    auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
-        context.clipPath(pathForOuterCornerShape(deviceScaleFactor));
+        context.clipPath(pathForOuterCornerShape(outerSnapped));
         return;
     }
 
-    if (pixelSnappedRect.hasNonZeroRadii())
-        context.clipRoundedRect(pixelSnappedRect);
+    if (outerSnapped.hasNonZeroRadii())
+        context.clipRoundedRect(outerSnapped);
     else
-        context.clip(pixelSnappedRect.rect());
+        context.clip(outerSnapped.rect());
 }
 
 void BorderShape::clipToInnerShape(GraphicsContext& context, float deviceScaleFactor) const
 {
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
-        context.clipPath(pathForInnerCornerShape(deviceScaleFactor));
+        context.clipPath(pathForInnerCornerShape(outerSnapped, innerSnapped));
         return;
     }
 
-    auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    ASSERT(pixelSnappedRect.isRenderable());
-    if (pixelSnappedRect.hasNonZeroRadii())
-        context.clipRoundedRect(pixelSnappedRect);
+    ASSERT(innerSnapped.isRenderable());
+    if (innerSnapped.hasNonZeroRadii())
+        context.clipRoundedRect(innerSnapped);
     else
-        context.clip(pixelSnappedRect.rect());
+        context.clip(innerSnapped.rect());
 }
 
 void BorderShape::clipOutOuterShape(GraphicsContext& context, float deviceScaleFactor) const
 {
-    auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    if (pixelSnappedRect.isEmpty())
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (outerSnapped.isEmpty())
         return;
 
     if (hasNonRoundCornerShape()) {
-        context.clipOut(pathForOuterCornerShape(deviceScaleFactor));
+        context.clipOut(pathForOuterCornerShape(outerSnapped));
         return;
     }
 
-    if (pixelSnappedRect.hasNonZeroRadii())
-        context.clipOutRoundedRect(pixelSnappedRect);
+    if (outerSnapped.hasNonZeroRadii())
+        context.clipOutRoundedRect(outerSnapped);
     else
-        context.clipOut(pixelSnappedRect.rect());
+        context.clipOut(outerSnapped.rect());
 }
 
 void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleFactor) const
 {
-    auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    if (pixelSnappedRect.isEmpty())
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (innerSnapped.isEmpty())
         return;
 
     if (hasNonRoundCornerShape()) {
-        context.clipOut(pathForInnerCornerShape(deviceScaleFactor));
+        context.clipOut(pathForInnerCornerShape(outerSnapped, innerSnapped));
         return;
     }
 
-    if (pixelSnappedRect.hasNonZeroRadii())
-        context.clipOutRoundedRect(pixelSnappedRect);
+    if (innerSnapped.hasNonZeroRadii())
+        context.clipOutRoundedRect(innerSnapped);
     else
-        context.clipOut(pixelSnappedRect.rect());
+        context.clipOut(innerSnapped.rect());
 }
 
 void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, float deviceScaleFactor) const
 {
     if (hasNonRoundCornerShape()) {
         // TODO: implement corner-shape fill.
-        return;
     }
 
-    auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    if (pixelSnappedRect.hasNonZeroRadii())
-        context.fillRoundedRect(pixelSnappedRect, color);
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (outerSnapped.hasNonZeroRadii())
+        context.fillRoundedRect(outerSnapped, color);
     else
-        context.fillRect(pixelSnappedRect.rect(), color);
+        context.fillRect(outerSnapped.rect(), color);
 }
 
 void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, float deviceScaleFactor) const
 {
     if (hasNonRoundCornerShape()) {
         // TODO: implement corner-shape fill.
-        return;
     }
 
-    auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    ASSERT(pixelSnappedRect.isRenderable());
-    if (pixelSnappedRect.hasNonZeroRadii())
-        context.fillRoundedRect(pixelSnappedRect, color);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    ASSERT(innerSnapped.isRenderable());
+    if (innerSnapped.hasNonZeroRadii())
+        context.fillRoundedRect(innerSnapped, color);
     else
-        context.fillRect(pixelSnappedRect.rect(), color);
+        context.fillRect(innerSnapped.rect(), color);
 }
 
 void BorderShape::fillRectWithInnerHoleShape(GraphicsContext& context, const LayoutRect& outerRect, const Color& color, float deviceScaleFactor) const
 {
-    auto pixelSnappedOuterRect = snapRectToDevicePixels(outerRect, deviceScaleFactor);
+    auto outerSnapped = snapRectToDevicePixels(outerRect, deviceScaleFactor);
 
     if (hasNonRoundCornerShape()) {
         // TODO: implement corner-shape fill.
-        return;
     }
 
-    auto innerSnappedRoundedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    ASSERT(innerSnappedRoundedRect.isRenderable());
-    context.fillRectWithRoundedHole(pixelSnappedOuterRect, innerSnappedRoundedRect, color);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    ASSERT(innerSnapped.isRenderable());
+    context.fillRectWithRoundedHole(outerSnapped, innerSnapped, color);
 }
 
 LayoutRoundedRect BorderShape::computeInnerEdgeRoundedRect(const LayoutRoundedRect& borderRoundedRect, const RectEdges<LayoutUnit>& borderWidths)

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -133,11 +133,11 @@ private:
     // True if any corner uses a non-`round` shape (curvature != 1), so the shape
     bool hasNonRoundCornerShape() const;
 
-    Path pathForOuterRoundedRect(float deviceScaleFactor) const;
-    Path pathForInnerRoundedRect(float deviceScaleFactor) const;
+    Path pathForOuterRoundedRect(const FloatRoundedRect& outerSnapped) const;
+    Path pathForInnerRoundedRect(const FloatRoundedRect& innerSnapped) const;
 
-    Path pathForOuterCornerShape(float deviceScaleFactor) const;
-    Path pathForInnerCornerShape(float deviceScaleFactor) const;
+    Path pathForOuterCornerShape(const FloatRoundedRect& outerSnapped) const;
+    Path pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped) const;
 
     LayoutRoundedRect m_borderRect;
     LayoutRoundedRect m_innerEdgeRect;


### PR DESCRIPTION
#### de288df8b7d08c4ed4eea9d2021ab20df5164e6b
<pre>
BorderShape: implement corner-shape dispatch and eliminate redundant pixel snapping in path helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=317453">https://bugs.webkit.org/show_bug.cgi?id=317453</a>
<a href="https://rdar.apple.com/180074651">rdar://180074651</a>

Reviewed by Simon Fraser.

This change implements both: cornerCurvaturesFromStyle now reads the
four curvature values from BorderData, and hasNonRoundCornerShape()
returns true when any corner has both a non-round curvature and a non-zero
radius — a zero-radius corner has no curve to shape so the check correctly
skips it. Also updates the private path-building helpers to take pre-computed
FloatRoundedRect parameters so each caller pixel-snaps once and passes
the result through, avoiding redundant snapping.

Passes existing tests

* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::cornerCurvaturesFromStyle):
(WebCore::BorderShape::hasNonRoundCornerShape const):
(WebCore::BorderShape::pathForOuterRoundedRect const):
(WebCore::BorderShape::pathForInnerRoundedRect const):
(WebCore::BorderShape::pathForOuterCornerShape const):
(WebCore::BorderShape::pathForInnerCornerShape const):
(WebCore::BorderShape::pathForOuterShape const):
(WebCore::BorderShape::pathForInnerShape const):
(WebCore::BorderShape::addOuterShapeToPath const):
(WebCore::BorderShape::addInnerShapeToPath const):
(WebCore::BorderShape::pathForBorderArea const):
(WebCore::BorderShape::clipToOuterShape const):
(WebCore::BorderShape::clipToInnerShape const):
(WebCore::BorderShape::clipOutOuterShape const):
(WebCore::BorderShape::clipOutInnerShape const):
(WebCore::BorderShape::fillOuterShape const):
(WebCore::BorderShape::fillInnerShape const):
(WebCore::BorderShape::fillRectWithInnerHoleShape const):
* Source/WebCore/rendering/BorderShape.h:

Canonical link: <a href="https://commits.webkit.org/315750@main">https://commits.webkit.org/315750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944d1789200d251aaffac9a95b4bd983f0b45181

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127479 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132309 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93218 "10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112812 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32446 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181725 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140757 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43345 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140591 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37898 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44034 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29125 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108315 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35857 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115799 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42545 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7225 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->