### PR TITLE
CoreIPCNSURLCredential::toID inserts the attributes dictionary as its own value

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
@@ -217,7 +217,7 @@ RetainPtr<id> CoreIPCNSURLCredential::toID() const
                         value = d.toID();
                     }
                 );
-                [attributes setObject:attributes.get() forKey:attributePair.first.toID().get()];
+                [attributes setObject:value.get() forKey:attributePair.first.toID().get()];
             }
             [dict setObject:attributes.get() forKey:@"attributes"];
         }

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -2029,6 +2029,7 @@ TEST(IPCSerialization, DDScannerResultPlist)
 
 @interface NSURLCredential (WKSecureCodingForTesting)
 - (instancetype)_initWithWebKitPropertyListData:(NSDictionary *)plist;
+- (NSDictionary *)_webKitPropertyListData;
 @end
 
 TEST(IPCSerialization, NSURLCredentialKerberosFlags)
@@ -2059,6 +2060,20 @@ TEST(IPCSerialization, NSURLCredentialAttributes)
     auto decoder = IPC::Decoder::create(encoder.span(), encoder.releaseAttachments());
     auto decoded = decoder->decode<WebKit::CoreIPCNSURLCredentialData>();
     EXPECT_EQ(decoded->attributes->size(), 1u);
+}
+
+TEST(IPCSerialization, NSURLCredentialAttributesToID)
+{
+    using Attributes = WebKit::CoreIPCNSURLCredentialData::Attributes;
+
+    WebKit::CoreIPCNSURLCredentialData credentialData;
+    credentialData.type = WebKit::CoreIPCNSURLCredentialType::Password;
+    credentialData.attributes = Vector<Attributes> { { WebKit::CoreIPCString(@"key"), WebKit::CoreIPCString(@"value") } };
+
+    WebKit::CoreIPCNSURLCredential wrapper(WTF::move(credentialData));
+    RetainPtr reconstructed = dynamic_objc_cast<NSURLCredential>(wrapper.toID().get());
+    RetainPtr attributes = dynamic_objc_cast<NSDictionary>([[reconstructed _webKitPropertyListData] objectForKey:@"attributes"]);
+    EXPECT_TRUE([[attributes objectForKey:@"key"] isEqual:@"value"]);
 }
 
 #endif // HAVE(WK_SECURE_CODING_NSURLCREDENTIAL)


### PR DESCRIPTION
#### 48e92e82ebc073d528b212cef33c8504eb689cfc
<pre>
CoreIPCNSURLCredential::toID inserts the attributes dictionary as its own value
<a href="https://bugs.webkit.org/show_bug.cgi?id=317456">https://bugs.webkit.org/show_bug.cgi?id=317456</a>
<a href="https://rdar.apple.com/180075625">rdar://180075625</a>

Reviewed by Sihui Liu.

The reconstruction loop computed `value` via switchOn, then discarded it and inserted
`attributes.get()` as the value for the key. This produced a self-referential dictionary mapping
every attribute key to the dictionary itself, so the real decoded attribute values were lost on the
receiving side. Insert value.get().

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm:
(WebKit::CoreIPCNSURLCredential::toID const):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, NSURLCredentialAttributesToID)):

Canonical link: <a href="https://commits.webkit.org/315793@main">https://commits.webkit.org/315793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6140ea1d2b380b123f950e7e603f8d83e2ff1c2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170097 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44020 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running checkout-pull-request; Compiled WebKit (warnings)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/179459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127809 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Running checkout-pull-request") | ⏳ 🛠 ios-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171963 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running bindings-tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43652 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/179459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/127809 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Running checkout-pull-request") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173056 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/179459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/28155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32414 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182056 "Failed to checkout and rebase branch from PR 67485") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/182056 "Failed to checkout and rebase branch from PR 67485") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43676 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/182056 "Failed to checkout and rebase branch from PR 67485") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44365 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Running compile-webkit") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25925 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/36129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116246 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Running checkout-pull-request") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42876 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/42268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42522 "Failed to checkout and rebase branch from PR 67485") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/42411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->