### PR TITLE
[JSC] Reduce # of Air::Code iteration in Greedy regalloc

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -860,26 +860,38 @@ public:
 
         dataLogLnIf(verbose() || shouldDumpFunction(), "Greedy register allocator: function ", m_code.proc().name(), " input IR:\n", m_code);
 
+        // Many functions do not have any FPs. We can easily reduce the cost by skipping FP version of setup completely when we have zero FP tmps.
+        bool hasFPTmps = m_code.numTmps(FP);
+        dataLogLnIf(Options::airGreedyRegAllocVerbose(), "Greedy: ", m_code.proc().name(), " GP tmps=", m_code.numTmps(GP), " FP tmps=", m_code.numTmps(FP), " (FP path ", hasFPTmps ? "RUN" : "SKIPPED", ")");
+
         // FIXME: reconsider use of padIntereference, https://bugs.webkit.org/show_bug.cgi?id=288122
         padInterference(m_code);
         buildRegisterSets();
         buildIndices();
-        buildLiveRanges();
-        initSpillCosts<GP>();
-        initSpillCosts<FP>();
+        {
+            IndexSet<Tmp::AbsolutelyIndexed<GP>> cannotSpillInPlaceGP;
+            IndexSet<Tmp::AbsolutelyIndexed<FP>> cannotSpillInPlaceFP;
+            buildLiveRanges(cannotSpillInPlaceGP, cannotSpillInPlaceFP);
+            initSpillCosts<GP>(cannotSpillInPlaceGP);
+            if (hasFPTmps)
+                initSpillCosts<FP>(cannotSpillInPlaceFP);
+        }
         coalesceWithPinnedRegisters();
         coalesceTmps<GP>();
-        coalesceTmps<FP>();
+        if (hasFPTmps)
+            coalesceTmps<FP>();
 
         dataLogLnIf(verbose() || shouldDumpFunction(), "Greedy register allocator: function ", m_code.proc().name(), " state before allocate registers:\n", *this, "IR:\n", m_code);
 
         allocateRegisters<GP>();
-        allocateRegisters<FP>();
+        if (hasFPTmps)
+            allocateRegisters<FP>();
 
         insertFixupCode();
 
         validateAssignments<GP>();
-        validateAssignments<FP>();
+        if (hasFPTmps)
+            validateAssignments<FP>();
 
         dataLogLnIf(verbose() || shouldDumpFunction(), "Greedy register allocator: function ", m_code.proc().name(), " about to assign registers:\n", *this, "IR:\n", m_code);
 
@@ -1246,7 +1258,7 @@ private:
         }
     }
 
-    void buildLiveRanges()
+    void buildLiveRanges(IndexSet<Tmp::AbsolutelyIndexed<GP>>& cannotSpillInPlaceGP, IndexSet<Tmp::AbsolutelyIndexed<FP>>& cannotSpillInPlaceFP)
     {
         CompilerTimingScope timingScope("Air"_s, "GreedyRegAlloc::buildLiveRanges"_s);
         UnifiedTmpLiveness liveness(m_code);
@@ -1341,9 +1353,21 @@ private:
             activeEnds[tmp] = 0;
         };
 
-        // First pass: collect all the potential coalescable pairs of Tmps.
+        // First pass: collect coalescable pairs and the cannot-spill-in-place set.
         for (BasicBlock* block : m_code) {
             for (Inst& inst : block->insts()) {
+                inst.forEachArg([&](Arg& arg, Arg::Role, Bank, Width) {
+                    if (arg.isTmp() && inst.admitsStack(arg))
+                        return;
+
+                    // Arg cannot be spilled in-place.
+                    arg.forEachTmpFast([&](Tmp& tmp) {
+                        if (tmp.bank() == GP)
+                            cannotSpillInPlaceGP.add(tmp);
+                        else
+                            cannotSpillInPlaceFP.add(tmp);
+                    });
+                });
                 if (mayBeCoalescable(inst)) {
                     ASSERT(inst.args.size() == 2);
                     if (inst.args[0].isReg() || inst.args[1].isReg()) {
@@ -2102,29 +2126,10 @@ private:
         }
     }
 
-    template<Bank bank>
-    void initSpillCosts()
+    template <Bank bank>
+    void initSpillCosts(const IndexSet<Tmp::AbsolutelyIndexed<bank>>& cannotSpillInPlace)
     {
         CompilerTimingScope timingScope("Air"_s, "GreedyRegAlloc::initSpillCosts"_s);
-
-        IndexSet<Tmp::AbsolutelyIndexed<bank>> cannotSpillInPlace;
-        for (BasicBlock* block : m_code) {
-            for (Inst& inst : block->insts()) {
-                inst.forEachArg([&](Arg& arg, Arg::Role, Bank, Width) {
-                    if (arg.isTmp() && (arg.tmp().bank() != bank || inst.admitsStack(arg)))
-                        return;
-                    // Arg cannot be spilled in-place.
-                    arg.forEachTmpFast([&](Tmp& tmp) {
-                        if (tmp.bank() != bank)
-                            return;
-                        if (!cannotSpillInPlace.contains(tmp)) {
-                            dataLogLnIf(verbose(), tmp, " cannot be spilled in-place: ", inst);
-                            cannotSpillInPlace.add(tmp);
-                        }
-                    });
-                });
-            }
-        }
 
         for (Reg reg : m_allowedRegistersInPriorityOrder[bank])
             m_map.get<bank>(Tmp(reg)).spillability = TmpData::Spillability::Unspillable;

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
@@ -31,6 +31,7 @@
 #include "AirCode.h"
 #include "AirInstInlines.h"
 #include "AirTmpWidthInlines.h"
+#include <optional>
 
 namespace JSC { namespace B3 { namespace Air {
 
@@ -38,45 +39,63 @@ TmpWidth::TmpWidth() = default;
 
 TmpWidth::TmpWidth(Code& code)
 {
-    recompute<GP>(code);
-    recompute<FP>(code);
+    recomputeBoth(code);
 }
 
 TmpWidth::~TmpWidth() = default;
 
-template <Bank bank>
+template <auto bankFilter>
 void TmpWidth::recompute(Code& code)
 {
     // Set this to true to cause this analysis to always return pessimistic results.
     constexpr bool beCareful = false;
     constexpr bool verbose = false;
 
+    constexpr auto shouldProcess = [](Bank bank) {
+        if constexpr (std::is_same_v<decltype(bankFilter), Bank>)
+            return bankFilter == bank;
+        else
+            return true;
+    };
+
     if (verbose) {
         dataLogLn("Code before TmpWidth:");
         dataLog(code);
     }
 
-    auto& bankWidthsVector = widthsVector(bank);
-    bankWidthsVector.resize(AbsoluteTmpMapper<bank>::absoluteIndex(code.numTmps(bank)));
-    for (unsigned i = 0; i < bankWidthsVector.size(); ++i)
-        bankWidthsVector[i] = Widths(bank);
-    
-    auto assumeTheWorst = [&] (Tmp tmp) {
-        if (bank == Arg(tmp).bank()) {
-            Width conservative = code.usesSIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank);
-            addWidths(tmp, { conservative, conservative });
+    forEachBank([&](Bank bank) {
+        if (!shouldProcess(bank))
+            return;
+
+        auto& bankWidthsVector = widthsVector(bank);
+        switch (bank) {
+        case GP:
+            bankWidthsVector.resize(AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP)));
+            break;
+        case FP:
+            bankWidthsVector.resize(AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP)));
+            break;
         }
+        bankWidthsVector.fill(Widths(bank));
+    });
+
+    auto assumeTheWorst = [&](Tmp tmp) {
+        Bank bank = Arg(tmp).bank();
+        if (!shouldProcess(bank))
+            return;
+
+        Width conservative = code.usesSIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank);
+        addWidths(tmp, { conservative, conservative });
     };
-    
+
     // Assume the worst for registers.
-    RegisterSet::allRegisters().forEach(
-        [&] (Reg reg) {
-            assumeTheWorst(Tmp(reg));
-        });
+    RegisterSet::allRegisters().forEach([&](Reg reg) {
+        assumeTheWorst(Tmp(reg));
+    });
 
     if (beCareful) {
         code.forEachTmp(assumeTheWorst);
-        
+
         // We fall through because the fixpoint that follows can only make things even more
         // conservative. This mode isn't meant to be fast, just safe.
     }
@@ -84,21 +103,22 @@ void TmpWidth::recompute(Code& code)
     // Now really analyze everything but Move's over Tmp's, but set aside those Move's so we can find
     // them quickly during the fixpoint below. Note that we can make this analysis stronger by
     // recognizing more kinds of Move's or anything that has Move-like behavior, though it's probably not
-    // worth it.
-    Vector<Inst*> moves;
+    // worth it. We bucket the Move's per-bank so the fixpoint can run independently for each bank.
+    std::array<Vector<Inst*>, numBanks> moves;
     for (BasicBlock* block : code) {
         for (Inst& inst : *block) {
             if (inst.kind.opcode == Move && inst.args[1].isTmp()) {
-                if (Arg(inst.args[1]).bank() != bank)
+                Bank dstBank = Arg(inst.args[1]).bank();
+                if (!shouldProcess(dstBank))
                     continue;
 
                 if (inst.args[0].isTmp()) {
-                    moves.append(&inst);
+                    moves[dstBank].append(&inst);
                     continue;
                 }
+
                 if (inst.args[0].isImm() && inst.args[0].value() >= 0) {
-                    Tmp tmp = inst.args[1].tmp();
-                    Widths& tmpWidths = widths(tmp);
+                    Widths& tmpWidths = widths(inst.args[1].tmp());
                     Width maxWidth = Width64;
                     if (inst.args[0].value() <= std::numeric_limits<int8_t>::max())
                         maxWidth = Width8;
@@ -108,13 +128,12 @@ void TmpWidth::recompute(Code& code)
                         maxWidth = Width32;
 
                     tmpWidths.def = std::max(tmpWidths.def, maxWidth);
-
                     continue;
                 }
             }
             inst.forEachTmp(
                 [&] (Tmp& tmp, Arg::Role role, Bank tmpBank, Width width) {
-                    if (Arg(tmp).bank() != bank)
+                    if (!shouldProcess(Arg(tmp).bank()))
                         return;
 
                     Widths& tmpWidths = widths(tmp);
@@ -130,44 +149,67 @@ void TmpWidth::recompute(Code& code)
     }
 
     // Finally, fixpoint over the Move's.
-    bool changed = true;
-    while (changed) {
-        changed = false;
-        for (Inst* move : moves) {
-            ASSERT(move->kind.opcode == Move);
-            ASSERT(move->args[0].isTmp());
-            ASSERT(move->args[1].isTmp());
+    auto fixpointMoves = [&](const Vector<Inst*>& moves) {
+        bool changed = true;
+        while (changed) {
+            changed = false;
+            for (Inst* move : moves) {
+                ASSERT(move->kind.opcode == Move);
+                ASSERT(move->args[0].isTmp());
+                ASSERT(move->args[1].isTmp());
 
-            Widths& srcWidths = widths(move->args[0].tmp());
-            Widths& dstWidths = widths(move->args[1].tmp());
+                Widths& srcWidths = widths(move->args[0].tmp());
+                Widths& dstWidths = widths(move->args[1].tmp());
 
-            // Legend:
-            //
-            //     Move %src, %dst
+                // Legend:
+                //
+                //     Move %src, %dst
 
-            // defWidth(%dst) is a promise about how many high bits are zero. The smaller the width, the
-            // stronger the promise. This Move may weaken that promise if we know that %src is making a
-            // weaker promise. Such forward flow is the only thing that determines defWidth().
-            if (dstWidths.def < srcWidths.def) {
-                dstWidths.def = srcWidths.def;
-                changed = true;
-            }
+                // defWidth(%dst) is a promise about how many high bits are zero. The smaller the width, the
+                // stronger the promise. This Move may weaken that promise if we know that %src is making a
+                // weaker promise. Such forward flow is the only thing that determines defWidth().
+                if (dstWidths.def < srcWidths.def) {
+                    dstWidths.def = srcWidths.def;
+                    changed = true;
+                }
 
-            // srcWidth(%src) is a promise about how many high bits are ignored. The smaller the width,
-            // the stronger the promise. This Move may weaken that promise if we know that %dst is making
-            // a weaker promise. Such backward flow is the only thing that determines srcWidth().
-            if (srcWidths.use < dstWidths.use) {
-                srcWidths.use = dstWidths.use;
-                changed = true;
+                // srcWidth(%src) is a promise about how many high bits are ignored. The smaller the width,
+                // the stronger the promise. This Move may weaken that promise if we know that %dst is making
+                // a weaker promise. Such backward flow is the only thing that determines srcWidth().
+                if (srcWidths.use < dstWidths.use) {
+                    srcWidths.use = dstWidths.use;
+                    changed = true;
+                }
             }
         }
-    }
+    };
+    forEachBank([&](Bank bank) {
+        if (!shouldProcess(bank))
+            return;
+
+        fixpointMoves(moves[bank]);
+    });
 
     if (verbose) {
-        dataLogLn("bank: ", bank, ", widthsVector: ");
-        for (unsigned i = 0; i < bankWidthsVector.size(); ++i)
-            dataLogLn("\t", AbsoluteTmpMapper<bank>::tmpFromAbsoluteIndex(i), " : ", bankWidthsVector[i]);
+        forEachBank([&](Bank bank) {
+            if (!shouldProcess(bank))
+                return;
+
+            dataLogLn("bank: ", bank, ", widthsVector: ");
+            auto& vector = widthsVector(bank);
+            for (unsigned i = 0; i < vector.size(); ++i) {
+                if (bank == GP)
+                    dataLogLn("\t", AbsoluteTmpMapper<GP>::tmpFromAbsoluteIndex(i), " : ", vector[i]);
+                else
+                    dataLogLn("\t", AbsoluteTmpMapper<FP>::tmpFromAbsoluteIndex(i), " : ", vector[i]);
+            }
+        });
     }
+}
+
+void TmpWidth::recomputeBoth(Code& code)
+{
+    recompute<std::nullopt>(code);
 }
 
 template <Bank bank>
@@ -195,7 +237,10 @@ void TmpWidth::Widths::dump(PrintStream& out) const
     out.print("{use = ", use, ", def = ", def, "}");
 }
 
+template void TmpWidth::recompute<GP>(Code&);
+template void TmpWidth::recompute<FP>(Code&);
+template void TmpWidth::recompute<std::nullopt>(Code&);
+
 } } } // namespace JSC::B3::Air
 
 #endif // ENABLE(B3_JIT)
-

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.h
@@ -40,8 +40,9 @@ public:
     TmpWidth(Code&);
     ~TmpWidth();
 
-    template <Bank bank>
+    template<auto bankFilter>
     void recompute(Code&);
+    void recomputeBoth(Code&);
 
     // The width of a Tmp is the number of bits that you need to be able to track without some trivial
     // recovery. A Tmp may have a "subwidth" (say, Width32 on a 64-bit system) if either of the following
@@ -104,7 +105,7 @@ private:
     template <Bank bank>
     void ensureSize(Tmp);
 
-    // These are initialized at the beginning of recompute<bank>, which is called in the constructor for both values of bank.
+    // These are initialized at the beginning of recompute(), which is called in the constructor for both banks.
     Vector<Widths> m_widthGP;
     Vector<Widths> m_widthFP;
 };


### PR DESCRIPTION
#### 0cc09201a8afe1445730995bcf2f0b7d5ae9970b
<pre>
[JSC] Reduce # of Air::Code iteration in Greedy regalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=317459">https://bugs.webkit.org/show_bug.cgi?id=317459</a>
<a href="https://rdar.apple.com/180079592">rdar://180079592</a>

Reviewed by Dan Hecht.

We iterate Air::Code several times unnecessarily, but this is costly
when Air::Code is very large. This patch introduces several
optimizations to reduce compile time.

1. cannotSpillInPlace collection is moved to buildLiveRanges time.
2. TmpWidth collection becomes unified for both GP and FP.
3. More than 90~% of program does not have FP. Thus we stop running
   various algorithm when there is no FP tmps.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::run):
(JSC::B3::Air::Greedy::GreedyAllocator::buildLiveRanges):
(JSC::B3::Air::Greedy::GreedyAllocator::initSpillCosts):
* Source/JavaScriptCore/b3/air/AirTmpWidth.cpp:
(JSC::B3::Air::TmpWidth::TmpWidth):
(JSC::B3::Air::TmpWidth::recompute):
(JSC::B3::Air::TmpWidth::recomputeBoth):
* Source/JavaScriptCore/b3/air/AirTmpWidth.h:

Canonical link: <a href="https://commits.webkit.org/315629@main">https://commits.webkit.org/315629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1e5c4dc6d06649f2dd31eadde5c1b79766f6b6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127312 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1c11732-abac-49f1-ada6-2150f30e31a8) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132148 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a8dde95-33e0-436e-a0f8-5c01ee2a214d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172559 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112651 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9eed919-1b2d-48dd-8a4d-b02b4e270877) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27656 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/925 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181558 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30855 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34266 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36451 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140597 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43178 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140433 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43867 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108089 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25841 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35703 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115632 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202279 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42377 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6972 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54234 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41770 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41913 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->