### PR TITLE
[GFC] Bail out when justify-content or align-content is not the initial value.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-end-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-end-001-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is at the bottom-left of the grid content area, inside the black border.</p>
+<div style="width: 100px; height: 100px; border: 10px solid black;">
+    <div style="width: 50px; height: 50px; margin-top: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-end-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-end-001-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is at the bottom-left of the grid content area, inside the black border.</p>
+<div style="width: 100px; height: 100px; border: 10px solid black;">
+    <div style="width: 50px; height: 50px; margin-top: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-end-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-end-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-content">
+<link rel="match" href="grid-align-content-end-001-ref.html">
+<style>
+.grid {
+    display: grid;
+    width: 100px;
+    height: 100px;
+    grid-template-columns: 50px;
+    grid-template-rows: 50px;
+    align-content: end;
+    border: 10px solid black;
+}
+.item {
+    width: 50px;
+    height: 50px;
+    grid-row: 1/2;
+    background-color: green;
+}
+</style>
+<p>Test passes if the green box is at the bottom-left of the grid content area, inside the black border.</p>
+<div class="grid">
+    <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-space-between-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-space-between-001-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<p>Test passes if there are two green boxes at the top and bottom edges of a 100px-tall area.</p>
+<div style="width: 50px; height: 100px; display: flex; flex-direction: column; justify-content: space-between;">
+    <div style="width: 50px; height: 25px; background-color: green;"></div>
+    <div style="width: 50px; height: 25px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-space-between-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-space-between-001-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<p>Test passes if there are two green boxes at the top and bottom edges of a 100px-tall area.</p>
+<div style="width: 50px; height: 100px; display: flex; flex-direction: column; justify-content: space-between;">
+    <div style="width: 50px; height: 25px; background-color: green;"></div>
+    <div style="width: 50px; height: 25px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-space-between-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-content-space-between-001.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-content">
+<link rel="match" href="grid-align-content-space-between-001-ref.html">
+<style>
+.grid {
+    display: grid;
+    width: 50px;
+    height: 100px;
+    grid-template-columns: 50px;
+    grid-template-rows: 25px 25px;
+    align-content: space-between;
+}
+.item1 {
+    width: 50px;
+    height: 25px;
+    grid-row: 1/2;
+    grid-column: 1/2;
+    background-color: green;
+}
+.item2 {
+    width: 50px;
+    height: 25px;
+    grid-row: 2/3;
+    grid-column: 1/2;
+    background-color: green;
+}
+</style>
+<p>Test passes if there are two green boxes at the top and bottom edges of a 100px-tall area.</p>
+<div class="grid">
+    <div class="item1"></div>
+    <div class="item2"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-end-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-end-001-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is at the top-right of the grid content area, inside the black border.</p>
+<div style="width: 100px; height: 100px; border: 10px solid black;">
+    <div style="width: 50px; height: 50px; margin-left: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-end-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-end-001-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>Test passes if the green box is at the top-right of the grid content area, inside the black border.</p>
+<div style="width: 100px; height: 100px; border: 10px solid black;">
+    <div style="width: 50px; height: 50px; margin-left: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-end-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-end-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#justify-content">
+<link rel="match" href="grid-justify-content-end-001-ref.html">
+<style>
+.grid {
+    display: grid;
+    width: 100px;
+    height: 100px;
+    grid-template-columns: 50px;
+    grid-template-rows: 50px;
+    justify-content: end;
+    border: 10px solid black;
+}
+.item {
+    width: 50px;
+    height: 50px;
+    grid-row: 1/2;
+    background-color: green;
+}
+</style>
+<p>Test passes if the green box is at the top-right of the grid content area, inside the black border.</p>
+<div class="grid">
+    <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-space-between-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-space-between-001-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<p>Test passes if there are two green boxes at the left and right edges of a 100px-wide area.</p>
+<div style="width: 100px; height: 50px; display: flex; justify-content: space-between;">
+    <div style="width: 25px; height: 50px; background-color: green;"></div>
+    <div style="width: 25px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-space-between-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-space-between-001-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<p>Test passes if there are two green boxes at the left and right edges of a 100px-wide area.</p>
+<div style="width: 100px; height: 50px; display: flex; justify-content: space-between;">
+    <div style="width: 25px; height: 50px; background-color: green;"></div>
+    <div style="width: 25px; height: 50px; background-color: green;"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-space-between-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-content-space-between-001.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#justify-content">
+<link rel="match" href="grid-justify-content-space-between-001-ref.html">
+<style>
+.grid {
+    display: grid;
+    width: 100px;
+    height: 50px;
+    grid-template-columns: 25px 25px;
+    grid-template-rows: 50px;
+    justify-content: space-between;
+}
+.item1 {
+    width: 25px;
+    height: 50px;
+    grid-row: 1/2;
+    grid-column: 1/2;
+    background-color: green;
+}
+.item2 {
+    width: 25px;
+    height: 50px;
+    grid-row: 1/2;
+    grid-column: 2/3;
+    background-color: green;
+}
+</style>
+<p>Test passes if there are two green boxes at the left and right edges of a 100px-wide area.</p>
+<div class="grid">
+    <div class="item1"></div>
+    <div class="item2"></div>
+</div>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -61,6 +61,8 @@ enum class GridAvoidanceReason : uint8_t {
     GridHasContainsSize,
     GridHasUnsupportedGridTemplateColumns,
     GridHasUnsupportedGridTemplateRows,
+    GridHasUnsupportedJustifyContent,
+    GridHasUnsupportedAlignContent,
     GridItemHasNonInitialMaxWidth,
     GridItemHasNonInitialMaxHeight,
     GridItemHasBorder,
@@ -397,6 +399,12 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
     if (renderGridStyle->usedContain().contains(Style::ContainValue::Size))
         ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridHasContainsSize, reasons, reasonCollectionMode);
 
+    if (!renderGridStyle->justifyContent().isNormal())
+        ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridHasUnsupportedJustifyContent, reasons, reasonCollectionMode);
+
+    if (!renderGridStyle->alignContent().isNormal())
+        ADD_REASON_AND_RETURN_IF_NEEDED(GridAvoidanceReason::GridHasUnsupportedAlignContent, reasons, reasonCollectionMode);
+
     ASSERT(renderGridStyle->gridAutoFlow().isRow(),
         "If we end up supporting column auto flow before broader implicit grid support then the logic using explicitlyPlacedItemsInRowCount will need to be reworked to be based upon the auto flow direction");
     Vector<size_t> explicitlyPlacedItemsInRowCount;
@@ -662,6 +670,12 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
         break;
     case GridAvoidanceReason::GridHasUnsupportedGridTemplateRows:
         stream << "grid has unsupported grid-template-rows";
+        break;
+    case GridAvoidanceReason::GridHasUnsupportedJustifyContent:
+        stream << "grid has unsupported justify-content";
+        break;
+    case GridAvoidanceReason::GridHasUnsupportedAlignContent:
+        stream << "grid has unsupported align-content";
         break;
     case GridAvoidanceReason::GridItemHasUnsupportedWidthValue:
         stream << "grid item has unsupported width value";


### PR DESCRIPTION
#### d0916175f52f6a2d22e7f6d95bbaffded1f3a2ad
<pre>
[GFC] Bail out when justify-content or align-content is not the initial value.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317461">https://bugs.webkit.org/show_bug.cgi?id=317461</a>
<a href="https://rdar.apple.com/problem/180081486">rdar://problem/180081486</a>

Reviewed by Alan Baradlay.

GFC does not yet implement content distribution or content positioning
for the grid container. When justify-content or align-content is set
to a non-initial value, fall back to legacy RenderGrid which handles
these properties correctly.

Canonical link: <a href="https://commits.webkit.org/315511@main">https://commits.webkit.org/315511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa16b370a1800ba8edd082d266041b96967304e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126975 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8261a29a-d7e2-45c1-bbe4-000ddb072c25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131833 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/272ab214-58f0-429d-be31-ba56f3b2dc5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172222 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112337 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c9738ea-2882-43de-a1a3-12452f041f63) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27319 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181219 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140288 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37702 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43530 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107461 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35400 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115295 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42040 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6586 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41433 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41576 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->