### PR TITLE
[JSC][Temporal] Unify ParseISODateTime

### DIFF
--- a/JSTests/stress/temporal-parseisodatetime.js
+++ b/JSTests/stress/temporal-parseisodatetime.js
@@ -1,0 +1,502 @@
+//@ requireOptions("--useTemporal=1")
+
+// Stress test for ParseISODateTime — https://tc39.es/proposal-temporal/#sec-temporal-parseisodatetime
+// Each section covers one spec step / sub-step. Test inputs are routed through the consumer
+// entry points that invoke parseISODateTime with the corresponding production mask:
+//   Temporal.Instant.from           → mask = { Instant }
+//   Temporal.PlainDate.from         → mask = { DateTimeUnzoned }
+//   Temporal.PlainDateTime.from     → mask = { DateTimeUnzoned }
+//   Temporal.PlainYearMonth.from    → mask = { YearMonth }
+//   Temporal.PlainMonthDay.from     → mask = { MonthDay }
+//   Temporal.PlainTime.from         → mask = { Time }
+//   Temporal.ZonedDateTime.from     → mask = { DateTimeZoned }
+//   property bag .calendar = string → full 6-production union (TemporalObject calendar canon).
+
+function shouldThrow(fn, expectedType, label) {
+    let error;
+    try { fn(); } catch (e) { error = e; }
+    if (!(error instanceof expectedType))
+        throw new Error(`${label}: expected ${expectedType.name} but got ${error?.constructor.name ?? 'no error'}: ${error?.message ?? ''}`);
+}
+function shouldBe(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${String(expected)} but got ${String(actual)}`);
+}
+function shouldNotThrow(fn, label) {
+    try { fn(); } catch (e) {
+        throw new Error(`${label}: unexpected ${e.constructor.name}: ${e.message}`);
+    }
+}
+
+// Helper: route a string through calendar canonicalization (full-union mask).
+function calendarOf(s) {
+    return Temporal.PlainMonthDay.from({ monthCode: "M11", day: 18, calendar: s }).calendarId;
+}
+
+// =============================================================================
+// Step 4 — goal dispatch: each TemporalXxxString matches its inputs.
+// =============================================================================
+
+// TemporalInstantString grammar: Date DateTimeSep Time DateTimeUTCOffset[+Z] TZAnno? Annotations?
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z").epochNanoseconds, 1705320000000000000n, "Instant: Z form");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05:00").epochNanoseconds, 1705302000000000000n, "Instant: numeric offset");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z[UTC]").epochNanoseconds, 1705320000000000000n, "Instant: Z + bracket");
+shouldThrow(() => Temporal.Instant.from("2024-01-15"), RangeError, "Instant: bare Date rejected");
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00"), RangeError, "Instant: missing Z/offset");
+shouldThrow(() => Temporal.Instant.from("12:00:00Z"), RangeError, "Instant: missing Date");
+
+// TemporalDateTimeString[~Zoned] — used by PlainDate and PlainDateTime; Z forbidden.
+shouldNotThrow(() => Temporal.PlainDate.from("2024-01-15"), "PlainDate: bare Date OK");
+shouldNotThrow(() => Temporal.PlainDate.from("2024-01-15T12:00:00"), "PlainDate: Date+Time OK");
+shouldNotThrow(() => Temporal.PlainDate.from("2024-01-15T12:00:00+05:00"), "PlainDate: Date+Time+offset OK");
+shouldNotThrow(() => Temporal.PlainDate.from("2024-01-15[America/New_York]"), "PlainDate: bare Date+TZ OK");
+shouldThrow(() => Temporal.PlainDate.from("2024-01-15T12:00:00Z"), RangeError, "PlainDate: Z rejected");
+shouldThrow(() => Temporal.PlainDate.from("2024-01-15T12:00:00Z[UTC]"), RangeError, "PlainDate: Z+bracket rejected");
+
+// TemporalDateTimeString[+Zoned] — used by ZonedDateTime; bracket TZ required.
+shouldNotThrow(() => Temporal.ZonedDateTime.from("2024-01-15T12:00:00[America/New_York]"), "ZDT: Date+Time+TZ OK");
+shouldNotThrow(() => Temporal.ZonedDateTime.from("2024-01-15T12:00:00Z[UTC]"), "ZDT: Z+TZ OK");
+shouldNotThrow(() => Temporal.ZonedDateTime.from("2024-01-15T12:00:00-05:00[America/New_York]"), "ZDT: offset+TZ OK");
+shouldThrow(() => Temporal.ZonedDateTime.from("2024-01-15T12:00:00Z"), RangeError, "ZDT: bare Z (no bracket)");
+shouldThrow(() => Temporal.ZonedDateTime.from("2024-01-15T12:00:00"), RangeError, "ZDT: no offset, no bracket");
+shouldThrow(() => Temporal.ZonedDateTime.from("2024-01-15"), RangeError, "ZDT: bare Date (no time, no bracket)");
+
+// TemporalYearMonthString — short form OR full datetime.
+shouldNotThrow(() => Temporal.PlainYearMonth.from("2024-01"), "YearMonth: short hyphenated");
+shouldNotThrow(() => Temporal.PlainYearMonth.from("202401"), "YearMonth: short compact");
+shouldNotThrow(() => Temporal.PlainYearMonth.from("2024-01-15"), "YearMonth: full date fallback");
+shouldNotThrow(() => Temporal.PlainYearMonth.from("2024-01-15T12:00:00"), "YearMonth: full datetime fallback");
+
+// TemporalMonthDayString — short form OR full datetime.
+shouldNotThrow(() => Temporal.PlainMonthDay.from("01-15"), "MonthDay: short hyphenated");
+shouldNotThrow(() => Temporal.PlainMonthDay.from("0115"), "MonthDay: short compact");
+shouldNotThrow(() => Temporal.PlainMonthDay.from("--01-15"), "MonthDay: short with -- prefix");
+shouldNotThrow(() => Temporal.PlainMonthDay.from("--0115"), "MonthDay: short compact with -- prefix");
+shouldNotThrow(() => Temporal.PlainMonthDay.from("2024-01-15"), "MonthDay: full date fallback");
+shouldNotThrow(() => Temporal.PlainMonthDay.from("2024-01-15T12:00:00"), "MonthDay: full datetime fallback");
+
+// TemporalTimeString — AnnotatedTime OR datetime with time.
+shouldNotThrow(() => Temporal.PlainTime.from("12:00"), "Time: HH:MM");
+shouldNotThrow(() => Temporal.PlainTime.from("12:00:00"), "Time: HH:MM:SS");
+shouldNotThrow(() => Temporal.PlainTime.from("120000"), "Time: HHMMSS compact");
+shouldNotThrow(() => Temporal.PlainTime.from("T12:00"), "Time: with TimeDesignator");
+shouldNotThrow(() => Temporal.PlainTime.from("2024-01-15T12:00:00"), "Time: datetime fallback");
+shouldThrow(() => Temporal.PlainTime.from("12:00:00Z"), RangeError, "Time: Z forbidden");
+shouldThrow(() => Temporal.PlainTime.from("2024-01-15"), RangeError, "Time: bare Date rejected");
+
+// =============================================================================
+// Step 4.a.ii.(1)–(2) — annotation processing & critical-flag rules.
+// =============================================================================
+
+// "u-ca" annotation extracted as calendar.
+shouldBe(calendarOf("2020-01-15[u-ca=hebrew]"), "hebrew", "annotation: u-ca extracted");
+shouldBe(calendarOf("2020-01-15"), "iso8601", "annotation: missing → iso8601");
+
+// Critical flag on u-ca: allowed (single).
+shouldBe(calendarOf("2020-01-15[!u-ca=hebrew]"), "hebrew", "annotation: critical u-ca single");
+
+// Critical flag on unknown key: RangeError.
+shouldThrow(() => Temporal.PlainDate.from("2020-01-15[!foo=bar]"), RangeError,
+    "annotation: critical unknown key");
+shouldThrow(() => Temporal.PlainDate.from("2020-01-15[u-ca=iso8601][!foo=bar]"), RangeError,
+    "annotation: critical unknown key after calendar");
+
+// Multiple calendar annotations: only one calendar kept; if EITHER is critical AND not the only one, RangeError.
+shouldThrow(() => Temporal.PlainDate.from("2020-01-15[!u-ca=hebrew][u-ca=iso8601]"), RangeError,
+    "annotation: critical first calendar + duplicate");
+shouldThrow(() => Temporal.PlainDate.from("2020-01-15[u-ca=hebrew][!u-ca=iso8601]"), RangeError,
+    "annotation: critical second calendar");
+
+// Non-critical unknown annotation: silently ignored.
+shouldNotThrow(() => Temporal.PlainDate.from("2020-01-15[foo=bar]"),
+    "annotation: non-critical unknown key OK");
+
+// =============================================================================
+// Step 4.a.ii.(3) — TemporalYearMonthString + no DateDay → calendar must be iso8601.
+// =============================================================================
+
+shouldNotThrow(() => Temporal.PlainYearMonth.from("2020-01"),
+    "YM short: no calendar OK");
+shouldNotThrow(() => Temporal.PlainYearMonth.from("2020-01[u-ca=iso8601]"),
+    "YM short: iso8601 calendar OK");
+shouldThrow(() => Temporal.PlainYearMonth.from("2020-01[u-ca=hebrew]"), RangeError,
+    "YM short: non-iso calendar rejected");
+// Long form bypasses the early-error: full date allows non-iso calendar.
+shouldNotThrow(() => Temporal.PlainYearMonth.from("2020-01-15[u-ca=hebrew]"),
+    "YM long form: non-iso calendar OK");
+
+// =============================================================================
+// Step 4.a.ii.(4) — TemporalMonthDayString + no DateYear → calendar must be iso8601; yearAbsent.
+// =============================================================================
+
+shouldNotThrow(() => Temporal.PlainMonthDay.from("01-15"),
+    "MD short: no calendar OK");
+shouldNotThrow(() => Temporal.PlainMonthDay.from("01-15[u-ca=iso8601]"),
+    "MD short: iso8601 calendar OK");
+shouldThrow(() => Temporal.PlainMonthDay.from("01-15[u-ca=hebrew]"), RangeError,
+    "MD short: non-iso calendar rejected");
+shouldNotThrow(() => Temporal.PlainMonthDay.from("2020-01-15[u-ca=hebrew]"),
+    "MD long form: non-iso calendar OK");
+
+// Property-bag .calendar route: short-form non-iso calendar string also rejected
+// (routes through ToTemporalCalendarIdentifier → ParseTemporalCalendarString).
+shouldThrow(() => Temporal.PlainDate.from({ year: 2020, month: 1, day: 15, calendar: "2020-01[u-ca=hebrew]" }),
+    RangeError, "calendar property: short-YM non-iso rejected");
+shouldThrow(() => Temporal.PlainDate.from({ year: 2020, month: 1, day: 15, calendar: "01-15[u-ca=hebrew]" }),
+    RangeError, "calendar property: short-MD non-iso rejected");
+shouldThrow(() => Temporal.PlainDate.from({ year: 2020, month: 1, day: 15, calendar: "--01-15[u-ca=hebrew]" }),
+    RangeError, "calendar property: short-MD basic non-iso rejected");
+// Full-form date with non-iso calendar in property bag is fine (no Step 4.a.ii.(3)/(4) violation).
+shouldNotThrow(() => Temporal.PlainDate.from({ year: 2020, month: 1, day: 15, calendar: "2020-01-15[u-ca=hebrew]" }),
+    "calendar property: full-form non-iso OK");
+
+// =============================================================================
+// Step 5 — no goal matched → RangeError.
+// =============================================================================
+
+shouldThrow(() => Temporal.PlainDate.from(""), RangeError, "Step 5: empty string");
+shouldThrow(() => Temporal.PlainDate.from("garbage"), RangeError, "Step 5: garbage");
+shouldThrow(() => Temporal.PlainDate.from("2020-13-01"), RangeError, "Step 5: month=13");
+shouldThrow(() => Temporal.PlainDate.from("2020-00-01"), RangeError, "Step 5: month=0");
+shouldThrow(() => Temporal.PlainDate.from("2020-01-32"), RangeError, "Step 5: day=32");
+shouldThrow(() => Temporal.PlainDate.from("2024-02-30"), RangeError, "Step 5: Feb 30");
+shouldThrow(() => Temporal.PlainDate.from("2020-01-15extra"), RangeError, "Step 5: trailing junk");
+
+// =============================================================================
+// Step 8 — yearMV (DateYear: 4-digit OR ±6-digit extended).
+// =============================================================================
+
+shouldNotThrow(() => Temporal.PlainDate.from("0000-01-01"), "year: 0000");
+shouldNotThrow(() => Temporal.PlainDate.from("9999-12-31"), "year: 9999");
+shouldNotThrow(() => Temporal.PlainDate.from("+275760-09-13"), "year: max valid extended");
+shouldNotThrow(() => Temporal.PlainDate.from("-271821-04-20"), "year: min valid extended");
+shouldThrow(() => Temporal.PlainDate.from("-000000-01-01"), RangeError, "year: -000000 forbidden");
+shouldNotThrow(() => Temporal.PlainDate.from("+000000-01-01"), "year: +000000 = 0");
+shouldThrow(() => Temporal.PlainDate.from("123-01-01"), RangeError, "year: 3-digit not allowed");
+
+// =============================================================================
+// Steps 9–10 — monthMV (DateMonth: 01-12).
+// =============================================================================
+
+for (let m = 1; m <= 12; ++m) {
+    const mm = String(m).padStart(2, "0");
+    shouldNotThrow(() => Temporal.PlainDate.from(`2024-${mm}-01`), `month=${mm}`);
+}
+shouldThrow(() => Temporal.PlainDate.from("2024-00-01"), RangeError, "month=00");
+shouldThrow(() => Temporal.PlainDate.from("2024-13-01"), RangeError, "month=13");
+
+// =============================================================================
+// Steps 11–12 — dayMV (DateDay: 01..daysInMonth).
+// =============================================================================
+
+shouldNotThrow(() => Temporal.PlainDate.from("2024-02-29"), "Feb 29 in leap year");
+shouldThrow(() => Temporal.PlainDate.from("2023-02-29"), RangeError, "Feb 29 in non-leap year");
+shouldNotThrow(() => Temporal.PlainDate.from("2024-04-30"), "Apr 30");
+shouldThrow(() => Temporal.PlainDate.from("2024-04-31"), RangeError, "Apr 31");
+shouldNotThrow(() => Temporal.PlainDate.from("2024-01-31"), "Jan 31");
+shouldThrow(() => Temporal.PlainDate.from("2024-01-32"), RangeError, "Jan 32");
+shouldThrow(() => Temporal.PlainDate.from("2024-01-00"), RangeError, "Jan 00");
+
+// =============================================================================
+// Steps 13–18 — hour/minute/second + leap-second clamp.
+// =============================================================================
+
+for (let h = 0; h <= 23; ++h)
+    shouldNotThrow(() => Temporal.PlainTime.from(`${String(h).padStart(2, "0")}:00`), `hour=${h}`);
+shouldThrow(() => Temporal.PlainTime.from("24:00"), RangeError, "hour=24");
+shouldThrow(() => Temporal.PlainTime.from("25:00"), RangeError, "hour=25");
+
+shouldNotThrow(() => Temporal.PlainTime.from("12:00"), "minute=00");
+shouldNotThrow(() => Temporal.PlainTime.from("12:59"), "minute=59");
+shouldThrow(() => Temporal.PlainTime.from("12:60"), RangeError, "minute=60");
+
+shouldNotThrow(() => Temporal.PlainTime.from("12:00:00"), "second=00");
+shouldNotThrow(() => Temporal.PlainTime.from("12:00:59"), "second=59");
+// Leap-second: :60 is grammar-valid and clamped to :59 (Step 18.b).
+shouldBe(Temporal.PlainTime.from("12:00:60").second, 59, "second=60 clamped to 59");
+shouldThrow(() => Temporal.PlainTime.from("12:00:61"), RangeError, "second=61");
+
+// =============================================================================
+// Steps 19–20 — fractional seconds (1–9 digits, '.' or ',').
+// =============================================================================
+
+for (let d = 1; d <= 9; ++d) {
+    const frac = "1".padEnd(d, "0");
+    shouldNotThrow(() => Temporal.PlainTime.from(`12:00:00.${frac}`), `${d} fractional digits`);
+}
+shouldThrow(() => Temporal.PlainTime.from("12:00:00.1234567890"), RangeError, "10 fractional digits");
+shouldThrow(() => Temporal.PlainTime.from("12:00:00."), RangeError, "trailing dot, no digits");
+
+// Both '.' and ',' are valid separators.
+shouldBe(Temporal.PlainTime.from("12:00:00,5").millisecond, 500, "comma fractional separator");
+
+// Padding to 9 digits (ms / us / ns split).
+const t = Temporal.PlainTime.from("12:00:00.123456789");
+shouldBe(t.millisecond, 123, "fractional → ms");
+shouldBe(t.microsecond, 456, "fractional → us");
+shouldBe(t.nanosecond, 789, "fractional → ns");
+const t2 = Temporal.PlainTime.from("12:00:00.1");
+shouldBe(t2.millisecond, 100, "0.1 → 100 ms");
+shouldBe(t2.microsecond, 0, "0.1 → 0 us");
+shouldBe(t2.nanosecond, 0, "0.1 → 0 ns");
+
+// =============================================================================
+// Step 21 — IsValidISODate assert (covered by parseDate's bounds check above).
+// =============================================================================
+
+// Already exercised by Steps 9-12 tests. Add boundary year cases:
+shouldNotThrow(() => Temporal.PlainDate.from("+275760-09-13"), "max ISO date");
+// One-day-past-max: year extension still parses but downstream validation rejects.
+shouldThrow(() => Temporal.PlainDate.from("+275760-09-14"), RangeError, "+1 past max");
+
+// =============================================================================
+// Steps 22–23 — time = start-of-day vs CreateTimeRecord.
+// =============================================================================
+
+// PlainDate accepts a bare Date (time absent → start-of-day in spec terms).
+shouldNotThrow(() => Temporal.PlainDate.from("2024-01-15"), "PlainDate: bare Date");
+// PlainDateTime with bare date → time defaults to 00:00:00.
+const pdt = Temporal.PlainDateTime.from("2024-01-15");
+shouldBe(pdt.hour, 0, "PlainDateTime bare date → hour=0");
+shouldBe(pdt.minute, 0, "PlainDateTime bare date → minute=0");
+shouldBe(pdt.second, 0, "PlainDateTime bare date → second=0");
+// PlainDateTime with full datetime → time populated.
+const pdt2 = Temporal.PlainDateTime.from("2024-01-15T17:30:45.123");
+shouldBe(pdt2.hour, 17, "PlainDateTime full → hour=17");
+shouldBe(pdt2.minute, 30, "PlainDateTime full → minute=30");
+shouldBe(pdt2.second, 45, "PlainDateTime full → second=45");
+shouldBe(pdt2.millisecond, 123, "PlainDateTime full → ms=123");
+
+// =============================================================================
+// Steps 24–27 — timeZoneResult ([[Z]], [[OffsetString]], [[TimeZoneAnnotation]]).
+// =============================================================================
+
+// Step 26: [[Z]] = true.
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z").epochNanoseconds, 1705320000000000000n,
+    "Step 26: Z designator");
+
+// Step 27: [[OffsetString]] from numeric offset.
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+00:00").epochNanoseconds, 1705320000000000000n,
+    "Step 27: +00:00 == Z");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00-00:00").epochNanoseconds, 1705320000000000000n,
+    "Step 27: -00:00 == Z");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+14:00").epochNanoseconds, 1705269600000000000n,
+    "Step 27: max +14:00");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00-14:00").epochNanoseconds, 1705370400000000000n,
+    "Step 27: min -14:00");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05:30:15").epochNanoseconds, 1705300185000000000n,
+    "Step 27: sub-minute precision (3-component)");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05:30:15.123456789").epochNanoseconds, 1705300184876543211n,
+    "Step 27: fractional offset");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00+05").epochNanoseconds, 1705302000000000000n,
+    "Step 27: bare ±HH");
+
+// Step 25: [[TimeZoneAnnotation]] from bracket.
+shouldNotThrow(() => Temporal.ZonedDateTime.from("2024-01-15T12:00:00[America/New_York]"),
+    "Step 25: named bracket");
+shouldNotThrow(() => Temporal.ZonedDateTime.from("2024-01-15T12:00:00[+05:00]"),
+    "Step 25: numeric bracket");
+shouldNotThrow(() => Temporal.ZonedDateTime.from("2024-01-15T12:00:00[!America/New_York]"),
+    "Step 25: critical named bracket");
+
+// Steps 24-27 all empty (PlainDate without time/zone).
+shouldNotThrow(() => Temporal.PlainDate.from("2024-01-15"), "Step 24: no TZ info");
+
+// =============================================================================
+// Step 28 — yearAbsent for MonthDay short form.
+// =============================================================================
+
+const md1 = Temporal.PlainMonthDay.from("--12-25");
+shouldBe(md1.toString(), "12-25", "Step 28: --MM-DD short form");
+const md2 = Temporal.PlainMonthDay.from("12-25");
+shouldBe(md2.toString(), "12-25", "Step 28: MM-DD short form");
+// Long form preserves date but PlainMonthDay still strips year.
+const md3 = Temporal.PlainMonthDay.from("2024-12-25");
+shouldBe(md3.toString(), "12-25", "Step 28: long form, year stripped");
+
+// =============================================================================
+// Step 29 — full record return (covered implicitly by all the above).
+// =============================================================================
+
+// Round-trip parity check: parse + reformat returns equivalent strings.
+shouldBe(Temporal.PlainDate.from("2024-01-15").toString(), "2024-01-15", "Step 29: round-trip Date");
+shouldBe(Temporal.PlainTime.from("12:30:45.123").toString(), "12:30:45.123", "Step 29: round-trip Time");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00Z").toString(), "2024-01-15T12:00:00Z",
+    "Step 29: round-trip Instant");
+
+// =============================================================================
+// Calendar canonicalization — full union mask (calendarOf helper).
+// All inputs accepted as ANY of the 6 production goals; calendar extracted or defaulted.
+// =============================================================================
+
+// Each TemporalXxxString form, with no calendar annotation → "iso8601".
+shouldBe(calendarOf("2024-01-15"), "iso8601", "calendarOf: bare Date → iso8601");
+shouldBe(calendarOf("2024-01-15T12:00:00"), "iso8601", "calendarOf: DateTime → iso8601");
+shouldBe(calendarOf("2024-01-15T12:00:00Z"), "iso8601", "calendarOf: Instant → iso8601");
+shouldBe(calendarOf("2024-01"), "iso8601", "calendarOf: YearMonth short → iso8601");
+shouldBe(calendarOf("01-15"), "iso8601", "calendarOf: MonthDay short → iso8601");
+shouldBe(calendarOf("12:00:00"), "iso8601", "calendarOf: Time → iso8601");
+shouldBe(calendarOf("2024-01-15T12:00:00[America/New_York]"), "iso8601",
+    "calendarOf: ZonedDateTime → iso8601");
+
+// Calendar annotation extraction.
+shouldBe(calendarOf("2024-01-15[u-ca=hebrew]"), "hebrew", "calendarOf: extracts hebrew");
+shouldBe(calendarOf("2024-01-15T12:00:00[u-ca=islamic-civil]"), "islamic-civil",
+    "calendarOf: extracts islamic-civil");
+
+// Mixed-case calendar key: lowercased.
+shouldBe(calendarOf("2024-01-15[u-ca=ISO8601]"), "iso8601", "calendarOf: case-insensitive value");
+
+// =============================================================================
+// AnnotatedTime ambiguity check (Step 4 static-semantics).
+// =============================================================================
+
+// Time-shaped inputs that are ALSO DateSpecYearMonth/DateSpecMonthDay are rejected by Time
+// production but may match other goals. With Time goal alone, ambiguous inputs throw.
+shouldNotThrow(() => Temporal.PlainTime.from("T12:00"),
+    "ambiguity: TimeDesignator disables ambiguity check");
+shouldNotThrow(() => Temporal.PlainTime.from("12:00"),
+    "ambiguity: HH:MM is unambiguous (hour 12, not month 12 — colon disambiguates)");
+// "1212" without TimeDesignator is ambiguous (could be 12:12 or YYYY=fail or MMDD=Dec 12).
+// Since our parser tries Time first when only Time is allowed, and disambiguity is checked,
+// the Time match is rejected → falls back to datetime which fails too → RangeError.
+shouldThrow(() => Temporal.PlainTime.from("1212"), RangeError,
+    "ambiguity: 1212 rejected (matches MMDD too)");
+
+// =============================================================================
+// Indirect entry points — equals, until, since, compare also call ToTemporal*.
+// =============================================================================
+
+{
+    const a = Temporal.PlainDate.from("2024-01-15");
+    shouldBe(a.equals("2024-01-15"), true, "PlainDate.equals(string)");
+    shouldThrow(() => a.equals("2024-01-15T12:00:00Z"), RangeError, "PlainDate.equals: Z forbidden");
+}
+{
+    const a = new Temporal.Instant(0n);
+    shouldBe(a.equals("1970-01-01T00:00:00Z"), true, "Instant.equals(string)");
+    shouldThrow(() => a.equals("1970-01-01"), RangeError, "Instant.equals: missing time/Z");
+}
+
+// =============================================================================
+// Annotation deep cases (Step 4.a.ii.(1)–(2))
+// =============================================================================
+
+// Empty calendar value: [u-ca=] is invalid grammar (AnnotationValue requires ≥3 chars).
+shouldThrow(() => Temporal.PlainDate.from("2020-01-15[u-ca=]"), RangeError,
+    "annotation: empty u-ca value");
+shouldThrow(() => Temporal.PlainDate.from("2020-01-15[u-ca=ab]"), RangeError,
+    "annotation: too-short u-ca value");
+
+// First non-critical calendar wins; subsequent non-critical calendars silently ignored.
+shouldBe(calendarOf("2020-01-15[u-ca=hebrew][u-ca=iso8601]"), "hebrew",
+    "annotation: first calendar wins, no critical flag");
+
+// Same iso8601 calendar repeated (no critical) — accepted, single calendar tracked.
+shouldBe(calendarOf("2020-01-15[u-ca=iso8601][u-ca=iso8601]"), "iso8601",
+    "annotation: duplicate non-critical iso8601");
+
+// Critical flag on non-calendar annotations — RangeError per spec.
+shouldThrow(() => Temporal.PlainDate.from("2020-01-15[!unknown=value]"), RangeError,
+    "annotation: critical unknown");
+// Multiple unknown annotations, none critical — all ignored.
+shouldNotThrow(() => Temporal.PlainDate.from("2020-01-15[foo=a][bar=b][baz=c]"),
+    "annotation: multiple non-critical unknowns OK");
+
+// =============================================================================
+// Case-insensitivity: T/Z designators per Stage 4 grammar (T | t, Z | z).
+// =============================================================================
+
+shouldBe(Temporal.Instant.from("2024-01-15t12:00:00Z").epochNanoseconds, 1705320000000000000n,
+    "case: lowercase t separator");
+shouldBe(Temporal.Instant.from("2024-01-15T12:00:00z").epochNanoseconds, 1705320000000000000n,
+    "case: lowercase z designator");
+shouldBe(Temporal.Instant.from("2024-01-15t12:00:00z").epochNanoseconds, 1705320000000000000n,
+    "case: both lowercase");
+
+// =============================================================================
+// Date space separator (per spec DateTimeSeparator: T | t | space).
+// =============================================================================
+
+shouldBe(Temporal.Instant.from("2024-01-15 12:00:00Z").epochNanoseconds, 1705320000000000000n,
+    "DateTimeSeparator: space");
+shouldNotThrow(() => Temporal.PlainDateTime.from("2024-01-15 12:00:00"), "PDT space sep");
+
+// =============================================================================
+// Calendar boundary years (Step 21 IsValidISODate).
+// =============================================================================
+
+// 1900 is NOT a leap year (divisible by 100, not by 400).
+shouldThrow(() => Temporal.PlainDate.from("1900-02-29"), RangeError, "1900 not leap");
+shouldNotThrow(() => Temporal.PlainDate.from("1900-02-28"), "1900 Feb 28 OK");
+// 2000 IS a leap year (divisible by 400).
+shouldNotThrow(() => Temporal.PlainDate.from("2000-02-29"), "2000 Feb 29 OK");
+// 2100 not leap.
+shouldThrow(() => Temporal.PlainDate.from("2100-02-29"), RangeError, "2100 not leap");
+
+// =============================================================================
+// Compact date forms (DateSeparator[~Extended]).
+// =============================================================================
+
+// Per spec Date production: separator presence must be CONSISTENT (all hyphens or none).
+shouldNotThrow(() => Temporal.PlainDate.from("20240115"), "compact YYYYMMDD");
+shouldNotThrow(() => Temporal.PlainDate.from("2024-01-15"), "extended YYYY-MM-DD");
+// Mixed forms forbidden.
+shouldThrow(() => Temporal.PlainDate.from("2024-0115"), RangeError, "mixed: separator-then-no");
+shouldThrow(() => Temporal.PlainDate.from("202401-15"), RangeError, "mixed: no-then-separator");
+
+// Extended year compact: ±YYYYYYMMDD (sign + 6-digit year + month + day, no separators).
+shouldNotThrow(() => Temporal.PlainDate.from("+0020240115"), "compact +002024 0115");
+shouldNotThrow(() => Temporal.PlainDate.from("-0019761118"), "compact -001976 1118");
+
+// =============================================================================
+// MonthDay short-form variants (DateSpecMonthDay).
+// =============================================================================
+
+// Both forms with and without leading "--".
+shouldBe(Temporal.PlainMonthDay.from("--01-15").toString(), "01-15", "MD: --MM-DD");
+shouldBe(Temporal.PlainMonthDay.from("--0115").toString(), "01-15", "MD: --MMDD");
+shouldBe(Temporal.PlainMonthDay.from("01-15").toString(), "01-15", "MD: MM-DD");
+shouldBe(Temporal.PlainMonthDay.from("0115").toString(), "01-15", "MD: MMDD");
+// Feb 29 in MonthDay is valid (1972 reference year is leap).
+shouldBe(Temporal.PlainMonthDay.from("--02-29").toString(), "02-29", "MD: Feb 29 OK (1972 leap)");
+shouldBe(Temporal.PlainMonthDay.from("02-29").toString(), "02-29", "MD: Feb 29 OK without --");
+
+// =============================================================================
+// YearMonth short-form variants (DateSpecYearMonth).
+// =============================================================================
+
+shouldBe(Temporal.PlainYearMonth.from("2024-01").toString(), "2024-01", "YM: hyphenated");
+shouldBe(Temporal.PlainYearMonth.from("202401").toString(), "2024-01", "YM: compact");
+shouldBe(Temporal.PlainYearMonth.from("+002024-01").toString(), "2024-01", "YM: extended hyphen");
+shouldBe(Temporal.PlainYearMonth.from("+00202401").toString(), "2024-01", "YM: extended compact");
+shouldBe(Temporal.PlainYearMonth.from("-001976-11").toString(), "-001976-11", "YM: extended negative");
+
+// =============================================================================
+// UTCOffset edge cases.
+// =============================================================================
+
+// Sub-minute precision: ±HH:MM:SS or ±HH:MM:SS.fffffffff.
+shouldNotThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+05:30:15"), "offset HH:MM:SS");
+shouldNotThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+05:30:15.5"), "offset HH:MM:SS.f");
+shouldNotThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+05:30:15.123456789"), "offset HH:MM:SS.fffffffff");
+// Compact offset forms.
+shouldNotThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+0530"), "compact offset ±HHMM");
+shouldNotThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+053015"), "compact offset ±HHMMSS");
+// Mixed extended/compact in offset rejected.
+shouldThrow(() => Temporal.Instant.from("2024-01-15T12:00:00+05:3015"), RangeError, "offset mixed");
+
+// =============================================================================
+// Round-trip from Temporal types via toString().
+// =============================================================================
+
+const inputs = [
+    ["Instant",       "2024-01-15T12:30:45.123456789Z"],
+    ["PlainDate",     "2024-01-15"],
+    ["PlainDateTime", "2024-01-15T12:30:45.123456789"],
+    ["PlainTime",     "12:30:45.123456789"],
+    ["PlainYearMonth","2024-01"],
+    ["PlainMonthDay", "01-15"],
+];
+for (const [name, str] of inputs)
+    shouldBe(Temporal[name].from(str).toString(), str, `round-trip ${name} "${str}"`);

--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -2017,7 +2017,7 @@ static void testAddLargeDurations()
 // ---------------------------------------------------------------------------
 // invalid_strings — mirrors temporal_rs plain_date.rs test invalid_strings
 // test262/test/built-ins/Temporal/Calendar/prototype/month/argument-string-invalid.js
-// Tests that parseCalendarDateTime rejects invalid/unsupported ISO 8601 strings.
+// Tests that parseISODateTime rejects invalid/unsupported ISO 8601 strings.
 // Note: "2020-01-01[u-ca=notexist]" is NOT tested here because it parses
 // successfully at the C++ layer; the calendar validation happens in JS.
 // ---------------------------------------------------------------------------
@@ -2074,7 +2074,7 @@ static void testInvalidDateStrings()
         "1970-01-01T00:00:00.1234567890",
     };
     for (auto* s : invalidStrings) {
-        auto r = ISO8601::parseCalendarDateTime(StringView::fromLatin1(s), TemporalDateFormat::Date);
+        auto r = ISO8601::parseISODateTime(StringView::fromLatin1(s), ISO8601::TemporalProduction::DateTimeUnzoned);
         TCHECK_TRUE(!r.has_value(), "invalidString: should reject");
     }
 }
@@ -2097,9 +2097,342 @@ static void testCriticalUnknownAnnotation()
         "1970-01-01T00:00[foo=bar][!_foo-bar0=Dont-Ignore-This-99999999999]",
     };
     for (auto* s : criticalAnnotationStrings) {
-        auto r = ISO8601::parseCalendarDateTime(StringView::fromLatin1(s), TemporalDateFormat::Date);
+        auto r = ISO8601::parseISODateTime(StringView::fromLatin1(s), ISO8601::TemporalProduction::DateTimeUnzoned);
         TCHECK_TRUE(!r.has_value(), "criticalAnnotation: should reject");
     }
+}
+
+// ---------------------------------------------------------------------------
+// parseISODateTime — comprehensive stress tests for the spec abstract op
+// ---------------------------------------------------------------------------
+
+namespace {
+using P = ISO8601::TemporalProduction;
+using PSet = ISO8601::TemporalProductionSet;
+}
+
+static void testParseInstantString()
+{
+    // TemporalInstantString ::= Date DateTimeSep Time DateTimeUTCOffset[+Z] TZAnno? Annotations?
+    auto r = ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, P::Instant);
+    TCHECK_TRUE(r.has_value(), "Instant: Z form");
+    TCHECK_TRUE(r->matched == P::Instant, "Instant: matched=Instant");
+    TCHECK_TRUE(r->date.has_value() && r->date->year() == 2024 && r->date->month() == 1 && r->date->day() == 15, "Instant: date populated");
+    TCHECK_TRUE(r->time.has_value() && r->time->hour() == 12, "Instant: time populated");
+    TCHECK_TRUE(r->timeZone.has_value() && r->timeZone->m_z, "Instant: Z designator");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00+05:30"_s, P::Instant);
+    TCHECK_TRUE(r.has_value() && r->timeZone->m_offset.has_value(), "Instant: numeric offset");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00Z[UTC]"_s, P::Instant);
+    TCHECK_TRUE(r.has_value() && r->timeZone->m_z, "Instant: Z + bracket");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00+05:30:15.123456789"_s, P::Instant);
+    TCHECK_TRUE(r.has_value() && r->timeZone->m_offsetHasSubMinutePrecision, "Instant: sub-minute precision");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("20240115T120000Z"_s, P::Instant).has_value(), "Instant: compact YYYYMMDDTHHMMSSZ");
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15t12:00:00z"_s, P::Instant).has_value(), "Instant: lowercase t/z");
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15 12:00:00Z"_s, P::Instant).has_value(), "Instant: space separator");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15"_s, P::Instant).has_value(), "Instant: bare date rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15T12:00:00"_s, P::Instant).has_value(), "Instant: missing Z/offset rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("12:00:00Z"_s, P::Instant).has_value(), "Instant: bare time rejected");
+}
+
+static void testParseDateTimeStringUnzoned()
+{
+    // TemporalDateTimeString[~Zoned] = AnnotatedDateTime[~Zoned, ~TimeRequired]; Z forbidden.
+    auto r = ISO8601::parseISODateTime("2024-01-15"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && !r->time.has_value() && !r->timeZone.has_value(), "Unzoned: bare date");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && r->time.has_value() && !r->timeZone.has_value(), "Unzoned: date+time");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00+05:00"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && r->timeZone.has_value() && r->timeZone->m_offset.has_value(), "Unzoned: numeric offset OK");
+
+    r = ISO8601::parseISODateTime("2024-01-15[America/New_York]"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && r->timeZone.has_value(), "Unzoned: bracket alone OK");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, P::DateTimeUnzoned).has_value(), "Unzoned: bare Z rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15T12:00:00Z[UTC]"_s, P::DateTimeUnzoned).has_value(), "Unzoned: Z+bracket rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-13-01"_s, P::DateTimeUnzoned).has_value(), "Unzoned: month=13 rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-02-30"_s, P::DateTimeUnzoned).has_value(), "Unzoned: Feb 30 rejected");
+}
+
+static void testParseDateTimeStringZoned()
+{
+    // TemporalDateTimeString[+Zoned]: bracket REQUIRED; Z allowed.
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15[America/New_York]"_s, P::DateTimeZoned).has_value(), "Zoned: bare date + bracket");
+
+    auto r = ISO8601::parseISODateTime("2024-01-15T12:00:00Z[UTC]"_s, P::DateTimeZoned);
+    TCHECK_TRUE(r.has_value() && r->timeZone->m_z, "Zoned: Z + bracket");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00+05:00[Asia/Kolkata]"_s, P::DateTimeZoned);
+    TCHECK_TRUE(r.has_value() && r->timeZone->m_offset.has_value(), "Zoned: offset + bracket");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15"_s, P::DateTimeZoned).has_value(), "Zoned: no bracket rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, P::DateTimeZoned).has_value(), "Zoned: Z without bracket rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15T12:00:00+05:00"_s, P::DateTimeZoned).has_value(), "Zoned: offset without bracket rejected");
+}
+
+static void testParseYearMonthString()
+{
+    // TemporalYearMonthString = AnnotatedYearMonth | AnnotatedDateTime[~Zoned, ~TimeRequired].
+    auto r = ISO8601::parseISODateTime("2024-01"_s, P::YearMonth);
+    TCHECK_TRUE(r.has_value() && r->isShortForm, "YM: hyphenated short");
+    TCHECK_TRUE(r->date.has_value() && r->date->year() == 2024 && r->date->month() == 1, "YM: year+month populated");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("202401"_s, P::YearMonth).value().isShortForm, "YM: compact short");
+    TCHECK_TRUE(ISO8601::parseISODateTime("+002024-01"_s, P::YearMonth).value().isShortForm, "YM: extended hyphenated");
+    TCHECK_TRUE(ISO8601::parseISODateTime("+00202401"_s, P::YearMonth).value().isShortForm, "YM: extended compact");
+    TCHECK_TRUE(ISO8601::parseISODateTime("-001976-11"_s, P::YearMonth).value().isShortForm, "YM: negative extended");
+
+    // Long-form fallback (full date) → isShortForm=false
+    r = ISO8601::parseISODateTime("2024-01-15"_s, P::YearMonth);
+    TCHECK_TRUE(r.has_value() && !r->isShortForm && r->matched == P::YearMonth, "YM: full date fallback retagged");
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15T12:00:00"_s, P::YearMonth).value().matched == P::YearMonth, "YM: full datetime fallback");
+
+    // Calendar extraction: short-form requires iso8601, full-form accepts any builtin.
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01[u-ca=hebrew]"_s, P::YearMonth).has_value(),
+        "YM: short-form non-iso8601 rejected (Step 4.a.ii.(3))");
+    r = ISO8601::parseISODateTime("2024-01-15[u-ca=hebrew]"_s, P::YearMonth);
+    TCHECK_TRUE(r.has_value() && r->calendar.has_value(), "YM: full-form calendar extracted");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-13"_s, P::YearMonth).has_value(), "YM: month=13 rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-00"_s, P::YearMonth).has_value(), "YM: month=00 rejected");
+}
+
+static void testParseMonthDayString()
+{
+    // TemporalMonthDayString = AnnotatedMonthDay | AnnotatedDateTime[~Zoned, ~TimeRequired].
+    auto r = ISO8601::parseISODateTime("01-15"_s, P::MonthDay);
+    TCHECK_TRUE(r.has_value() && r->isShortForm, "MD: MM-DD");
+    TCHECK_TRUE(r->date.has_value() && r->date->month() == 1 && r->date->day() == 15, "MD: month+day populated");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("0115"_s, P::MonthDay).value().isShortForm, "MD: MMDD compact");
+    TCHECK_TRUE(ISO8601::parseISODateTime("--01-15"_s, P::MonthDay).value().isShortForm, "MD: --MM-DD");
+    TCHECK_TRUE(ISO8601::parseISODateTime("--0115"_s, P::MonthDay).value().isShortForm, "MD: --MMDD");
+
+    // Feb 29 OK (1972 reference is leap)
+    TCHECK_TRUE(ISO8601::parseISODateTime("02-29"_s, P::MonthDay).has_value(), "MD: Feb 29 OK");
+
+    // Long-form fallback
+    r = ISO8601::parseISODateTime("2024-01-15"_s, P::MonthDay);
+    TCHECK_TRUE(r.has_value() && !r->isShortForm && r->matched == P::MonthDay, "MD: full date fallback retagged");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("01-32"_s, P::MonthDay).has_value(), "MD: day=32 rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("02-30"_s, P::MonthDay).has_value(), "MD: Feb 30 rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("13-01"_s, P::MonthDay).has_value(), "MD: month=13 rejected");
+}
+
+static void testParseTimeString()
+{
+    // TemporalTimeString = AnnotatedTime | AnnotatedDateTime[~Zoned, +TimeRequired].
+    auto r = ISO8601::parseISODateTime("12:00"_s, P::Time);
+    TCHECK_TRUE(r.has_value() && !r->date.has_value() && r->time.has_value(), "Time: HH:MM (no date)");
+    TCHECK_TRUE(r->matched == P::Time, "Time: matched=Time");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("12:00:00"_s, P::Time).has_value(), "Time: HH:MM:SS");
+    TCHECK_TRUE(ISO8601::parseISODateTime("120000"_s, P::Time).has_value(), "Time: compact");
+    TCHECK_TRUE(ISO8601::parseISODateTime("12:00:00.123456789"_s, P::Time).has_value(), "Time: 9-digit fraction");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("T12:00"_s, P::Time).has_value(), "Time: T prefix");
+    TCHECK_TRUE(ISO8601::parseISODateTime("t12:00"_s, P::Time).has_value(), "Time: t prefix");
+
+    // Datetime fallback
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00"_s, P::Time);
+    TCHECK_TRUE(r.has_value() && r->date.has_value() && r->matched == P::Time, "Time: datetime fallback retagged");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("12:00:00+05:00"_s, P::Time).has_value(), "Time: time + offset OK");
+    TCHECK_TRUE(ISO8601::parseISODateTime("12:00:00[UTC]"_s, P::Time).has_value(), "Time: time + bracket OK");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("12:00:00Z"_s, P::Time).has_value(), "Time: Z forbidden");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, P::Time).has_value(), "Time: datetime+Z forbidden");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15"_s, P::Time).has_value(), "Time: bare date rejected");
+
+    // Ambiguity: 1212 matches HHMM AND DateSpec*; rejected without TimeDesignator
+    TCHECK_TRUE(!ISO8601::parseISODateTime("1212"_s, P::Time).has_value(), "Time: ambiguous 1212 rejected");
+    TCHECK_TRUE(ISO8601::parseISODateTime("T1212"_s, P::Time).has_value(), "Time: T1212 unambiguous");
+}
+
+static void testParseDateMVs()
+{
+    // Steps 8-12: DateYear (4-digit or ±6-digit) + DateMonth (01-12) + DateDay (per IsValidISODate).
+    auto r = ISO8601::parseISODateTime("0000-01-01"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && !r->date->year(), "Step 8: year=0000");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("9999-12-31"_s, P::DateTimeUnzoned).has_value(), "Step 8: year=9999");
+    TCHECK_TRUE(ISO8601::parseISODateTime("+275760-09-13"_s, P::DateTimeUnzoned).has_value(), "Step 8: max valid extended");
+    TCHECK_TRUE(ISO8601::parseISODateTime("-271821-04-20"_s, P::DateTimeUnzoned).has_value(), "Step 8: min valid extended");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("-000000-01-01"_s, P::DateTimeUnzoned).has_value(), "Step 8: -000000 forbidden");
+    TCHECK_TRUE(ISO8601::parseISODateTime("+000000-01-01"_s, P::DateTimeUnzoned).has_value(), "Step 8: +000000 = year 0");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("123-01-01"_s, P::DateTimeUnzoned).has_value(), "Step 8: 3-digit year rejected");
+
+    // Month bounds (Steps 9-10)
+    for (unsigned m = 1; m <= 12; ++m) {
+        char buf[16];
+        SAFE_SPRINTF(std::span { buf }, "2024-%02u-01", m);
+        TCHECK_TRUE(ISO8601::parseISODateTime(StringView::fromLatin1(buf), P::DateTimeUnzoned).has_value(), "Step 9-10: month bounds");
+    }
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-00-01"_s, P::DateTimeUnzoned).has_value(), "Step 9-10: month=00 rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-13-01"_s, P::DateTimeUnzoned).has_value(), "Step 9-10: month=13 rejected");
+
+    // Day bounds + IsValidISODate (Step 21)
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-02-29"_s, P::DateTimeUnzoned).has_value(), "Step 21: leap Feb 29");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2023-02-29"_s, P::DateTimeUnzoned).has_value(), "Step 21: non-leap Feb 29 rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-04-31"_s, P::DateTimeUnzoned).has_value(), "Step 21: Apr 31 rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-32"_s, P::DateTimeUnzoned).has_value(), "Step 21: day=32 rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("1900-02-29"_s, P::DateTimeUnzoned).has_value(), "Step 21: 1900 not leap");
+    TCHECK_TRUE(ISO8601::parseISODateTime("2000-02-29"_s, P::DateTimeUnzoned).has_value(), "Step 21: 2000 is leap");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2100-02-29"_s, P::DateTimeUnzoned).has_value(), "Step 21: 2100 not leap");
+
+    // Mixed extended/compact forbidden
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-0115"_s, P::DateTimeUnzoned).has_value(), "Step 11-12: mixed sep-then-no");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("202401-15"_s, P::DateTimeUnzoned).has_value(), "Step 11-12: mixed no-then-sep");
+}
+
+static void testParseTimeMVs()
+{
+    // Steps 13-20: hour/minute/second + leap-clamp + fractional padding.
+    for (unsigned h = 0; h <= 23; ++h) {
+        char buf[8];
+        SAFE_SPRINTF(std::span { buf }, "%02u:00", h);
+        TCHECK_TRUE(ISO8601::parseISODateTime(StringView::fromLatin1(buf), P::Time).has_value(), "Step 13-14: hour bounds");
+    }
+    TCHECK_TRUE(!ISO8601::parseISODateTime("24:00"_s, P::Time).has_value(), "Step 13-14: hour=24 rejected");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("12:59"_s, P::Time).has_value(), "Step 15-16: minute=59");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("12:60"_s, P::Time).has_value(), "Step 15-16: minute=60 rejected");
+
+    auto r = ISO8601::parseISODateTime("12:00:60"_s, P::Time);
+    TCHECK_TRUE(r.has_value() && r->time->second() == 59, "Step 18.b: leap-clamp 60→59");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("12:00:61"_s, P::Time).has_value(), "Step 17-18: second=61 rejected");
+
+    r = ISO8601::parseISODateTime("12:00:00.1"_s, P::Time);
+    TCHECK_TRUE(r.has_value() && r->time->millisecond() == 100, "Step 19-20: 0.1 → ms=100");
+    TCHECK_TRUE(!r->time->microsecond() && !r->time->nanosecond(), "Step 19-20: 0.1 → us=ns=0");
+
+    r = ISO8601::parseISODateTime("12:00:00.123456789"_s, P::Time);
+    TCHECK_TRUE(r.has_value() && r->time->millisecond() == 123 && r->time->microsecond() == 456 && r->time->nanosecond() == 789, "Step 19-20: 9-digit ms/us/ns");
+
+    r = ISO8601::parseISODateTime("12:00:00,5"_s, P::Time);
+    TCHECK_TRUE(r.has_value() && r->time->millisecond() == 500, "Step 19-20: comma separator");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("12:00:00.1234567890"_s, P::Time).has_value(), "Step 19-20: 10 frac digits rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("12:00:00."_s, P::Time).has_value(), "Step 19-20: trailing dot rejected");
+}
+
+static void testParseTimeZoneFields()
+{
+    // Steps 22-27: time + timeZone field population.
+    auto r = ISO8601::parseISODateTime("2024-01-15"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && !r->time.has_value(), "Step 22: bare date → time absent");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && r->time.has_value(), "Step 23: time present → CreateTimeRecord");
+
+    r = ISO8601::parseISODateTime("2024-01-15"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && !r->timeZone.has_value(), "Step 24: no TZ info → timeZone absent");
+
+    r = ISO8601::parseISODateTime("2024-01-15[America/New_York]"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && r->timeZone.has_value(), "Step 25: bracket → timeZone present");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, P::Instant);
+    TCHECK_TRUE(r.has_value() && r->timeZone->m_z && !r->timeZone->m_offset.has_value(), "Step 26: Z → m_z=true, no offset");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00+05:00"_s, P::Instant);
+    TCHECK_TRUE(r.has_value() && r->timeZone->m_offset.has_value() && !r->timeZone->m_z, "Step 27: offset → m_z=false");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00+05:30:15.123"_s, P::Instant);
+    TCHECK_TRUE(r.has_value() && r->timeZone->m_offsetHasSubMinutePrecision, "Step 27: sub-minute precision flag");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00+05:30"_s, P::Instant);
+    TCHECK_TRUE(r.has_value() && !r->timeZone->m_offsetHasSubMinutePrecision, "Step 27: HH:MM no sub-minute");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15T12:00:00+0530"_s, P::Instant).has_value(), "Step 27: ±HHMM compact");
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15T12:00:00+053015"_s, P::Instant).has_value(), "Step 27: ±HHMMSS compact");
+
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00+00:00"_s, P::Instant);
+    TCHECK_TRUE(r.has_value() && !r->timeZone->m_z, "Step 27: +00:00 is offset, not Z");
+}
+
+static void testParseAnnotationProcessing()
+{
+    // Step 4.a.ii.(1)-(2): annotation loop + critical-flag rules.
+    auto r = ISO8601::parseISODateTime("2024-01-15[u-ca=hebrew]"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && r->calendar.has_value(), "Annotation: u-ca extracted");
+
+    r = ISO8601::parseISODateTime("2024-01-15"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && !r->calendar.has_value(), "Annotation: no u-ca → calendar nullopt");
+
+    r = ISO8601::parseISODateTime("2024-01-15[!u-ca=hebrew]"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && r->calendar.has_value(), "Annotation: critical u-ca single OK");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15[!foo=bar]"_s, P::DateTimeUnzoned).has_value(), "Annotation: critical unknown rejected");
+
+    // First non-critical wins
+    r = ISO8601::parseISODateTime("2024-01-15[u-ca=hebrew][u-ca=iso8601]"_s, P::DateTimeUnzoned);
+    TCHECK_TRUE(r.has_value() && r->calendar.has_value(), "Annotation: first non-critical wins");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15[!u-ca=hebrew][u-ca=iso8601]"_s, P::DateTimeUnzoned).has_value(), "Annotation: critical-then-dup rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15[u-ca=hebrew][!u-ca=iso8601]"_s, P::DateTimeUnzoned).has_value(), "Annotation: dup-then-critical rejected");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15[foo=bar]"_s, P::DateTimeUnzoned).has_value(), "Annotation: non-critical unknown ignored");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15[u-ca=]"_s, P::DateTimeUnzoned).has_value(), "Annotation: empty u-ca value rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15[u-ca=ab]"_s, P::DateTimeUnzoned).has_value(), "Annotation: 2-char value rejected");
+}
+
+static void testParseShortFormFlag()
+{
+    // Step 4.a.ii.(3)/(4): isShortForm flag for YearMonth/MonthDay short forms.
+    TCHECK_TRUE(ISO8601::parseISODateTime("2020-01"_s, P::YearMonth).value().isShortForm, "Step 4.a.ii.(3): YM short form");
+    TCHECK_TRUE(ISO8601::parseISODateTime("202001"_s, P::YearMonth).value().isShortForm, "Step 4.a.ii.(3): YM compact");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2020-01-15"_s, P::YearMonth).value().isShortForm, "Step 4.a.ii.(3): YM full date → not short");
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("01-15"_s, P::MonthDay).value().isShortForm, "Step 4.a.ii.(4): MD short form");
+    TCHECK_TRUE(ISO8601::parseISODateTime("--01-15"_s, P::MonthDay).value().isShortForm, "Step 4.a.ii.(4): MD --MM-DD");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2020-01-15"_s, P::MonthDay).value().isShortForm, "Step 4.a.ii.(4): MD full date → not short");
+
+    // Other goals never set isShortForm
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2020-01-15"_s, P::DateTimeUnzoned).value().isShortForm, "isShortForm: false for DateTimeUnzoned");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("12:00:00"_s, P::Time).value().isShortForm, "isShortForm: false for Time");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, P::Instant).value().isShortForm, "isShortForm: false for Instant");
+}
+
+static void testParseFullUnion()
+{
+    // ParseTemporalCalendarString uses the full 6-production union.
+    PSet fullUnion {
+        P::DateTimeZoned, P::DateTimeUnzoned, P::Instant,
+        P::YearMonth, P::MonthDay, P::Time,
+    };
+
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15"_s, fullUnion).has_value(), "Full union: bare date");
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, fullUnion).value().matched == P::Instant, "Full union: Instant priority");
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01-15T12:00:00[UTC]"_s, fullUnion).value().matched == P::DateTimeZoned, "Full union: Zoned over Unzoned");
+    TCHECK_TRUE(ISO8601::parseISODateTime("2024-01"_s, fullUnion).value().matched == P::YearMonth, "Full union: YearMonth match");
+    TCHECK_TRUE(ISO8601::parseISODateTime("01-15"_s, fullUnion).value().matched == P::MonthDay, "Full union: MonthDay match");
+    TCHECK_TRUE(ISO8601::parseISODateTime("12:00:00"_s, fullUnion).value().matched == P::Time, "Full union: Time match");
+
+    TCHECK_TRUE(!ISO8601::parseISODateTime("garbage"_s, fullUnion).has_value(), "Full union: garbage rejected");
+    TCHECK_TRUE(!ISO8601::parseISODateTime(""_s, fullUnion).has_value(), "Full union: empty rejected");
+}
+
+static void testParseDispatchPriority()
+{
+    // Dispatcher tries goals most-specific first; matched tag reflects narrowest production.
+    PSet maskA { P::Instant, P::DateTimeUnzoned };
+    auto r = ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, maskA);
+    TCHECK_TRUE(r.has_value() && r->matched == P::Instant, "Priority: Instant before DateTimeUnzoned");
+    TCHECK_TRUE(!ISO8601::parseISODateTime("2024-01-15T12:00:00Z"_s, P::DateTimeUnzoned).has_value(), "Priority: Unzoned alone rejects Z");
+
+    PSet maskB { P::DateTimeZoned, P::DateTimeUnzoned };
+    r = ISO8601::parseISODateTime("2024-01-15T12:00:00[UTC]"_s, maskB);
+    TCHECK_TRUE(r.has_value() && r->matched == P::DateTimeZoned, "Priority: Zoned before Unzoned for bracketed");
+
+    r = ISO8601::parseISODateTime("2024-01-15"_s, maskB);
+    TCHECK_TRUE(r.has_value() && r->matched == P::DateTimeUnzoned, "Priority: bare date falls to Unzoned");
 }
 
 // ---------------------------------------------------------------------------
@@ -3396,6 +3729,21 @@ static void runStressTests()
     testCalendarICUNonISO(); // Non-ISO calendars (hebrew, chinese, japanese, persian)
     testCalendarDateFromFields(); // calendarDateFromFields: era, monthCode, overflow, ROC, Japanese
     testCalendarFieldsFunctions(); // yearMonthFromFields, monthDayFromFields, differenceYearMonth, plainYearMonthAdd, etc.
+
+    // parseISODateTime
+    testParseInstantString();
+    testParseDateTimeStringUnzoned();
+    testParseDateTimeStringZoned();
+    testParseYearMonthString();
+    testParseMonthDayString();
+    testParseTimeString();
+    testParseDateMVs();
+    testParseTimeMVs();
+    testParseTimeZoneFields();
+    testParseAnnotationProcessing();
+    testParseShortFormFlag();
+    testParseFullUnion();
+    testParseDispatchPriority();
 }
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -740,103 +740,6 @@ static std::optional<Variant<Vector<Latin1Character>, int64_t>> parseTimeZoneAnn
 }
 
 template<typename CharacterType>
-static std::optional<TimeZoneRecord> parseTimeZone(StringParsingBuffer<CharacterType>& buffer)
-{
-    if (buffer.atEnd())
-        return std::nullopt;
-    switch (static_cast<char16_t>(*buffer)) {
-    // UTCDesignator
-    // https://tc39.es/proposal-temporal/#prod-UTCDesignator
-    case 'z':
-    case 'Z': {
-        buffer.advance();
-        if (!buffer.atEnd() && *buffer == '[' && canBeTimeZone(buffer, *buffer)) {
-            auto timeZone = parseTimeZoneAnnotation(buffer);
-            if (!timeZone)
-                return std::nullopt;
-            return TimeZoneRecord { true, std::nullopt, WTF::move(timeZone.value()) };
-        }
-        return TimeZoneRecord { true, std::nullopt, { } };
-    }
-    // TimeZoneUTCOffsetSign
-    // https://tc39.es/proposal-temporal/#prod-TimeZoneUTCOffsetSign
-    case '+':
-    case '-': {
-        bool hasSubMinute = false;
-        auto offset = parseUTCOffset(buffer, true /* parseSubMinutePrecision */, &hasSubMinute);
-        if (!offset)
-            return std::nullopt;
-        if (!buffer.atEnd() && *buffer == '[' && canBeTimeZone(buffer, *buffer)) {
-            auto timeZone = parseTimeZoneAnnotation(buffer);
-            if (!timeZone)
-                return std::nullopt;
-            return TimeZoneRecord { false, offset.value(), WTF::move(timeZone.value()), hasSubMinute };
-        }
-        return TimeZoneRecord { false, offset.value(), { }, hasSubMinute };
-    }
-    // TimeZoneBracketedAnnotation
-    // https://tc39.es/proposal-temporal/#prod-TimeZoneBracketedAnnotation
-    case '[': {
-        auto timeZone = parseTimeZoneAnnotation(buffer);
-        if (!timeZone)
-            return std::nullopt;
-        return TimeZoneRecord { false, std::nullopt, WTF::move(timeZone.value()) };
-    }
-    default:
-        return std::nullopt;
-    }
-}
-
-// parseTimeZoneForIdentifier — like parseTimeZone but restricts inline offsets to ±HH:MM (no sub-minute).
-// Used for TemporalTimeZoneString parsing per Stage 4 spec.
-template<typename CharacterType>
-static std::optional<TimeZoneRecord> parseTimeZoneForIdentifier(StringParsingBuffer<CharacterType>& buffer)
-{
-    if (buffer.atEnd())
-        return std::nullopt;
-    switch (static_cast<char16_t>(*buffer)) {
-    // UTCDesignator
-    // https://tc39.es/proposal-temporal/#prod-UTCDesignator
-    case 'z':
-    case 'Z': {
-        buffer.advance();
-        if (!buffer.atEnd() && *buffer == '[' && canBeTimeZone(buffer, *buffer)) {
-            auto timeZone = parseTimeZoneAnnotation(buffer);
-            if (!timeZone)
-                return std::nullopt;
-            return TimeZoneRecord { true, std::nullopt, WTF::move(timeZone.value()) };
-        }
-        return TimeZoneRecord { true, std::nullopt, { } };
-    }
-    // TimeZoneUTCOffsetSign
-    // https://tc39.es/proposal-temporal/#prod-TimeZoneUTCOffsetSign
-    case '+':
-    case '-': {
-        auto offset = parseUTCOffset(buffer, false);
-        if (!offset)
-            return std::nullopt;
-        if (!buffer.atEnd() && *buffer == '[' && canBeTimeZone(buffer, *buffer)) {
-            auto timeZone = parseTimeZoneAnnotation(buffer);
-            if (!timeZone)
-                return std::nullopt;
-            return TimeZoneRecord { false, offset.value(), WTF::move(timeZone.value()) };
-        }
-        return TimeZoneRecord { false, offset.value(), { } };
-    }
-    // TimeZoneAnnotation
-    // https://tc39.es/proposal-temporal/#prod-TimeZoneAnnotation
-    case '[': {
-        auto timeZone = parseTimeZoneAnnotation(buffer);
-        if (!timeZone)
-            return std::nullopt;
-        return TimeZoneRecord { false, std::nullopt, WTF::move(timeZone.value()) };
-    }
-    default:
-        return std::nullopt;
-    }
-}
-
-template<typename CharacterType>
 static std::optional<RFC9557Annotation> parseOneRFC9557Annotation(StringParsingBuffer<CharacterType>& buffer)
 {
     // For BNF, see comment in canBeRFC9557Annotation()
@@ -978,440 +881,551 @@ parseCalendar(StringParsingBuffer<CharacterType>& buffer)
     return result;
 }
 
-template<typename CharacterType>
-static std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>>> parseTime(StringParsingBuffer<CharacterType>& buffer)
-{
-    // https://tc39.es/proposal-temporal/#prod-Time
-    // Time :
-    //     TimeSpec TimeZone[opt]
-    auto plainTime = parseTimeSpec(buffer, Second60Mode::Accept);
-    if (!plainTime)
-        return std::nullopt;
-    if (buffer.atEnd())
-        return std::tuple { WTF::move(plainTime.value()), std::nullopt };
-    if (canBeTimeZone(buffer, *buffer)) {
-        auto timeZone = parseTimeZone(buffer);
-        if (!timeZone)
-            return std::nullopt;
-        return std::tuple { WTF::move(plainTime.value()), WTF::move(timeZone) };
-    }
-    return std::tuple { WTF::move(plainTime.value()), std::nullopt };
-}
+// Date primitives — strict per-production parsers per spec grammar.
+// https://tc39.es/proposal-temporal/#prod-Date
 
 template<typename CharacterType>
-static bool NODELETE canBeYear(StringParsingBuffer<CharacterType>& buffer)
+static std::optional<int32_t> NODELETE parseDateYear(StringParsingBuffer<CharacterType>& buffer)
 {
-    // 4 characters for year, plus 2 more for month
-    if (buffer.lengthRemaining() < 6)
-        return false;
-    bool hasPrefix = buffer[0] == '+' || buffer[0] == '-';
-    if (!isASCIIDigit(buffer[0]) && !hasPrefix)
-        return false;
-    size_t start = hasPrefix ? 1 : 0;
-    for (size_t i = start; i < 4 + start; i++) {
+    if (buffer.atEnd())
+        return std::nullopt;
+    bool extended = false;
+    int factor = 1;
+    if (*buffer == '+') {
+        buffer.advance();
+        extended = true;
+    } else if (*buffer == '-') {
+        buffer.advance();
+        extended = true;
+        factor = -1;
+    }
+    unsigned digits = extended ? 6 : 4;
+    if (buffer.lengthRemaining() < digits)
+        return std::nullopt;
+    for (unsigned i = 0; i < digits; ++i) {
         if (!isASCIIDigit(buffer[i]))
-            return false;
+            return std::nullopt;
     }
-    // The character after the 4-digit year must be '-' or a digit (for YYYY-MM or YYYYMMDD).
-    // If it is '[' (timezone annotation start), the 4 digits are MMDD, not a year.
-    // e.g. "1118[+01:00]" — buffer[4]='[' -> not a year, treat as MMDD.
-    auto following = buffer[4 + start];
-    return isASCIIDigit(following) || following == '-';
+    int32_t year = parseDecimalInt32(std::span { buffer.position(), digits }) * factor;
+    // -000000 is not allowed per spec.
+    if (!year && factor < 0)
+        return std::nullopt;
+    buffer.advanceBy(digits);
+    return year;
 }
 
 template<typename CharacterType>
-static std::optional<PlainDate> NODELETE parseDate(StringParsingBuffer<CharacterType>& buffer, TemporalDateFormat format)
+static std::optional<unsigned> parseDateMonth(StringParsingBuffer<CharacterType>& buffer)
 {
-    // https://tc39.es/proposal-temporal/#prod-Date
-    // Date :
-    //     DateYear - DateMonth - DateDay
-    //     DateYear DateMonth DateDay
-    //
-    // DateYear :
-    //     DateFourDigitYear
-    //     DateExtendedYear
-    //
-    // DateFourDigitYear :
-    //     Digit Digit Digit Digit
-    //
-    // DateExtendedYear :
-    //     Sign Digit Digit Digit Digit Digit Digit
-    //
-    // DateMonth :
-    //     0 NonzeroDigit
-    //     10
-    //     11
-    //     12
-    //
-    // DateDay :
-    //     0 NonzeroDigit
-    //     1 Digit
-    //     2 Digit
-    //     30
-    //     31
-    //
-    //  DateSpecYearMonth :::
-    //      DateYear DateSeparator_[+Extended] DateMonth
-    //      DateYear DateSeparator_[~Extended] DateMonth
-    //
-    //  DateSpecMonthDay :::
-    //      --opt DateMonth DateSeparator_[+Extended] DateDay
-    //      --opt DateMonth DateSeparator_[~Extended] DateDay
-
-    if (buffer.atEnd())
-        return std::nullopt;
-
-    int32_t year = 0;
-    bool splitByHyphen = false;
-
-    if (*buffer == '-') {
-        if (buffer.lengthRemaining() > 2
-            && buffer[1] == '-'
-            && format == TemporalDateFormat::MonthDay) {
-            buffer.advanceBy(2);
-        }
-    }
-
-    // Look ahead to distinguish month from year
-    if (canBeYear(buffer)) {
-        bool sixDigitsYear = false;
-        int yearFactor = 1;
-        if (*buffer == '+') {
-            buffer.advance();
-            sixDigitsYear = true;
-        } else if (*buffer == '-') {
-            yearFactor = -1;
-            buffer.advance();
-            sixDigitsYear = true;
-        } else if (!isASCIIDigit(*buffer))
-            return std::nullopt;
-
-        if (sixDigitsYear) {
-            if (buffer.lengthRemaining() < 6)
-                return std::nullopt;
-            for (unsigned index = 0; index < 6; ++index) {
-                if (!isASCIIDigit(buffer[index]))
-                    return std::nullopt;
-            }
-            year = parseDecimalInt32(std::span { buffer.position(), 6 }) * yearFactor;
-            if (!year && yearFactor < 0)
-                return std::nullopt;
-            buffer.advanceBy(6);
-        } else {
-            if (buffer.lengthRemaining() < 4)
-                return std::nullopt;
-            for (unsigned index = 0; index < 4; ++index) {
-                if (!isASCIIDigit(buffer[index]))
-                return std::nullopt;
-            }
-            year = parseDecimalInt32(std::span { buffer.position(), 4 });
-            buffer.advanceBy(4);
-        }
-
-        if (buffer.atEnd())
-            return std::nullopt;
-
-        if (*buffer == '-') {
-            splitByHyphen = true;
-            buffer.advance();
-        }
-    } else {
-        // Per the Temporal grammar, Date and DateSpecYearMonth both require DateYear.
-        // Only DateSpecMonthDay permits the no-year form.
-        if (format != TemporalDateFormat::MonthDay)
-            return std::nullopt;
-    }
-
-    unsigned month = 0;
     if (buffer.lengthRemaining() < 2)
         return std::nullopt;
-    auto firstMonthCharacter = *buffer;
-    if (firstMonthCharacter == '0' || firstMonthCharacter == '1') {
-        buffer.advance();
-        auto secondMonthCharacter = *buffer;
-        if (!isASCIIDigit(secondMonthCharacter))
-            return std::nullopt;
-        month = (secondMonthCharacter - '0') + 10 * (firstMonthCharacter - '0');
-        if (!month || month > 12)
-            return std::nullopt;
-        buffer.advance();
-    } else
+    auto c1 = *buffer;
+    if (c1 != '0' && c1 != '1')
         return std::nullopt;
-
-    // For YearMonth format: return after year+month. If we used a hyphen separator
-    // and the next char is not '-', there is no day component (e.g. "2020-01[u-ca=..."],
-    // "2020-01", "2020-01Z"). For compact format (splitByHyphen=false), fall through
-    // so the day digits (e.g. "18" in "19761118T...") are consumed correctly.
-    if (format == TemporalDateFormat::YearMonth && (buffer.atEnd() || (splitByHyphen && *buffer != '-'))) {
-        if (!isYearWithinLimits(year)) [[unlikely]]
-            year = outOfRangeYear;
-        return PlainDate(year, month, 1);
-    }
-
-    if (buffer.atEnd())
+    auto c2 = buffer[1];
+    if (!isASCIIDigit(c2))
         return std::nullopt;
-
-    bool consumedDaySeparator = false;
-    if (*buffer == '-') {
-        if (splitByHyphen || format != TemporalDateFormat::Date) {
-            buffer.advance();
-            consumedDaySeparator = true;
-        } else
-            return std::nullopt;
-    } else if (splitByHyphen)
-        return std::nullopt;
-
-    unsigned day = 0;
-    if (buffer.lengthRemaining() >= 2 && *buffer >= '0' && *buffer <= '3') {
-        auto firstDayCharacter = *buffer;
-        buffer.advance();
-        auto secondDayCharacter = *buffer;
-        if (!isASCIIDigit(secondDayCharacter))
-            return std::nullopt;
-        day = (secondDayCharacter - '0') + 10 * (firstDayCharacter - '0');
-        if (!day || day > daysInMonth(year, month))
-            return std::nullopt;
-        buffer.advance();
-    } else if (consumedDaySeparator || format != TemporalDateFormat::YearMonth)
-        return std::nullopt;
-
-    // PlainDate represents out-of-range years using outOfRangeYear
-    if (!isYearWithinLimits(year)) [[unlikely]]
-        year = outOfRangeYear;
-
-    switch (format) {
-    case TemporalDateFormat::Date:
-        return PlainDate(year, month, day);
-    case TemporalDateFormat::YearMonth:
-        return PlainDate(year, month, 1);
-    case TemporalDateFormat::MonthDay:
-        return PlainDate(1972, month, day);
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-}
-
-template<typename CharacterType>
-static std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>>> parseDateTime(StringParsingBuffer<CharacterType>& buffer, TemporalDateFormat format)
-{
-    // https://tc39.es/proposal-temporal/#prod-DateTime
-    // DateTime :
-    //     Date TimeSpecSeparator[opt] TimeZone[opt]
-    //
-    // TimeSpecSeparator :
-    //     DateTimeSeparator TimeSpec
-    auto plainDate = parseDate(buffer, format);
-    if (!plainDate)
-        return std::nullopt;
-    if (buffer.atEnd())
-        return std::tuple { WTF::move(plainDate.value()), std::nullopt, std::nullopt };
-
-    if (*buffer == ' ' || *buffer == 'T' || *buffer == 't') {
-        buffer.advance();
-        auto plainTimeAndTimeZone = parseTime(buffer);
-        if (!plainTimeAndTimeZone)
-            return std::nullopt;
-        auto [plainTime, timeZone] = WTF::move(plainTimeAndTimeZone.value());
-        return std::tuple { WTF::move(plainDate.value()), WTF::move(plainTime), WTF::move(timeZone) };
-    }
-
-    if (!buffer.atEnd() && *buffer == '[' && canBeTimeZone(buffer, *buffer)) {
-        // DateTime : Date TimeZoneAnnotation  (no time separator) — e.g. "2020-01-01[+09:00]"
-        // Only bracket annotations are valid after a bare date; bare UTC offsets (Z, +HH:MM) require a time.
-        auto timeZone = parseTimeZone(buffer);
-        if (!timeZone)
-            return std::nullopt;
-        return std::tuple { WTF::move(plainDate.value()), std::nullopt, WTF::move(timeZone) };
-    }
-
-    if (canBeTimeZone(buffer, *buffer))
-        return std::nullopt;
-
-    return std::tuple { WTF::move(plainDate.value()), std::nullopt, std::nullopt };
-}
-
-template<typename CharacterType>
-static std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarTime(StringParsingBuffer<CharacterType>& buffer)
-{
-    // https://tc39.es/proposal-temporal/#prod-CalendarTime
-    // CalendarTime :
-    //     TimeDesignator TimeSpec TimeZone[opt] Calendar[opt]
-    //     TimeSpec TimeZone[opt] Calendar
-    //     TimeSpecWithOptionalTimeZoneNotAmbiguous
-
-    if (buffer.atEnd())
-        return std::nullopt;
-
-    if (*buffer == 'T' || *buffer == 't')
-        buffer.advance();
-
-    auto plainTime = parseTimeSpec(buffer, Second60Mode::Accept);
-    if (!plainTime)
-        return std::nullopt;
-    if (buffer.atEnd())
-        return std::tuple { WTF::move(plainTime.value()), std::nullopt, std::nullopt };
-
-    std::optional<TimeZoneRecord> timeZoneOptional;
-    if (canBeTimeZone(buffer, *buffer)) {
-        auto timeZone = parseTimeZone(buffer);
-        if (!timeZone)
-            return std::nullopt;
-        timeZoneOptional = WTF::move(timeZone);
-    }
-
-    if (buffer.atEnd())
-        return std::tuple { WTF::move(plainTime.value()), WTF::move(timeZoneOptional), std::nullopt };
-
-    std::optional<CalendarID> calendarOptional;
-    if (canBeRFC9557Annotation(buffer)) {
-        auto calendars = parseCalendar(buffer);
-        if (!calendars)
-            return std::nullopt;
-        if (calendars.value().size() > 0)
-            calendarOptional = WTF::move(calendars.value()[0]);
-    }
-
-    return std::tuple { WTF::move(plainTime.value()), WTF::move(timeZoneOptional), WTF::move(calendarOptional) };
-}
-
-template<typename CharacterType>
-static std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarDateTime(StringParsingBuffer<CharacterType>& buffer, TemporalDateFormat format)
-{
-    // https://tc39.es/proposal-temporal/#prod-DateTime
-    // CalendarDateTime :
-    //     DateTime CalendarName[opt]
-    //
-    auto dateTime = parseDateTime(buffer, format);
-    if (!dateTime)
-        return std::nullopt;
-
-    auto [plainDate, plainTimeOptional, timeZoneOptional] = WTF::move(dateTime.value());
-
-    std::optional<CalendarID> calendarOptional;
-    if (!buffer.atEnd() && canBeRFC9557Annotation(buffer)) {
-        auto calendars = parseCalendar(buffer);
-        if (!calendars)
-            return std::nullopt;
-        if (calendars.value().size() > 0)
-            calendarOptional = WTF::move(calendars.value()[0]);
-    }
-
-    return std::tuple { WTF::move(plainDate), WTF::move(plainTimeOptional), WTF::move(timeZoneOptional), WTF::move(calendarOptional) };
-}
-
-std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>>> parseTime(StringView string)
-{
-    return readCharactersForParsing(string, [](auto buffer) -> std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>>> {
-        auto result = parseTime(buffer);
-        if (!buffer.atEnd())
-            return std::nullopt;
-        return result;
-    });
-}
-
-template<typename CharacterType>
-static bool NODELETE isAmbiguousCalendarTime(StringParsingBuffer<CharacterType>& buffer)
-{
-    auto length = buffer.lengthRemaining();
-    ASSERT(length > 1);
-
-    // There is no ambiguity if we have a TimeDesignator.
-    if (toASCIIUpper(*buffer) == 'T')
-        return false;
-
-    // The string is known to be valid as `TimeSpec TimeZone[opt] Calendar[opt]`.
-    // The ambiguity check compares the time-spec PREFIX against date patterns.
-    // Timezone/calendar annotations follow the spec portion, so we must check only
-    // the spec-length prefix — not the full string. Scan forward to find where the
-    // spec ends: the first '[' or 'Z'/'z' starts a timezone/calendar annotation.
-    unsigned specLength = 0;
-    while (specLength < length && buffer[specLength] != '[' && toASCIIUpper(buffer[specLength]) != 'Z')
-        specLength++;
-
-    // Actual ambiguous possibilities are YYYY-MM, YYYYMM, MM-DD, MMDD.
-    ASSERT(isASCIIDigit(buffer[0]) && isASCIIDigit(buffer[1]));
-
-    unsigned monthPartLength = 2;
-    switch (specLength) {
-    case 7:
-        if (!isASCIIDigit(buffer[2]) || !isASCIIDigit(buffer[3]) || buffer[4] != '-' || !isASCIIDigit(buffer[5]) || !isASCIIDigit(buffer[6]))
-            return false;
-        buffer.advanceBy(5);
-        break;
-    case 6:
-        if (!isASCIIDigit(buffer[2]) || !isASCIIDigit(buffer[3]) || !isASCIIDigit(buffer[4]) || !isASCIIDigit(buffer[5]))
-            return false;
-        buffer.advanceBy(4);
-        break;
-    case 5:
-        if (buffer[2] != '-' || !isASCIIDigit(buffer[3]) || !isASCIIDigit(buffer[4]))
-            return false;
-        monthPartLength++;
-        break;
-    case 4:
-        if (!isASCIIDigit(buffer[2]) || !isASCIIDigit(buffer[3]))
-            return false;
-        break;
-    default:
-        return false;
-    }
-
-    // Any YYYY is valid, we just need to check the MM and DD.
-    unsigned month = (buffer[0] - '0') * 10 + (buffer[1] - '0');
+    unsigned month = (c2 - '0') + 10 * (c1 - '0');
     if (!month || month > 12)
+        return std::nullopt;
+    buffer.advanceBy(2);
+    return month;
+}
+
+template<typename CharacterType>
+static std::optional<unsigned> parseDateDay(StringParsingBuffer<CharacterType>& buffer, int32_t year, unsigned month)
+{
+    if (buffer.lengthRemaining() < 2)
+        return std::nullopt;
+    auto c1 = *buffer;
+    if (c1 < '0' || c1 > '3')
+        return std::nullopt;
+    auto c2 = buffer[1];
+    if (!isASCIIDigit(c2))
+        return std::nullopt;
+    unsigned day = (c2 - '0') + 10 * (c1 - '0');
+    if (!day || day > daysInMonth(year, month))
+        return std::nullopt;
+    buffer.advanceBy(2);
+    return day;
+}
+
+// Date :::
+//   DateYear DateSeparator[+Extended] DateMonth DateSeparator[+Extended] DateDay   (YYYY-MM-DD)
+//   DateYear DateSeparator[~Extended] DateMonth DateSeparator[~Extended] DateDay   (YYYYMMDD)
+// Both separators must be the SAME mode (extended-with-hyphen or compact-no-hyphen).
+template<typename CharacterType>
+static std::optional<PlainDate> NODELETE parseDate(StringParsingBuffer<CharacterType>& buffer)
+{
+    auto year = parseDateYear(buffer);
+    if (!year)
+        return std::nullopt;
+    bool extended = false;
+    if (!buffer.atEnd() && *buffer == '-') {
+        extended = true;
+        buffer.advance();
+    }
+    auto month = parseDateMonth(buffer);
+    if (!month)
+        return std::nullopt;
+    if (extended) {
+        if (buffer.atEnd() || *buffer != '-')
+            return std::nullopt;
+        buffer.advance();
+    } else if (!buffer.atEnd() && *buffer == '-') {
+        // Mixed compact/extended forbidden.
+        return std::nullopt;
+    }
+    auto day = parseDateDay(buffer, *year, *month);
+    if (!day)
+        return std::nullopt;
+    int32_t y = *year;
+    if (!isYearWithinLimits(y)) [[unlikely]]
+        y = outOfRangeYear;
+    return PlainDate(y, *month, *day);
+}
+
+// DateSpecYearMonth ::: DateYear DateSeparator[?Extended] DateMonth   (YYYY-MM or YYYYMM)
+template<typename CharacterType>
+static std::optional<PlainDate> NODELETE parseDateSpecYearMonth(StringParsingBuffer<CharacterType>& buffer)
+{
+    auto year = parseDateYear(buffer);
+    if (!year)
+        return std::nullopt;
+    if (!buffer.atEnd() && *buffer == '-')
+        buffer.advance();
+    auto month = parseDateMonth(buffer);
+    if (!month)
+        return std::nullopt;
+    int32_t y = *year;
+    if (!isYearWithinLimits(y)) [[unlikely]]
+        y = outOfRangeYear;
+    return PlainDate(y, *month, 1);
+}
+
+// DateSpecMonthDay :::
+//   `--`? DateMonth DateSeparator[+Extended] DateDay   (--MM-DD or MM-DD)
+//   `--`? DateMonth DateSeparator[~Extended] DateDay   (--MMDD or MMDD)
+template<typename CharacterType>
+static std::optional<PlainDate> NODELETE parseDateSpecMonthDay(StringParsingBuffer<CharacterType>& buffer)
+{
+    if (buffer.lengthRemaining() >= 2 && buffer[0] == '-' && buffer[1] == '-')
+        buffer.advanceBy(2);
+    auto month = parseDateMonth(buffer);
+    if (!month)
+        return std::nullopt;
+    if (!buffer.atEnd() && *buffer == '-')
+        buffer.advance();
+    auto day = parseDateDay(buffer, /* reference year for daysInMonth */ 1972, *month);
+    if (!day)
+        return std::nullopt;
+    return PlainDate(1972, *month, *day);
+}
+
+struct ISO8601ParseTokens {
+    std::optional<int32_t> year; // DateYear
+    std::optional<unsigned> month; // DateMonth
+    std::optional<unsigned> day; // DateDay
+    std::optional<PlainTime> time; // Hour-bearing Time (already CreateTimeRecord'd)
+    bool hasUTCDesignator { false };
+    std::optional<int64_t> utcOffsetNs;
+    bool offsetHasSubMinutePrecision { false };
+    Variant<std::monostate, Vector<Latin1Character>, int64_t> tzAnnotation { std::monostate { } };
+    std::optional<CalendarID> calendar;
+    TemporalProduction matchedGoal { };
+};
+
+// Parse `TimeZoneAnnotation? Annotations?`. annotationRequired enforces [+Zoned].
+template<typename CharacterType>
+static bool parseTrailingTokens(StringParsingBuffer<CharacterType>& buffer, ISO8601ParseTokens& tokens, bool annotationRequired)
+{
+    if (!buffer.atEnd() && *buffer == '[' && canBeTimeZone(buffer, *buffer)) {
+        auto annotation = parseTimeZoneAnnotation(buffer);
+        if (!annotation)
+            return false;
+        if (auto* name = std::get_if<Vector<Latin1Character>>(&*annotation))
+            tokens.tzAnnotation = WTF::move(*name);
+        else
+            tokens.tzAnnotation = std::get<int64_t>(*annotation);
+    } else if (annotationRequired)
         return false;
 
-    buffer.advanceBy(monthPartLength);
-    // Check for a DD component only when the next character is a digit.
-    // After advancing past MM, the buffer may point at a '[' or '+'/'-' from a
-    // timezone annotation rather than actual day digits — guard with isASCIIDigit.
-    if (buffer.hasCharactersRemaining() && isASCIIDigit(buffer[0])) {
-        unsigned day = (buffer[0] - '0') * 10 + (buffer[1] - '0');
-        if (!day || day > daysInMonth(month))
+    if (!buffer.atEnd() && canBeRFC9557Annotation(buffer)) {
+        // Step 4.a.ii.(1)–(2): annotation loop + critical-flag rules.
+        auto calendars = parseCalendar(buffer);
+        if (!calendars)
             return false;
+        if (calendars->size() > 0)
+            tokens.calendar = WTF::move((*calendars)[0]);
     }
-
     return true;
 }
 
-std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarTime(StringView string)
+// TemporalInstantString :::
+//   Date DateTimeSeparator Time DateTimeUTCOffset[+Z] TimeZoneAnnotation? Annotations?
+template<typename CharacterType>
+static std::optional<ISO8601ParseTokens> tokenizeTemporalInstantString(StringParsingBuffer<CharacterType>& buffer)
 {
-    auto tuple = readCharactersForParsing(string, [](auto buffer) -> std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> {
-        auto result = parseCalendarTime(buffer);
-        if (!buffer.atEnd())
-            return std::nullopt;
-        return result;
-    });
+    ISO8601ParseTokens tokens;
 
-    // Verify the parse isn't ambiguous with DateSpecYearMonth or DateSpecMonthDay.
-    // A calendar annotation does NOT resolve ambiguity — "2021-12[u-ca=iso8601]" is
-    // still ambiguous (year-month vs time). Only a T prefix makes it unambiguous.
-    if (tuple) {
-        if (readCharactersForParsing(string, [](auto buffer) -> bool { return isAmbiguousCalendarTime(buffer); }))
+    auto date = parseDate(buffer);
+    if (!date)
+        return std::nullopt;
+    tokens.year = date->year();
+    tokens.month = date->month();
+    tokens.day = date->day();
+
+    // DateTimeSeparator (required).
+    if (buffer.atEnd() || (*buffer != 'T' && *buffer != 't' && *buffer != ' '))
+        return std::nullopt;
+    buffer.advance();
+
+    auto time = parseTimeSpec(buffer, Second60Mode::Accept);
+    if (!time)
+        return std::nullopt;
+    tokens.time = *time;
+
+    // DateTimeUTCOffset[+Z] (required by grammar): UTCDesignator OR UTCOffset.
+    if (buffer.atEnd())
+        return std::nullopt;
+    if (*buffer == 'Z' || *buffer == 'z') {
+        tokens.hasUTCDesignator = true;
+        buffer.advance();
+    } else if (*buffer == '+' || *buffer == '-') {
+        bool subMinute = false;
+        auto off = parseUTCOffset(buffer, true, &subMinute);
+        if (!off)
             return std::nullopt;
+        tokens.utcOffsetNs = *off;
+        tokens.offsetHasSubMinutePrecision = subMinute;
+    } else
+        return std::nullopt;
+
+    if (!parseTrailingTokens(buffer, tokens, false))
+        return std::nullopt;
+    tokens.matchedGoal = TemporalProduction::Instant;
+    return tokens;
+}
+
+// TemporalDateTimeString[Zoned] ::: AnnotatedDateTime[?Zoned, ~TimeRequired]
+// AnnotatedDateTime[+Zoned, _] ::: DateTime[+Z, _] TimeZoneAnnotation Annotations?
+// AnnotatedDateTime[~Zoned, _] ::: DateTime[~Z, _] TimeZoneAnnotation? Annotations?
+// DateTime[Z, ~TimeRequired] ::: Date | Date DateTimeSeparator Time DateTimeUTCOffset[?Z]?
+// (timeRequired=true forbids the bare-Date alternative.)
+template<typename CharacterType>
+static std::optional<ISO8601ParseTokens> tokenizeTemporalDateTimeString(StringParsingBuffer<CharacterType>& buffer, bool zoned, bool timeRequired)
+{
+    ISO8601ParseTokens tokens;
+
+    auto date = parseDate(buffer);
+    if (!date)
+        return std::nullopt;
+    tokens.year = date->year();
+    tokens.month = date->month();
+    tokens.day = date->day();
+
+    if (!buffer.atEnd() && (*buffer == 'T' || *buffer == 't' || *buffer == ' ')) {
+        buffer.advance();
+        auto time = parseTimeSpec(buffer, Second60Mode::Accept);
+        if (!time)
+            return std::nullopt;
+        tokens.time = *time;
+        if (!buffer.atEnd()) {
+            if (*buffer == 'Z' || *buffer == 'z') {
+                if (!zoned) // [~Zoned] forbids Z
+                    return std::nullopt;
+                tokens.hasUTCDesignator = true;
+                buffer.advance();
+            } else if (*buffer == '+' || *buffer == '-') {
+                bool subMinute = false;
+                auto off = parseUTCOffset(buffer, true, &subMinute);
+                if (!off)
+                    return std::nullopt;
+                tokens.utcOffsetNs = *off;
+                tokens.offsetHasSubMinutePrecision = subMinute;
+            }
+        }
+    } else if (timeRequired)
+        return std::nullopt;
+
+    if (!parseTrailingTokens(buffer, tokens, zoned))
+        return std::nullopt;
+    tokens.matchedGoal = zoned ? TemporalProduction::DateTimeZoned : TemporalProduction::DateTimeUnzoned;
+    return tokens;
+}
+
+// TemporalYearMonthString ::: AnnotatedYearMonth | AnnotatedDateTime[~Zoned, ~TimeRequired]
+// AnnotatedYearMonth ::: DateSpecYearMonth TimeZoneAnnotation? Annotations?
+template<typename CharacterType>
+static std::optional<ISO8601ParseTokens> tokenizeTemporalYearMonthString(StringParsingBuffer<CharacterType>& buffer)
+{
+    auto restorePoint = buffer;
+    if (auto date = parseDateSpecYearMonth(buffer)) {
+        ISO8601ParseTokens tokens;
+        tokens.year = date->year();
+        tokens.month = date->month();
+        // Intentionally leave tokens.day as nullopt — DateSpecYearMonth has no DateDay Parse Node.
+        if (parseTrailingTokens(buffer, tokens, false) && buffer.atEnd()) {
+            tokens.matchedGoal = TemporalProduction::YearMonth;
+            return tokens;
+        }
+    }
+    // Fall back to AnnotatedDateTime[~Zoned, ~TimeRequired].
+    buffer = restorePoint;
+    auto t = tokenizeTemporalDateTimeString(buffer, /* zoned */ false, /* timeRequired */ false);
+    if (!t)
+        return std::nullopt;
+    t->matchedGoal = TemporalProduction::YearMonth;
+    return t;
+}
+
+// TemporalMonthDayString ::: AnnotatedMonthDay | AnnotatedDateTime[~Zoned, ~TimeRequired]
+// AnnotatedMonthDay ::: DateSpecMonthDay TimeZoneAnnotation? Annotations?
+template<typename CharacterType>
+static std::optional<ISO8601ParseTokens> tokenizeTemporalMonthDayString(StringParsingBuffer<CharacterType>& buffer)
+{
+    auto restorePoint = buffer;
+    if (auto date = parseDateSpecMonthDay(buffer)) {
+        ISO8601ParseTokens tokens;
+        // Intentionally leave tokens.year as nullopt — DateSpecMonthDay has no DateYear Parse Node.
+        tokens.month = date->month();
+        tokens.day = date->day();
+        if (parseTrailingTokens(buffer, tokens, false) && buffer.atEnd()) {
+            tokens.matchedGoal = TemporalProduction::MonthDay;
+            return tokens;
+        }
+    }
+    buffer = restorePoint;
+    auto t = tokenizeTemporalDateTimeString(buffer, /* zoned */ false, /* timeRequired */ false);
+    if (!t)
+        return std::nullopt;
+    t->matchedGoal = TemporalProduction::MonthDay;
+    return t;
+}
+
+// AnnotatedTime branch of TemporalTimeString:
+//   TimeDesignator? Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
+// (TemporalTimeString also matches AnnotatedDateTime[~Zoned, +TimeRequired]; tried as fallback.)
+template<typename CharacterType>
+static std::optional<ISO8601ParseTokens> tokenizeTemporalAnnotatedTime(StringParsingBuffer<CharacterType>& buffer)
+{
+    if (!buffer.atEnd() && (*buffer == 'T' || *buffer == 't'))
+        buffer.advance();
+    auto time = parseTimeSpec(buffer, Second60Mode::Accept);
+    if (!time)
+        return std::nullopt;
+
+    ISO8601ParseTokens tokens;
+    tokens.time = *time;
+
+    if (!buffer.atEnd()) {
+        if (*buffer == 'Z' || *buffer == 'z')
+            return std::nullopt; // DateTimeUTCOffset[~Z] forbids Z.
+        if (*buffer == '+' || *buffer == '-') {
+            bool subMinute = false;
+            auto off = parseUTCOffset(buffer, true, &subMinute);
+            if (!off)
+                return std::nullopt;
+            tokens.utcOffsetNs = *off;
+            tokens.offsetHasSubMinutePrecision = subMinute;
+        }
+    }
+    if (!parseTrailingTokens(buffer, tokens, false))
+        return std::nullopt;
+    tokens.matchedGoal = TemporalProduction::Time;
+    return tokens;
+}
+
+// AnnotatedTime: Static Semantics: Early Errors
+// https://tc39.es/proposal-temporal/#sec-temporal-iso8601grammar-static-semantics-early-errors
+//
+// AnnotatedTime ::: Time DateTimeUTCOffset[~Z]? TimeZoneAnnotation? Annotations?
+template<typename CharacterType>
+static bool NODELETE isAmbiguousAnnotatedTime(StringParsingBuffer<CharacterType>& buffer)
+{
+    if (!buffer.hasCharactersRemaining())
+        return false;
+
+    // The rules attach to the no-TimeDesignator alternative only.
+    if (toASCIIUpper(*buffer) == 'T')
+        return false;
+
+    // Step 1. Extract the substring corresponding to `Time DateTimeUTCOffset[~Z]`: scan to
+    // the optional TimeZoneAnnotation `[`. The `[~Z]` parameter forbids `Z`/`z` here, so `[`
+    // is the only delimiter that can appear.
+    auto length = buffer.lengthRemaining();
+    unsigned prefixLength = 0;
+    while (prefixLength < length && buffer[prefixLength] != '[')
+        prefixLength++;
+    auto prefix = buffer.span().first(prefixLength);
+
+    // Step 2. ParseText(prefix, DateSpecMonthDay) — Syntax Error if it is a Parse Node.
+    {
+        StringParsingBuffer p(prefix);
+        if (parseDateSpecMonthDay(p) && p.atEnd())
+            return true;
     }
 
-    return tuple;
+    // Step 3. ParseText(prefix, DateSpecYearMonth) — Syntax Error if it is a Parse Node.
+    {
+        StringParsingBuffer p(prefix);
+        if (parseDateSpecYearMonth(p) && p.atEnd())
+            return true;
+    }
+
+    return false;
 }
 
-std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>>> parseDateTime(StringView string, TemporalDateFormat format)
+// ParseISODateTime ( isoString, allowedFormats )
+// https://tc39.es/proposal-temporal/#sec-temporal-parseisodatetime
+//
+// FIXME: temporal_rs uses icu4x/utils/ixdtf (single-pass, ~3000 LoC) instead of
+// per-production tokenizers. ICU4C has no port; revisit if parsing profiles hot.
+std::optional<ParsedISODateTime> parseISODateTime(StringView string, TemporalProductionSet allowed)
 {
-    return readCharactersForParsing(string, [format](auto buffer) -> std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>>> {
-        auto result = parseDateTime(buffer, format);
-        if (!buffer.atEnd())
-            return std::nullopt;
-        return result;
-    });
-}
+    // Step 1. Let parseResult be ~empty~.
+    std::optional<ISO8601ParseTokens> parseResult;
 
-std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarDateTime(StringView string, TemporalDateFormat format)
-{
-    return readCharactersForParsing(string, [format](auto buffer) -> std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> {
-        auto result = parseCalendarDateTime(buffer, format);
-        if (!buffer.atEnd())
-            return std::nullopt;
-        return result;
-    });
+    // Step 2. Let calendar be ~empty~. (Stored in parseResult->calendar.)
+    // Step 3. Let yearAbsent be false. (Encoded as isShortForm && matchedGoal == MonthDay.)
+
+    // Step 4. For each goal: ParseText (Step 4.a.i) + annotation/short-form rules
+    //   (Steps 4.a.ii.(1)-(4)). Goals tried most-specific to least so the matched tag
+    //   reflects the narrowest production.
+    auto tryGoal = [&](auto&& tokenizer) {
+        if (parseResult) // Step 4.a guard.
+            return;
+        parseResult = readCharactersForParsing(string, [&](auto buf) -> std::optional<ISO8601ParseTokens> {
+            auto t = tokenizer(buf);
+            if (!t || !buf.atEnd())
+                return std::nullopt;
+            return t;
+        });
+    };
+
+    if (allowed.contains(TemporalProduction::Instant)) {
+        tryGoal([](auto& b) {
+            return tokenizeTemporalInstantString(b);
+        });
+    }
+    if (allowed.contains(TemporalProduction::DateTimeZoned)) {
+        tryGoal([](auto& b) {
+            return tokenizeTemporalDateTimeString(b, /* zoned */ true, /* timeRequired */ false);
+        });
+    }
+    if (allowed.contains(TemporalProduction::YearMonth)) {
+        tryGoal([](auto& b) {
+            return tokenizeTemporalYearMonthString(b);
+        });
+    }
+    if (allowed.contains(TemporalProduction::MonthDay)) {
+        tryGoal([](auto& b) {
+            return tokenizeTemporalMonthDayString(b);
+        });
+    }
+    if (allowed.contains(TemporalProduction::Time) && !parseResult) {
+        // TemporalTimeString = AnnotatedTime | AnnotatedDateTime[~Zoned, +TimeRequired].
+        tryGoal([](auto& b) {
+            return tokenizeTemporalAnnotatedTime(b);
+        });
+        if (parseResult) {
+            // AnnotatedTime: Static Semantics: Early Errors
+            bool ambiguous = readCharactersForParsing(string, [](auto buffer) -> bool {
+                return isAmbiguousAnnotatedTime(buffer);
+            });
+            if (ambiguous)
+                parseResult = std::nullopt;
+        }
+        if (!parseResult) {
+            tryGoal([](auto& b) -> std::optional<ISO8601ParseTokens> {
+                auto t = tokenizeTemporalDateTimeString(b, /* zoned */ false, /* timeRequired */ true);
+                if (t)
+                    t->matchedGoal = TemporalProduction::Time;
+                return t;
+            });
+        }
+    }
+    if (allowed.contains(TemporalProduction::DateTimeUnzoned)) {
+        tryGoal([](auto& b) {
+            return tokenizeTemporalDateTimeString(b, /* zoned */ false, /* timeRequired */ false);
+        });
+    }
+
+    // Step 4.a.ii.(3): goal=YearMonth and no DateDay -> calendar must be iso8601 or empty.
+    // Step 4.a.ii.(4): goal=MonthDay and no DateYear -> calendar must be iso8601 or empty.
+    // Both rules: throw RangeError if calendar is non-iso8601 — surfaced as nullopt to the caller.
+    bool isShortForm = false;
+    if (parseResult && parseResult->matchedGoal == TemporalProduction::YearMonth && !parseResult->day.has_value())
+        isShortForm = true;
+    if (parseResult && parseResult->matchedGoal == TemporalProduction::MonthDay && !parseResult->year.has_value())
+        isShortForm = true;
+    if (parseResult && isShortForm && parseResult->calendar && !WTF::equalIgnoringASCIICase(StringView(*parseResult->calendar), "iso8601"_s))
+        return std::nullopt;
+
+    // Step 5. If !parseResult, throw RangeError. (Caller wraps with type-specific message.)
+    if (!parseResult)
+        return std::nullopt;
+
+    // Step 6. NOTE: short numeric strings — StringToNumber lossless.
+
+    // Step 7. Extract source text per Parse Node (encoded in parseResult fields).
+
+    // Step 8. yearMV = ℝ(StringToNumber(year)).
+    int32_t yearMV = parseResult->year.value_or(0);
+    // Steps 9-10. monthMV (default 1).
+    unsigned monthMV = parseResult->month.value_or(1);
+    // Steps 11-12. dayMV (default 1).
+    unsigned dayMV = parseResult->day.value_or(1);
+    // Steps 13-20. hour/minute/second/fSeconds — already MV-extracted by parseTimeSpec
+    //   (Step 18.b leap-clamp + Steps 19-20 fractional padding folded in there).
+    PlainTime timeFields = parseResult->time.value_or(PlainTime { });
+
+    // Step 21. Assert IsValidISODate. parseDate validated the day against the parsed
+    // year before clamping out-of-range years to outOfRangeYear (see parseDate); the
+    // sentinel year is not necessarily a leap year, so allow it.
+    ASSERT(yearMV == outOfRangeYear || isValidISODate(yearMV, monthMV, dayMV));
+
+    // Steps 22-23. time = ~start-of-day~ if hour absent; else CreateTimeRecord(...).
+    std::optional<PlainTime> time;
+    if (parseResult->time.has_value())
+        time = timeFields;
+
+    // Step 24. timeZoneResult = { [[Z]]: false, [[OffsetString]]: ~empty~, [[TimeZoneAnnotation]]: ~empty~ }.
+    std::optional<TimeZoneRecord> timeZoneResult;
+    bool anyTzInfo = parseResult->hasUTCDesignator || parseResult->utcOffsetNs.has_value() || !std::holds_alternative<std::monostate>(parseResult->tzAnnotation);
+    if (anyTzInfo) {
+        TimeZoneRecord tz;
+        // Step 25. Set [[TimeZoneAnnotation]].
+        if (auto* name = std::get_if<Vector<Latin1Character>>(&parseResult->tzAnnotation))
+            tz.m_nameOrOffset = WTF::move(*name);
+        else if (auto* offsetVal = std::get_if<int64_t>(&parseResult->tzAnnotation))
+            tz.m_nameOrOffset = *offsetVal;
+        else
+            tz.m_nameOrOffset = Vector<Latin1Character> { };
+        // Step 26. Set [[Z]].
+        tz.m_z = parseResult->hasUTCDesignator;
+        // Step 27. Set [[OffsetString]].
+        tz.m_offset = parseResult->utcOffsetNs;
+        tz.m_offsetHasSubMinutePrecision = parseResult->offsetHasSubMinutePrecision;
+        timeZoneResult = WTF::move(tz);
+    }
+
+    // Step 28. yearReturn = empty if yearAbsent (encoded via isShortForm + matchedGoal == MonthDay).
+
+    // Step 29. Return ISO Date-Time Parse Record.
+    std::optional<PlainDate> dateOut;
+    bool dateBearingGoal = parseResult->matchedGoal != TemporalProduction::Time || parseResult->month.has_value();
+    if (dateBearingGoal)
+        dateOut = PlainDate(yearMV, monthMV, dayMV);
+
+    return ParsedISODateTime {
+        WTF::move(dateOut),
+        WTF::move(time),
+        WTF::move(timeZoneResult),
+        WTF::move(parseResult->calendar),
+        parseResult->matchedGoal,
+        isShortForm,
+    };
 }
 
 // https://tc39.es/proposal-temporal/#sec-parsetimezoneidentifier
@@ -2075,55 +2089,39 @@ std::optional<TimeZone> parseTemporalTimeZoneIdentifier(StringView string)
     if (auto tzId = parseTimeZoneName(string))
         return TimeZone::fromID(*tzId);
 
-    // 3. Let result be ? ParseISODateTime(timeZoneString, ...).
-    return readCharactersForParsing(string, [](auto buffer) -> std::optional<TimeZone> {
-        auto plainDate = parseDate(buffer, TemporalDateFormat::Date);
-        if (!plainDate)
-            return std::nullopt;
-
-        if (!buffer.atEnd() && (*buffer == 'T' || *buffer == 't' || *buffer == ' ')) {
-            buffer.advance();
-            auto plainTime = parseTimeSpec(buffer, Second60Mode::Accept);
-            if (!plainTime)
-                return std::nullopt;
-        }
-
-        if (buffer.atEnd() || !canBeTimeZone(buffer, *buffer))
-            return std::nullopt;
-
-        auto tzRecord = parseTimeZoneForIdentifier(buffer);
-        if (!tzRecord)
-            return std::nullopt;
-
-        if (!buffer.atEnd() && canBeRFC9557Annotation(buffer)) {
-            auto calendars = parseCalendar(buffer);
-            if (!calendars)
-                return std::nullopt;
-        }
-
-        if (!buffer.atEnd())
-            return std::nullopt;
-
-        // 4. Let timeZoneResult be result.[[TimeZone]].
-        // 5. If timeZoneResult.[[TimeZoneAnnotation]] is not ~empty~, return ! ParseTimeZoneIdentifier(timeZoneResult.[[TimeZoneAnnotation]]).
-        auto& nameOrOffset = tzRecord->m_nameOrOffset;
-        if (std::holds_alternative<int64_t>(nameOrOffset))
-            return TimeZone::fromUTCOffset(std::get<int64_t>(nameOrOffset));
-        auto& name = std::get<Vector<Latin1Character>>(nameOrOffset);
-        if (!name.isEmpty()) {
-            if (auto tzId = parseTimeZoneName(StringView(name.span())))
-                return TimeZone::fromID(*tzId);
-            return std::nullopt;
-        }
-        // 6. If timeZoneResult.[[Z]] is true, return ! ParseTimeZoneIdentifier("UTC").
-        if (tzRecord->m_z)
-            return TimeZone::fromID(utcTimeZoneID());
-        // 7. If timeZoneResult.[[OffsetString]] is not ~empty~, return ? ParseTimeZoneIdentifier(timeZoneResult.[[OffsetString]]).
-        if (tzRecord->m_offset)
-            return TimeZone::fromUTCOffset(*tzRecord->m_offset);
-        // 8. Throw a RangeError exception.
+    // 3. Let result be ? ParseISODateTime(timeZoneString,
+    //      « TemporalDateTimeString[+Zoned], TemporalInstantString »).
+    auto parsed = parseISODateTime(string, { TemporalProduction::DateTimeZoned, TemporalProduction::Instant });
+    if (!parsed || !parsed->timeZone)
         return std::nullopt;
-    });
+
+    // 4. Let timeZoneResult be result.[[TimeZone]].
+    const auto& tz = *parsed->timeZone;
+
+    // 5. If timeZoneResult.[[TimeZoneAnnotation]] is not ~empty~, return ! ParseTimeZoneIdentifier(...).
+    if (std::holds_alternative<int64_t>(tz.m_nameOrOffset))
+        return TimeZone::fromUTCOffset(std::get<int64_t>(tz.m_nameOrOffset));
+    const auto& name = std::get<Vector<Latin1Character>>(tz.m_nameOrOffset);
+    if (!name.isEmpty()) {
+        if (auto tzId = parseTimeZoneName(StringView(name.span())))
+            return TimeZone::fromID(*tzId);
+        return std::nullopt;
+    }
+
+    // 6. If timeZoneResult.[[Z]] is true, return ! ParseTimeZoneIdentifier("UTC").
+    if (tz.m_z)
+        return TimeZone::fromID(utcTimeZoneID());
+
+    // 7-8. Let offsetString be timeZoneResult.[[OffsetString]]; return ? ParseTimeZoneIdentifier(offsetString).
+    //   ParseTimeZoneIdentifier uses UTCOffset[~SubMinutePrecision], so reject sub-minute offsets.
+    if (tz.m_offset) {
+        if (tz.m_offsetHasSubMinutePrecision)
+            return std::nullopt;
+        return TimeZone::fromUTCOffset(*tz.m_offset);
+    }
+
+    // 9. Throw a RangeError exception.
+    return std::nullopt;
 }
 
 } // namespace ISO8601

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/IntlObject.h>
 #include <JavaScriptCore/TemporalObject.h>
 #include <wtf/Int128.h>
+#include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -475,10 +476,33 @@ std::optional<int64_t> parseUTCOffset(StringView, bool parseSubMinutePrecision =
 std::optional<int64_t> parseUTCOffsetInMinutes(StringView);
 enum class ValidateTimeZoneID : bool { No, Yes };
 using CalendarID = RFC9557Value;
-std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>>> parseTime(StringView);
-std::optional<std::tuple<PlainTime, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarTime(StringView);
-std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>>> parseDateTime(StringView, TemporalDateFormat);
-JS_EXPORT_PRIVATE std::optional<std::tuple<PlainDate, std::optional<PlainTime>, std::optional<TimeZoneRecord>, std::optional<CalendarID>>> parseCalendarDateTime(StringView, TemporalDateFormat);
+
+enum class TemporalProduction : uint8_t {
+    Instant = 1 << 0, // TemporalInstantString
+    DateTimeZoned = 1 << 1, // TemporalDateTimeString[+Zoned]
+    DateTimeUnzoned = 1 << 2, // TemporalDateTimeString[~Zoned]
+    YearMonth = 1 << 3, // TemporalYearMonthString
+    MonthDay = 1 << 4, // TemporalMonthDayString
+    Time = 1 << 5, // TemporalTimeString
+};
+using TemporalProductionSet = OptionSet<TemporalProduction>;
+
+struct ParsedISODateTime {
+    std::optional<PlainDate> date;
+    std::optional<PlainTime> time;
+    std::optional<TimeZoneRecord> timeZone;
+    std::optional<CalendarID> calendar;
+    TemporalProduction matched { };
+    // True when the matched goal was the SHORT FORM:
+    //   AnnotatedYearMonth (DateDay absent) or AnnotatedMonthDay (DateYear absent).
+    // parseISODateTime already enforces Step 4.a.ii.(3)/(4) (short-form goals require
+    // iso8601 calendar — returns std::nullopt otherwise). This flag remains for
+    // consumers that branch on full-date vs short-form (e.g. PlainMonthDay).
+    bool isShortForm { false };
+};
+
+JS_EXPORT_PRIVATE std::optional<ParsedISODateTime> parseISODateTime(StringView, TemporalProductionSet);
+
 std::optional<TimeZone> JS_EXPORT_PRIVATE parseTemporalTimeZoneIdentifier(StringView);
 // Strict variant: accepts only a bare UTC offset or bare IANA name — no embedded datetime strings.
 std::optional<TimeZone> parseTimeZoneIdentifierStrict(StringView);

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -552,36 +552,29 @@ static RelativeToRecord toRelativeTemporalObject(JSGlobalObject* globalObject, J
         return { };
     }
 
-    // Step 7: Let result be ? ParseISODateTime(value, «TemporalDateTimeString[+Zoned], TemporalDateTimeString[~Zoned]»).
+    // Step 7: Let result be ? ParseISODateTime(value, « TemporalDateTimeString[+Zoned], TemporalDateTimeString[~Zoned] »).
     String string = relativeToValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto parsed = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
+    auto parsed = ISO8601::parseISODateTime(string, { ISO8601::TemporalProduction::DateTimeZoned, ISO8601::TemporalProduction::DateTimeUnzoned });
     if (!parsed) [[unlikely]] {
         throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(200, string), "' is not a valid date or ZonedDateTime string"_s));
         return { };
     }
-    auto& [parsedDate, parsedTimeOpt, parsedTzOpt, parsedCalOpt] = *parsed;
+    auto& [parsedDateOpt, parsedTimeOpt, parsedTzOpt, parsedCalOpt, matched, isShortForm] = *parsed;
+    ASSERT(parsedDateOpt);
+    const auto& parsedDate = *parsedDateOpt;
 
     // Step 8: Let timeZone be result.[[TimeZone]].
-    // Steps 13-17 (ZDT path) vs step 12 (PlainDate path):
-    if (parsedTzOpt) {
-        bool hasBracket = std::holds_alternative<int64_t>(parsedTzOpt->m_nameOrOffset)
-            || !std::get<Vector<Latin1Character>>(parsedTzOpt->m_nameOrOffset).isEmpty();
-        if (hasBracket) {
-            // Bracket annotation present → steps 13-17 (ZDT): delegate to TemporalZonedDateTime::from
-            // which implements ToTemporalTimeZoneIdentifier + InterpretISODateTimeOffset.
-            auto* zdt = TemporalZonedDateTime::from(globalObject, relativeToValue, jsUndefined());
-            RETURN_IF_EXCEPTION(scope, { });
-            return RelativeToRecord { zdt, { }, false };
-        }
-        // Z without bracket: rejected — Z requires a bracket annotation per the grammar.
-        if (parsedTzOpt->m_z) [[unlikely]] {
-            throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(200, string), "' is not a valid relativeTo string: 'Z' designator requires a time zone annotation"_s));
-            return { };
-        }
-        // Bare numeric offset without bracket → annotation is ~empty~ → timeZone is ~unset~ → PlainDate.
+    // Steps 13-17 (ZDT path) vs step 12 (PlainDate path): DateTimeZoned matched → bracket present.
+    if (matched == ISO8601::TemporalProduction::DateTimeZoned) {
+        // Delegate to TemporalZonedDateTime::from which implements ToTemporalTimeZoneIdentifier
+        // + InterpretISODateTimeOffset.
+        auto* zdt = TemporalZonedDateTime::from(globalObject, relativeToValue, jsUndefined());
+        RETURN_IF_EXCEPTION(scope, { });
+        return RelativeToRecord { zdt, { }, false };
     }
+    // DateTimeUnzoned matched → no Z, no bracket required → PlainDate path.
 
     // Steps 9-11: calendar = result.[[Calendar]]; if ~empty~ → "iso8601"; CanonicalizeCalendar.
     CalendarID calendarId = iso8601CalendarID();

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -141,31 +141,23 @@ TemporalInstant* TemporalInstant::toInstant(JSGlobalObject* globalObject, JSValu
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     // Step 3: Let parsed be ? ParseISODateTime(item, « TemporalInstantString »).
-    //   parseCalendarDateTime accepts a superset; the Time-present and Offset/Z-present guards
-    //   below restrict the accepted set to the TemporalInstantString production.
-    // FIXME: Replace with a unified ParseISODateTime(string, ProductionMask) that bakes in
-    //   per-production grammar restrictions, matching the spec abstract op 1:1. Today the four
-    //   parsers (parseCalendarDateTime, parseCalendarTime, parseDateTime, parseTime) each cover
-    //   a subset, forcing every consumer to re-implement production guards. See ISO8601.h.
-    auto parsedOpt = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
+    auto parsedOpt = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::Instant);
     if (!parsedOpt) [[unlikely]] {
         throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, string), "' is not a valid Temporal.Instant string"_s));
         return nullptr;
     }
-    auto [plainDate, plainTimeOpt, timeZoneOpt, calendarOpt] = WTF::move(*parsedOpt);
-    if (!plainTimeOpt || !timeZoneOpt || (!timeZoneOpt->m_z && !timeZoneOpt->m_offset)) [[unlikely]] {
-        throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, string), "' is not a valid Temporal.Instant string"_s));
-        return nullptr;
-    }
+    auto [plainDateOpt, plainTimeOpt, timeZoneOpt, calendarOpt, matched, isShortForm] = WTF::move(*parsedOpt);
+    ASSERT(plainDateOpt && plainTimeOpt && timeZoneOpt);
 
     // Step 4: Assert: parsed.[[TimeZone]].[[OffsetString]] is not empty XOR parsed.[[TimeZone]].[[Z]] is true.
-    //   No-op: the grammar `DateTimeUTCOffset[+Z]` makes Z and offset mutually exclusive.
+    //   No-op: parseISODateTime guarantees this for the Instant production.
 
     // Step 5: offsetNanoseconds = Z ? 0 : ParseDateTimeUTCOffset(OffsetString).
     int64_t offsetNanoseconds = timeZoneOpt->m_z ? 0 : *timeZoneOpt->m_offset;
 
     // Step 6: Let time be parsed.[[Time]].
     const ISO8601::PlainTime& plainTime = *plainTimeOpt;
+    const ISO8601::PlainDate& plainDate = *plainDateOpt;
 
     // Step 7: Assert: time is not start-of-day. (No-op: parser guarantees this.)
 

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -614,54 +614,14 @@ String temporalShowCalendarName(JSGlobalObject* globalObject, JSObject* options)
         "calendarName must be \"auto\", \"always\", \"never\", or \"critical\""_s, "auto"_s);
 }
 
+// ToTemporalCalendarIdentifier ( temporalCalendarLike )
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporalcalendaridentifier
 CalendarID toTemporalCalendarIdentifier(JSGlobalObject* globalObject, JSValue calendarLike)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (calendarLike.isString()) {
-        auto calendarString = calendarLike.toWTFString(globalObject);
-        RETURN_IF_EXCEPTION(scope, iso8601CalendarID());
-
-        // Fast path: direct calendar ID (case-insensitive). isBuiltinCalendar handles legacy aliases.
-        if (auto calendarId = isBuiltinCalendar(calendarString))
-            return *calendarId;
-
-        // Try parsing as a temporal date string to extract the [u-ca=...] annotation.
-        // Try Date, then YearMonth, then MonthDay (YearMonth before MonthDay to avoid asserting on "2020-01").
-        auto parsed = ISO8601::parseCalendarDateTime(calendarString, TemporalDateFormat::Date);
-        if (!parsed)
-            parsed = ISO8601::parseCalendarDateTime(calendarString, TemporalDateFormat::YearMonth);
-        if (!parsed)
-            parsed = ISO8601::parseCalendarDateTime(calendarString, TemporalDateFormat::MonthDay);
-        if (!parsed) {
-            // Per spec ParseTemporalCalendarString, also try TemporalTimeString.
-            // A time string with no calendar annotation returns "iso8601".
-            auto parsedTime = ISO8601::parseCalendarTime(calendarString);
-            if (!parsedTime) [[unlikely]] {
-                throwRangeError(globalObject, scope, makeString("invalid calendar identifier: "_s, calendarString));
-                return iso8601CalendarID();
-            }
-            auto& calAnnotation = std::get<2>(parsedTime.value());
-            if (!calAnnotation)
-                return iso8601CalendarID();
-            if (auto calendarId = isBuiltinCalendar(StringView(*calAnnotation)))
-                return *calendarId;
-            throwRangeError(globalObject, scope, makeString("invalid calendar identifier: "_s, StringView(*calAnnotation)));
-            return iso8601CalendarID();
-        }
-        auto& calendarAnnotation = std::get<3>(parsed.value());
-        if (!calendarAnnotation)
-            return iso8601CalendarID();
-        if (auto calendarId = isBuiltinCalendar(StringView(*calendarAnnotation)))
-            return *calendarId;
-        throwRangeError(globalObject, scope, makeString("invalid calendar identifier: "_s, StringView(*calendarAnnotation)));
-        return iso8601CalendarID();
-    }
-
-    // Fast path: read [[Calendar]] from Temporal date-like objects without invoking
-    // the "calendar" property getter (per spec ToTemporalCalendar step 1.b).
+    // Step 1: If calendarLike is an Object with a Temporal-date-like internal slot, return its [[Calendar]].
     if (calendarLike.isObject()) {
         JSObject* obj = asObject(calendarLike);
         if (obj->inherits<TemporalPlainDate>())
@@ -676,7 +636,51 @@ CalendarID toTemporalCalendarIdentifier(JSGlobalObject* globalObject, JSValue ca
             return uncheckedDowncast<TemporalZonedDateTime>(obj)->calendarID();
     }
 
-    throwTypeError(globalObject, scope, "calendar argument must be a string or a Temporal date-like object"_s);
+    // Step 2: If calendarLike is not a String, throw TypeError.
+    if (!calendarLike.isString()) [[unlikely]] {
+        throwTypeError(globalObject, scope, "calendar must be a string or Temporal object"_s);
+        return iso8601CalendarID();
+    }
+
+    auto calendarString = calendarLike.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, iso8601CalendarID());
+
+    // Fast path: bare builtin calendar id ("iso8601", "hebrew", ...). Skips
+    // ParseTemporalCalendarString entirely since both that op and CanonicalizeCalendar
+    // would just round-trip the string through the same isBuiltinCalendar lookup.
+    if (auto calendarId = isBuiltinCalendar(calendarString))
+        return *calendarId;
+
+    // Step 3: identifier = ? ParseTemporalCalendarString(string).
+    // https://tc39.es/proposal-temporal/#sec-temporal-parsetemporalcalendarstring
+    //   PTCS Step 1: parseResult = Completion(ParseISODateTime(string,
+    //     « TDS[+Zoned], TDS[~Zoned], TIS, TimeString, MonthDayString, YearMonthString »)).
+    //   PTCS Step 2: If normal completion → calendar (default "iso8601").
+    //   PTCS Steps 3-5: Otherwise, ParseText(string, AnnotationValue) fallback. We
+    //     collapse 3-5 with CanonicalizeCalendar below: any input that's not a builtin
+    //     name (fast path failed above) and isn't a Temporal date string can never pass
+    //     CanonicalizeCalendar, so throw immediately.
+    auto parsed = ISO8601::parseISODateTime(calendarString, {
+        ISO8601::TemporalProduction::DateTimeZoned,
+        ISO8601::TemporalProduction::DateTimeUnzoned,
+        ISO8601::TemporalProduction::Instant,
+        ISO8601::TemporalProduction::YearMonth,
+        ISO8601::TemporalProduction::MonthDay,
+        ISO8601::TemporalProduction::Time,
+    });
+    if (!parsed) [[unlikely]] {
+        throwRangeError(globalObject, scope, makeString("invalid calendar identifier: "_s, calendarString));
+        return iso8601CalendarID();
+    }
+    // PTCS Step 2.a-c: extract calendar (or default to "iso8601").
+    String identifier = parsed->calendar
+        ? StringView(*parsed->calendar).convertToASCIILowercase()
+        : "iso8601"_s;
+
+    // Step 4: Return ? CanonicalizeCalendar(identifier).
+    if (auto calendarId = isBuiltinCalendar(identifier))
+        return *calendarId;
+    throwRangeError(globalObject, scope, makeString("invalid calendar identifier: "_s, identifier));
     return iso8601CalendarID();
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -282,16 +282,14 @@ static TemporalPlainDate* fromImpl(JSGlobalObject* globalObject, JSValue itemVal
     auto string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto dateTime = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
+    // Step 4: result = ? ParseISODateTime(item, « TemporalDateTimeString[~Zoned] »).
+    auto dateTime = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::DateTimeUnzoned);
     if (dateTime) [[likely]] {
-        auto [plainDate, plainTimeOptional, timeZoneOptional, calendarOptional] = WTF::move(dateTime.value());
+        auto [plainDateOpt, plainTimeOptional, timeZoneOptional, calendarOptional, matched, isShortForm] = WTF::move(*dateTime);
+        ASSERT(plainDateOpt);
+        auto plainDate = WTF::move(*plainDateOpt);
 
-        // Step 4 ([~Zoned] grammar): reject Z designator.
-        if (timeZoneOptional && timeZoneOptional->m_z) [[unlikely]] {
-            throwRangeError(globalObject, scope, "invalid date string"_s);
-            return { };
-        }
-
+        // Steps 5-7: calendar = result.[[Calendar]]; if ~empty~ → "iso8601"; CanonicalizeCalendar.
         CalendarID calendarId = iso8601CalendarID();
         if (calendarOptional) {
             auto rawCal = StringView(*calendarOptional).convertToASCIILowercase();
@@ -302,6 +300,10 @@ static TemporalPlainDate* fromImpl(JSGlobalObject* globalObject, JSValue itemVal
             }
             calendarId = *canonicalized;
         }
+        // Steps 8-9: GetOptionsObject + GetTemporalOverflowOption.
+        //   Options aren't reachable on the compare path (compare takes no options arg); the
+        //   spec calls are no-ops on undefined and the overflow value is unused for strings.
+        // Steps 10-11: isoDate = CreateISODateRecord(...); Return ? CreateTemporalDate(isoDate, calendar).
         if (calendarId == iso8601CalendarID())
             RELEASE_AND_RETURN(scope, TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(plainDate)));
         RELEASE_AND_RETURN(scope, TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(plainDate), WTF::move(calendarId)));
@@ -379,18 +381,14 @@ TemporalPlainDate* TemporalPlainDate::from(JSGlobalObject* globalObject, JSValue
         return { };
     }
 
-    // Step 4: result = ? ParseISODateTime(item, «TemporalDateTimeString[~Zoned]»).
+    // Step 4: result = ? ParseISODateTime(item, « TemporalDateTimeString[~Zoned] »).
     auto string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
-    auto dateTime = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
+    auto dateTime = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::DateTimeUnzoned);
     if (dateTime) [[likely]] {
-        auto [plainDate, plainTimeOptional, timeZoneOptional, calendarOptional] = WTF::move(dateTime.value());
-
-        // Step 4 ([~Zoned] grammar): Z designator rejected before options are read.
-        if (timeZoneOptional && timeZoneOptional->m_z) [[unlikely]] {
-            throwRangeError(globalObject, scope, "invalid date string"_s);
-            return { };
-        }
+        auto [plainDateOpt, plainTimeOptional, timeZoneOptional, calendarOptional, matched, isShortForm] = WTF::move(*dateTime);
+        ASSERT(plainDateOpt);
+        auto plainDate = WTF::move(*plainDateOpt);
 
         // Steps 5-7: calendar = result.[[Calendar]]; if ~empty~ → "iso8601"; CanonicalizeCalendar.
         CalendarID calendarId = iso8601CalendarID();

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -378,10 +378,12 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
     auto string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 4: ParseISODateTime(item, {TemporalDateTimeString}).
-    auto dateTime = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
+    // Step 4: ? ParseISODateTime(item, « TemporalDateTimeString[~Zoned] »).
+    auto dateTime = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::DateTimeUnzoned);
     if (dateTime) [[likely]] {
-        auto [plainDate, plainTimeOptional, timeZoneOptional, calendarOptional] = WTF::move(dateTime.value());
+        auto [plainDateOpt, plainTimeOptional, timeZoneOptional, calendarOptional, matched, isShortForm] = WTF::move(*dateTime);
+        ASSERT(plainDateOpt);
+        auto plainDate = WTF::move(*plainDateOpt);
         // Steps 5-7: extract and canonicalize [[Calendar]].
         CalendarID calendarId = iso8601CalendarID();
         if (calendarOptional) {
@@ -399,13 +401,11 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
             RETURN_IF_EXCEPTION(scope, { });
         }
         // Steps 9-13: CreateISODateRecord + CombineISODateAndTimeRecord + CreateTemporalDateTime.
-        if (!(timeZoneOptional && timeZoneOptional->m_z)) {
-            auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), plainTimeOptional.value_or(ISO8601::PlainTime()));
-            RETURN_IF_EXCEPTION(scope, { });
-            if (result && calendarId != iso8601CalendarID())
-                result->setCalendarID(calendarId);
-            return result;
-        }
+        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), plainTimeOptional.value_or(ISO8601::PlainTime()));
+        RETURN_IF_EXCEPTION(scope, { });
+        if (result && calendarId != iso8601CalendarID())
+            result->setCalendarID(calendarId);
+        return result;
     }
 
     throwRangeError(globalObject, scope, "invalid date string"_s);

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -193,36 +193,23 @@ static TemporalPlainMonthDay* fromMonthDayString(JSGlobalObject* globalObject, W
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 4: ParseISODateTime(item, {TemporalMonthDayString}).
-    auto dateTime = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::MonthDay);
-    if (!dateTime || (std::get<2>(dateTime.value()) && std::get<2>(dateTime.value())->m_z)) [[unlikely]] {
+    // Step 4: ParseISODateTime(item, « TemporalMonthDayString »).
+    auto dateTime = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::MonthDay);
+    if (!dateTime) [[unlikely]] {
         String message = tryMakeString("Temporal.PlainMonthDay.from: invalid date string "_s, string);
         throwRangeError(globalObject, scope, message.isNull() ? "Temporal.PlainMonthDay.from: invalid date string"_s : message);
         return { };
     }
-    auto [plainDate, plainTimeOptional, timeZoneOptional, calendarOptional] = WTF::move(*dateTime);
+    auto [plainDateOpt, plainTimeOptional, timeZoneOptional, calendarOptional, matched, isShortForm] = WTF::move(*dateTime);
+    ASSERT(plainDateOpt);
+    auto plainDate = WTF::move(*plainDateOpt);
 
-    // Steps 5-7: extract and canonicalize [[Calendar]].
-    // MM-DD short form only valid with iso8601.
-    bool looksLikeShortForm = false;
-    {
-        unsigned digitGroups = 0;
-        bool inDigits = false;
-        for (unsigned j = 0; j < string.length() && string[j] != '['; j++) {
-            if (isASCIIDigit(string[j])) {
-                if (!inDigits) {
-                    digitGroups++;
-                    inDigits = true;
-                }
-            } else
-                inDigits = false;
-        }
-        looksLikeShortForm = (digitGroups <= 2);
-    }
-    if (looksLikeShortForm && calendarOptional && !WTF::equalIgnoringASCIICase(StringView(*calendarOptional), "iso8601"_s)) [[unlikely]] {
-        throwRangeError(globalObject, scope, "PlainMonthDay string must use iso8601 calendar"_s);
-        return { };
-    }
+    // (parseISODateTime already enforced Step 4.a.ii.(4): short-form non-iso8601 → nullopt.)
+    bool looksLikeShortForm = isShortForm;
+
+    // Step 5: Let calendar be result.[[Calendar]].
+    // Step 6: If calendar is ~empty~, set calendar to "iso8601".
+    // Step 7: Set calendar to ? CanonicalizeCalendar(calendar).
     CalendarID calendarId = iso8601CalendarID();
     if (calendarOptional) {
         auto rawCal = StringView(*calendarOptional).convertToASCIILowercase();
@@ -241,11 +228,9 @@ static TemporalPlainMonthDay* fromMonthDayString(JSGlobalObject* globalObject, W
     }
 
     // Steps 11-12: isoDate = {year,month,day}; ISODateWithinLimits check.
-    // Re-parse as full date to recover the original year (MonthDay parser may strip it).
-    auto dateParse = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
+    // For short form (no year), plainDate.year() defaults to a parser sentinel; for full form,
+    // it's the parsed year.
     int32_t fullYear = plainDate.year();
-    if (dateParse)
-        fullYear = std::get<0>(dateParse.value()).year();
     if (!ISO8601::isYearWithinLimits(fullYear) || !ISO8601::isDateTimeWithinLimits(fullYear, plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
         throwRangeError(globalObject, scope, "Date is not within ISO date time limits"_s);
         return { };
@@ -253,10 +238,9 @@ static TemporalPlainMonthDay* fromMonthDayString(JSGlobalObject* globalObject, W
 
     // Steps 13-15: ISODateToFields + CalendarMonthDayFromFields(~constrain~) + CreateTemporalMonthDay.
     // (Fused into plainMonthDayFromISODate for non-ISO full date strings.)
-    if (!looksLikeShortForm && dateParse) {
-        auto& fullDate = std::get<0>(dateParse.value());
-        if (ISO8601::isYearWithinLimits(fullDate.year())) {
-            auto resolved = TemporalCore::plainMonthDayFromISODate(calendarId, fullDate, TemporalOverflow::Constrain);
+    if (!looksLikeShortForm) {
+        if (ISO8601::isYearWithinLimits(plainDate.year())) {
+            auto resolved = TemporalCore::plainMonthDayFromISODate(calendarId, plainDate, TemporalOverflow::Constrain);
             if (!resolved) [[unlikely]] {
                 throwRangeError(globalObject, scope, String(resolved.error().message));
                 return { };

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -504,42 +504,25 @@ TemporalPlainTime* TemporalPlainTime::from(JSGlobalObject* globalObject, JSValue
         return { };
     }
 
-    // Step 3.b: parseResult = ? ParseISODateTime(item, «TemporalTimeString»).
-    // TemporalTimeString accepts both time-only ("14:30:00") and datetime ("2021-01-01T14:30:00")
-    // formats. Implemented as two parsers that mirror the grammar productions:
-    //   parseCalendarTime: time-only production.
-    //   parseCalendarDateTime: fallback for the datetime production.
-    // Strings with a Z designator are rejected (they throw RangeError per test262).
+    // Step 3.b: parseResult = ? ParseISODateTime(item, « TemporalTimeString »).
+    //   TemporalTimeString accepts both time-only ("14:30:00") and datetime ("2021-01-01T14:30:00")
+    //   forms; parseISODateTime tries the time-only production first then falls back to datetime.
     auto string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto timeResult = ISO8601::parseCalendarTime(string);
-    if (timeResult) {
-        auto [plainTime, timeZoneOptional, calendarOptional] = WTF::move(timeResult.value());
-        if (!(timeZoneOptional && timeZoneOptional->m_z)) {
-            // Step 3.c: Assert _parseResult_.[[Time]] is not ~start-of-day~. (guaranteed by grammar)
-            // Step 3.d: Set _result_ to _parseResult_.[[Time]].
-            // Step 3.e: NOTE.
-            // Step 3.f: resolvedOptions = ? GetOptionsObject(options).
-            // Step 3.g: Perform ? GetTemporalOverflowOption(resolvedOptions). (result unused for strings)
-            // Step 4: Return ! CreateTemporalTime(_result_).
-            toTemporalOverflow(globalObject, optionsValue);
-            RETURN_IF_EXCEPTION(scope, { });
-            return TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTF::move(plainTime));
-        }
-    }
-
-    // Time-only parse failed or was a Z string — try the datetime production.
-    auto dateTimeResult = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
-    if (dateTimeResult) [[likely]] {
-        auto [plainDate, plainTimeOptional, timeZoneOptional, calendarOptional] = WTF::move(dateTimeResult.value());
-        // Require an explicit time (no ~start-of-day~, satisfying step 3.c Assert) and no Z.
-        if (plainTimeOptional && !(timeZoneOptional && timeZoneOptional->m_z)) {
-            // Steps 3.f-3.g + Step 4: same as time-only path above.
-            toTemporalOverflow(globalObject, optionsValue);
-            RETURN_IF_EXCEPTION(scope, { });
-            return TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTF::move(plainTimeOptional.value()));
-        }
+    auto parsed = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::Time);
+    if (parsed) [[likely]] {
+        auto [plainDateOpt, plainTimeOpt, timeZoneOpt, calendarOpt, matched, isShortForm] = WTF::move(*parsed);
+        ASSERT(plainTimeOpt);
+        auto plainTime = WTF::move(*plainTimeOpt);
+        // Step 3.c: Assert _parseResult_.[[Time]] is not ~start-of-day~. (guaranteed by grammar)
+        // Step 3.d: Set _result_ to _parseResult_.[[Time]].
+        // Step 3.f: resolvedOptions = ? GetOptionsObject(options).
+        // Step 3.g: Perform ? GetTemporalOverflowOption(resolvedOptions). (result unused for strings)
+        // Step 4: Return ! CreateTemporalTime(_result_).
+        toTemporalOverflow(globalObject, optionsValue);
+        RETURN_IF_EXCEPTION(scope, { });
+        return TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTF::move(plainTime));
     }
 
     // Step 3.b: ParseISODateTime failed → throw RangeError.

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
@@ -194,43 +194,22 @@ static TemporalPlainYearMonth* fromYearMonthString(JSGlobalObject* globalObject,
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 4: ParseISODateTime(item, {TemporalYearMonthString}).
-    auto dateTime = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::YearMonth);
-    if (!dateTime || (dateTime && std::get<2>(dateTime.value()) && std::get<2>(dateTime.value())->m_z)) {
+    // Step 4: ParseISODateTime(item, « TemporalYearMonthString »).
+    auto dateTime = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::YearMonth);
+    if (!dateTime) {
         String message = tryMakeString("Temporal.PlainYearMonth.from: invalid year-month string "_s, string);
         throwRangeError(globalObject, scope, message.isNull() ? "Temporal.PlainYearMonth.from: invalid year-month string"_s : message);
         return { };
     }
-    auto [plainDate, plainTimeOptional, timeZoneOptional, calendarOptional] = WTF::move(*dateTime);
-
-    // Detect year-month-only strings (e.g. "1976-11") by counting digit groups.
-    // A string with ≤ 2 digit groups has no day component; these are only valid with iso8601.
-    bool looksLikeYearMonthOnly = false;
-    {
-        int digitGroups = 0;
-        bool inDigits = false;
-        for (unsigned idx = 0; idx < string.length(); ++idx) {
-            UChar c = string[idx];
-            if (c >= '0' && c <= '9') {
-                if (!inDigits) {
-                    ++digitGroups;
-                    inDigits = true;
-                }
-            } else
-                inDigits = false;
-        }
-        looksLikeYearMonthOnly = (digitGroups <= 2);
-    }
+    auto [plainDateOpt, plainTimeOptional, timeZoneOptional, calendarOptional, matched, isShortForm] = WTF::move(*dateTime);
+    ASSERT(plainDateOpt);
+    auto plainDate = WTF::move(*plainDateOpt);
 
     // Steps 5-7: extract and canonicalize [[Calendar]].
+    // (parseISODateTime already enforced Step 4.a.ii.(3): short-form non-iso8601 → nullopt.)
     CalendarID calendarId = iso8601CalendarID();
     if (calendarOptional) {
         auto rawCal = StringView(*calendarOptional).convertToASCIILowercase();
-        // YYYY-MM format with non-iso8601 calendar annotation is invalid per spec.
-        if (looksLikeYearMonthOnly && !WTF::equalIgnoringASCIICase(StringView(*calendarOptional), "iso8601"_s)) [[unlikely]] {
-            throwRangeError(globalObject, scope, "YYYY-MM format is only valid with iso8601 calendar"_s);
-            return { };
-        }
         auto canonicalized = isBuiltinCalendar(rawCal);
         if (!canonicalized) [[unlikely]] {
             throwRangeError(globalObject, scope, makeString("'"_s, rawCal, "' is not a valid calendar identifier"_s));
@@ -240,10 +219,7 @@ static TemporalPlainYearMonth* fromYearMonthString(JSGlobalObject* globalObject,
     }
 
     // Step 10: isoDate = CreateISODateRecord(year, month, day).
-    // For iso8601 / year-month-only strings: plainDate (day=1) IS the record.
-    // For non-ISO full-date strings: the YearMonth parser produces day=1, but the
-    // spec needs the actual day to identify the correct calendar month — recovered
-    // into fullISODate below via a re-parse with TemporalDateFormat::Date.
+    //   For short form (YYYY-MM), parser stores day=1; for full date, parser extracts the actual day.
     // Step 11: ISOYearMonthWithinLimits — enforced inside tryCreateIfValid.
     // Step 12: ISODateToFields(calendar, isoDate, ~year-month~).
     // Steps 14-15: CalendarYearMonthFromFields(~constrain~) + CreateTemporalYearMonth — inside tryCreateIfValid.
@@ -252,19 +228,8 @@ static TemporalPlainYearMonth* fromYearMonthString(JSGlobalObject* globalObject,
 
     // Non-ISO steps 12+14+15: ISODateToFields → CalendarYearMonthFromFields → CreateTemporalYearMonth
     // (fused into plainYearMonthFromISODate + tryCreateIfValid).
-    // The YearMonth parser always stores day=1. For non-ISO full date strings (e.g.
-    // "2024-06-08[u-ca=islamicc]"), re-parse with Date format to recover the actual
-    // day so plainYearMonthFromISODate can determine the correct calendar month.
-    ISO8601::PlainDate fullISODate = plainDate;
-    if (!looksLikeYearMonthOnly) {
-        auto fullDateTime = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
-        if (fullDateTime) {
-            auto& fullDate = std::get<0>(*fullDateTime);
-            if (ISO8601::isYearWithinLimits(fullDate.year()))
-                fullISODate = fullDate;
-        }
-    }
-    auto resolved = TemporalCore::plainYearMonthFromISODate(calendarId, fullISODate);
+    // For short form (YYYY-MM), parser stores day=1; otherwise day was extracted from the input.
+    auto resolved = TemporalCore::plainYearMonthFromISODate(calendarId, plainDate);
     if (!resolved) [[unlikely]] {
         throwRangeError(globalObject, scope, String(resolved.error().message));
         return { };

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTime.cpp
@@ -168,29 +168,18 @@ static std::optional<ZDTEpochArgs> toEpochArgsFromString(JSGlobalObject* globalO
     String string = item->value(globalObject);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
 
-    // Step 5.b: ParseISODateTime(item, «TemporalDateTimeString[+Zoned]»).
-    auto parsed = ISO8601::parseCalendarDateTime(string, TemporalDateFormat::Date);
+    // Step 5.b: ParseISODateTime(item, « TemporalDateTimeString[+Zoned] »).
+    //   The DateTimeZoned production already requires a bracket TZ annotation, so the
+    //   "TimeZoneAnnotation Parse Node present" check (spec step 5.d) is satisfied by parsing.
+    auto parsed = ISO8601::parseISODateTime(string, ISO8601::TemporalProduction::DateTimeZoned);
     if (!parsed) [[unlikely]] {
         throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(100, string), "' is not a valid Temporal.ZonedDateTime string"_s));
         return std::nullopt;
     }
-    auto [plainDate, plainTimeOptional, tzRecordOptional, calendarOptional] = WTF::move(*parsed);
-
-    if (!tzRecordOptional) [[unlikely]] {
-        throwRangeError(globalObject, scope, "Temporal.ZonedDateTime string requires a time zone annotation"_s);
-        return std::nullopt;
-    }
+    auto [plainDateOpt, plainTimeOptional, tzRecordOptional, calendarOptional, matched, isShortForm] = WTF::move(*parsed);
+    ASSERT(plainDateOpt && tzRecordOptional);
+    auto plainDate = WTF::move(*plainDateOpt);
     auto& tzRecord = *tzRecordOptional;
-
-    // Steps 5.c-5.d: The spec parses item as TemporalDateTimeString[+Zoned], which requires a
-    // bracket annotation. Our parser (parseCalendarDateTime) does not enforce the +Zoned flag,
-    // so we check explicitly and throw the RangeError that the grammar would normally prevent.
-    bool hasBracket = std::holds_alternative<int64_t>(tzRecord.m_nameOrOffset)
-        || !std::get<Vector<Latin1Character>>(tzRecord.m_nameOrOffset).isEmpty();
-    if (!hasBracket) [[unlikely]] {
-        throwRangeError(globalObject, scope, "Temporal.ZonedDateTime string requires a bracketed time zone annotation"_s);
-        return std::nullopt;
-    }
 
     // Step 5.e: timeZone = ? ToTemporalTimeZoneIdentifier(annotation). (fused into timeZoneFromRecord)
     auto timeZoneOpt = timeZoneFromRecord(tzRecord);


### PR DESCRIPTION
#### 9d0510b40b57822c4095858d4295a2d8b501244a
<pre>
[JSC][Temporal] Unify ParseISODateTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=317463">https://bugs.webkit.org/show_bug.cgi?id=317463</a>
<a href="https://rdar.apple.com/180084451">rdar://180084451</a>

Reviewed by Yusuke Suzuki.

The four overlapping parsers (parseTime, parseCalendarTime,
parseDateTime, parseCalendarDateTime) duplicated date/time/offset/
annotation logic and produced real ambiguity bugs: length-10 strings
matching either DateSpec* or full Date; the Time goal clobbering
MonthDay matches in calendar canonicalization; PlainDate accepting
Z+bracket inputs that [~Zoned] should reject; ParseTemporalCalendarString
silently accepting YearMonth/MonthDay short forms paired with non-iso8601
calendars (a Step 4.a.ii.(3)/(4) violation).

Replaced with one ISO8601::parseISODateTime mirroring the algorithm at
<a href="https://tc39.es/proposal-temporal/#sec-temporal-parseisodatetime">https://tc39.es/proposal-temporal/#sec-temporal-parseisodatetime</a>, with
each of the 29 spec steps annotated. Every Temporal consumer passes the
TemporalProductionSet its spec citation specifies. Per-production
tokenizers replace the loose-mode parseDate, and strict primitives
(parseDateSpecYearMonth / parseDateSpecMonthDay) eliminate the length-10
ambiguity by matching the named grammar productions. The AnnotatedTime
early-error rule is now implemented as literal ParseText calls.

parseISODateTime enforces Step 4.a.ii.(3)/(4) internally — short-form
YearMonth/MonthDay with a non-iso8601 calendar returns std::nullopt,
surfacing as RangeError at every consumer. This fixes the property-bag
calendar path (e.g. Temporal.PlainDate.from({calendar:
&quot;2024-01[u-ca=hebrew]&quot;})) which previously slipped through.

A FIXME above parseISODateTime references temporal_rs/parsers.rs and
icu4x/utils/ixdtf as the upstream single-pass tokenizer; ICU4C has no
equivalent, so the in-house per-production tokenizers stay.

Tests:
JSTests/stress/temporal-parseisodatetime.js
Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp

Canonical link: <a href="https://commits.webkit.org/315556@main">https://commits.webkit.org/315556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a9558c1a9e6f875c3964cc6306e1bc63f4507e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127112 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0180dfa8-ea63-41c0-9c2a-13d873bd29ec) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131954 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59b89a64-b10e-46a2-93e7-c3bb40daca2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172359 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112458 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22ca5faa-f659-4976-9778-89545a9b0d54) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32094 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27456 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/686 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181356 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30655 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140407 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42978 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140243 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43667 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107724 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25811 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35516 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115432 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202079 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42177 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6733 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54192 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41570 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41825 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->