### PR TITLE
Add a WPT helper to compare SVGTransform objects

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgtransform-animation-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgtransform-animation-1.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/SVGAnimationTestCase-testharness.js"></script>
+<script src="/svg/resources/svg-transform-equals.js"></script>
 
 <svg>
 </svg>
@@ -40,57 +41,43 @@ rootSVGElement.appendChild(rect);
 function sample1() {
     // Check initial/end conditions
     assert_equals(rect.transform.animVal.numberOfItems, 1);
-    assert_equals(rect.transform.animVal.getItem(0).type, SVGTransform.SVG_TRANSFORM_SCALE);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.a, 0, epsilon);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.d, 0, epsilon);
+    assert_svg_transform_equals(rect.transform.animVal.getItem(0), {scale: [0]}, epsilon);
     assert_equals(rect.transform.baseVal.numberOfItems, 0);
 }
 
 function sample2() {
     assert_equals(rect.transform.animVal.numberOfItems, 1);
-    assert_equals(rect.transform.animVal.getItem(0).type, SVGTransform.SVG_TRANSFORM_SCALE);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.a, 1, epsilon);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.d, 1, epsilon);
+    assert_svg_transform_equals(rect.transform.animVal.getItem(0), {scale: [1]}, epsilon);
     assert_equals(rect.transform.baseVal.numberOfItems, 0);
 }
 
 function sample3() {
     assert_equals(rect.transform.animVal.numberOfItems, 1);
-    assert_equals(rect.transform.animVal.getItem(0).type, SVGTransform.SVG_TRANSFORM_SCALE);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.a, 2, epsilon);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.d, 2, epsilon);
+    assert_svg_transform_equals(rect.transform.animVal.getItem(0), {scale: [2]}, epsilon);
     assert_equals(rect.transform.baseVal.numberOfItems, 0);
 }
 
 function sample4() {
     assert_equals(rect.transform.animVal.numberOfItems, 1);
-    assert_equals(rect.transform.animVal.getItem(0).type, SVGTransform.SVG_TRANSFORM_SCALE);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.a, 3, epsilon);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.d, 3, epsilon);
+    assert_svg_transform_equals(rect.transform.animVal.getItem(0), {scale: [3]}, epsilon);
     assert_equals(rect.transform.baseVal.numberOfItems, 0);
 }
 
 function sample5() {
     assert_equals(rect.transform.animVal.numberOfItems, 1);
-    assert_equals(rect.transform.animVal.getItem(0).type, SVGTransform.SVG_TRANSFORM_SCALE);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.a, 4, epsilon);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.d, 4, epsilon);
+    assert_svg_transform_equals(rect.transform.animVal.getItem(0), {scale: [4]}, epsilon);
     assert_equals(rect.transform.baseVal.numberOfItems, 0);
 }
 
 function sample6() {
     assert_equals(rect.transform.animVal.numberOfItems, 1);
-    assert_equals(rect.transform.animVal.getItem(0).type, SVGTransform.SVG_TRANSFORM_SCALE);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.a, 5, epsilon);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.d, 5, epsilon);
+    assert_svg_transform_equals(rect.transform.animVal.getItem(0), {scale: [5]}, epsilon);
     assert_equals(rect.transform.baseVal.numberOfItems, 0);
 }
 
 function sample7() {
     assert_equals(rect.transform.animVal.numberOfItems, 1);
-    assert_equals(rect.transform.animVal.getItem(0).type, SVGTransform.SVG_TRANSFORM_SCALE);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.a, 6, epsilon);
-    assert_approx_equals(rect.transform.animVal.getItem(0).matrix.d, 6, epsilon);
+    assert_svg_transform_equals(rect.transform.animVal.getItem(0), {scale: [6]}, epsilon);
     assert_equals(rect.transform.baseVal.numberOfItems, 0);
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/resources/svg-transform-equals.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/resources/svg-transform-equals.js
@@ -1,0 +1,65 @@
+// Helper for SVG WPT tests: assert that two SVGTransform objects are equal.
+//
+// Per SVG 2 §8.5, an SVGTransform's observable state is (type, angle,
+// matrix.{a,b,c,d,e,f}); `angle` is 0 by spec for matrix/translate/scale.
+// https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransform
+//
+// Default epsilon absorbs tan(45°) round-trip and 32-to-64-bit float
+// conversions while still catching real divergence.
+//
+// Two ways to call it:
+//
+//   // 1. With an SVGTransform built via the DOM API:
+//   const expected = svg.createSVGTransform();
+//   expected.setTranslate(50, 0);
+//   assert_svg_transform_equals(text.transform.animVal.getItem(0), expected);
+//
+//   // 2. With a literal descriptor object (no createSVGTransform boilerplate):
+//   assert_svg_transform_equals(text.transform.animVal.getItem(0),
+//                               {translate: [50, 0]});
+
+function assert_svg_transform_equals(actual, expected, epsilon = 1e-6, description = '') {
+  if (!(expected instanceof SVGTransform)) {
+    expected = svg_transform_from_descriptor(expected);
+  }
+  const prefix = description ? description + ': ' : '';
+  assert_equals(actual.type, expected.type, prefix + 'type');
+  assert_approx_equals(actual.angle, expected.angle, epsilon, prefix + 'angle');
+  for (const matrix_component of ['a', 'b', 'c', 'd', 'e', 'f']) {
+    assert_approx_equals(actual.matrix[matrix_component], expected.matrix[matrix_component], epsilon,
+                         prefix + 'matrix.' + matrix_component);
+  }
+}
+
+// Build an SVGTransform from a literal descriptor:
+//   {translate: [tx, ty?]}        ty defaults to 0
+//   {scale: [sx, sy?]}            sy defaults to sx
+//   {rotate: [angle, cx?, cy?]}   cx/cy default to 0
+//   {skewX: angle} | {skewY: angle}
+//   {matrix: [a, b, c, d, e, f]}
+function svg_transform_from_descriptor(d) {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  const t = svg.createSVGTransform();
+  if ('translate' in d) {
+    const [tx, ty = 0] = d.translate;
+    t.setTranslate(tx, ty);
+  } else if ('scale' in d) {
+    const [sx, sy = sx] = d.scale;
+    t.setScale(sx, sy);
+  } else if ('rotate' in d) {
+    const [angle, cx = 0, cy = 0] = d.rotate;
+    t.setRotate(angle, cx, cy);
+  } else if ('skewX' in d) {
+    t.setSkewX(d.skewX);
+  } else if ('skewY' in d) {
+    t.setSkewY(d.skewY);
+  } else if ('matrix' in d) {
+    const m = svg.createSVGMatrix();
+    [m.a, m.b, m.c, m.d, m.e, m.f] = d.matrix;
+    t.setMatrix(m);
+  } else {
+    throw new Error('assert_svg_transform_equals: unknown descriptor ' +
+                    JSON.stringify(d));
+  }
+  return t;
+}


### PR DESCRIPTION
#### 8f10937bfed77edde600b06f5836563271deb07b
<pre>
Add a WPT helper to compare SVGTransform objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=317457">https://bugs.webkit.org/show_bug.cgi?id=317457</a>
<a href="https://rdar.apple.com/180088995">rdar://180088995</a>

Reviewed by Rob Buis.

Add `assert_svg_transform_equals(actual, expected, epsilon, description)`
under `svg/resources/`.

You can use it two ways:

1. With an SVGTransform built via the DOM API:
const expected = svg.createSVGTransform();
expected.setTranslate(50, 0);
assert_svg_transform_equals(text.transform.animVal.getItem(0), expected

2. With a literal descriptor object (no createSVGTransform boilerplate):
assert_svg_transform_equals(text.transform.animVal.getItem(0),
                            {translate: [50, 0]});

/svg/animations/svgtransform-animation-1.html has been converted to use
this new helper as a proof of concept. We could migrate the old tests
in a future PR. And we can start using the new method right away for new
tests.

Thanks to Rob Buis for voicing the need for it.

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgtransform-animation-1.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/resources/svg-transform-equals.js: Added.
(assert_svg_transform_equals):
(svg_transform_from_descriptor):

Canonical link: <a href="https://commits.webkit.org/315538@main">https://commits.webkit.org/315538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47bc6122151b9a18dec3be6dac28850c0476de9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127067 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c3247af-01c1-4a1c-bd6c-bfc115cfdb5b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131917 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/508be0a6-e062-4ccf-b4e2-6cc0841aae8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172314 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112421 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3728061c-8507-465a-9842-3ac9a967aa4e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27411 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181311 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36226 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140374 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42933 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140210 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37725 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43622 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107636 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35479 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42132 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6676 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41525 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41780 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->