### PR TITLE
[JSC] Use `vectorLengthHint` in `ArrayAllocationProfile` for `NewArrayWithSize` node

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-filter-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-filter-int32.js
@@ -1,0 +1,19 @@
+function test(array) {
+    return array.filter(x => (x & 1) === 0);
+}
+noInline(test);
+
+var array = [];
+for (var i = 0; i < 64; ++i)
+    array.push(i);
+
+var result;
+for (var i = 0; i < 1e6; ++i)
+    result = test(array);
+
+if (result.length !== 32)
+    throw new Error("bad length: " + result.length);
+for (var i = 0; i < 32; ++i) {
+    if (result[i] !== i * 2)
+        throw new Error("bad value at " + i + ": " + result[i]);
+}

--- a/JSTests/stress/new-array-with-size-vector-length-hint.js
+++ b/JSTests/stress/new-array-with-size-vector-length-hint.js
@@ -1,0 +1,78 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+// Array.prototype.filter result must have the exact length of the number of
+// elements that passed the predicate, regardless of the vectorLengthHint
+// learned by ArrayAllocationProfile in earlier tiers.
+(function() {
+    function test(array) {
+        return array.filter(x => x % 3 === 0);
+    }
+    noInline(test);
+
+    var array = [];
+    for (var i = 0; i < 16; ++i)
+        array.push(i);
+
+    for (var iter = 0; iter < 1e5; ++iter) {
+        var r = test(array);
+        shouldBe(r.length, 6);
+        shouldBe(r[0], 0);
+        shouldBe(r[5], 15);
+        shouldBe(6 in r, false);
+    }
+})();
+
+// No elements pass; result must be empty even if a non-zero vectorLengthHint
+// was learned for the allocation site.
+(function() {
+    function test(array) {
+        return array.filter(x => false);
+    }
+    noInline(test);
+
+    var array = [1, 2, 3, 4, 5, 6, 7, 8];
+    for (var iter = 0; iter < 1e5; ++iter) {
+        var r = test(array);
+        shouldBe(r.length, 0);
+        shouldBe(0 in r, false);
+    }
+})();
+
+// new Array(n) with subsequent growth: vectorLengthHint must not affect the
+// observable publicLength.
+(function() {
+    function test(n) {
+        var a = new Array(n);
+        for (var i = 0; i < 20; ++i)
+            a[i] = i;
+        return a;
+    }
+    noInline(test);
+
+    for (var iter = 0; iter < 1e5; ++iter) {
+        var r = test(3);
+        shouldBe(r.length, 20);
+        shouldBe(r[0], 0);
+        shouldBe(r[19], 19);
+    }
+})();
+
+// @newArrayWithSize via Array.from on array-like: ensure correctness with
+// the learned hint.
+(function() {
+    function test(obj) {
+        return Array.from(obj);
+    }
+    noInline(test);
+
+    var obj = { length: 8, 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7 };
+    for (var iter = 0; iter < 1e5; ++iter) {
+        var r = test(obj);
+        shouldBe(r.length, 8);
+        shouldBe(r[7], 7);
+        shouldBe(8 in r, false);
+    }
+})();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -8270,7 +8270,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
         case op_new_array_with_size: {
             auto bytecode = currentInstruction->as<OpNewArrayWithSize>();
             ArrayAllocationProfile& profile = bytecode.metadata(codeBlock).m_arrayAllocationProfile;
-            set(bytecode.m_dst, addToGraph(NewArrayWithSize, OpInfo(profile.selectIndexingTypeConcurrently()), get(bytecode.m_length)));
+            set(bytecode.m_dst, addToGraph(NewArrayWithSize, OpInfo(profile.selectIndexingTypeConcurrently()), OpInfo(profile.vectorLengthHintConcurrently()), get(bytecode.m_length)));
             NEXT_OPCODE(op_new_array_with_size);
         }
 
@@ -8283,7 +8283,8 @@ void ByteCodeParser::parseBlock(unsigned limit)
             NewArrayWithSpeciesData data { };
             data.arrayMode = arrayMode.asWord();
             data.indexingMode = profile.selectIndexingTypeConcurrently();
-            set(bytecode.m_dst, addToGraph(NewArrayWithSpecies, OpInfo(data.asQuadWord()), OpInfo(prediction), Edge(get(bytecode.m_length)), Edge(get(bytecode.m_array), KnownCellUse)));
+            data.vectorLengthHint = profile.vectorLengthHintConcurrently();
+            set(bytecode.m_dst, addToGraph(NewArrayWithSpecies, OpInfo(data.asQuadWord), OpInfo(prediction), Edge(get(bytecode.m_length)), Edge(get(bytecode.m_array), KnownCellUse)));
             NEXT_OPCODE(op_new_array_with_species);
         }
 

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1157,7 +1157,7 @@ private:
                                 m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
                                 alreadyHandled = true; // Don't allow the default constant folder to do things to this.
 
-                                Node* butterfly = m_insertionSet.insertNode(indexInBlock, SpecNone, NewButterflyWithSize, node->origin, OpInfo(node->indexingType()), node->child1());
+                                Node* butterfly = m_insertionSet.insertNode(indexInBlock, SpecNone, NewButterflyWithSize, node->origin, OpInfo(node->indexingType()), OpInfo(node->vectorLengthHint()), node->child1());
                                 node->convertToNewArrayWithButterfly(m_graph, butterfly);
                                 changed = true;
                         }

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -263,9 +263,11 @@ void Node::convertToNewArrayWithSize()
 {
     ASSERT(op() == NewArrayWithSpecies);
     IndexingType indexingType = this->indexingType();
+    unsigned vectorLengthHint = this->vectorLengthHint();
     setOpAndDefaultFlags(NewArrayWithSize);
     children.child2() = Edge();
     m_opInfo = indexingType;
+    m_opInfo2 = vectorLengthHint;
 }
 
 void Node::convertToNewArrayWithButterfly(Graph&, Node* butterfly)

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -142,13 +142,18 @@ static_assert(sizeof(IndexingType) <= sizeof(unsigned));
 static_assert(sizeof(NewArrayBufferData) == sizeof(uint64_t));
 
 struct NewArrayWithSpeciesData {
-    unsigned arrayMode { 0 };
-    unsigned indexingMode { 0 };
-
-    uint64_t asQuadWord() const { return std::bit_cast<uint64_t>(*this); }
+    union {
+        struct {
+            unsigned arrayMode;
+            uint8_t indexingMode;
+            uint8_t vectorLengthHint;
+        };
+        uint64_t asQuadWord;
+    };
 };
-static_assert(sizeof(IndexingType) <= sizeof(unsigned));
+static_assert(sizeof(IndexingType) <= sizeof(uint8_t));
 static_assert(sizeof(ArrayMode) <= sizeof(unsigned));
+static_assert(sizeof(NewArrayWithSpeciesData) == sizeof(uint64_t));
 
 struct DataViewData {
     union {
@@ -1494,18 +1499,30 @@ public:
         case NewArray:
         case NewArrayBuffer:
         case PhantomNewArrayBuffer:
+        case NewArrayWithSize:
+        case NewButterflyWithSize:
+        case PhantomNewButterflyWithSize:
+        case NewArrayWithSpecies:
             return true;
         default:
             return false;
         }
     }
-    
+
     unsigned vectorLengthHint()
     {
         ASSERT(hasVectorLengthHint());
-        if (op() == NewArray)
+        switch (op()) {
+        case NewArray:
+        case NewArrayWithSize:
+        case NewButterflyWithSize:
+        case PhantomNewButterflyWithSize:
             return m_opInfo2.as<unsigned>();
-        return newArrayBufferData().vectorLengthHint;
+        case NewArrayWithSpecies:
+            return newArrayWithSpeciesData().vectorLengthHint;
+        default:
+            return newArrayBufferData().vectorLengthHint;
+        }
     }
 
     bool hasIndexingType()
@@ -2820,7 +2837,7 @@ public:
         case NewArrayWithSpecies: {
             auto data = newArrayWithSpeciesData();
             data.arrayMode = arrayMode.asWord();
-            m_opInfo = data.asQuadWord();
+            m_opInfo = data.asQuadWord;
             return true;
         }
         case MultiGetByVal:

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -1882,7 +1882,7 @@ escapeChildren:
             Node* node = allocation.identifier();
 
             return m_graph.addNode(node->prediction(),  NewButterflyWithSize,
-                where->origin.withSemantic(node->origin.semantic), OpInfo(node->indexingType()));
+                where->origin.withSemantic(node->origin.semantic), OpInfo(node->indexingType()), OpInfo(node->vectorLengthHint()));
         }
 
         case Allocation::Kind::Object: {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15740,11 +15740,12 @@ void SpeculativeJIT::compileNewButterflyWithSize(Node* node)
     IndexingType indexingMode = node->indexingMode();
     ASSERT(!hasAnyArrayStorage(indexingMode));
     ASSERT(!isCopyOnWrite(indexingMode));
-    unsigned butterflyLength = node->child1()->asInt32();
-    ASSERT(butterflyLength < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
+    unsigned publicLength = node->child1()->asInt32();
+    unsigned vectorLength = std::max(publicLength, node->vectorLengthHint());
+    ASSERT(vectorLength < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
 
     constexpr bool hasIndexingHeader = true;
-    size_t allocationSize = Butterfly::totalSize(0, 0, hasIndexingHeader, butterflyLength * sizeof(JSValue));
+    size_t allocationSize = Butterfly::totalSize(0, 0, hasIndexingHeader, vectorLength * sizeof(JSValue));
 
     JumpList slowCases;
     emitAllocate(storageGPR, JITAllocator::constant(vm().auxiliarySpace().allocatorForNonInline(allocationSize, AllocatorForMode::EnsureAllocator)), scratchGPR, scratch2GPR, slowCases, SlowAllocationResult::UndefinedBehavior);
@@ -15753,19 +15754,20 @@ void SpeculativeJIT::compileNewButterflyWithSize(Node* node)
 
     GPRReg sizeGPR = scratch2GPR;
 
-    move(Imm32(butterflyLength), sizeGPR);
+    move(Imm32(vectorLength), sizeGPR);
+    move(Imm32(publicLength), scratchGPR);
 
     // FIXME: do post increment store pair.
     addPtr(TrustedImm32(sizeof(IndexingHeader)), storageGPR);
     static_assert(Butterfly::offsetOfPublicLength() + static_cast<ptrdiff_t>(sizeof(uint32_t)) == Butterfly::offsetOfVectorLength());
-    storePair32(sizeGPR, sizeGPR, storageGPR, TrustedImm32(Butterfly::offsetOfPublicLength()));
+    storePair32(scratchGPR, sizeGPR, storageGPR, TrustedImm32(Butterfly::offsetOfPublicLength()));
 
     constexpr unsigned zeroFillUnrollLimit = 16;
-    if (butterflyLength <= zeroFillUnrollLimit) {
+    if (vectorLength <= zeroFillUnrollLimit) {
         if (hasDouble(indexingMode))
-            emitFillStorageWithDoubleEmpty(storageGPR, 0, butterflyLength, scratchGPR);
+            emitFillStorageWithDoubleEmpty(storageGPR, 0, vectorLength, scratchGPR);
         else
-            emitFillStorageWithJSEmpty(storageGPR, 0, butterflyLength, scratchGPR);
+            emitFillStorageWithJSEmpty(storageGPR, 0, vectorLength, scratchGPR);
     } else {
         if (hasDouble(indexingMode))
             moveTrustedValue(jsNaN(), scratchRegs);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -11002,9 +11002,11 @@ IGNORE_CLANG_WARNINGS_END
         ASSERT(!isCopyOnWrite(m_node->indexingMode()));
 
         LValue publicLength = lowInt32(m_node->child1());
+        LValue vectorLengthHint = m_out.constInt32(m_node->vectorLengthHint());
+        LValue vectorLength = m_out.select(m_out.aboveOrEqual(publicLength, vectorLengthHint), publicLength, vectorLengthHint);
         LValue indexingType = m_out.constInt32(m_node->indexingType());
 
-        LValue butterfly = allocateButterfly(indexingType, m_out.int32Zero, publicLength, publicLength);
+        LValue butterfly = allocateButterfly(indexingType, m_out.int32Zero, publicLength, vectorLength);
 
         setStorage(butterfly);
         // No mutator fence is needed. Butterflies are only scanned when the GC discovers them in an object not on the stack.


### PR DESCRIPTION
#### 6654fe520c0b94de12aff50be1839be853f9e15e
<pre>
[JSC] Use `vectorLengthHint` in `ArrayAllocationProfile` for `NewArrayWithSize` node
<a href="https://bugs.webkit.org/show_bug.cgi?id=317466">https://bugs.webkit.org/show_bug.cgi?id=317466</a>

Reviewed by Yusuke Suzuki.

Array.prototype.filter creates its result via op_new_array_with_species
with length 0, which the DFG converts to NewArrayWithSize(0). The
resulting JSArray has a tiny initial vector, so appending elements
repeatedly reallocates the butterfly (~56% of filter time spent in
ensureLengthSlow / reallocArrayRightIfPossible / memmove / memset).

ArrayAllocationProfile already learns the eventual vectorLength of the
last allocated array (capped at BASE_CONTIGUOUS_VECTOR_LEN_MAX = 25),
but NewArrayWithSize was not consuming it. This patch threads the
profile vectorLengthHint through NewArrayWithSpecies / NewArrayWithSize
into NewButterflyWithSize and uses it as the initial vectorLength while
keeping publicLength unchanged. Because the hint is adaptive and capped,
low-selectivity filters and small arrays do not over-allocate.

                                     Baseline                  Patched

array-prototype-filter-int32    119.0802+-0.6515     ^     70.6984+-1.3794        ^ definitely 1.6843x faster

* JSTests/microbenchmarks/array-prototype-filter-int32.js: Added.
* JSTests/stress/new-array-with-size-vector-length-hint.js: Added.
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToNewArrayWithSize):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasVectorLengthHint):
(JSC::DFG::Node::vectorLengthHint):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileNewButterflyWithSize):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNewButterflyWithSize):

Canonical link: <a href="https://commits.webkit.org/317563@main">https://commits.webkit.org/317563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e436ddf07660755b2eb1279fecaf8074af87315

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185129 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136682 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38746 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37132 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5954 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36938 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33604 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36804 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187554 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49142 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145653 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39217 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49822 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145490 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40311 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122015 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115796 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48329 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->