### PR TITLE
[JSC] Use `CompareBelow` for fast array iterator next done check

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -12065,27 +12065,21 @@ void ByteCodeParser::handleIteratorNext(const JSInstruction* currentInstruction,
         auto prediction = getPredictionWithoutOSRExit(BytecodeIndex(m_currentIndex.offset(), OpIteratorNext::getValue));
 
         {
-            // FIXME: doneIndex is -1 so it seems like we should be able to do CompareBelow(index, length). See: https://bugs.webkit.org/show_bug.cgi?id=210927
+            static_assert(JSArrayIterator::doneIndex == -1);
             Node* iterator = get(bytecode.m_iterator);
-            Node* doneIndex = jsConstant(jsNumber(JSArrayIterator::doneIndex));
             Node* index = addToGraph(GetInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::Index)), OpInfo(SpecInt32Only), iterator);
-            Node* isDone = addToGraph(CompareStrictEq, index, doneIndex);
 
             Node* iteratedObject = addToGraph(GetInternalField, OpInfo(static_cast<uint32_t>(JSArrayIterator::Field::IteratedObject)), OpInfo(SpecObject), iterator);
             Node* butterfly = addToGraph(GetButterfly, iteratedObject);
             Node* length = addToGraph(GetArrayLength, OpInfo(arrayMode.asWord()), Edge(iteratedObject), Edge(butterfly, KnownStorageUse));
             // GetArrayLength is pessimized prior to fixup.
             emitExitOK();
-            Node* isOutOfBounds = addToGraph(CompareGreaterEq, Edge(index, Int32Use), Edge(length, Int32Use));
-
-            isDone = addToGraph(ArithBitOr, isDone, isOutOfBounds);
-            // The above compare doesn't produce effects since we know the values are booleans. We don't set UseKinds because Fixup likes to add edges.
-            emitExitOK();
+            Node* isInBounds = addToGraph(CompareBelow, Edge(index, Int32Use), Edge(length, Int32Use));
 
             BranchData* branchData = m_graph.m_branchData.add();
-            branchData->taken = BranchTarget(isDoneBlock);
-            branchData->notTaken = BranchTarget(doLoadBlock);
-            addToGraph(Branch, OpInfo(branchData), isDone);
+            branchData->taken = BranchTarget(doLoadBlock);
+            branchData->notTaken = BranchTarget(isDoneBlock);
+            addToGraph(Branch, OpInfo(branchData), isInBounds);
         }
 
         {

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1198,7 +1198,6 @@ public:
                     }
                     
                     auto extractRelationship = [&](Node* compare) -> Relationship {
-                        // FIXME: Handle CompareBelow and CompareBelowEq.
                         if (!compare || !compare->isBinaryUseKind(Int32Use))
                             return Relationship();
                         switch (compare->op()) {
@@ -1255,6 +1254,16 @@ public:
                                 relationshipForFalse.append(relationship);
                             if (auto relationship = extractRelationship(r).inverse())
                                 relationshipForFalse.append(relationship);
+                        }
+                    } else if ((condition->op() == CompareBelow || condition->op() == CompareBelowEq) && condition->isBinaryUseKind(Int32Use)) {
+                        Node* left = condition->child1().node();
+                        Node* right = condition->child2().node();
+                        if (provablyNonNegative(right)) {
+                            int offset = condition->op() == CompareBelow ? 0 : 1;
+                            if (auto rel = Relationship::safeCreate(left, right, Relationship::LessThan, offset))
+                                relationshipForTrue.append(rel);
+                            if (auto rel = Relationship::safeCreate(left, m_zero, Relationship::GreaterThan, -1))
+                                relationshipForTrue.append(rel);
                         }
                     } else {
                         if (auto relationship = extractRelationship(condition))


### PR DESCRIPTION
#### 0f8ab3f489630d0571929926d2b63eab1d601e91
<pre>
[JSC] Use `CompareBelow` for fast array iterator next done check
<a href="https://bugs.webkit.org/show_bug.cgi?id=210927">https://bugs.webkit.org/show_bug.cgi?id=210927</a>

Reviewed by NOBODY (OOPS!).

The fast array iterator next previously emitted CompareStrictEq(index, -1),
CompareGreaterEq(index, length), and ArithBitOr to decide doneness. Since
doneIndex is -1, a single unsigned CompareBelow(index, length) covers both
cases. To keep CheckInBounds elimination working, IntegerRangeOptimization
now learns 0 &lt;= left &lt; right (signed) on the taken edge of
Branch(CompareBelow(left, right)) when right is provably non-negative.

                              TipOfTree                  Patched

for-of-array                3.1351+-0.0669     ^      2.9919+-0.0503        ^ definitely 1.0479x faster

* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIteratorNext):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f8ab3f489630d0571929926d2b63eab1d601e91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127006 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131863 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92800 "8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112367 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32005 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27350 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/568 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143575 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181250 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30549 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140320 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42872 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140158 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43561 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107505 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35427 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115326 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201973 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42071 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6615 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54173 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41464 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41719 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->