### PR TITLE
calc() serializes 'vmax' in the wrong order relative to other dimensions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-dimension-serialization-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-dimension-serialization-order-expected.txt
@@ -1,0 +1,46 @@
+
+PASS all dimensions reverse-sorted serialize back in canonical order
+PASS cap sorts after %
+PASS ch sorts after cap
+PASS cqb sorts after ch
+PASS cqh sorts after cqb
+PASS cqi sorts after cqh
+PASS cqmax sorts after cqi
+PASS cqmin sorts after cqmax
+PASS cqw sorts after cqmin
+PASS dvb sorts after cqw
+PASS dvh sorts after dvb
+PASS dvi sorts after dvh
+PASS dvmax sorts after dvi
+PASS dvmin sorts after dvmax
+PASS dvw sorts after dvmin
+PASS em sorts after dvw
+PASS ex sorts after em
+PASS ic sorts after ex
+PASS lh sorts after ic
+PASS lvb sorts after lh
+PASS lvh sorts after lvb
+PASS lvi sorts after lvh
+PASS lvmax sorts after lvi
+PASS lvmin sorts after lvmax
+PASS lvw sorts after lvmin
+PASS px sorts after lvw
+PASS rcap sorts after px
+PASS rch sorts after rcap
+PASS rem sorts after rch
+PASS rex sorts after rem
+PASS ric sorts after rex
+PASS rlh sorts after ric
+PASS svb sorts after rlh
+PASS svh sorts after svb
+PASS svi sorts after svh
+PASS svmax sorts after svi
+PASS svmin sorts after svmax
+PASS svw sorts after svmin
+PASS vb sorts after svw
+PASS vh sorts after vb
+PASS vi sorts after vh
+PASS vmax sorts after vi
+PASS vmin sorts after vmax
+PASS vw sorts after vmin
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-dimension-serialization-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-dimension-serialization-order.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Values and Units: serialization order of dimensions in calc()</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-serialize">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#sort-a-calculations-children">
+<meta name="assert" content="In a calc() Sum, a percentage sorts before any dimension, and dimensions are serialized sorted by their unit, ordered ASCII case-insensitively. This test exercises every relative-length unit (font-relative, container-query and viewport units) plus a percentage. Absolute lengths are intentionally omitted because they all canonicalize to 'px' and would not remain as distinct sorted terms.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="target"></div>
+<script>
+const target = document.getElementById("target");
+
+// Terms in their canonical (already-sorted) order, as required by
+// https://drafts.csswg.org/css-values-4/#sort-a-calculations-children :
+//   percentage first, then dimensions ordered ASCII case-insensitively by unit.
+// Only units that stay distinct through calc() simplification are listed; the
+// absolute lengths (cm, in, mm, pc, pt, px, q) all collapse to a single px term
+// and so cannot exercise inter-unit ordering -- px stands in for that group.
+const sortedTerms = [
+  "3%",
+  "1cap", "1ch",
+  "1cqb", "1cqh", "1cqi", "1cqmax", "1cqmin", "1cqw",
+  "1dvb", "1dvh", "1dvi", "1dvmax", "1dvmin", "1dvw",
+  "1em", "1ex", "1ic", "1lh",
+  "1lvb", "1lvh", "1lvi", "1lvmax", "1lvmin", "1lvw",
+  "1px",
+  "1rcap", "1rch", "1rem", "1rex", "1ric", "1rlh",
+  "1svb", "1svh", "1svi", "1svmax", "1svmin", "1svw",
+  "1vb", "1vh", "1vi", "1vmax", "1vmin", "1vw",
+];
+
+function setHeight(value) {
+  target.style.height = "";
+  target.style.height = value;
+  return target.style.height;
+}
+
+// Human-readable label for a term ("3%" -> "%", "1vmax" -> "vmax").
+function label(term) {
+  return term.replace(/^[0-9.]+/, "");
+}
+
+// Exhaustive global check: feed every term in reverse order and require it to
+// serialize back in full canonical order. This catches any unit whose sort key
+// is globally misplaced.
+test(() => {
+  const scrambled = [...sortedTerms].reverse();
+  const specified = `calc(${scrambled.join(" + ")})`;
+  const expected = `calc(${sortedTerms.join(" + ")})`;
+  assert_not_equals(setHeight(specified), "", "all units should parse, leaving a non-empty calc()");
+  assert_equals(setHeight(specified), expected);
+}, "all dimensions reverse-sorted serialize back in canonical order");
+
+// Adjacent-pair sweep: for every consecutive pair (a before b) verify that the
+// swapped input "calc(b + a)" serializes as "calc(a + b)". This pinpoints a
+// single out-of-place unit (the original 'vmax' regression was exactly this).
+for (let i = 1; i < sortedTerms.length; ++i) {
+  const a = sortedTerms[i - 1];
+  const b = sortedTerms[i];
+  test(() => {
+    assert_equals(setHeight(`calc(${b} + ${a})`), `calc(${a} + ${b})`);
+  }, `${label(b)} sorts after ${label(a)}`);
+}
+</script>

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -33,6 +33,7 @@
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSUnits.h"
+#include <limits>
 #include <ranges>
 #include <wtf/text/StringBuilder.h>
 
@@ -116,6 +117,18 @@ template<typename Op> static void serializeCalculationTree(StringBuilder&, const
 
 // MARK: Sorting
 
+// Sort keys are assigned sequentially via __COUNTER__ rather than hand-numbered,
+// so that adding, removing or reordering a case cannot accidentally collide with
+// or skip a value (which is how 'vmax' came to share 'svb's key and skip its own).
+// The base is captured once so the keys start at 0 regardless of any prior
+// __COUNTER__ use in this translation unit.
+static constexpr unsigned sortPriorityBase = __COUNTER__;
+#define SORT_PRIORITY_NEXT (__COUNTER__ - sortPriorityBase - 1)
+
+// Sentinels that sort after every real unit, independent of how many there are.
+static constexpr unsigned errorSortPriority = std::numeric_limits<unsigned>::max() - 1;
+static constexpr unsigned otherSortPriority = std::numeric_limits<unsigned>::max();
+
 static unsigned NODELETE sortPriority(CSSUnitType unit)
 {
     // Sort order: number, percentage, dimension (by unit, ordered ASCII case-insensitively), other.
@@ -123,73 +136,73 @@ static unsigned NODELETE sortPriority(CSSUnitType unit)
     switch (unit) {
     // number
     case CSSUnitType::CSS_NUMBER:
-    case CSSUnitType::CSS_INTEGER:      return 0;
+    case CSSUnitType::CSS_INTEGER:      return SORT_PRIORITY_NEXT;
     // percentage
-    case CSSUnitType::CSS_PERCENTAGE:   return 1;
+    case CSSUnitType::CSS_PERCENTAGE:   return SORT_PRIORITY_NEXT;
 
     // dimension (by unit, ordered ASCII case-insensitively)
-    case CSSUnitType::CSS_CAP:          return 2;
-    case CSSUnitType::CSS_CH:           return 3;
-    case CSSUnitType::CSS_CM:           return 4;
-    case CSSUnitType::CSS_CQB:          return 5;
-    case CSSUnitType::CSS_CQH:          return 6;
-    case CSSUnitType::CSS_CQI:          return 7;
-    case CSSUnitType::CSS_CQMAX:        return 8;
-    case CSSUnitType::CSS_CQMIN:        return 9;
-    case CSSUnitType::CSS_CQW:          return 10;
-    case CSSUnitType::CSS_DEG:          return 11;
-    case CSSUnitType::CSS_DPCM:         return 12;
-    case CSSUnitType::CSS_DPI:          return 13;
-    case CSSUnitType::CSS_DPPX:         return 14;
-    case CSSUnitType::CSS_DVB:          return 15;
-    case CSSUnitType::CSS_DVH:          return 16;
-    case CSSUnitType::CSS_DVI:          return 17;
-    case CSSUnitType::CSS_DVMAX:        return 18;
-    case CSSUnitType::CSS_DVMIN:        return 19;
-    case CSSUnitType::CSS_DVW:          return 20;
-    case CSSUnitType::CSS_EM:           return 21;
-    case CSSUnitType::CSS_EX:           return 22;
-    case CSSUnitType::CSS_FR:           return 23;
-    case CSSUnitType::CSS_GRAD:         return 24;
-    case CSSUnitType::CSS_HZ:           return 25;
-    case CSSUnitType::CSS_IC:           return 26;
-    case CSSUnitType::CSS_IN:           return 27;
-    case CSSUnitType::CSS_KHZ:          return 28;
-    case CSSUnitType::CSS_LH:           return 29;
-    case CSSUnitType::CSS_LVB:          return 30;
-    case CSSUnitType::CSS_LVH:          return 31;
-    case CSSUnitType::CSS_LVI:          return 32;
-    case CSSUnitType::CSS_LVMAX:        return 33;
-    case CSSUnitType::CSS_LVMIN:        return 34;
-    case CSSUnitType::CSS_LVW:          return 35;
-    case CSSUnitType::CSS_MM:           return 36;
-    case CSSUnitType::CSS_MS:           return 37;
-    case CSSUnitType::CSS_PC:           return 38;
-    case CSSUnitType::CSS_PT:           return 39;
-    case CSSUnitType::CSS_PX:           return 40;
-    case CSSUnitType::CSS_Q:            return 41;
-    case CSSUnitType::CSS_RAD:          return 42;
-    case CSSUnitType::CSS_RCAP:         return 43;
-    case CSSUnitType::CSS_RCH:          return 44;
-    case CSSUnitType::CSS_REM:          return 45;
-    case CSSUnitType::CSS_REX:          return 46;
-    case CSSUnitType::CSS_RIC:          return 47;
-    case CSSUnitType::CSS_RLH:          return 48;
-    case CSSUnitType::CSS_S:            return 49;
-    case CSSUnitType::CSS_SVB:          return 50;
-    case CSSUnitType::CSS_SVH:          return 51;
-    case CSSUnitType::CSS_SVI:          return 52;
-    case CSSUnitType::CSS_SVMAX:        return 53;
-    case CSSUnitType::CSS_SVMIN:        return 54;
-    case CSSUnitType::CSS_SVW:          return 55;
-    case CSSUnitType::CSS_TURN:         return 56;
-    case CSSUnitType::CSS_VB:           return 57;
-    case CSSUnitType::CSS_VH:           return 58;
-    case CSSUnitType::CSS_VI:           return 59;
-    case CSSUnitType::CSS_VMAX:         return 50;
-    case CSSUnitType::CSS_VMIN:         return 61;
-    case CSSUnitType::CSS_VW:           return 62;
-    case CSSUnitType::CSS_X:            return 63;
+    case CSSUnitType::CSS_CAP:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_CH:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_CM:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_CQB:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_CQH:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_CQI:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_CQMAX:        return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_CQMIN:        return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_CQW:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DEG:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DPCM:         return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DPI:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DPPX:         return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DVB:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DVH:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DVI:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DVMAX:        return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DVMIN:        return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_DVW:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_EM:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_EX:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_FR:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_GRAD:         return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_HZ:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_IC:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_IN:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_KHZ:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_LH:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_LVB:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_LVH:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_LVI:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_LVMAX:        return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_LVMIN:        return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_LVW:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_MM:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_MS:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_PC:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_PT:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_PX:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_Q:            return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_RAD:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_RCAP:         return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_RCH:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_REM:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_REX:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_RIC:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_RLH:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_S:            return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_SVB:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_SVH:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_SVI:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_SVMAX:        return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_SVMIN:        return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_SVW:          return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_TURN:         return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_VB:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_VH:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_VI:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_VMAX:         return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_VMIN:         return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_VW:           return SORT_PRIORITY_NEXT;
+    case CSSUnitType::CSS_X:            return SORT_PRIORITY_NEXT;
 
     // Non-numeric types are not supported.
     case CSSUnitType::CSS_CALC:
@@ -201,8 +214,10 @@ static unsigned NODELETE sortPriority(CSSUnitType unit)
     }
 
     ASSERT_NOT_REACHED();
-    return 64;
+    return errorSortPriority;
 }
+
+#undef SORT_PRIORITY_NEXT
 
 static unsigned sortPriority(const Child& child)
 {
@@ -213,7 +228,7 @@ static unsigned sortPriority(const Child& child)
             return sortPriority(toCSSUnit(root));
         },
         [](const auto&) -> unsigned {
-            return 65; // NOTE: 65 is greater than any numeric unit type, even the error case.
+            return otherSortPriority; // Sorts after every numeric unit, even the error case.
         }
     );
 }


### PR DESCRIPTION
#### 6338be7750407682e1b45f0c9cb227ec5be4da63
<pre>
calc() serializes &apos;vmax&apos; in the wrong order relative to other dimensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=317468">https://bugs.webkit.org/show_bug.cgi?id=317468</a>

Reviewed by Darin Adler and Sam Weinig.

When serializing a calc() Sum or Product, its dimension children must be sorted
by their unit, ordered ASCII case-insensitively, per:
- <a href="https://drafts.csswg.org/css-values-4/#sort-a-calculations-children">https://drafts.csswg.org/css-values-4/#sort-a-calculations-children</a>

sortPriority() hand-numbered each unit&apos;s sort key. &apos;vmax&apos; was given the key 50,
which both collided with &apos;svb&apos; (also 50) and skipped the intended slot 60
between &apos;vi&apos; (59) and &apos;vmin&apos; (61). As a result &apos;vmax&apos; sorted ahead of every unit
in the 50-59 range that it should have followed (svh, svi, svmax, svmin, svw,
turn, vb, vh, vi), so e.g. calc(1vmax + 1vh) serialized as &quot;calc(1vmax + 1vh)&quot;
instead of the canonical &quot;calc(1vh + 1vmax)&quot;.

Rather than just correct the one key, assign the keys sequentially via __COUNTER__
so that this whole class of bug (a collision or a skipped slot from hand-numbering)
becomes impossible: adding, removing or reordering a case now renumbers
automatically. The base is captured once so the keys still start at 0 regardless
of any earlier __COUNTER__ use in the translation unit, and the two sentinels that
must sort after every real unit (the unreachable error case and non-numeric
children) are derived from std::numeric_limits so they no longer depend on the
unit count. The resulting keys are identical to the hand-numbered ones, except
&apos;vmax&apos; now correctly gets 60.

Add an exhaustive (but fast) test that exercises the full ordering. It lists
every relative-length unit that survives calc() simplification as a distinct
term (the font-relative, container-query and viewport units, plus px standing
in for the absolute lengths that all canonicalize to px) plus a leading
percentage, in canonical order. It then (a) feeds them all in reverse order and
checks they serialize back in canonical order, and (b) sweeps every adjacent
pair, swapping the two and checking they serialize back sorted -- which
pinpoints any single out-of-place unit, exactly the failure mode of the &apos;vmax&apos;
bug (&apos;vmax&apos; was caught by the &apos;vmax sorts after vi&apos; and &apos;vmin sorts after vmax&apos;
pairs).

Test: imported/w3c/web-platform-tests/css/css-values/calc-dimension-serialization-order.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-dimension-serialization-order-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-dimension-serialization-order.html: Added.
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::sortPriority):

Canonical link: <a href="https://commits.webkit.org/315557@main">https://commits.webkit.org/315557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96875b1247d110776dd6ce97ff4303f8ec761fe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127113 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91433404-234b-4a98-a051-c6d87d5b7962) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131955 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3872e36c-4744-49d6-afb6-71486edd9f83) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172360 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112459 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad0f3884-8b42-4ea2-b226-440aa38f1839) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32095 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27457 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181358 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140409 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140245 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37733 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43668 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107725 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35517 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115433 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42178 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6726 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41571 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41714 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->