### PR TITLE
clamp() fails to parse whitespace after 'none'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-none-whitespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-none-whitespace-expected.txt
@@ -1,0 +1,5 @@
+
+PASS clamp() accepts whitespace between a 'none' min argument and the following comma
+PASS clamp() accepts whitespace after a trailing 'none' max argument
+PASS clamp() accepts whitespace around 'none' for both bounds
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-none-whitespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-none-whitespace.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values: clamp() accepts whitespace around a 'none' argument</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#funcdef-clamp">
+<meta name="assert" content="clamp( [ <calc-sum> | none ], <calc-sum>, [ <calc-sum> | none ] ) must accept optional whitespace around the 'none' keyword, including before the following comma and after a trailing 'none', exactly as it does for a <calc-sum> argument.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+// Returns the serialized specified value of 'width' for the given declaration,
+// or "" if the declaration was rejected as invalid.
+function serializeWidth(value) {
+  const el = document.createElement("div");
+  el.style.width = value;
+  return el.style.width;
+}
+
+// The 'none' argument with insignificant whitespace must parse identically to
+// the same value without that whitespace. Comparing against the no-whitespace
+// control avoids hard-coding clamp()'s canonical serialization.
+test(() => {
+  const control = serializeWidth("clamp(none, 5px, 10px)");
+  assert_not_equals(control, "", "clamp() with 'none' as the min argument is supported");
+  assert_equals(serializeWidth("clamp(none , 5px, 10px)"), control,
+    "whitespace between 'none' and the following comma");
+}, "clamp() accepts whitespace between a 'none' min argument and the following comma");
+
+test(() => {
+  const control = serializeWidth("clamp(5px, 6px, none)");
+  assert_not_equals(control, "", "clamp() with 'none' as the max argument is supported");
+  assert_equals(serializeWidth("clamp(5px, 6px, none )"), control,
+    "whitespace after a trailing 'none'");
+}, "clamp() accepts whitespace after a trailing 'none' max argument");
+
+test(() => {
+  const control = serializeWidth("clamp(none, 5px, none)");
+  assert_not_equals(control, "", "clamp() with 'none' as both bounds is supported");
+  assert_equals(serializeWidth("clamp( none , 5px , none )"), control,
+    "whitespace around both 'none' bounds");
+}, "clamp() accepts whitespace around 'none' for both bounds");
+</script>

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -463,7 +463,7 @@ static std::optional<TypedChild> consumeClamp(CSSParserTokenRange& tokens, int d
     };
     auto parseCalcSumOrNone = [](auto& tokens, auto depth, auto& state) -> std::optional<TypedChildOrNone> {
         if (tokens.peek().id() == CSSValueNone) {
-            tokens.consume();
+            tokens.consumeIncludingWhitespace();
             return TypedChildOrNone { ChildOrNone { CSS::Keyword::None { } }, Type { } };
         }
         auto sum = parseCalcSum(tokens, depth, state);


### PR DESCRIPTION
#### 98c7df9af85fbea21d3bf6328bf3d92a10be31dc
<pre>
clamp() fails to parse whitespace after &apos;none&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=317469">https://bugs.webkit.org/show_bug.cgi?id=317469</a>

Reviewed by Darin Adler.

When parsing a &apos;none&apos; bound, consumeClamp() consumed only the &apos;none&apos; token via
CSSParserTokenRange::consume(), leaving any trailing whitespace in the range.
The &lt;calc-sum&gt; branch, by contrast, ends in consumeIncludingWhitespace(). Since
consumeCommaIncludingWhitespace() requires the next token to be a comma (it does
not skip leading whitespace), a space between &apos;none&apos; and the following comma made
the comma check fail; likewise, trailing whitespace after a final &apos;none&apos; tripped
the atEnd() check. As a result, clamp(none , 5px, 10px) and clamp(5px, 6px, none )
were rejected even though clamp(none, 5px, 10px) and clamp(5px, 6px, none) parsed.

Consume the trailing whitespace after &apos;none&apos;, matching the &lt;calc-sum&gt; branch.

Test: imported/w3c/web-platform-tests/css/css-values/clamp-none-whitespace.html

The test is failing in Shipping Safari but passing in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-none-whitespace-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-none-whitespace.html: Added.
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeClamp):

Canonical link: <a href="https://commits.webkit.org/315536@main">https://commits.webkit.org/315536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/244059462fcb3c91c3a6ac4b5478b2590d2c483a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127008 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6590f59-58a7-48bb-86ea-316279a613df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64db2b5c-60a3-4d83-90d2-0d9d9117c7fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172255 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112369 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12e5de51-5c79-4134-94cc-fdac61c20580) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27352 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/628 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181252 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33962 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 33900 issues") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140322 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42874 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37727 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43563 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107508 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35429 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115328 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42073 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6675 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41466 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41721 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41609 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->