### PR TITLE
anchor()/anchor-size() crash on a function-form zero fallback

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-zero-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-zero-fallback-expected.txt
@@ -1,0 +1,8 @@
+
+PASS e.style['width'] = "anchor-size(width, calc(0))" should not set the property value
+PASS e.style['width'] = "anchor-size(width, min(0, 0))" should not set the property value
+PASS e.style['height'] = "anchor-size(height, max(0))" should not set the property value
+PASS e.style['left'] = "anchor(left, calc(0))" should not set the property value
+PASS e.style['width'] = "anchor-size(width, 0)" should set the property value
+PASS e.style['width'] = "anchor-size(width, 10px)" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-zero-fallback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-zero-fallback.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Anchor Position: a function-form zero is not a valid anchor()/anchor-size() fallback</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-size-fn">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#funcdef-anchor">
+<meta name="assert" content="The unitless-zero quirk only accepts a bare '0' as a <length> fallback for anchor()/anchor-size(). A math function that resolves to a unitless zero (calc(0), min(0, 0), ...) is number-typed, not a <length-percentage>, so it is invalid. A bare '0' and a real <length> remain valid fallbacks.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function assertInvalid(property, value) {
+  test(() => {
+    const div = document.createElement('div');
+    div.style[property] = value;
+    assert_equals(div.style.getPropertyValue(property), "");
+  }, "e.style['" + property + "'] = " + JSON.stringify(value) + " should not set the property value");
+}
+
+function assertValid(property, value) {
+  test(() => {
+    const div = document.createElement('div');
+    div.style[property] = value;
+    assert_not_equals(div.style.getPropertyValue(property), "");
+  }, "e.style['" + property + "'] = " + JSON.stringify(value) + " should set the property value");
+}
+
+// A math function that resolves to a unitless zero has number type, not
+// <length-percentage>, so it is not a valid fallback. (These previously
+// aborted the parser instead of being rejected.)
+assertInvalid('width', 'anchor-size(width, calc(0))');
+assertInvalid('width', 'anchor-size(width, min(0, 0))');
+assertInvalid('height', 'anchor-size(height, max(0))');
+assertInvalid('left', 'anchor(left, calc(0))');
+
+// Controls: a bare unitless 0 and a real length are still valid fallbacks, so
+// the parser is rejecting the function-form zero specifically, not all of them.
+assertValid('width', 'anchor-size(width, 0)');
+assertValid('width', 'anchor-size(width, 10px)');
+</script>

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -1110,9 +1110,11 @@ static std::optional<TypedChild> consumeAnchorFallback(CSSParserTokenRange& toke
         if (state.parserOptions.propertyOptions.unitlessZeroLength != UnitlessZeroQuirk::Allow)
             return { };
 
-        // Allow unitless 0.
-        auto value = std::get<Number>(typedFallback->child.value);
-        if (value.value)
+        // Allow unitless 0, but only as a bare <number> leaf. A math function
+        // such as calc(0) or min(0, 0) also has number type but is wrapped in a
+        // Sum node, so it is not a valid unitless-zero fallback.
+        auto* number = std::get_if<Number>(&typedFallback->child.value);
+        if (!number || number->value)
             return { };
 
         return TypedChild { makeNumeric(0, CSSUnitType::CSS_PX), Type::makeLength() };


### PR DESCRIPTION
#### 8be326aecef7fb3b3086f012e035a7471212c03f
<pre>
anchor()/anchor-size() crash on a function-form zero fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=317470">https://bugs.webkit.org/show_bug.cgi?id=317470</a>

Reviewed by Darin Adler.

The unitless-zero quirk lets a bare &apos;0&apos; stand in for a &lt;length&gt; fallback in
anchor() and anchor-size(). consumeAnchorFallback() handled this by extracting
the value with std::get&lt;Number&gt;() whenever the fallback had number type. But a
math function that resolves to a unitless zero (calc(0), min(0, 0), ...) also
has number type, and consumeValueWithoutSimplifyingRootCalc() wraps such a
function-produced leaf in a Sum node rather than leaving it a bare Number. So
std::get&lt;Number&gt;() was applied to a variant holding a Sum, throwing
std::bad_variant_access and aborting the process at parse time (e.g.
width: anchor-size(width, calc(0))).

Extract the Number with std::get_if&lt;&gt; and bail if the fallback is not a bare
&lt;number&gt; leaf, so a function-form zero is rejected as an invalid fallback
instead of aborting. A bare &apos;0&apos; and a &lt;length&gt; remain valid fallbacks.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-zero-fallback.html

This test is crashing in shipping Safari but passing in Chrome and Firefox.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-zero-fallback-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-zero-fallback.html: Added.
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::consumeAnchorFallback):

Canonical link: <a href="https://commits.webkit.org/315535@main">https://commits.webkit.org/315535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf0e4e9d800fb3492ee13f2e5b2db709e8788c9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127010 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0881c07-cc30-41cd-8473-86a1a454f598) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131867 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5568402e-107a-4e3f-90ac-5c121ab63a8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172257 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112371 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40fcd6f8-77ff-475e-8b9f-ab73b4221ecf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27354 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181254 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140323 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37726 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43565 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28530 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107516 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35431 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115330 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42075 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6620 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41468 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41723 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41611 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->