### PR TITLE
WebKit encodes path separator as %2F after percent-encoded Armenian path segment

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -166,7 +166,11 @@ template<typename CharacterType> inline bool NODELETE isASCIIDigitOrValidHostCha
 template <UScriptCode ScriptType>
 bool isLookalikeSequence(const std::optional<char32_t>& previousCodePoint, char32_t codePoint)
 {
-    if (!previousCodePoint || *previousCodePoint == '/')
+    if (!previousCodePoint
+        || codePoint == '/' || *previousCodePoint == '/'
+        || codePoint == ':' // Only digits should be after a colon when used as a URL separator before a port, so no check for previousCodePoint here.
+        || codePoint == '?' || *previousCodePoint == '?'
+        || codePoint == '#' || *previousCodePoint == '#')
         return false;
 
     auto isLookalikePair = [] (char16_t first, char16_t second) {

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -196,8 +196,14 @@ TEST(URLExtras, URLExtras_NotSpoofed)
     EXPECT_STREQ("https://\u0551\u0535and!$^&*()-~+={}or<>,.?\u0575\u0543.biz", userVisibleString(literalURL("https://\u0551\u0535and!$^&*()-~+={}or<>,.?\u0575\u0543.biz")));
     EXPECT_STREQ("https://\u0551%67/", userVisibleString(literalURL("https://\u0551g/")));
     EXPECT_STREQ("https://\u0581%67/", userVisibleString(literalURL("https://\u0581g/")));
-    EXPECT_STREQ("https://o%D5%95%2F", userVisibleString(literalURL("https://o\u0555/")));
-    EXPECT_STREQ("https://o%D6%85%2F", userVisibleString(literalURL("https://o\u0585/")));
+    EXPECT_STREQ("https://o%D5%95/", userVisibleString(literalURL("https://o\u0555/")));
+    EXPECT_STREQ("https://o%D6%85/", userVisibleString(literalURL("https://o\u0585/")));
+    EXPECT_STREQ("https://example.org/anything/\xD4\xB1\xD5\x8D/test", userVisibleString(literalURL("https://example.org/anything/%D4%B1%D5%8D/test")));
+    EXPECT_STREQ("https://example.\xD4\xB1\xD5\x8D:123/anything", userVisibleString(literalURL("https://example.\xD4\xB1\xD5\x8D:123/anything")));
+    EXPECT_STREQ("https://example.com:123/\xD4\xB1\xD5\x8D?query", userVisibleString(literalURL("https://example.com:123/\xD4\xB1\xD5\x8D?query")));
+    EXPECT_STREQ("https://example.com:123/?\xD5\x8D\xD4\xB1", userVisibleString(literalURL("https://example.com:123/?\xD5\x8D\xD4\xB1")));
+    EXPECT_STREQ("https://example.com:123/\xD4\xB1\xD5\x8D#fragment", userVisibleString(literalURL("https://example.com:123/\xD4\xB1\xD5\x8D#fragment")));
+    EXPECT_STREQ("https://example.com:123/#\xD5\x8D\xD4\xB1", userVisibleString(literalURL("https://example.com:123/#\xD5\x8D\xD4\xB1")));
 
     // Tamil
     EXPECT_STREQ("https://\u0BE6\u0BE7\u0BE8\u0BE9count/", userVisibleString(literalURL("https://\u0BE6\u0BE7\u0BE8\u0BE9count/")));


### PR DESCRIPTION
#### 0de4332c951191998d698fdffa122d988e0daf3f
<pre>
WebKit encodes path separator as %2F after percent-encoded Armenian path segment
<a href="https://bugs.webkit.org/show_bug.cgi?id=317364">https://bugs.webkit.org/show_bug.cgi?id=317364</a>
<a href="https://rdar.apple.com/180067095">rdar://180067095</a>

Reviewed by Anne van Kesteren.

In 236210@main I made it so that Armenian characters that look like Latin characters
are percent encoded or punycode encoded unless they are surrounded by other Armenian
characters or immediately after a slash.  I should&apos;ve allowed them to go un-encoded
if they are immediately before a slash, too.  The example from Tom the reporter had
U+057D after another Armenian character and before a slash in the path of a URL.
This is not trying to make U+057D look like the Latin U character out of context,
this is in a reasonable Armenian context.

I did the same with all URL separators: #, /, ?, and :.

Test: Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm

* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::isLookalikeSequence):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(URLExtras, URLExtras_NotSpoofed)):

Canonical link: <a href="https://commits.webkit.org/315627@main">https://commits.webkit.org/315627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be7e2ea7ddab5475c7806d29be0654ed2af9c89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127280 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19e1f211-d3ea-4eb2-bdbe-7a453edf92bb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171434 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132117 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93049 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ce10200-8c41-48ef-b69e-169baf6fcd21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172527 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112620 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7307b63f-3a81-428a-990b-1b8c223baacf) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32256 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27624 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/891 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181526 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30823 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140566 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43146 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140402 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108043 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35671 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115600 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202247 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42345 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6938 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54228 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41738 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41993 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->