### PR TITLE
[GTK][WPE] Skia compositor: use promise images for layers having a native image as content

### DIFF
--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -78,6 +78,7 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+        platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.cpp
         platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
         platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
         platform/graphics/texmap/coordinated/GraphicsContextGLTextureMapperANGLECoordinated.cpp

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.cpp
@@ -45,4 +45,16 @@ GraphicsLayerCompositingCoordinatesOrientation GraphicsLayerContentsDisplayDeleg
 }
 #endif
 
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+void GraphicsLayerContentsDisplayDelegate::setThreadSafeGrContext(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    m_threadSafeGrContext = threadSafeGrContext;
 }
+
+const sk_sp<GrContextThreadSafeProxy>& GraphicsLayerContentsDisplayDelegate::threadSafeGrContext() const
+{
+    return m_threadSafeGrContext;
+}
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
@@ -31,6 +31,12 @@
 #include <WebCore/PlatformLayer.h>
 #endif
 
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace WebCore {
 class ImageBuffer;
 #if USE(CA)
@@ -58,8 +64,18 @@ public:
 #elif USE(COORDINATED_GRAPHICS)
     virtual void setDisplayBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&) = 0;
     virtual bool display(CoordinatedPlatformLayer&, std::optional<Damage>&&) = 0;
+#if USE(SKIA)
+    void setThreadSafeGrContext(const sk_sp<GrContextThreadSafeProxy>&);
+    const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext() const;
+#endif
+
 #else
     virtual PlatformLayer* platformLayer() const = 0;
+#endif
+
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+protected:
+    sk_sp<GrContextThreadSafeProxy> m_threadSafeGrContext;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -51,6 +51,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include "BitmapTexture.h"
 #include "CoordinatedPlatformLayerBufferNativeImage.h"
 #include "CoordinatedPlatformLayerBufferRGB.h"
+#include "CoordinatedPlatformLayerBufferSkiaImage.h"
 #include "GraphicsLayerContentsDisplayDelegateCoordinated.h"
 #include "TextureMapperFlags.h"
 #endif
@@ -265,8 +266,12 @@ void ImageBufferSkiaAcceleratedBackend::prepareForDisplay()
 
     ASSERT(grContext == PlatformDisplay::sharedDisplay().skiaGrContext());
 
-    m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferNativeImage::create(image.releaseNonNull(),
-        SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get())));
+    if (auto threadSafeGrContext = m_layerContentsDisplayDelegate->threadSafeGrContext())
+        m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferSkiaImage::create(image->platformImage(), threadSafeGrContext));
+    else {
+        m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferNativeImage::create(image.releaseNonNull(),
+            SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get())));
+    }
 
     // Re-enable recording mode for subsequent drawing operations.
     // This allows batching to occur again after each prepareForDisplay() cycle.

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -65,6 +65,7 @@ public:
     static bool isDDLEnabled();
 
     bool useThreadedRendering() const { return m_paintingWorkerPool; }
+    const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext() const { return m_threadSafeGrContext; }
 
     Ref<CoordinatedTileBuffer> paint(const GraphicsLayerCoordinated&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
     Ref<SkiaRecordingResult> record(const GraphicsLayerCoordinated&, const IntRect& recordRect, bool contentsOpaque, float contentsScale);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
@@ -28,6 +28,7 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "CoordinatedPlatformLayerBufferNativeImage.h"
+#include "CoordinatedPlatformLayerBufferSkiaImage.h"
 #include "NativeImage.h"
 
 namespace WebCore {
@@ -39,15 +40,30 @@ Ref<CoordinatedImageBackingStore> CoordinatedImageBackingStore::create(Ref<Nativ
 
 CoordinatedImageBackingStore::CoordinatedImageBackingStore(Ref<NativeImage>&& nativeImage)
     : m_buffer(CoordinatedPlatformLayerBufferNativeImage::create(WTF::move(nativeImage), nullptr))
+    , m_uniqueID(downcast<CoordinatedPlatformLayerBufferNativeImage>(*m_buffer).image()->uniqueID())
 {
 }
+
+#if USE(SKIA)
+Ref<CoordinatedImageBackingStore> CoordinatedImageBackingStore::create(Ref<NativeImage>&& nativeImage, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    if (!threadSafeGrContext)
+        return CoordinatedImageBackingStore::create(WTF::move(nativeImage));
+    return adoptRef(*new CoordinatedImageBackingStore(WTF::move(nativeImage), threadSafeGrContext));
+}
+
+CoordinatedImageBackingStore::CoordinatedImageBackingStore(Ref<NativeImage>&& nativeImage, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+    : m_buffer(CoordinatedPlatformLayerBufferSkiaImage::create(nativeImage->platformImage(), threadSafeGrContext))
+    , m_uniqueID(nativeImage->uniqueID())
+{
+}
+#endif
 
 CoordinatedImageBackingStore::~CoordinatedImageBackingStore() = default;
 
 bool CoordinatedImageBackingStore::isSameNativeImage(const NativeImage& nativeImage)
 {
-    auto* image = downcast<CoordinatedPlatformLayerBufferNativeImage>(*m_buffer).image();
-    return image && nativeImage.uniqueID() == image->uniqueID();
+    return nativeImage.uniqueID() == m_uniqueID;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -926,6 +926,14 @@ Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::paint(const IntRect& dirtyR
 }
 
 #if USE(SKIA)
+sk_sp<GrContextThreadSafeProxy> CoordinatedPlatformLayer::threadSafeGrContext() const
+{
+    if (!m_client)
+        return nullptr;
+
+    return m_client->paintingEngine().threadSafeGrContext();
+}
+
 Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordRect)
 {
     ASSERT(m_lock.isHeld());

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -38,6 +38,12 @@
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace WebCore {
 class CoordinatedAnimatedBackingStoreClient;
 class CoordinatedBackingStore;
@@ -100,6 +106,7 @@ public:
     TextureMapperLayer& ensureTarget();
 #if USE(SKIA)
     SkiaCompositingLayer& ensureSkiaTarget();
+    sk_sp<GrContextThreadSafeProxy> threadSafeGrContext() const;
 #endif
     void invalidateTarget();
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
@@ -50,7 +50,10 @@ public:
         HolePunch,
         Video,
         DMABuf,
-        NativeImage
+        NativeImage,
+#if USE(SKIA)
+        SkiaImage
+#endif
     };
 
     virtual ~CoordinatedPlatformLayerBuffer() = default;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,43 +23,32 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "CoordinatedPlatformLayerBufferSkiaImage.h"
 
-#if USE(COORDINATED_GRAPHICS)
-#include <wtf/ThreadSafeRefCounted.h>
-
-#if USE(SKIA)
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "PlatformDisplay.h"
+#include "SkiaUtilities.h"
 
 namespace WebCore {
 
-class CoordinatedPlatformLayerBuffer;
-class NativeImage;
+std::unique_ptr<CoordinatedPlatformLayerBufferSkiaImage> CoordinatedPlatformLayerBufferSkiaImage::create(const sk_sp<SkImage>& image, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    sk_sp<SkImage> skiaImage = image->isTextureBacked() ? SkiaUtilities::createPromiseImageIfNeeded(image, threadSafeGrContext) : image;
+    return makeUnique<CoordinatedPlatformLayerBufferSkiaImage>(WTF::move(skiaImage));
+}
 
-class CoordinatedImageBackingStore final : public ThreadSafeRefCounted<CoordinatedImageBackingStore> {
-public:
-    static Ref<CoordinatedImageBackingStore> create(Ref<NativeImage>&&);
-#if USE(SKIA)
-    static Ref<CoordinatedImageBackingStore> create(Ref<NativeImage>&&, const sk_sp<GrContextThreadSafeProxy>&);
-#endif
-    ~CoordinatedImageBackingStore();
+CoordinatedPlatformLayerBufferSkiaImage::CoordinatedPlatformLayerBufferSkiaImage(sk_sp<SkImage>&& image)
+    : CoordinatedPlatformLayerBuffer(Type::SkiaImage, { image->width(), image->height() }, { }, nullptr)
+    , m_image(WTF::move(image))
+{
+}
 
-    bool isSameNativeImage(const NativeImage&);
-    CoordinatedPlatformLayerBuffer* buffer() const LIFETIME_BOUND { return m_buffer.get(); }
-
-private:
-    explicit CoordinatedImageBackingStore(Ref<NativeImage>&&);
-#if USE(SKIA)
-    CoordinatedImageBackingStore(Ref<NativeImage>&&, const sk_sp<GrContextThreadSafeProxy>&);
-#endif
-
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;
-    uint64_t m_uniqueID { 0 };
-};
+void CoordinatedPlatformLayerBufferSkiaImage::paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
 
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS)
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,41 +25,30 @@
 
 #pragma once
 
-#if USE(COORDINATED_GRAPHICS)
-#include <wtf/ThreadSafeRefCounted.h>
+#if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "CoordinatedPlatformLayerBuffer.h"
 
-#if USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif
 
 namespace WebCore {
 
-class CoordinatedPlatformLayerBuffer;
-class NativeImage;
-
-class CoordinatedImageBackingStore final : public ThreadSafeRefCounted<CoordinatedImageBackingStore> {
+class CoordinatedPlatformLayerBufferSkiaImage final : public CoordinatedPlatformLayerBuffer {
 public:
-    static Ref<CoordinatedImageBackingStore> create(Ref<NativeImage>&&);
-#if USE(SKIA)
-    static Ref<CoordinatedImageBackingStore> create(Ref<NativeImage>&&, const sk_sp<GrContextThreadSafeProxy>&);
-#endif
-    ~CoordinatedImageBackingStore();
-
-    bool isSameNativeImage(const NativeImage&);
-    CoordinatedPlatformLayerBuffer* buffer() const LIFETIME_BOUND { return m_buffer.get(); }
+    static std::unique_ptr<CoordinatedPlatformLayerBufferSkiaImage> create(const sk_sp<SkImage>&, const sk_sp<GrContextThreadSafeProxy>&);
+    explicit CoordinatedPlatformLayerBufferSkiaImage(sk_sp<SkImage>&&);
+    virtual ~CoordinatedPlatformLayerBufferSkiaImage() = default;
 
 private:
-    explicit CoordinatedImageBackingStore(Ref<NativeImage>&&);
-#if USE(SKIA)
-    CoordinatedImageBackingStore(Ref<NativeImage>&&, const sk_sp<GrContextThreadSafeProxy>&);
-#endif
+    void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
+    sk_sp<SkImage> skiaImage() override { return m_image; }
 
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;
-    uint64_t m_uniqueID { 0 };
+    sk_sp<SkImage> m_image;
 };
 
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS)
+SPECIALIZE_TYPE_TRAITS_COORDINATED_PLATFORM_LAYER_BUFFER_TYPE(CoordinatedPlatformLayerBufferSkiaImage, Type::SkiaImage)
+
+#endif // USE(COORDINATED_GRAPHICS) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.cpp
@@ -28,6 +28,7 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "CoordinatedPlatformLayerBufferNativeImage.h"
+#include "CoordinatedPlatformLayerBufferSkiaImage.h"
 #include "GraphicsLayer.h"
 #include "GraphicsLayerContentsDisplayDelegateCoordinated.h"
 #include "ImageBuffer.h"
@@ -50,6 +51,12 @@ bool GraphicsLayerAsyncContentsDisplayDelegateCoordinated::tryCopyToLayer(ImageB
     if (!image)
         return false;
 
+#if USE(SKIA)
+    if (m_threadSafeGrContext) {
+        m_delegate->setDisplayBuffer(CoordinatedPlatformLayerBufferSkiaImage::create(image->platformImage(), m_threadSafeGrContext));
+        return true;
+    }
+#endif
     m_delegate->setDisplayBuffer(CoordinatedPlatformLayerBufferNativeImage::create(image.releaseNonNull(), nullptr));
     return true;
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -38,7 +38,7 @@
 #include "CoordinatedPlatformLayerBufferProxy.h"
 #include "FloatQuad.h"
 #include "GraphicsLayerAsyncContentsDisplayDelegateCoordinated.h"
-#include "GraphicsLayerContentsDisplayDelegate.h"
+#include "GraphicsLayerContentsDisplayDelegateCoordinated.h"
 #include "GraphicsLayerFactory.h"
 #include "GraphicsLayerFilterAnimationValue.h"
 #include "GraphicsLayerKeyframeValueList.h"
@@ -408,6 +408,9 @@ void GraphicsLayerCoordinated::setContentsDisplayDelegate(RefPtr<GraphicsLayerCo
 
     EnumSet<Change> change = { Change::ContentsBuffer };
     if (m_contentsDisplayDelegate) {
+#if USE(SKIA)
+        m_contentsDisplayDelegate->setThreadSafeGrContext(m_platformLayer->threadSafeGrContext());
+#endif
         if (m_contentsBufferProxy) {
             m_contentsBufferProxy->setTargetLayer(nullptr);
             m_contentsBufferProxy = nullptr;
@@ -423,7 +426,11 @@ RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayerCoordinated::crea
         static_cast<GraphicsLayerAsyncContentsDisplayDelegateCoordinated*>(existing)->updateGraphicsLayer(*this);
         return existing;
     }
-    return GraphicsLayerAsyncContentsDisplayDelegateCoordinated::create(*this);
+    auto delegate = GraphicsLayerAsyncContentsDisplayDelegateCoordinated::create(*this);
+#if USE(SKIA)
+    delegate->setThreadSafeGrContext(m_platformLayer->threadSafeGrContext());
+#endif
+    return delegate;
 }
 
 void GraphicsLayerCoordinated::setContentsToImage(Image* image)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -387,7 +387,7 @@ Ref<CoordinatedImageBackingStore> LayerTreeHost::imageBackingStore(Ref<NativeIma
 {
     auto nativeImageID = nativeImage->uniqueID();
     auto addResult = m_imageBackingStores.ensure(nativeImageID, [&] {
-        return CoordinatedImageBackingStore::create(WTF::move(nativeImage));
+        return CoordinatedImageBackingStore::create(WTF::move(nativeImage), m_compositor->threadSafeGrContext());
     });
     return addResult.iterator->value;
 }


### PR DESCRIPTION
#### 574389090c0720faaa03ebe3d431960e05a1dbf3
<pre>
[GTK][WPE] Skia compositor: use promise images for layers having a native image as content
<a href="https://bugs.webkit.org/show_bug.cgi?id=317478">https://bugs.webkit.org/show_bug.cgi?id=317478</a>

Reviewed by Alejandro G. Castro.

For accelerated images we can use a promise image instead of rewrapping,
and for non-accelerated images we can pass the image to the compositor
directly and skia will upload the pixels and reuse internally. This
patch introduces CoordinatedPlatformLayerBufferSkiaImage that is used
instead of CoordinatedPlatformLayerBufferNativeImage when a thread safe
gr context is available.

* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.cpp:
(WebCore::GraphicsLayerContentsDisplayDelegate::setThreadSafeGrContext):
(WebCore::GraphicsLayerContentsDisplayDelegate::threadSafeGrContext const):
* Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::prepareForDisplay):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
(WebCore::SkiaPaintingEngine::threadSafeGrContext const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp:
(WebCore::CoordinatedImageBackingStore::CoordinatedImageBackingStore):
(WebCore::CoordinatedImageBackingStore::create):
(WebCore::CoordinatedImageBackingStore::isSameNativeImage):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::threadSafeGrContext const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.cpp: Copied from Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp.
(WebCore::CoordinatedPlatformLayerBufferSkiaImage::create):
(WebCore::CoordinatedPlatformLayerBufferSkiaImage::CoordinatedPlatformLayerBufferSkiaImage):
(WebCore::m_image):
(WebCore::CoordinatedPlatformLayerBufferSkiaImage::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferSkiaImage.h: Copied from Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h.
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.cpp:
(WebCore::GraphicsLayerAsyncContentsDisplayDelegateCoordinated::tryCopyToLayer):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::setContentsDisplayDelegate):
(WebCore::GraphicsLayerCoordinated::createAsyncContentsDisplayDelegate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::imageBackingStore):

Canonical link: <a href="https://commits.webkit.org/315529@main">https://commits.webkit.org/315529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afb77460b5445ba0e9dbe6d3ef6980332f228319

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43263 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36531 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42891 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172300 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112412 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181297 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36218 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42919 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43608 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107605 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35469 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115373 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42118 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41511 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->