### PR TITLE
[JSC] `Object.freeze`/`seal`/`preventExtensions` should not allocate `ArrayStorage` for `NonArray` objects

### DIFF
--- a/JSTests/microbenchmarks/object-freeze-blank-for-in.js
+++ b/JSTests/microbenchmarks/object-freeze-blank-for-in.js
@@ -1,0 +1,14 @@
+function test() {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i) {
+        let o = Object.freeze({ a: i, b: i, c: i, d: i });
+        for (let k in o)
+            result += o[k];
+    }
+    return result;
+}
+noInline(test);
+
+let result = test();
+if (result !== 4 * 1e4 * (1e4 - 1) / 2)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/object-freeze-blank-is-frozen.js
+++ b/JSTests/microbenchmarks/object-freeze-blank-is-frozen.js
@@ -1,0 +1,16 @@
+function test() {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i) {
+        let o = Object.freeze({ a: i, b: i + 1 });
+        if (Object.isFrozen(o))
+            ++result;
+        if (Object.isSealed(o))
+            ++result;
+    }
+    return result;
+}
+noInline(test);
+
+let result = test();
+if (result !== 2e4)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/object-freeze-blank-keys.js
+++ b/JSTests/microbenchmarks/object-freeze-blank-keys.js
@@ -1,0 +1,14 @@
+function test() {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i) {
+        let o = Object.freeze({ a: i, b: i, c: i, d: i });
+        result += Object.keys(o).length;
+        result += Object.getOwnPropertyNames(o).length;
+    }
+    return result;
+}
+noInline(test);
+
+let result = test();
+if (result !== 8e4)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/object-freeze-blank.js
+++ b/JSTests/microbenchmarks/object-freeze-blank.js
@@ -1,0 +1,11 @@
+function test() {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += Object.freeze({ a: i, b: i + 1 }).a;
+    return result;
+}
+noInline(test);
+
+let result = test();
+if (result !== 1e4 * (1e4 - 1) / 2)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/object-prevent-extensions-blank.js
+++ b/JSTests/microbenchmarks/object-prevent-extensions-blank.js
@@ -1,0 +1,11 @@
+function test() {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += Object.preventExtensions({ a: i, b: i + 1 }).a;
+    return result;
+}
+noInline(test);
+
+let result = test();
+if (result !== 1e4 * (1e4 - 1) / 2)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/object-seal-blank.js
+++ b/JSTests/microbenchmarks/object-seal-blank.js
@@ -1,0 +1,11 @@
+function test() {
+    let result = 0;
+    for (let i = 0; i < 1e4; ++i)
+        result += Object.seal({ a: i, b: i + 1 }).a;
+    return result;
+}
+noInline(test);
+
+let result = test();
+if (result !== 1e4 * (1e4 - 1) / 2)
+    throw new Error("bad result: " + result);

--- a/JSTests/stress/object-integrity-blank-indexing.js
+++ b/JSTests/stress/object-integrity-blank-indexing.js
@@ -1,0 +1,237 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType) && e.name !== errorType.name)
+            throw new Error("threw wrong error type: " + e);
+    }
+    if (!threw)
+        throw new Error("did not throw");
+}
+
+// freeze / seal / preventExtensions on a plain (NonArray, blank indexing)
+// object skips the eager ArrayStorage allocation; verify that no observable
+// behavior changes.
+for (let i = 0; i < testLoopCount; ++i) {
+    {
+        let o = Object.freeze({ a: 1, b: 2 });
+        shouldBe(Object.isFrozen(o), true);
+        shouldBe(Object.isSealed(o), true);
+        shouldBe(Object.isExtensible(o), false);
+        shouldBe(Object.getOwnPropertyDescriptor(o, "a").writable, false);
+        shouldBe(Object.getOwnPropertyDescriptor(o, "a").configurable, false);
+
+        // [[Set]] indexed: silently fail in sloppy, throw in strict.
+        o[0] = 42;
+        shouldBe(o[0], undefined);
+        shouldBe(Reflect.set(o, 0, 42), false);
+        shouldThrow(() => { "use strict"; o[5] = 42; }, TypeError);
+
+        // [[DefineOwnProperty]] indexed: rejected.
+        shouldThrow(() => Object.defineProperty(o, "0", { value: 1 }), TypeError);
+        shouldBe(Reflect.defineProperty(o, "0", { value: 1 }), false);
+        shouldBe(Object.getOwnPropertyNames(o).join(","), "a,b");
+        shouldBe(Object.keys(o).join(","), "a,b");
+
+        let keys = [];
+        for (let k in o)
+            keys.push(k);
+        shouldBe(keys.join(","), "a,b");
+
+        // [[Delete]] indexed: vacuously true.
+        shouldBe(delete o[0], true);
+    }
+    {
+        let o = Object.seal({ a: 1 });
+        shouldBe(Object.isSealed(o), true);
+        shouldBe(Object.isFrozen(o), false);
+        shouldBe(Object.isExtensible(o), false);
+        o.a = 2;
+        shouldBe(o.a, 2);
+        o[0] = 42;
+        shouldBe(o[0], undefined);
+        shouldThrow(() => { "use strict"; o[0] = 42; }, TypeError);
+        shouldThrow(() => Object.defineProperty(o, "0", { value: 1 }), TypeError);
+    }
+    {
+        let o = Object.preventExtensions({ a: 1 });
+        shouldBe(Object.isExtensible(o), false);
+        shouldBe(Object.isSealed(o), false);
+        o[0] = 42;
+        shouldBe(o[0], undefined);
+        shouldThrow(() => { "use strict"; o[0] = 42; }, TypeError);
+        shouldBe(Reflect.defineProperty(o, "0", { value: 1 }), false);
+    }
+    {
+        let o = Object.freeze({});
+        shouldBe(Object.isFrozen(o), true);
+        shouldBe(Object.getOwnPropertyNames(o).length, 0);
+        shouldThrow(() => { "use strict"; o[0] = 1; }, TypeError);
+    }
+    {
+        let o = Object.freeze(Object.create(null, { a: { value: 1, enumerable: true } }));
+        shouldBe(Object.isFrozen(o), true);
+        let keys = [];
+        for (let k in o)
+            keys.push(k);
+        shouldBe(keys.join(","), "a");
+    }
+}
+
+// Invariant: enterDictionaryIndexingMode now leaves NonArray objects as
+// NonArray. Any later indexed write must go through indexingShouldBeSparse()
+// and lazily allocate ArrayStorage on demand (and then reject the write).
+// Exercise every indexed-write entry point and verify the indexing mode at
+// each step via $vm.indexingMode().
+function indexingMode(o) { return $vm.indexingMode(o); }
+noInline(indexingMode);
+
+function shouldBeNonArray(o) { shouldBe(indexingMode(o), "NonArray"); }
+function shouldBeArrayStorage(o) {
+    // --alwaysHaveABadTime=true (e.g. lockdown) yields SlowPutArrayStorage.
+    let mode = indexingMode(o);
+    if (mode !== "NonArrayWithArrayStorage" && mode !== "NonArrayWithSlowPutArrayStorage")
+        throw new Error("bad value: " + mode + " expected: NonArrayWith{SlowPut,}ArrayStorage");
+}
+
+for (let make of [() => Object.freeze({ a: 1 }), () => Object.seal({ a: 1 }), () => Object.preventExtensions({ a: 1 }), () => Object.freeze({})]) {
+    for (let i = 0; i < testLoopCount; ++i) {
+        // Immediately after the integrity-level transition, no indexing storage.
+        shouldBeNonArray(make());
+
+        // putByIndex (sloppy): lazily enters dictionary indexing, write is rejected.
+        {
+            let o = make();
+            o[0] = 42;
+            shouldBeArrayStorage(o);
+            shouldBe(o[0], undefined);
+            shouldBe(0 in o, false);
+            // Second write on the same object must keep being rejected.
+            o[1] = 42;
+            shouldBe(o[1], undefined);
+        }
+        // putByIndex (strict): lazily enters dictionary indexing, throws.
+        {
+            let o = make();
+            shouldThrow(() => { "use strict"; o[0] = 42; }, TypeError);
+            shouldBeArrayStorage(o);
+            shouldBe(0 in o, false);
+        }
+        // putByIndex via Reflect.set.
+        {
+            let o = make();
+            shouldBe(Reflect.set(o, 5, 42), false);
+            shouldBeArrayStorage(o);
+            shouldBe(5 in o, false);
+        }
+        // putByIndex via Array.prototype.push (generic [[Set]] on a non-array).
+        {
+            let o = make();
+            shouldThrow(() => { "use strict"; Array.prototype.push.call(o, 42); }, TypeError);
+            shouldBe(0 in o, false);
+        }
+        // Large index (sparse path).
+        {
+            let o = make();
+            o[0xFFFFFFFE] = 42;
+            shouldBeArrayStorage(o);
+            shouldBe(0xFFFFFFFE in o, false);
+        }
+        // defineOwnIndexedProperty: data descriptor.
+        {
+            let o = make();
+            shouldThrow(() => Object.defineProperty(o, "0", { value: 42 }), TypeError);
+            shouldBeArrayStorage(o);
+            shouldBe(0 in o, false);
+        }
+        // defineOwnIndexedProperty: data descriptor with attributes.
+        {
+            let o = make();
+            shouldBe(Reflect.defineProperty(o, "0", { value: 42, writable: false, configurable: false }), false);
+            shouldBeArrayStorage(o);
+            shouldBe(0 in o, false);
+        }
+        // defineOwnIndexedProperty: accessor descriptor.
+        {
+            let o = make();
+            shouldBe(Reflect.defineProperty(o, "0", { get() { return 42; } }), false);
+            shouldBeArrayStorage(o);
+            shouldBe(0 in o, false);
+        }
+        // putDirectIndex via Object.defineProperties.
+        {
+            let o = make();
+            shouldThrow(() => Object.defineProperties(o, { 0: { value: 42 } }), TypeError);
+            shouldBe(0 in o, false);
+        }
+        // Read paths must not allocate storage.
+        {
+            let o = make();
+            shouldBe(o[0], undefined);
+            shouldBe(0 in o, false);
+            shouldBe(Object.getOwnPropertyDescriptor(o, "0"), undefined);
+            shouldBe(delete o[0], true);
+            shouldBeNonArray(o);
+        }
+        // for-in / Object.keys must not allocate storage and must use the cache.
+        {
+            let o = make();
+            let keys = [];
+            for (let k in o)
+                keys.push(k);
+            shouldBe(keys.indexOf("0"), -1);
+            Object.keys(o);
+            Object.getOwnPropertyNames(o);
+            shouldBeNonArray(o);
+        }
+        // Object.isFrozen / isSealed must not allocate storage (fast path).
+        {
+            let o = make();
+            Object.isFrozen(o);
+            Object.isSealed(o);
+            Object.isExtensible(o);
+            shouldBeNonArray(o);
+        }
+    }
+}
+
+// Setting an indexed property on a child whose prototype is frozen+blank must
+// succeed on the child (the rejection is per-receiver, not per-prototype).
+{
+    let proto = Object.freeze({ a: 1 });
+    shouldBeNonArray(proto);
+    let child = Object.create(proto);
+    child[0] = 42;
+    shouldBe(child[0], 42);
+    shouldBeNonArray(proto);
+    shouldBe(0 in proto, false);
+}
+
+// ArrayClass (the other ALL_BLANK_INDEXING_TYPES case, e.g. Array.prototype)
+// is intentionally NOT short-circuited; JSArray code paths such as
+// setLengthWritable/pushInline assume enterDictionaryIndexingMode allocated
+// ArrayStorage. Guard against regressing that. Use a fresh realm so we don't
+// poison this realm's Array.prototype.
+{
+    let other = $vm.createGlobalObject();
+    let proto = other.Array.prototype;
+    shouldBe(other.Array.isArray(proto), true);
+    Object.preventExtensions(proto);
+    shouldThrow(() => { "use strict"; proto.push(1); }, TypeError);
+    shouldBe(proto.length, 0);
+}
+{
+    let other = $vm.createGlobalObject();
+    let proto = other.Array.prototype;
+    Object.defineProperty(proto, "length", { writable: false });
+    shouldBe(Object.getOwnPropertyDescriptor(proto, "length").writable, false);
+    shouldThrow(() => { "use strict"; proto.length = 5; }, TypeError);
+    shouldBe(proto.length, 0);
+}

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1192,7 +1192,17 @@ ArrayStorage* JSObject::enterDictionaryIndexingModeWhenArrayStorageAlreadyExists
 void JSObject::enterDictionaryIndexingMode(VM& vm)
 {
     switch (indexingType()) {
-    case ALL_BLANK_INDEXING_TYPES:
+    case NonArray:
+        // No indexed properties to convert. Once the caller makes the structure
+        // non-extensible, indexingShouldBeSparse() lazily handles later indexed
+        // writes; staying blank also keeps for-in enumerator caching usable.
+        // JSArray code paths (e.g. setLengthWritable) assume this method
+        // allocated ArrayStorage, so do not skip for JSArray subclasses that
+        // use NonArray indexing (e.g. $vm RuntimeArray with DerivedArrayType).
+        if (!inherits<JSArray>()) [[likely]]
+            return;
+        [[fallthrough]];
+    case ArrayClass:
     case ALL_UNDECIDED_INDEXING_TYPES:
     case ALL_INT32_INDEXING_TYPES:
     case ALL_DOUBLE_INDEXING_TYPES:


### PR DESCRIPTION
#### db8790f1137d8124d16cca8c6d244cc336357dda
<pre>
[JSC] `Object.freeze`/`seal`/`preventExtensions` should not allocate `ArrayStorage` for `NonArray` objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=317479">https://bugs.webkit.org/show_bug.cgi?id=317479</a>

Reviewed by Yusuke Suzuki.

enterDictionaryIndexingMode() eagerly allocated an empty ArrayStorage +
SparseArrayValueMap even for plain objects with no indexed properties
(indexingType() == NonArray). This is unnecessary: once the caller&apos;s
non-extensible structure transition runs, indexingShouldBeSparse() becomes
true and every indexed-write entry point already enters dictionary indexing
lazily on demand.

Staying NonArray also keeps hasIndexedProperties() false, so frozen plain
objects keep using the for-in enumerator cache and the Object.isFrozen /
isSealed fast path.

ArrayClass is left on the existing path because JSArray code
(setLengthWritable / pushInline / setLength) relies on
enterDictionaryIndexingMode having allocated ArrayStorage.

                                          baseline                  patched

object-freeze-blank                    0.5419+-0.0447     ^      0.3077+-0.0140        ^ definitely 1.7612x faster
object-seal-blank                      0.4859+-0.0229     ^      0.3171+-0.0238        ^ definitely 1.5321x faster
object-prevent-extensions-blank        0.5033+-0.0342     ^      0.2967+-0.0212        ^ definitely 1.6963x faster
object-freeze-blank-for-in             1.3237+-0.0580     ^      0.4573+-0.0244        ^ definitely 2.8947x faster
object-freeze-blank-is-frozen          1.3314+-0.0561     ^      0.4308+-0.0253        ^ definitely 3.0908x faster
object-freeze-blank-keys               1.4120+-0.0712     ^      0.4747+-0.0357        ^ definitely 2.9748x faster

Tests: JSTests/microbenchmarks/object-freeze-blank-for-in.js
       JSTests/microbenchmarks/object-freeze-blank-is-frozen.js
       JSTests/microbenchmarks/object-freeze-blank-keys.js
       JSTests/microbenchmarks/object-freeze-blank.js
       JSTests/microbenchmarks/object-prevent-extensions-blank.js
       JSTests/microbenchmarks/object-seal-blank.js
       JSTests/stress/object-integrity-blank-indexing.js

* JSTests/microbenchmarks/object-freeze-blank-for-in.js: Added.
(test):
* JSTests/microbenchmarks/object-freeze-blank-is-frozen.js: Added.
(test):
* JSTests/microbenchmarks/object-freeze-blank-keys.js: Added.
(test):
* JSTests/microbenchmarks/object-freeze-blank.js: Added.
(test):
* JSTests/microbenchmarks/object-prevent-extensions-blank.js: Added.
(test):
* JSTests/microbenchmarks/object-seal-blank.js: Added.
(test):
* JSTests/stress/object-integrity-blank-indexing.js: Added.
(shouldBe):
(shouldThrow):
(i.shouldThrow):
(i.shouldBe):
(indexingMode):
(shouldBeNonArray):
(shouldBeArrayStorage):
(Object.freeze.get shouldBeArrayStorage):
(Object.freeze):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::enterDictionaryIndexingMode):

Canonical link: <a href="https://commits.webkit.org/315722@main">https://commits.webkit.org/315722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/128138b08b23155f6525a22916d165c292249afa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127164 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132005 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92939 "11 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33701 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32145 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27508 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/746 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181410 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30707 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140456 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43030 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140292 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37881 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43719 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28705 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107845 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35565 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115484 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202131 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42229 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6793 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54203 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->