### PR TITLE
[CSS Scroll Snap] Re-snap does not prefer the focused or fragment-targeted snap area among multiple aligned snap targets

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL scroller selects targeted area box1 among multiple aligned areas. assert_equals: scroller followed box1 in y axis after layout change expected 100 but got 0
-FAIL scroller selects targeted area box2 among multiple aligned areas. assert_equals: scroller followed box2 in y axis after layout change expected 100 but got 0
-FAIL scroller selects targeted area box3 among multiple aligned areas. assert_equals: scroller followed box3 in y axis after layout change expected 100 but got 0
-FAIL scroller selects targeted area box4 among multiple aligned areas. assert_equals: scroller followed box4 in y axis after layout change expected 300 but got 100
-FAIL scroller selects targeted area box5 among multiple aligned areas. assert_equals: scroller followed box5 in y axis after layout change expected 300 but got 100
-FAIL scroller selects targeted area box6 among multiple aligned areas. assert_equals: scroller followed box6 in y axis after layout change expected 300 but got 100
-FAIL scroller selects targeted area box7 among multiple aligned areas. assert_equals: scroller followed box7 in y axis after layout change expected 500 but got 200
-FAIL scroller selects targeted area box8 among multiple aligned areas. assert_equals: scroller followed box8 in y axis after layout change expected 500 but got 200
-FAIL scroller selects targeted area box9 among multiple aligned areas. assert_equals: scroller followed box9 in y axis after layout change expected 500 but got 200
+PASS scroller selects targeted area box1 among multiple aligned areas.
+PASS scroller selects targeted area box2 among multiple aligned areas.
+PASS scroller selects targeted area box3 among multiple aligned areas.
+PASS scroller selects targeted area box4 among multiple aligned areas.
+PASS scroller selects targeted area box5 among multiple aligned areas.
+PASS scroller selects targeted area box6 among multiple aligned areas.
+PASS scroller selects targeted area box7 among multiple aligned areas.
+PASS scroller selects targeted area box8 among multiple aligned areas.
+PASS scroller selects targeted area box9 among multiple aligned areas.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-main-frame-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-main-frame-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL targeted box is selected snap target. assert_equals: expected "9," but got "0,,Can't find variable: n,Can't find variable: n,Can't find variable: n,Can't find variable: n,Can't find variable: n,Can't find variable: n,Can't find variable: n,Can't find variable: n,Can't find variable: n"
+PASS targeted box is selected snap target.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-positioned-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-positioned-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL prefer-targeted-element-positioned assert_equals: scroller followed target1 in y axis after layout change expected 500 but got 400
-FAIL prefer-targeted-element-positioned 1 assert_equals: scroller followed target2 in y axis after layout change expected 500 but got 400
-FAIL prefer-targeted-element-positioned 2 assert_equals: scroller followed target3 in y axis after layout change expected 500 but got 400
-FAIL prefer-targeted-element-positioned 3 assert_equals: scroller followed target4 in y axis after layout change expected 500 but got 400
-FAIL prefer-targeted-element-positioned 4 assert_equals: scroller followed target5 in y axis after layout change expected 500 but got 400
+PASS prefer-targeted-element-positioned
+PASS prefer-targeted-element-positioned 1
+PASS prefer-targeted-element-positioned 2
+PASS prefer-targeted-element-positioned 3
+PASS prefer-targeted-element-positioned 4
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1820,7 +1820,6 @@ imported/w3c/web-platform-tests/css/css-scroll-snap/snap-fling-in-large-area.htm
 
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/common-to-both-axes-supercedes-first-in-tree-order.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-focused-nested-containers.html [ Pass Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element.html [ Skip ]
 
 webkit.org/b/170629  memory/memory-pressure-simulation.html [ Pass Failure Crash ]
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -926,7 +926,7 @@ void LocalFrameView::updateSnapOffsets()
     LayoutRect viewport = LayoutRect(IntPoint(), baseLayoutViewportSize());
     viewport.move(-rootRenderer->marginLeft(), -rootRenderer->marginTop());
 
-    updateSnapOffsetsForScrollableArea(*this, *rootRenderer, *styleToUse, viewport, rootRenderer->style().writingMode(), protect(m_frame->document()->focusedElement()).get());
+    updateSnapOffsetsForScrollableArea(*this, *rootRenderer, *styleToUse, viewport, rootRenderer->style().writingMode(), protect(m_frame->document()->focusedElement()).get(), protect(m_frame->document()->cssTarget()).get());
 }
 
 bool LocalFrameView::isScrollSnapInProgress() const

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -312,7 +312,7 @@ bool mayHaveScrollSnappedBoxes(const RenderBox& scrollingElementBox)
     return true;
 }
 
-void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const RenderBox& scrollingElementBox, const Style::ComputedStyle& scrollingElementStyle, LayoutRect viewportRectInBorderBoxCoordinates, WritingMode writingMode, Element* focusedElement)
+void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const RenderBox& scrollingElementBox, const Style::ComputedStyle& scrollingElementStyle, LayoutRect viewportRectInBorderBoxCoordinates, WritingMode writingMode, Element* focusedElement, Element* targetElement)
 {
     auto scrollSnapTypeContainer = scrollingElementStyle.scrollSnapType().tryContainer();
     const auto& boxesWithScrollSnapPositions = scrollingElementBox.view().boxesWithScrollSnapPositions();
@@ -321,18 +321,33 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
         return;
     }
 
-    auto addOrUpdateStopForSnapOffset = [](HashMap<LayoutUnit, SnapOffset<LayoutUnit>>& offsets, LayoutUnit newOffset, ScrollSnapStop stop, bool hasSnapAreaLargerThanViewport, bool isFocused, NodeIdentifier snapTargetID, size_t snapAreaIndices)
+    // When several snap areas resolve to the same snap offset (an aligned "tie"), the snap offset's
+    // snapTargetID records the box that should be re-snapped to per the priority order in
+    // https://drafts.csswg.org/css-scroll-snap-1/#re-snap: a focused element, then a fragment-targeted
+    // element, then the first box in tree order. isFocused/isTarget accumulate across all areas
+    // sharing the offset (not just the first one added).
+    auto addOrUpdateStopForSnapOffset = [](HashMap<LayoutUnit, SnapOffset<LayoutUnit>>& offsets, LayoutUnit newOffset, ScrollSnapStop stop, bool hasSnapAreaLargerThanViewport, bool isFocused, bool isTarget, NodeIdentifier snapTargetID, size_t snapAreaIndices)
     {
         if (!offsets.isValidKey(newOffset))
             return;
 
         auto& offset = offsets.ensure(newOffset, [&] {
-            return SnapOffset<LayoutUnit> { newOffset, stop, hasSnapAreaLargerThanViewport, isFocused, snapTargetID, { } };
+            return SnapOffset<LayoutUnit> { newOffset, stop, hasSnapAreaLargerThanViewport, isFocused, isTarget, snapTargetID, { } };
         }).iterator->value;
 
         // If the offset already exists, we ensure that it has ScrollSnapStop::Always, when appropriate.
         if (stop == ScrollSnapStop::Always)
             offset.stop = ScrollSnapStop::Always;
+
+        // A focused box takes precedence over a fragment-targeted one, which takes precedence over the
+        // box that first established this offset. Update snapTargetID to reflect the highest-priority
+        // box seen so far so that re-snapping follows it.
+        if (isFocused && !offset.isFocused)
+            offset.snapTargetID = snapTargetID;
+        else if (isTarget && !offset.isFocused && !offset.isTarget)
+            offset.snapTargetID = snapTargetID;
+        offset.isFocused |= isFocused;
+        offset.isTarget |= isTarget;
 
         offset.hasSnapAreaLargerThanViewport |= hasSnapAreaLargerThanViewport;
         offset.snapAreaIndices.append(snapAreaIndices);
@@ -414,18 +429,19 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
         snapAreas.append(scrollSnapAreaAsOffsets);
         
         auto isFocused = child->element() ? focusedElement == child->element() : false;
+        auto isTarget = child->element() ? targetElement == child->element() : false;
         auto identifier = protect(child->element())->nodeIdentifier();
         snapAreasIDs.append(identifier);
 
         if (snapsHorizontally) {
             auto absoluteScrollXPosition = computeScrollSnapAlignOffset(scrollSnapArea.x(), scrollSnapArea.maxX(), xAlign, areaXAxisFlipped) - computeScrollSnapAlignOffset(scrollSnapPort.x(), scrollSnapPort.maxX(), xAlign, areaXAxisFlipped);
             auto absoluteScrollOffset = clampTo<int>(scrollableArea.scrollOffsetFromPosition({ roundToInt(absoluteScrollXPosition), 0 }).x(), 0, maxScrollOffset.x());
-            addOrUpdateStopForSnapOffset(horizontalSnapOffsetsMap, absoluteScrollOffset, stop, scrollSnapAreaAsOffsets.width() > scrollSnapPort.width(), isFocused, identifier, snapAreas.size() - 1);
+            addOrUpdateStopForSnapOffset(horizontalSnapOffsetsMap, absoluteScrollOffset, stop, scrollSnapAreaAsOffsets.width() > scrollSnapPort.width(), isFocused, isTarget, identifier, snapAreas.size() - 1);
         }
         if (snapsVertically) {
             auto absoluteScrollYPosition = computeScrollSnapAlignOffset(scrollSnapArea.y(), scrollSnapArea.maxY(), yAlign, areaYAxisFlipped) - computeScrollSnapAlignOffset(scrollSnapPort.y(), scrollSnapPort.maxY(), yAlign, areaYAxisFlipped);
             auto absoluteScrollOffset = clampTo<int>(scrollableArea.scrollOffsetFromPosition({ 0, roundToInt(absoluteScrollYPosition) }).y(), 0, maxScrollOffset.y());
-            addOrUpdateStopForSnapOffset(verticalSnapOffsetsMap, absoluteScrollOffset, stop, scrollSnapAreaAsOffsets.height() > scrollSnapPort.height(), isFocused, identifier, snapAreas.size() - 1);
+            addOrUpdateStopForSnapOffset(verticalSnapOffsetsMap, absoluteScrollOffset, stop, scrollSnapAreaAsOffsets.height() > scrollSnapPort.height(), isFocused, isTarget, identifier, snapAreas.size() - 1);
         }
 
         if (!snapAreas.isEmpty())
@@ -474,7 +490,7 @@ static ScrollSnapOffsetsInfo<OutputType, OutputRectType> convertOffsetInfo(const
     auto convertOffsets = [scaleFactor](const Vector<SnapOffset<InputType>>& input)
     {
         return input.map([scaleFactor](auto& offset) -> SnapOffset<OutputType> {
-            return { convertOffsetUnit(offset.offset, scaleFactor), offset.stop, offset.hasSnapAreaLargerThanViewport, offset.isFocused, offset.snapTargetID, offset.snapAreaIndices };
+            return { convertOffsetUnit(offset.offset, scaleFactor), offset.stop, offset.hasSnapAreaLargerThanViewport, offset.isFocused, offset.isTarget, offset.snapTargetID, offset.snapAreaIndices };
         });
     };
 

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
@@ -50,6 +50,7 @@ struct SnapOffset {
     ScrollSnapStop stop;
     bool hasSnapAreaLargerThanViewport;
     bool isFocused;
+    bool isTarget;
     Markable<NodeIdentifier> snapTargetID;
     Vector<size_t, 1> snapAreaIndices;
 };
@@ -113,11 +114,11 @@ WEBCORE_EXPORT std::pair<LayoutUnit, std::optional<unsigned>> LayoutScrollSnapOf
 // which defines the scroll-snap properties, and the viewport rectangle with the origin at the top left of
 // the scrolling container's border box.
 bool NODELETE mayHaveScrollSnappedBoxes(const RenderBox& scrollingElementBox);
-void updateSnapOffsetsForScrollableArea(ScrollableArea&, const RenderBox& scrollingElementBox, const Style::ComputedStyle& scrollingElementStyle, LayoutRect viewportRectInBorderBoxCoordinates, WritingMode, Element*);
+void updateSnapOffsetsForScrollableArea(ScrollableArea&, const RenderBox& scrollingElementBox, const Style::ComputedStyle& scrollingElementStyle, LayoutRect viewportRectInBorderBoxCoordinates, WritingMode, Element* focusedElement, Element* targetElement);
 
 template <typename T> WTF::TextStream& operator<<(WTF::TextStream& ts, SnapOffset<T> offset)
 {
-    ts << offset.offset << " snapTargetID: "_s <<  offset.snapTargetID << " isFocused: "_s << offset.isFocused << " snapAreaIndices: " << offset.snapAreaIndices;
+    ts << offset.offset << " snapTargetID: "_s <<  offset.snapTargetID << " isFocused: "_s << offset.isFocused << " isTarget: "_s << offset.isTarget << " snapAreaIndices: " << offset.snapAreaIndices;
     if (offset.stop == ScrollSnapStop::Always)
         ts << " (always)"_s;
     return ts;

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -103,15 +103,15 @@ float ScrollSnapAnimatorState::adjustedScrollDestination(ScrollEventAxis axis, F
 bool ScrollSnapAnimatorState::preserveCurrentTargetForAxis(ScrollEventAxis axis, NodeIdentifier boxID)
 {
     auto snapOffsets = snapOffsetsForAxis(axis);
-    
-    auto found = std::ranges::find_if(snapOffsets, [boxID](SnapOffset<LayoutUnit> p) -> bool {
-        return *p.snapTargetID == boxID;
+
+    auto found = std::ranges::find_if(snapOffsets, [boxID](const SnapOffset<LayoutUnit>& p) -> bool {
+        return p.snapTargetID && *p.snapTargetID == boxID;
     });
     if (found == snapOffsets.end()) {
         setActiveSnapIndexForAxis(axis, std::nullopt);
         return false;
     }
-    
+
     setActiveSnapIndexForAxis(axis, std::distance(snapOffsets.begin(), found));
     return true;
 }
@@ -163,22 +163,40 @@ void ScrollSnapAnimatorState::updateCurrentlySnappedBoxes()
     m_currentlySnappedBoxes = currentlySnappedBoxes(horizontalOffsets, verticalOffsets);
 }
 
+// Among aligned snap targets, returns the box that an explicit preference points to: a focused box
+// first, then a fragment-targeted box, per https://drafts.csswg.org/css-scroll-snap-1/#re-snap
+// ("prefer the focused box, followed by the targeted box"). snapTargetID records the highest-priority
+// box at each offset (see addOrUpdateStopForSnapOffset). Returns nullopt when none of the snapped
+// boxes is focused or targeted.
+static std::optional<NodeIdentifier> preferredSnapTarget(const HashSet<NodeIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
+{
+    auto findFlagged = [&](const Vector<SnapOffset<LayoutUnit>>& offsets, bool SnapOffset<LayoutUnit>::*flag) -> std::optional<NodeIdentifier> {
+        auto found = std::ranges::find_if(offsets, [&](const SnapOffset<LayoutUnit>& p) {
+            return p.snapTargetID && snappedBoxes.contains(*p.snapTargetID) && p.*flag;
+        });
+        if (found != offsets.end())
+            return *found->snapTargetID;
+        return std::nullopt;
+    };
+
+    if (auto box = findFlagged(horizontalOffsets, &SnapOffset<LayoutUnit>::isFocused))
+        return box;
+    if (auto box = findFlagged(verticalOffsets, &SnapOffset<LayoutUnit>::isFocused))
+        return box;
+    if (auto box = findFlagged(horizontalOffsets, &SnapOffset<LayoutUnit>::isTarget))
+        return box;
+    if (auto box = findFlagged(verticalOffsets, &SnapOffset<LayoutUnit>::isTarget))
+        return box;
+    return std::nullopt;
+}
+
 static NodeIdentifier chooseBoxToResnapTo(const HashSet<NodeIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
 {
     ASSERT(snappedBoxes.size());
 
-    auto found = std::ranges::find_if(horizontalOffsets, [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
-        return snappedBoxes.contains(*p.snapTargetID) && p.isFocused;
-    });
-    if (found != horizontalOffsets.end())
-        return *found->snapTargetID;
-    
-    found = std::ranges::find_if(verticalOffsets, [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
-        return snappedBoxes.contains(*p.snapTargetID) && p.isFocused;
-    });
-    if (found != verticalOffsets.end())
-        return *found->snapTargetID;
-    
+    if (auto box = preferredSnapTarget(snappedBoxes, horizontalOffsets, verticalOffsets))
+        return *box;
+
     return *snappedBoxes.begin();
 }
 
@@ -207,14 +225,21 @@ bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const
 
     auto wasSnappedToMultipleBoxes = previouslySnappedBoxes.size() > 1;
     auto currentlySnappedToMultipleBoxes = m_currentlySnappedBoxes.size() > 1;
-    
-    if (wasSnappedToMultipleBoxes && !currentlySnappedToMultipleBoxes) {
-        auto box = chooseBoxToResnapTo(previouslySnappedBoxes, snapOffsetsHorizontal, snapOffsetsVertical);
-        snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, box);
-        snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, box);
 
-        updateCurrentlySnappedBoxes();
-        LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - multiple boxes snapped; chose " << box << " (changed " << snapPointChanged << ") m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
+    if (wasSnappedToMultipleBoxes) {
+        // A fragment-targeted or focused box is followed to its post-layout offset even if other
+        // boxes remain aligned at the old offset (https://drafts.csswg.org/css-scroll-snap-1/#re-snap).
+        // Without such an explicit preference, only re-choose a target when the tie has collapsed to a
+        // single box, preserving the scroll position otherwise.
+        auto preferred = preferredSnapTarget(previouslySnappedBoxes, snapOffsetsHorizontal, snapOffsetsVertical);
+        if (preferred || !currentlySnappedToMultipleBoxes) {
+            auto box = preferred ? *preferred : chooseBoxToResnapTo(previouslySnappedBoxes, snapOffsetsHorizontal, snapOffsetsVertical);
+            snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, box);
+            snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, box);
+
+            updateCurrentlySnappedBoxes();
+            LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - multiple boxes snapped; chose " << box << " (changed " << snapPointChanged << ") m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
+        }
     }
 
     return snapPointChanged;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -54,6 +54,7 @@
 #include "DocumentInlines.h"
 #include "DocumentView.h"
 #include "Editor.h"
+#include "ElementInlines.h"
 #include "ElementInlinesLight.h"
 #include "ElementRuleCollector.h"
 #include "EventHandler.h"
@@ -1628,7 +1629,7 @@ void RenderLayerScrollableArea::updateSnapOffsets()
         clearSnapOffsets();
         return;
     }
-    updateSnapOffsetsForScrollableArea(*this, *box, box->style(), box->paddingBoxRect(), box->style().writingMode(), protect(m_layer.renderer().document().focusedElement()).get());
+    updateSnapOffsetsForScrollableArea(*this, *box, box->style(), box->paddingBoxRect(), box->style().writingMode(), protect(m_layer.renderer().document().focusedElement()).get(), protect(m_layer.renderer().document().cssTarget()).get());
 }
 
 bool RenderLayerScrollableArea::isScrollSnapInProgress() const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1611,6 +1611,7 @@ enum class WebCore::ScrollSnapStop : bool;
     WebCore::ScrollSnapStop stop;
     bool hasSnapAreaLargerThanViewport;
     bool isFocused;
+    bool isTarget;
     Markable<WebCore::NodeIdentifier> snapTargetID;
     Vector<size_t, 1> snapAreaIndices;
 };


### PR DESCRIPTION
#### 689b91ff1913069d73cf1700b733c14e41e05c25
<pre>
[CSS Scroll Snap] Re-snap does not prefer the focused or fragment-targeted snap area among multiple aligned snap targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=317481">https://bugs.webkit.org/show_bug.cgi?id=317481</a>
<a href="https://rdar.apple.com/180108825">rdar://180108825</a>

Reviewed by Simon Fraser.

When several snap areas resolve to the same snap offset (an aligned &quot;tie&quot;), the
re-snap performed after a layout change must follow the highest-priority box per
<a href="https://drafts.csswg.org/css-scroll-snap-1/#re-snap">https://drafts.csswg.org/css-scroll-snap-1/#re-snap</a>: a focused box, then a
fragment-targeted (:target) box, then the box first in tree order.

WebCore only tracked focused boxes, and only re-chose a target when the tie
collapsed to a single box. So a fragment-targeted box was never preferred, and
when nothing was focused the choice fell back to an arbitrary hash-set order.

Track the document&apos;s fragment-targeted element through the snap-offset pipeline,
mirroring the existing focused-element handling:

- Add SnapOffset::isTarget, populated from Document::cssTarget(), and serialize
  it so the async scrolling tree observes it as well.
- Accumulate isFocused/isTarget across every area that shares an offset (not
  just the first one added), and point the offset&apos;s snapTargetID at the
  highest-priority box (focused, then targeted, then first added) so re-snapping
  resolves to it.
- During re-snap, when the scroller was snapped to multiple aligned boxes, follow
  a focused or targeted box to its post-layout offset even if other boxes remain
  aligned at the old offset. With no such explicit preference, behavior is
  unchanged: a target is only re-chosen once the tie collapses to a single box.

* LayoutTests/platform/mac/TestExpectations: Unskip now passing test
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-main-frame-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-targeted-element-positioned-expected.txt: Ditto
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateSnapOffsets): Pass the fragment-targeted element
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::updateSnapOffsetsForScrollableArea): Accept the targeted element;
accumulate isFocused/isTarget and choose the representative snapTargetID,
preferring focused over targeted over the first box in tree order.
(WebCore::convertOffsetInfo):
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::preserveCurrentTargetForAxis):
(WebCore::preferredSnapTarget): Return the focused-then-targeted box, if any.
(WebCore::chooseBoxToResnapTo): Use preferredSnapTarget before the fallback.
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout): Follow a preferred box
even while peers remain aligned.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateSnapOffsets): Pass the fragment-targeted element.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/315880@main">https://commits.webkit.org/315880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db6806dfccc5502e8a3643eb81327c9241d5ce25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179746 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128083 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93c2b16c-1915-469e-a7e1-362b8f1b2f80) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132844 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fcd1d99-3600-4880-98e3-530fcdc35e0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173330 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113344 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a0e1ac5-c9a7-4e1f-ba3e-c959a7efba0f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28429 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182331 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35120 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141294 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141114 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37987 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44640 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109087 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36381 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116522 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43150 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7760 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42556 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->