### PR TITLE
[314997@main] facebook.com: Audio plays on reels for less than a second

### DIFF
--- a/LayoutTests/media/media-source/media-source-audio-priming-no-spurious-gap-expected.txt
+++ b/LayoutTests/media/media-source/media-source-audio-priming-no-spurious-gap-expected.txt
@@ -1,0 +1,11 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("audio/mock; codecs=mock"))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(samplesToAppend))
+EVENT(updateend)
+EXPECTED (enqueuedSamples.length == '2') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-audio-priming-no-spurious-gap.html
+++ b/LayoutTests/media/media-source/media-source-audio-priming-no-spurious-gap.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-audio-priming-no-spurious-gap</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression test for https://bugs.webkit.org/show_bug.cgi?id=317485
+    //
+    // When an audio sample carries encoder priming (`dts < pts`), `duration`
+    // reports the post-trim presentation span, so `dts + duration`
+    // underestimated the sample's decode-end. The next contiguous sample's
+    // DTS then looked like it fell past TrackBuffer's discontinuity boundary,
+    // which caused `nextSample()` to bail and never recover — audio playback
+    // died after the first sample because subsequent appends only added
+    // samples behind the rejected one in the decode queue.
+    //
+    // Crafted to fall in the bug window:
+    //   timescale: 1000  (timeFudgeFactor = 2002/24000 ≈ 83 ms)
+    //   sample 1: dts=-114, pts=0,   duration=396
+    //               → dts+duration         = 282
+    //               → presentationEndTime  = 396
+    //   sample 2: dts=396, pts=396 (decode-contiguous with sample 1's
+    //               presentationEndTime, but past sample 1's dts+duration)
+    //
+    //   Old boundary = dts+duration+tolerance ≈ 282+83 = 365
+    //                  → sample 2 (396) > 365  → BAIL, sample 2 stuck
+    //   New boundary = max(dts+duration, presentationEndTime)+tolerance
+    //                ≈ 396+83 = 479
+    //                  → sample 2 (396) ≤ 479 → enqueued
+    //
+    // We observe via internals.enqueuedSamplesForTrackID: with the fix both
+    // samples reach the decode queue's enqueued list; without it, only the
+    // first one did.
+
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var samplesToAppend;
+    var enqueuedSamples;
+
+    const TRACK_ID = 1;
+    const TIMESCALE = 1000;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    async function runTest() {
+        findMediaElement();
+        source = new MediaSource();
+        const sourceOpened = waitFor(source, 'sourceopen');
+        run('video.src = URL.createObjectURL(source)');
+        await sourceOpened;
+
+        run(`sourceBuffer = source.addSourceBuffer("audio/mock; codecs=mock")`);
+
+        initSegment = makeAInit(10, [makeATrack(TRACK_ID, 'mock', TRACK_KIND.AUDIO)]);
+        run('sourceBuffer.appendBuffer(initSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Single buffer carrying two samples back-to-back.
+        // Sample 1 has dts < pts (priming-shaped); sample 2 sits at sample 1's
+        // presentationEndTime — decode-contiguous, but past sample 1's
+        // dts+duration.
+        samplesToAppend = concatenateSamples([
+            makeASample(/* pts */ 0,   /* dts */ -114, /* dur */ 396, TIMESCALE, TRACK_ID, SAMPLE_FLAG.SYNC, 0),
+            makeASample(/* pts */ 396, /* dts */ 396,  /* dur */ 100, TIMESCALE, TRACK_ID, SAMPLE_FLAG.SYNC, 0),
+        ]);
+        run('sourceBuffer.appendBuffer(samplesToAppend)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        enqueuedSamples = await internals.enqueuedSamplesForTrackID(sourceBuffer, TRACK_ID);
+
+        // Both appended samples must end up enqueued. Pre-fix only the first
+        // one made it through; the second was rejected by the discontinuity
+        // boundary check and never recovered.
+        testExpected('enqueuedSamples.length', 2);
+    }
+
+    window.addEventListener('load', () => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -212,10 +212,11 @@ RefPtr<MediaSample> TrackBuffer::nextSample()
 
     MediaTime samplePresentationEnd = sample->presentationEndTime();
     if (highestEnqueuedPresentationTime().isInvalid() || samplePresentationEnd > highestEnqueuedPresentationTime())
-        setHighestEnqueuedPresentationTime(WTF::move(samplePresentationEnd));
+        setHighestEnqueuedPresentationTime(samplePresentationEnd);
 
     setLastEnqueuedDecodeKey({ sample->decodeTime(), sample->presentationTime() });
-    setEnqueueDiscontinuityBoundary(sample->decodeTime() + sample->duration() + m_discontinuityTolerance);
+    auto decodeEnd = std::max(sample->decodeTime() + sample->duration(), samplePresentationEnd);
+    setEnqueueDiscontinuityBoundary(decodeEnd + m_discontinuityTolerance);
 
     m_minimumEnqueuedPresentationTime = MediaTime::invalidTime();
     if (m_hasOutOfOrderFrames)


### PR DESCRIPTION
#### fd129dbc23d11f0970707dddbbd0576c8d2b83a1
<pre>
[314997@main] facebook.com: Audio plays on reels for less than a second
<a href="https://bugs.webkit.org/show_bug.cgi?id=317485">https://bugs.webkit.org/show_bug.cgi?id=317485</a>
<a href="https://rdar.apple.com/180020210">rdar://180020210</a>

Reviewed by Youenn Fablet.

After 314997@main tightened TrackBuffer&apos;s enqueue discontinuity tolerance
from a hardcoded 1s down to MediaSource::timeFudgeFactor() (≈83ms),
playback of HE-AAC content carrying encoder priming died after the first
audio sample reached the renderer.
The bug was upstream of the tolerance change; tightening the tolerance
just exposed it.

A primed AAC sample is exposed to the engine with `dts &lt; pts`: the
decode timeline is shifted earlier by the priming duration so the decoder
can run-up to the first displayable PCM frame at pts=0. The sample&apos;s
reported `duration` is the post-trim presentation span — only the audible
portion — so `dts + duration` lands `priming` seconds short of the
sample&apos;s true decode-end. The next contiguous sample&apos;s DTS, which is
authored at the previous sample&apos;s true decode-end (= presentationEndTime
under the AAC priming convention), then looked like it sat past a gap.

`TrackBuffer::nextSample` had been anchoring its discontinuity boundary
on `dts + duration + tolerance`, which is correct only when `dts == pts`.
For primed audio it underestimated the boundary by the priming amount.
The 1s tolerance happened to absorb that error; 83ms didn&apos;t. Once the
check rejected the next sample, recovery was impossible: the rejected
sample sat at the front of the decode queue and only `nextSample`&apos;s
success path advanced the boundary, so every subsequent
`reenqueueMediaIfNeeded` re-tested the same sample against the same
stale boundary and bailed again. Audio was dead until a seek.

Anchor the boundary on whichever endpoint is later — `dts + duration` or
`presentationEndTime` — so primed samples report their true decode-end.
For unprimed samples the two are equal and behavior is unchanged. No
other site that consumes `MediaSample::duration()` is touched, so
buffered-range, append-window, and coded-frame-processing semantics
remain in their presentation-domain meaning.

* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::nextSample):

* LayoutTests/media/media-source/media-source-audio-priming-no-spurious-gap.html: Added.
* LayoutTests/media/media-source/media-source-audio-priming-no-spurious-gap-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/315532@main">https://commits.webkit.org/315532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a02b6b3055e930d0ad77697de7b2d6ef0e5f50c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127061 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcaa5892-4b18-443b-abc4-d810b4841fed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42899 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d691632-dad8-4683-84a9-7bde02833ba3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172308 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112420 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8389a5d-e190-46b3-a627-3068a97c98d4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27405 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181305 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36225 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42927 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140208 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37722 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43616 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107626 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35477 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115381 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42126 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6674 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41519 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41774 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->