### PR TITLE
REGRESSION(296936@main) export-w3c-test-changes fails to create a pull request when --branch-name is used

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -326,10 +326,10 @@ class WebPlatformTestExporter(object):
         pr = self._remote.pull_requests.create(
             title=title,
             body=body,
-            head=self._wpt_repo.branch,
+            head=remote_branch_name,
         )
         if not pr:
-            _log.error(f"Failed to create pull-request for '{self._wpt_repo.branch}'\n")
+            _log.error(f"Failed to create pull-request for '{remote_branch_name}'\n")
             return None
         print(f"Created '{pr}'!")
         return pr


### PR DESCRIPTION
#### 1f2ea6f4ef2ced34d3c8fba1d18ff257250f96f7
<pre>
REGRESSION(296936@main) export-w3c-test-changes fails to create a pull request when --branch-name is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=317494">https://bugs.webkit.org/show_bug.cgi?id=317494</a>

Reviewed by Brianna Fan.

When export-w3c-test-changes is run with --branch-name (-bn) to give the
exported branch a public name that differs from the local branch, creating
the WPT pull request fails with a GitHub 422 error:
```
    Error Message: Validation Failed
    Field: head
    The formatting of a field is invalid.
```
The local branch is always named &quot;wpt-export-for-webkit-&lt;bug&gt;&quot;, but the
branch is pushed to the fork under the public name (the refspec is
&lt;branch_name&gt;:&lt;public_branch_name&gt;). create_wpt_pull_request already builds
the correct head string &quot;&lt;fork_remote&gt;:&lt;public_branch_name&gt;&quot; and passes it
in as remote_branch_name, but only uses it for log messages; the actual
GitHub API call passed head=self._wpt_repo.branch, i.e. the local branch
name. GitHub then looked for a branch that does not exist on the fork and
rejected the request.

This regressed in 296936@main, which converted the exporter to webkitscmpy
and replaced the create_pr(remote_branch_name, ...) call with
pull_requests.create(..., head=self._wpt_repo.branch), substituting the
local branch name for the remote_branch_name that was previously used.

This was masked in the common case because, without --branch-name, the
public branch name equals the local branch name, so the two happened to
coincide.

Pass remote_branch_name as the head so the pull request points at the
branch that was actually pushed, and use it consistently in the failure
log message.

* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.create_wpt_pull_request):

Canonical link: <a href="https://commits.webkit.org/315552@main">https://commits.webkit.org/315552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76d9db99b3c1de4bbc0f70c0a9c4bab189a98f11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127078 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c56b5e20-9ffe-4ee9-bea1-3aecfb912630) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131927 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1fb8776-ee0d-42b5-88ea-1416e1e4f413) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172325 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112431 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b928eb62-f46f-4629-9a1d-21a539d4b54b) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/168687 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27422 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31626 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181322 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34032 "Build is in progress. Recent messages:") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140381 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42944 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140217 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37731 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43633 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107663 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35491 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42143 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6691 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41536 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41791 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->