### PR TITLE
input[type=hidden] should be display:none !important in the UA stylesheet

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/input-type-hidden-important-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/input-type-hidden-important-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Author `input { display: block }` must not override UA !important
+PASS Author `input.flex { display: flex }` must not override UA !important
+PASS Author `input#by-id { display: inline-block }` must not override UA !important
+PASS Author `input[type=hidden] { display: grid }` (normal) must not override UA !important
+PASS Inline `style=display:block` (normal) must not override UA !important
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/input-type-hidden-important.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/input-type-hidden-important.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>input[type=hidden] is display:none !important in the UA stylesheet</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#hidden-elements">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-page">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  /* All of these are *normal* (non-!important) author declarations.
+     The UA rule is `input[type=hidden i] { display: none !important; }`,
+     so none of them may take effect: hidden inputs must stay display:none.
+     A UA rule without !important (as in WebKit previously) would lose to
+     these author rules and wrongly reveal the input. */
+  input            { display: block; }
+  input.flex       { display: flex; }
+  input#by-id      { display: inline-block; }
+  input[type=hidden i] { display: grid; }  /* same specificity as UA, but normal vs UA-important */
+</style>
+
+<input type="hidden" id="default">
+<input type="hidden" class="flex" id="flex">
+<input type="hidden" id="by-id">
+<input type="hidden" id="attr-selector">
+
+<script>
+function displayOf(id) {
+  return getComputedStyle(document.getElementById(id)).display;
+}
+
+test(() => {
+  assert_equals(displayOf("default"), "none");
+}, "Author `input { display: block }` must not override UA !important");
+
+test(() => {
+  assert_equals(displayOf("flex"), "none");
+}, "Author `input.flex { display: flex }` must not override UA !important");
+
+test(() => {
+  assert_equals(displayOf("by-id"), "none");
+}, "Author `input#by-id { display: inline-block }` must not override UA !important");
+
+test(() => {
+  assert_equals(displayOf("attr-selector"), "none");
+}, "Author `input[type=hidden] { display: grid }` (normal) must not override UA !important");
+
+test(() => {
+  const el = document.createElement("input");
+  el.type = "hidden";
+  el.style.display = "block"; // inline style, normal importance
+  document.body.appendChild(el);
+  assert_equals(getComputedStyle(el).display, "none");
+}, "Inline `style=display:block` (normal) must not override UA !important");
+</script>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -394,7 +394,7 @@ input, textarea, select, button {
 }
 
 input[type="hidden"] {
-    display: none;
+    display: none !important;
 }
 
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY


### PR DESCRIPTION
#### 9e91f375cf99af97d10d41a730eb2d6998d1e4ba
<pre>
input[type=hidden] should be display:none !important in the UA stylesheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=317495">https://bugs.webkit.org/show_bug.cgi?id=317495</a>
<a href="https://rdar.apple.com/180137214">rdar://180137214</a>

Reviewed by Tim Nguyen.

The HTML Rendering specification [1] renders hidden inputs with an
!important UA declaration:

    input[type=hidden i] { display: none !important; }

WebKit&apos;s rule omitted !important, so a normal-importance author rule such
as `input { display: block }` (or a `display`-setting CSS reset) would win
the cascade and reveal hidden inputs, diverging from the spec and from
other browsers.

Add !important to match the specification and other browsers.

[1] <a href="https://html.spec.whatwg.org/multipage/rendering.html#hidden-elements">https://html.spec.whatwg.org/multipage/rendering.html#hidden-elements</a>

Test: imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/input-type-hidden-important.html

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/input-type-hidden-important-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/input-type-hidden-important.html: Added.
* Source/WebCore/css/html.css:
(input[type=&quot;hidden&quot;]):

Canonical link: <a href="https://commits.webkit.org/315559@main">https://commits.webkit.org/315559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0239b5c1aeeccf248d78578658ea83aa5845c8c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169371 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43293 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127083 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92015f7a-c3a2-497e-9708-39742af58a4c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171237 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43400 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b24a0487-64a4-4609-b803-d43c525900cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112435 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a2ecc31-c9cf-41b3-a491-488ecc403bb5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32070 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27427 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181327 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140384 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37735 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43638 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28605 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107668 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35492 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115403 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42148 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6694 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41541 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->