### PR TITLE
[WebAuthn] Use structured input/output for largeBlob

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h
@@ -31,6 +31,21 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Staging protocol for Safari's category to use
+@protocol _WKAuthenticationExtensionsLargeBlobOutputsStaging
+@property (nonatomic, readonly) BOOL supported;
+@property (nullable, nonatomic, readonly, copy) NSData *blob;
+@property (nonatomic, readonly) BOOL written;
+@end
+
+// Concrete class that conforms to the staging protocol
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4))
+@interface _WKAuthenticationExtensionsLargeBlobOutputs : NSObject <_WKAuthenticationExtensionsLargeBlobOutputsStaging>
+@property (nonatomic, readonly) BOOL supported;
+@property (nullable, nonatomic, readonly, copy) NSData *blob;
+@property (nonatomic, readonly) BOOL written;
+@end
+
 WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @interface _WKAuthenticationExtensionsClientOutputs : NSObject
 
@@ -38,6 +53,7 @@ WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @property (nonatomic, readonly) BOOL prfEnabled;
 @property (nullable, nonatomic, readonly, copy) NSData *prfFirst;
 @property (nullable, nonatomic, readonly, copy) NSData *prfSecond;
+@property (nullable, nonatomic, readonly, strong) id <_WKAuthenticationExtensionsLargeBlobOutputsStaging> largeBlob;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm
@@ -31,6 +31,7 @@
 @implementation _WKAuthenticationExtensionsClientOutputs {
     RetainPtr<NSData> _prfFirst;
     RetainPtr<NSData> _prfSecond;
+    RetainPtr<_WKAuthenticationExtensionsLargeBlobOutputs> _largeBlob;
 }
 
 - (instancetype)initWithAppid:(BOOL)appid
@@ -55,6 +56,15 @@
     return self;
 }
 
+- (instancetype)initWithAppid:(BOOL)appid prfEnabled:(BOOL)prfEnabled prfFirst:(NSData *)prfFirst prfSecond:(NSData *)prfSecond largeBlob:(_WKAuthenticationExtensionsLargeBlobOutputs *)largeBlob
+{
+    if (!(self = [self initWithAppid:appid prfEnabled:prfEnabled prfFirst:prfFirst prfSecond:prfSecond]))
+        return nil;
+
+    _largeBlob = largeBlob;
+    return self;
+}
+
 - (NSData *)prfFirst
 {
     return _prfFirst.get();
@@ -63,6 +73,38 @@
 - (NSData *)prfSecond
 {
     return _prfSecond.get();
+}
+
+- (id<_WKAuthenticationExtensionsLargeBlobOutputsStaging>)largeBlob
+{
+    return _largeBlob.get();
+}
+
+- (void)dealloc
+{
+    [super dealloc];
+}
+
+@end
+
+@implementation _WKAuthenticationExtensionsLargeBlobOutputs {
+    RetainPtr<NSData> _blob;
+}
+
+- (instancetype)initWithSupported:(BOOL)supported blob:(NSData *)blob written:(BOOL)written
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _supported = supported;
+    _blob = blob;
+    _written = written;
+    return self;
+}
+
+- (NSData *)blob
+{
+    return _blob.get();
 }
 
 - (void)dealloc

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h
@@ -33,6 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithAppid:(BOOL)appid;
 - (instancetype)initWithAppid:(BOOL)appid prfEnabled:(BOOL)prfEnabled prfFirst:(NSData *)prfFirst prfSecond:(NSData *)prfSecond;
+- (instancetype)initWithAppid:(BOOL)appid prfEnabled:(BOOL)prfEnabled prfFirst:(nullable NSData *)prfFirst prfSecond:(nullable NSData *)prfSecond largeBlob:(nullable _WKAuthenticationExtensionsLargeBlobOutputs *)largeBlob;
+
+@end
+
+@interface _WKAuthenticationExtensionsLargeBlobOutputs ()
+
+- (instancetype)initWithSupported:(BOOL)supported blob:(nullable NSData *)blob written:(BOOL)written;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -1097,7 +1097,14 @@ static RetainPtr<_WKAuthenticationExtensionsClientOutputs> wkAuthenticationExten
         if (secondBuffer)
             second = WTF::toNSData(secondBuffer->span());
     }
-    return adoptNS([[_WKAuthenticationExtensionsClientOutputs alloc] initWithAppid:(outputs.appid && *outputs.appid) prfEnabled:(outputs.prf && outputs.prf->enabled && *outputs.prf->enabled) prfFirst:first.get() prfSecond:second.get()]);
+    RetainPtr<_WKAuthenticationExtensionsLargeBlobOutputs> largeBlob;
+    if (outputs.largeBlob) {
+        RetainPtr<NSData> blob;
+        if (RefPtr blobBuffer = outputs.largeBlob->blob)
+            blob = WTF::toNSData(blobBuffer->span());
+        largeBlob = adoptNS([[_WKAuthenticationExtensionsLargeBlobOutputs alloc] initWithSupported:outputs.largeBlob->supported.value_or(false) blob:blob.get() written:outputs.largeBlob->written.value_or(false)]);
+    }
+    return adoptNS([[_WKAuthenticationExtensionsClientOutputs alloc] initWithAppid:(outputs.appid && *outputs.appid) prfEnabled:(outputs.prf && outputs.prf->enabled && *outputs.prf->enabled) prfFirst:first.get() prfSecond:second.get() largeBlob:largeBlob.get()]);
 }
 
 static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestationResponse(const WebCore::AuthenticatorResponseData& data, NSData *clientDataJSON, WebCore::AuthenticatorAttachment attachment)


### PR DESCRIPTION
#### 0c4a8d7f21e829938a4ba038f51a2686bd519a01
<pre>
[WebAuthn] Use structured input/output for largeBlob
<a href="https://bugs.webkit.org/show_bug.cgi?id=317233">https://bugs.webkit.org/show_bug.cgi?id=317233</a>
<a href="https://rdar.apple.com/173450970">rdar://173450970</a>

Reviewed by Charlie Wolfe.

The largeBlob extension output was only exposed through the CBOR-encoded
extensionOutputsCBOR, which is being phased out in favor of the structured
_WKAuthenticationExtensionsClientOutputs object. This patch adds a largeBlob
property to _WKAuthenticationExtensionsClientOutputs, backed by a new
_WKAuthenticationExtensionsLargeBlobOutputs class exposing the supported,
blob, and written fields, mirroring how the largeBlob input is already
plumbed. _WKWebAuthenticationPanel now populates it from the WebCore
extension outputs so clients can read the registration support flag and the
assertion read/write results without decoding CBOR.

* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputs.mm:
(-[_WKAuthenticationExtensionsClientOutputs initWithAppid:prfEnabled:prfFirst:prfSecond:largeBlob:]):
(-[_WKAuthenticationExtensionsClientOutputs largeBlob]):
(-[_WKAuthenticationExtensionsClientOutputs dealloc]):
(-[_WKAuthenticationExtensionsLargeBlobOutputs initWithSupported:blob:written:]):
(-[_WKAuthenticationExtensionsLargeBlobOutputs blob]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientOutputsInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(wkAuthenticationExtensionsClientOutputs):

Canonical link: <a href="https://commits.webkit.org/315616@main">https://commits.webkit.org/315616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be7d67a7303e6d46a970824046cc05c12275f781

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178741 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127097 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36f31d8c-b187-462d-8960-531b5f961d50) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131943 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92878 "10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edb161dd-8d04-4b5f-b39e-21573963a990) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172344 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34934 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112447 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c74f0674-4ad4-4ef2-802d-9754daf9a0cd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32082 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27441 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181341 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140396 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42963 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37778 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43652 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28629 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107697 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35504 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115417 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42162 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6718 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41555 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41810 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41698 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->