### PR TITLE
[JSC] Disable InferSwitch in B3 for Wasm

### DIFF
--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -88,7 +88,15 @@ void generateToAir(Procedure& procedure)
             hoistLoopInvariantValues(procedure);
         eliminateCommonSubexpressions(procedure);
         eliminateDeadCode(procedure);
-        inferSwitches(procedure);
+
+        // Wasm has br_table instruction, so intent of the switch is already represented
+        // and OMG generates Switch nodes directly.
+        // In JS, switch can involve variables (non-constant values) and bytecode can fail
+        // to be in op_switch. Thus after FTL with type speculation & constant folding,
+        // we can infer a switch from if-else chain.
+        if (!procedure.isWasm())
+            inferSwitches(procedure);
+
         if (Options::useB3TailDup())
             duplicateTails(procedure);
         fixSSA(procedure);

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -315,6 +315,9 @@ public:
     AbstractHeapRepository& heaps() { return m_heaps.get(); }
     const AbstractHeapRepository& heaps() const { return m_heaps.get(); }
 
+    void setIsWasm(bool flag) { m_isWasm = flag; }
+    bool isWasm() const { return m_isWasm; }
+
 private:
     friend class BlockInsertionSet;
 
@@ -347,6 +350,7 @@ private:
     bool m_needsPCToOriginMap { false };
     bool m_shouldDumpIR { false };
     bool m_usesSIMD { false };
+    bool m_isWasm { false };
 };
     
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -6701,6 +6701,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
     compilationContext.procedure = makeUniqueWithoutFastMallocCheck<Procedure>(info.usesSIMD(functionIndex));
 
     Procedure& procedure = *compilationContext.procedure;
+    procedure.setIsWasm(true);
     procedure.setName(callee.nameWithHash());
     if (shouldDumpIRFor(functionIndex + info.importFunctionCount()))
         procedure.setShouldDumpIR();


### PR DESCRIPTION
#### 7e85ef8b2e2817032b0255afe64b809b1a193258
<pre>
[JSC] Disable InferSwitch in B3 for Wasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=317502">https://bugs.webkit.org/show_bug.cgi?id=317502</a>
<a href="https://rdar.apple.com/180151237">rdar://180151237</a>

Reviewed by Marcus Plutowski.

In JS, bytecode cannot emit a switch when it involves variables for
example since these things need to be evaluated at each case clause
evaluation.

    switch (expr) {
    case 1 + 2: {
    }

    case Variable.Expression: {
    }
    }

So, these code generates if-else chain (since we cannot evaluate 1 + 2
before jumping. If side effect exists, that&apos;s wrong semantics). And DFG
/ FTL will put type speculation / constant folding to make them much
cleaner form. Then if we identified that case conditions are actually
constant, we can use Switch form. So B3 InferSwitch is analyzing these
form and reconstruct Switch from if-else chain for that.

But Wasm does not need it. Wasm has br_table instruction which
constructs a switch table. And Wasm compiler will emit it if necessary.

This patch disables InferSwitch when B3 is compiling Wasm to skip B3
graph iteration.

* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::setIsWasm):
(JSC::B3::Procedure::isWasm const):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::parseAndCompileOMG):

Canonical link: <a href="https://commits.webkit.org/315613@main">https://commits.webkit.org/315613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4715991a882f7d90e9c304fad9e5d4970800323

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127095 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9afafc73-0149-4b9f-94f5-e7ef077c18ef) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131941 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92876 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/204338b7-ddad-458d-ae66-223a5a6ae39c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172342 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0ae13d8-48db-4a4c-886c-73b79c7992c1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32080 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27439 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/661 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181339 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30638 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140394 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42961 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140230 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43650 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28619 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107689 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25831 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Marcus Plutowski; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35502 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115415 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202062 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42160 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6708 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54188 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41553 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41808 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41696 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->