### PR TITLE
[WPE][cross-toolchain-helper] Disable Swift on armv7 (32-bit) targets, keep clang

### DIFF
--- a/Tools/yocto/README.md
+++ b/Tools/yocto/README.md
@@ -43,7 +43,7 @@ bbappends inside ```meta-openembedded_and_meta-webkit.patch```.
 | Target                    | Swift | Toolchain | Notes |
 | ------------------------- | ----- | --------- | ----- |
 | rpi3/4/5 64-bit (mesa)    | yes   | clang     | aarch64 |
-| rpi3/4 32-bit (mesa)      | yes   | clang     | armv7 |
+| rpi3/4 32-bit (mesa)      | no    | clang     | armv7; Swift does not compile on armv7 at present |
 | rpi3-32bits-userland      | no    | gcc       | wpebackend-rdk + constrained build; Swift opted out in its local.conf |
 | qemu-riscv64              | no    | gcc       | upstream Swift has no riscv64 target |
 

--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -851,12 +851,11 @@ new file mode 100644
 index 0000000..2b3c4d5
 --- /dev/null
 +++ b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend
-@@ -0,0 +1,5 @@
-+# Pull the Swift runtime (from meta-swift) into the WPE WebKit packagegroup on
-+# arches where the stdlib builds. riscv64 has no upstream Swift target.
-+
+@@ -0,0 +1,4 @@
++# Pull the Swift runtime (from meta-swift) into the WPE WebKit packagegroup.
++# Only aarch64: Swift does not compile on armv7 at present and riscv64 has no
++# upstream Swift target.
 +RDEPENDS:packagegroup-wpewebkit-depends-core:append:aarch64 = " swift-stdlib swift-foundation libdispatch"
-+RDEPENDS:packagegroup-wpewebkit-depends-core:append:arm = " swift-stdlib swift-foundation libdispatch"
 diff --git a/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bbappend b/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bbappend
 new file mode 100644
 index 0000000..3c4d5e6


### PR DESCRIPTION
#### 20dafd8a6438824e6f66e7265d19fbce533a95a4
<pre>
[WPE][cross-toolchain-helper] Disable Swift on armv7 (32-bit) targets, keep clang

Reviewed by Carlos Alberto Lopez Perez.

Swift does not compile on armv7 at present, so drop the :arm Swift runtime
injection in the WPE WebKit packagegroup bbappend. The aarch64 (64-bit)
targets keep Swift, and the 32-bit mesa targets keep building with clang.

* Tools/yocto/README.md:
* Tools/yocto/meta-openembedded_and_meta-webkit.patch:

Canonical link: <a href="https://commits.webkit.org/315550@main">https://commits.webkit.org/315550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b24ed871e4e4f1dfebaf2c013c6d5ab5fd380bb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43308 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127098 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42936 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172345 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/112448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/27442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181342 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42964 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/140233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43653 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107698 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25808 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/35505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42163 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->