### PR TITLE
[WTF] Work-around for clang static analyzer crash on 128-bit overflow builtins

### DIFF
--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -231,7 +231,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
 
     [[nodiscard]] static inline bool add(LHS lhs, RHS rhs, ResultType& result)
     {
-#if !HAVE(INT128_T)
+#if !HAVE(INT128_T) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
             ResultType temp;
@@ -239,7 +239,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
                 return false;
             result = temp;
             return true;
-#if !HAVE(INT128_T)
+#if !HAVE(INT128_T) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         }
 #endif
         if (signsMatch(lhs, rhs)) {
@@ -258,7 +258,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
 
     [[nodiscard]] static inline bool sub(LHS lhs, RHS rhs, ResultType& result)
     {
-#if !HAVE(INT128_T)
+#if !HAVE(INT128_T) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
             ResultType temp;
@@ -266,7 +266,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
                 return false;
             result = temp;
             return true;
-#if !HAVE(INT128_T)
+#if !HAVE(INT128_T) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         }
 #endif
         if (!signsMatch(lhs, rhs)) {
@@ -288,7 +288,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         // Don't use the builtin if the int128 type is WTF::[U]Int128Impl.
         // Also don't use the builtin for __[u]int128_t on Clang/Linux.
         // See https://bugs.llvm.org/show_bug.cgi?id=16404
-#if !HAVE(INT128_T) || (COMPILER(CLANG) && OS(LINUX))
+#if !HAVE(INT128_T) || (COMPILER(CLANG) && OS(LINUX)) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
             ResultType temp;
@@ -296,7 +296,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
                 return false;
             result = temp;
             return true;
-#if !HAVE(INT128_T) || (COMPILER(CLANG) && OS(LINUX))
+#if !HAVE(INT128_T) || (COMPILER(CLANG) && OS(LINUX)) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         }
 #endif
 #endif
@@ -343,14 +343,14 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
     [[nodiscard]] static inline bool add(LHS lhs, RHS rhs, ResultType& result)
     {
         ResultType temp;
-#if !HAVE(INT128_T)
+#if !HAVE(INT128_T) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
             if (__builtin_add_overflow(lhs, rhs, &temp))
                 return false;
             result = temp;
             return true;
-#if !HAVE(INT128_T)
+#if !HAVE(INT128_T) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         }
 #endif
         temp = lhs + rhs;
@@ -363,14 +363,14 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
     [[nodiscard]] static inline bool sub(LHS lhs, RHS rhs, ResultType& result)
     {
         ResultType temp;
-#if !HAVE(INT128_T)
+#if !HAVE(INT128_T) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
             if (__builtin_sub_overflow(lhs, rhs, &temp))
                 return false;
             result = temp;
             return true;
-#if !HAVE(INT128_T)
+#if !HAVE(INT128_T) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         }
 #endif
         temp = lhs - rhs;
@@ -386,7 +386,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         // Don't use the builtin if the int128 type is WTF::Int128Impl.
         // Also don't use the builtin for __int128_t on Clang/Linux.
         // See https://bugs.llvm.org/show_bug.cgi?id=16404
-#if !HAVE(INT128_T) || (COMPILER(CLANG) && OS(LINUX))
+#if !HAVE(INT128_T) || (COMPILER(CLANG) && OS(LINUX)) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
 #endif
             ResultType temp;
@@ -394,7 +394,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
                 return false;
             result = temp;
             return true;
-#if !HAVE(INT128_T) || (COMPILER(CLANG) && OS(LINUX))
+#if !HAVE(INT128_T) || (COMPILER(CLANG) && OS(LINUX)) || HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)
         }
 #endif
 #endif

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -185,6 +185,14 @@
 #define HAVE_INT128_T 1
 #endif
 
+// Work around a clang static analyzer crash modeling __builtin_*_overflow on a
+// 128-bit result type (llvm/llvm-project#173795; fixed in
+// apple-clang-2100.3.6.4 / macOS 27 / Xcode 27). Set only for older analyzers,
+// so CheckedArithmetic.h takes its manual (non-builtin) 128-bit overflow path.
+#if defined(__clang_analyzer__) && defined(__apple_build_version__) && __apple_build_version__ < 21000323
+#define HAVE_BROKEN_STATIC_ANALYZER_INT128_OVERFLOW 1
+#endif
+
 #if OS(UNIX) && !OS(FUCHSIA)
 #define HAVE_RESOURCE_H 1
 #endif


### PR DESCRIPTION
#### fe014f0ddd4533a7dd3c3c549dda2d78afb15039
<pre>
[WTF] Work-around for clang static analyzer crash on 128-bit overflow builtins
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=317509">https://bugs.webkit.org/show_bug.cgi?id=317509</a>&gt;
&lt;<a href="https://rdar.apple.com/180158368">rdar://180158368</a>&gt;

Unreviewed build fix.

The clang static analyzer crashes with a segmentation fault when it
models a `__builtin_add_overflow`, `__builtin_sub_overflow`, or
`__builtin_mul_overflow` call whose overflow result type is a 128-bit
integer: `getSufficientTypeForOverflowOp()` asks for an integer type
twice as wide as the result (256-bit), which does not exist, and then
dereferences the resulting null `QualType`.  WTF&apos;s `Checked&lt;&gt;`
arithmetic emits these builtins, so analyzing any code that performs
128-bit checked arithmetic aborts the entire `analyze` action, leaving
every project built after the one that trips it without static-analysis
coverage (for example WebCore, built after JavaScriptCore).

Define `HAVE(BROKEN_STATIC_ANALYZER_INT128_OVERFLOW)` for Apple clang
that predates the fix (`__apple_build_version__ &lt; 21000323`), and only
while the analyzer is running, and take the existing manual
(non-builtin) overflow path for 128-bit operands when it is set.
Ordinary compilation and analyzers that already contain the fix keep
using the overflow builtins, so generated code is unaffected and the
work-around deactivates automatically once the toolchain is current.

This is a toolchain bug fixed in apple-clang-2100.3.6.4; see
llvm/llvm-project#173795 (fixed by llvm/llvm-project#174335).

No new tests since this change is not directly testable.

* Source/WTF/wtf/PlatformHave.h:
* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::ArithmeticOperations&lt;LHS, RHS, ResultType, true, true&gt;::add):
(WTF::ArithmeticOperations&lt;LHS, RHS, ResultType, true, true&gt;::sub):
(WTF::ArithmeticOperations&lt;LHS, RHS, ResultType, true, true&gt;::multiply):
(WTF::ArithmeticOperations&lt;LHS, RHS, ResultType, false, false&gt;::add):
(WTF::ArithmeticOperations&lt;LHS, RHS, ResultType, false, false&gt;::sub):
(WTF::ArithmeticOperations&lt;LHS, RHS, ResultType, false, false&gt;::multiply):

Canonical link: <a href="https://commits.webkit.org/315555@main">https://commits.webkit.org/315555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f97356311d06b30cd9c2fae3517593c4945ee4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43328 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127118 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d48690a7-7d38-48bb-abfa-d96725cc8feb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42956 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/131961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f755dc94-6091-41e5-b2c4-c5be7aec3279) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172365 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd98984a-2ee3-4b80-b353-1032706f44b8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27462 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181363 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30661 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34072 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42984 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140250 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43673 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107741 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25810 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/35523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115438 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202085 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42183 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54195 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41576 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41831 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->