### PR TITLE
[LegacySVG] Nested clip-path (clip-path on a clipPath) ignores zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-nested-clippath-zoom-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-nested-clippath-zoom-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-nested-clippath-zoom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-nested-clippath-zoom.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>CSS Masking: nested clip-path (clip-path on a clipPath) honors zoom</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="match" href="reference/green-100x100.html">
+<style>
+#target {
+    top: 4px;
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    clip-path: url(#outer);
+    zoom: 2;
+}
+</style>
+</head>
+<body>
+<svg width="0" height="0">
+  <clipPath id="outer" clipPathUnits="userSpaceOnUse" clip-path="url(#inner)">
+    <rect x="0" y="0" width="100" height="50"/>
+    <rect x="0" y="50" width="100" height="50"/>
+  </clipPath>
+  <clipPath id="inner" clipPathUnits="userSpaceOnUse">
+    <rect x="0" y="0" width="50" height="50"/>
+  </clipPath>
+</svg>
+<div id="target"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -222,7 +222,7 @@ auto LegacyRenderSVGResourceClipper::applyClippingToContext(GraphicsContext& con
         if (resources && (clipper = resources->clipper())) {
             GraphicsContextStateSaver stateSaver(maskContext);
 
-            if (!clipper->applyClippingToContext(maskContext, *this, objectBoundingBox, clippedContentBounds))
+            if (!clipper->applyClippingToContext(maskContext, *this, objectBoundingBox, clippedContentBounds, usedZoom))
                 return { };
 
             succeeded = drawContentIntoMaskImage(Ref { *clipperData.imageBuffer }, objectBoundingBox, usedZoom);


### PR DESCRIPTION
#### 897e0e8f7d8a30e32066ada735fcb452036789ac
<pre>
[LegacySVG] Nested clip-path (clip-path on a clipPath) ignores zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=317512">https://bugs.webkit.org/show_bug.cgi?id=317512</a>
<a href="https://rdar.apple.com/180162723">rdar://180162723</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Blink / Chromium.

When a &lt;clipPath&gt; is itself clipped by another clipPath, the painted-mask
clipping path recurses into LegacyRenderSVGResourceClipper::applyClippingToContext()
to apply the nested clip. That recursive call omitted the trailing usedZoom
argument, so it silently fell back to the default value of 1. As a result a
nested userSpaceOnUse clip was not scaled by the zoom factor, while the outer
clip was, producing a clipped region of the wrong size under non-default zoom.

Fix by forwarding usedZoom to the nested applyClippingToContext() call, matching
how it is threaded through the rest of the clipping code.

NOTE: This bug is not present in Layer Based SVG Engine (LBSE).

Test: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-nested-clippath-zoom.html

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::applyClippingToContext): Pass usedZoom
to the nested clipper so the inner clip is scaled consistently with the outer clip.

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-nested-clippath-zoom.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-nested-clippath-zoom-expected.html: Added.

Canonical link: <a href="https://commits.webkit.org/315562@main">https://commits.webkit.org/315562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c88da736a6486479d615f7bbe90e99786c7f3333

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127122 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d91a5c67-20b1-4cb4-bba7-63ed23dca137) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131965 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92900 "1 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35b97c48-88e6-45ab-9c84-2bdbf3d88989) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172369 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112469 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f940311-546e-49c4-98e4-be97388d0b7d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32104 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27466 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181367 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140418 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140254 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37738 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43677 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28649 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107752 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35527 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115442 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42187 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6738 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41580 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41835 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41723 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->