### PR TITLE
[webkitcorepy] Suppress benign urllib3 NotOpenSSLWarning under LibreSSL

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -25,6 +25,9 @@ import sys
 if sys.version_info < (3, 9):  # noqa: UP036
     raise ImportError("webkitcorepy requires Python 3.9 or above")
 
+import warnings
+warnings.filterwarnings('ignore', message='urllib3 v2 only supports OpenSSL')
+
 import logging
 import platform
 


### PR DESCRIPTION
#### ae9d4afc72be51b934acb93445a31a0114c21867
<pre>
[webkitcorepy] Suppress benign urllib3 NotOpenSSLWarning under LibreSSL
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=317514">https://bugs.webkit.org/show_bug.cgi?id=317514</a>&gt;
&lt;<a href="https://rdar.apple.com/180166620">rdar://180166620</a>&gt;

Reviewed by NOBODY (OOPS!).

The system Python on macOS links against LibreSSL, so urllib3 v2 prints
a NotOpenSSLWarning at import time.  The warning is benign but clutters
the output of every WebKit tool that imports `requests` (e.g. `git
commit` via the prepare-commit-msg hook).

Install a process-wide warnings filter in webkitcorepy, which all WebKit
command-line tooling imports before `requests`, so the benign warning
is suppressed everywhere downstream.

No new tests since this change is not directly testable.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae9d4afc72be51b934acb93445a31a0114c21867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127124 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9ea1d62-3be8-4905-a01d-f9acc1925025) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131967 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92901 "2 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b56e64f-7668-4bca-9220-128e46365847) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112471 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/904be9cb-8ba6-4a3d-8c10-3f4680affb86) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/168733 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32105 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27468 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181369 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140420 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/168812 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42990 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140256 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43679 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28659 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107757 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35526 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42189 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6748 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41582 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41725 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->