### PR TITLE
Script-triggerable crash inserting an @namespace rule after an @import rule via CSSOM

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-namespace-after-import-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-namespace-after-import-expected.txt
@@ -1,0 +1,4 @@
+
+PASS insertRule places an @namespace rule after a single @import rule
+PASS insertRule places an @namespace rule after two @import rules
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-namespace-after-import.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-namespace-after-import.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Test: CSSOM StyleSheet insertRule with a namespace rule after an existing import rule</title>
+    <link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstylesheet-insertrule">
+    <meta name="flags" content="dom">
+    <meta name="assert" content="Inserting an @namespace rule at an index following one or more @import rules places it correctly without corrupting the rule list.">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style id="oneImport">
+        @import url("support/a-green.css");
+    </style>
+    <style id="twoImports">
+        @import url("support/a-green.css");
+        @import url("support/b-green.css");
+    </style>
+</head>
+<body>
+<div id="log"></div>
+<script>
+    test(function() {
+        var sheet = document.getElementById("oneImport").sheet;
+        assert_equals(sheet.cssRules.length, 1, "precondition: one @import rule");
+        assert_equals(sheet.cssRules[0].type, CSSRule.IMPORT_RULE);
+
+        // The @namespace rule must be inserted at index 1 (right after the @import).
+        // Internally the engine keeps separate vectors for @import and @namespace rules,
+        // so the global index (1) differs from the namespace-vector-local index (0).
+        var returnedIndex = sheet.insertRule('@namespace foo url("http://example.com/ns");', 1);
+        assert_equals(returnedIndex, 1, "insertRule returns the requested index");
+
+        assert_equals(sheet.cssRules.length, 2, "rule list grew by one");
+        assert_equals(sheet.cssRules[0].type, CSSRule.IMPORT_RULE, "import rule still first");
+
+        var nsRule = sheet.cssRules[1];
+        assert_true(nsRule instanceof CSSNamespaceRule, "inserted rule is a CSSNamespaceRule");
+        assert_equals(nsRule.prefix, "foo", "namespace prefix round-trips");
+        assert_equals(nsRule.namespaceURI, "http://example.com/ns", "namespace URI round-trips");
+    }, "insertRule places an @namespace rule after a single @import rule");
+
+    test(function() {
+        var sheet = document.getElementById("twoImports").sheet;
+        assert_equals(sheet.cssRules.length, 2, "precondition: two @import rules");
+
+        // Insert at index 2, after both imports. The namespace-vector-local index is 0
+        // while the global index is 2, maximizing the gap that triggers the bug.
+        var returnedIndex = sheet.insertRule('@namespace bar url("http://example.com/ns2");', 2);
+        assert_equals(returnedIndex, 2, "insertRule returns the requested index");
+
+        assert_equals(sheet.cssRules.length, 3, "rule list grew by one");
+        assert_equals(sheet.cssRules[0].type, CSSRule.IMPORT_RULE);
+        assert_equals(sheet.cssRules[1].type, CSSRule.IMPORT_RULE);
+
+        var nsRule = sheet.cssRules[2];
+        assert_true(nsRule instanceof CSSNamespaceRule, "inserted rule is a CSSNamespaceRule");
+        assert_equals(nsRule.prefix, "bar", "namespace prefix round-trips");
+        assert_equals(nsRule.namespaceURI, "http://example.com/ns2", "namespace URI round-trips");
+    }, "insertRule places an @namespace rule after two @import rules");
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -319,7 +319,7 @@ bool StyleSheetContents::wrapperInsertRule(Ref<StyleRuleBase>&& rule, unsigned i
         if (!m_childRules.isEmpty() || !m_layerRulesBeforeImportRules.isEmpty())
             return false;
 
-        m_namespaceRules.insert(index, *namespaceRule);
+        m_namespaceRules.insert(childVectorIndex, *namespaceRule);
         
         // For now to be compatible with IE and Firefox if a namespace rule with the same
         // prefix is added, it overwrites previous ones.


### PR DESCRIPTION
#### 44ba2b5c111ec26ba583c657cb32bfc9f7f01084
<pre>
Script-triggerable crash inserting an @namespace rule after an @import rule via CSSOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=317517">https://bugs.webkit.org/show_bug.cgi?id=317517</a>

Reviewed by Anne van Kesteren.

StyleSheetContents::wrapperInsertRule() converts the caller-supplied
global rule index into a vector-local index (childVectorIndex) by
successively subtracting the sizes of m_layerRulesBeforeImportRules and
m_importRules. Every branch inserts using this adjusted local index --
except the @namespace branch, which used the original, unadjusted index:
```
      m_namespaceRules.insert(index, *namespaceRule);
```
When the sheet already contains one or more @import rules, the global
index is strictly greater than the namespace-vector-local index, so
`index` can exceed m_namespaceRules.size(). That out-of-bounds position
is passed to Vector::insert(), whose mutableSpan().subspan(position) trips
libc++ hardening (_LIBCPP_HARDENING_MODE_EXTENSIVE) and aborts the
process before any write occurs.

This is reachable from script: CSSStyleSheet::insertRule() only rejects
index &gt; length(), then forwards the index to wrapperInsertRule(). For a
sheet such as `@import url(x);`, calling
`insertRule(&apos;@namespace foo url(y);&apos;, 1)` reaches the @namespace branch
with `childVectorIndex == 0` but calls `m_namespaceRules.insert(1, ...)`
on an empty vector, crashing the process.

Fixed by inserting at childVectorIndex, matching every other branch in
the function (and wrapperDeleteRule).

Test: imported/w3c/web-platform-tests/css/cssom/insertRule-namespace-after-import.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-namespace-after-import-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/insertRule-namespace-after-import.html: Added.
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::wrapperInsertRule):

Canonical link: <a href="https://commits.webkit.org/315573@main">https://commits.webkit.org/315573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/297ab327047fd7d0c045768849ab3851828397bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127127 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f34d603-1eb8-491a-b81d-a0352ba7f108) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131970 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92904 "11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb39f6f7-6a14-460c-9c17-ae5a17781b38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112474 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/054420de-a6c5-4fa1-a168-cd6f0925be32) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32109 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27471 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181372 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140423 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140259 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37749 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43682 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28652 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107761 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35531 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115447 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42192 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6741 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41585 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->