### PR TITLE
CSS preload scanner fails to preload @import rules that follow an @layer statement rule

### DIFF
--- a/LayoutTests/http/tests/loading/preload-css-import-after-other-rules-expected.txt
+++ b/LayoutTests/http/tests/loading/preload-css-import-after-other-rules-expected.txt
@@ -1,0 +1,10 @@
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+Preload scanner should preload @import rules that follow @charset and @layer statement rules
+
+PASS
+PASS
+PASS
+PASS
+

--- a/LayoutTests/http/tests/loading/preload-css-import-after-other-rules.html
+++ b/LayoutTests/http/tests/loading/preload-css-import-after-other-rules.html
@@ -1,0 +1,51 @@
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.dumpFrameLoadCallbacks();
+}
+
+var results=[];
+function checkForPreload(url, shouldbe) {
+    var preloaded = internals.isPreloaded(url);
+    if ((preloaded && shouldbe) || (!preloaded && !shouldbe))
+        results.push("PASS\n");
+    else
+        results.push("FAIL\n");
+}
+function printResults(){
+    for(var i = 0; i < results.length; i++)
+        log.textContent += results[i];
+}
+
+</script>
+<script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=1000"></script>
+<script>
+checkForPreload("resources/small_mq.css?1", true);
+checkForPreload("resources/small_mq.css?2", true);
+checkForPreload("resources/small_mq.css?3", true);
+checkForPreload("resources/small_mq.css?4", true);
+</script>
+<style>
+@charset "utf-8";
+@import url("resources/small_mq.css?1");
+</style>
+<style>
+@layer foo, bar;
+@import url("resources/small_mq.css?2");
+</style>
+<style>
+@charset "utf-8";
+@layer foo, bar;
+@import url("resources/small_mq.css?3");
+</style>
+<style>
+@layer foo, bar;
+@import url("resources/small_mq.css?4") layer(foo);
+</style>
+<body>
+<p>Preload scanner should preload @import rules that follow @charset and @layer statement rules</p>
+<pre id=log></pre>
+<script>
+printResults();
+</script>

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile, Inc. http://www.torchmobile.com/
  * Copyright (C) 2010-2020 Google Inc. All rights reserved.
  *
@@ -246,7 +246,7 @@ void CSSPreloadScanner::emitRule()
             m_requests->append(makeUnique<PreloadRequest>("css"_s, url, m_predictedBaseElementURL, CachedResource::Type::CSSStyleSheet, String(), ScriptType::Classic, ReferrerPolicy::EmptyString));
         }
         m_state = Initial;
-    } else if (equalLettersIgnoringASCIICase(rule, "charset"_s))
+    } else if (equalLettersIgnoringASCIICase(rule, "charset"_s) || equalLettersIgnoringASCIICase(rule, "layer"_s))
         m_state = Initial;
     else
         m_state = DoneParsingImportRules;


### PR DESCRIPTION
#### f28a05dbdb97a892a64d14201bcabd4510acccca
<pre>
CSS preload scanner fails to preload @import rules that follow an @layer statement rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=317519">https://bugs.webkit.org/show_bug.cgi?id=317519</a>
<a href="https://rdar.apple.com/180170656">rdar://180170656</a>

Reviewed by Chris Dumez.

The CSS preload scanner only continued scanning past a @charset rule; any
other at-rule sent it to the DoneParsingImportRules state and stopped it from
preloading subsequent @import rules. Cascade layers commonly declare layer
order up front with an empty @layer statement rule (e.g. `@layer foo, bar;`)
before the @import rules, which legally precede @import per the cascade layers
spec. Because of this, none of the @import rules after such a statement were
being speculatively preloaded.

Treat a @layer statement rule like @charset in CSSPreloadScanner::emitRule()
and keep scanning. A @layer block rule (`@layer foo { ... }`) is unaffected:
it hits &apos;{&apos; and transitions to DoneParsingImportRules before emitRule() is
ever reached, so only the statement form (terminated by &apos;;&apos;) flows through the
new branch.

* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(WebCore::CSSPreloadScanner::emitRule): Continue scanning past @layer statement
rules so following @import rules are still preloaded.
* LayoutTests/http/tests/loading/preload-css-import-after-other-rules.html: Added.
* LayoutTests/http/tests/loading/preload-css-import-after-other-rules-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/315576@main">https://commits.webkit.org/315576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b40d0d0117fee935eae50946444fd90246a0f77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127130 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d69ac0b-f3f7-4f48-90c4-85ec0ede535e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131973 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92907 "11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37bf360c-2fac-4093-8ea9-95f4ad4879d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172377 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112477 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ab5b797-61dc-4ca6-89f4-fe009eb5bd97) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32116 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27474 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181375 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140425 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140261 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37752 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43685 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107764 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35533 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115450 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42195 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6745 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41588 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41843 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41731 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->