### PR TITLE
animation-range shorthand serialization drops a 0% offset on animation-range-end

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-end-zero-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-end-zero-offset-expected.txt
@@ -1,0 +1,8 @@
+
+PASS e.style['animation-range'] = "normal cover 0%" should set the property value
+PASS e.style['animation-range'] = "entry 0% exit 0%" should set the property value
+PASS e.style['animation-range'] = "cover 50% exit 0%" should set the property value
+PASS e.style['animation-range'] = "normal cover 100%" should set the property value
+PASS e.style['animation-range'] = "entry 0% exit 100%" should set the property value
+PASS e.style['animation-range'] = "normal exit 50%" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-end-zero-offset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-end-zero-offset.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>animation-range shorthand serialization preserves a 0% end offset</title>
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#propdef-animation-range">
+<link rel="help" href="https://drafts.csswg.org/cssom/#serialize-a-css-value">
+<meta name="assert" content="A 0% offset on animation-range-end is not the end default (100%) and must be preserved when serializing the animation-range shorthand.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<div id="target" style="font-size:10px"></div>
+<script>
+// The omittable default offset is 0% for animation-range-start and 100% for
+// animation-range-end. So a 0% offset on the END is meaningful and must round-trip.
+// The collapse-to-bare-name path only fires when the end's range name differs from
+// the start's, which is the case these tests exercise.
+
+// Bug cases: end has a 0% offset and a different range name than the start.
+test_valid_value("animation-range", "normal cover 0%");
+test_valid_value("animation-range", "entry 0% exit 0%", "entry exit 0%");
+test_valid_value("animation-range", "cover 50% exit 0%");
+
+// Control: 100% IS the end default, so it correctly collapses to the bare name.
+test_valid_value("animation-range", "normal cover 100%", "normal cover");
+test_valid_value("animation-range", "entry 0% exit 100%", "entry exit");
+
+// Control: a non-default end offer is kept (passes regardless of the bug).
+test_valid_value("animation-range", "normal exit 50%");
+</script>

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1556,7 +1556,7 @@ String ShorthandSerializer::serializeSingleAnimationRange(const CSSValue& value,
     if (RefPtr pair = dynamicDowncast<CSSValuePair>(value)) {
         bool isSameNameAsStart = isValueID(pair->first(), startValueID);
         bool isStartValue = type == Style::SingleAnimationRangeType::Start;
-        bool isDefaultValue = isDefault(dynamicDowncast<CSSPrimitiveValue>(pair->second()), Style::SingleAnimationRangeType::Start);
+        bool isDefaultValue = isDefault(dynamicDowncast<CSSPrimitiveValue>(pair->second()), type);
         if (isDefaultValue && (isStartValue || !isSameNameAsStart))
             return nameLiteral(valueID(pair->first()));
         return pair->cssText(m_serializationContext);


### PR DESCRIPTION
#### 2a404f3390176be6347117592a7cd12e5975a6a2
<pre>
animation-range shorthand serialization drops a 0% offset on animation-range-end
<a href="https://bugs.webkit.org/show_bug.cgi?id=317518">https://bugs.webkit.org/show_bug.cgi?id=317518</a>

Reviewed by Anne van Kesteren.

When serializing the animation-range shorthand, an offset is omitted only
when it equals the range&apos;s default: 0% for animation-range-start and 100%
for animation-range-end. ShorthandSerializer::serializeSingleAnimationRange()
already had an isDefault() helper that branches on the range type to apply
the right default, but its single call site passed a hardcoded
Style::SingleAnimationRangeType::Start, so the end value was always tested
against 0% instead of 100%.

As a result a 0% offset on the end value -- which is not the end default and
must be preserved -- was treated as omittable and collapsed to the bare range
name. This was web-observable via getPropertyValue(&apos;animation-range&apos;) /
cssText: e.g. `animation-range: normal cover 0%` serialized as `normal cover`,
which re-parses to `cover 100%`, silently losing the authored value. (A 100%
end offset, the actual end default, never reached this path because the
longhand normalizes `cover 100%` to `cover` beforehand.) The bug only
surfaced when the end&apos;s range name differed from the start&apos;s, so the existing
`contain 100% contain 0%` coverage did not catch it.

Fixed by passing the function&apos;s own `type` parameter to isDefault(), matching
its evident design and WebCore&apos;s Style model
(StyleSingleAnimationRange::defaultValue(): 0% for Start, 100% for End).

Test: LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-end-zero-offset.html

The 3 new subtests are passing in Chrome already so this aligns our behavior
with them.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-end-zero-offset-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-range-shorthand-end-zero-offset.html: Added.
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeSingleAnimationRange const):

Canonical link: <a href="https://commits.webkit.org/315574@main">https://commits.webkit.org/315574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41c6828cc9e9a2587407c35457c1b87828dcc4d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127203 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc0232fc-e73a-413f-b6a8-76bc74f99cfc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132044 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92976 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/319ea795-e2ab-49b6-bf57-58d3910221f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172450 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112547 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c2a63ff-e2e1-429a-bfa2-ba2ddf9d82b8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32182 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27547 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181449 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140492 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140328 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37750 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43758 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107904 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35599 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115523 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42268 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6847 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41661 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41916 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41804 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->