### PR TITLE
Fix serialization of CSSViewTransitionRule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-with-types-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-with-types-parsing-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL types: nOnE shoud result in [] assert_equals: expected "@view-transition { types: none; }" but got "@view-transition { }"
-FAIL types: abc shoud result in ["abc"] assert_equals: expected "@view-transition { types: abc; }" but got "@view-transition { types: abc}}"
-FAIL types: abc xyz shoud result in ["abc","xyz"] assert_equals: expected "@view-transition { types: abc xyz; }" but got "@view-transition { types: abc xyz}}"
-FAIL types: abc\ xyz shoud result in ["abc xyz"] assert_equals: expected "@view-transition { types: abc\\ xyz; }" but got "@view-transition { types: abc xyz}}"
-FAIL types:    abc 	xyz  shoud result in ["abc","xyz"] assert_equals: expected "@view-transition { types: abc xyz; }" but got "@view-transition { types: abc xyz}}"
+PASS types: nOnE shoud result in []
+PASS types: abc shoud result in ["abc"]
+PASS types: abc xyz shoud result in ["abc","xyz"]
+PASS types: abc\ xyz shoud result in ["abc xyz"]
+PASS types:    abc 	xyz  shoud result in ["abc","xyz"]
 PASS types: abc none shoud result in []
 PASS types: abc, def shoud result in []
 PASS types: dEfAuLt shoud result in []
 PASS types: abc -ua-something shoud result in []
-FAIL types: abc -uA-something shoud result in ["abc","-uA-something"] assert_equals: expected "@view-transition { types: abc -uA-something; }" but got "@view-transition { types: abc -uA-something}}"
-FAIL types: abc -ok-something shoud result in ["abc","-ok-something"] assert_equals: expected "@view-transition { types: abc -ok-something; }" but got "@view-transition { types: abc -ok-something}}"
-FAIL types: abc abc shoud result in ["abc","abc"] assert_equals: expected "@view-transition { types: abc abc; }" but got "@view-transition { types: abc abc}}"
-FAIL types: abc ABC shoud result in ["abc","ABC"] assert_equals: expected "@view-transition { types: abc ABC; }" but got "@view-transition { types: abc ABC}}"
+PASS types: abc -uA-something shoud result in ["abc","-uA-something"]
+PASS types: abc -ok-something shoud result in ["abc","-ok-something"]
+PASS types: abc abc shoud result in ["abc","abc"]
+PASS types: abc ABC shoud result in ["abc","ABC"]
 PASS types: 123 shoud result in []
 PASS types: * shoud result in []
 PASS types: *11 abc shoud result in []

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCustomIdentValue.h"
 #include "CSSKeywordValue.h"
+#include "CSSMarkup.h"
 #include "CSSPropertyParser.h"
 #include "CSSStyleSheet.h"
 #include "CSSTokenizer.h"
@@ -57,6 +58,8 @@ StyleRuleViewTransition::StyleRuleViewTransition(Ref<StyleProperties>&& properti
     m_navigation = toViewTransitionNavigationEnum(properties->getPropertyCSSValue(CSSPropertyNavigation));
 
     if (auto value = properties->getPropertyCSSValue(CSSPropertyTypes)) {
+        m_explicitlySetTypes = true;
+
         auto processSingleValue = [&](const CSSValue& currentValue) {
             if (RefPtr customIdentValue = dynamicDowncast<CSSCustomIdentValue>(currentValue))
                 m_types.append(customIdentValue->customIdent().value);
@@ -66,7 +69,8 @@ StyleRuleViewTransition::StyleRuleViewTransition(Ref<StyleProperties>&& properti
                 processSingleValue(currentValue);
         } else
             processSingleValue(*value);
-    }
+    } else
+        m_explicitlySetTypes = false;
 }
 
 Ref<StyleRuleViewTransition> StyleRuleViewTransition::create(Ref<StyleProperties>&& properties)
@@ -103,14 +107,21 @@ String CSSViewTransitionRule::cssText() const
         builder.append("; "_s);
     }
 
-    if (!types().isEmpty())
+    if (m_viewTransitionRule->explicitlySetTypes()) {
         builder.append("types:"_s);
-    for (auto& type : types()) {
-        builder.append(' ');
-        builder.append(type);
+
+        const auto& types = this->types();
+
+        if (!types.isEmpty()) {
+            for (auto& type : types) {
+                builder.append(' ');
+                serializeIdentifier(builder, type);
+            }
+        } else
+            builder.append(" none"_s);
+
+        builder.append("; "_s);
     }
-    if (!types().isEmpty())
-        builder.append('}');
 
     builder.append('}');
     return builder.toString();

--- a/Source/WebCore/css/CSSViewTransitionRule.h
+++ b/Source/WebCore/css/CSSViewTransitionRule.h
@@ -46,13 +46,18 @@ public:
 
     std::optional<ViewTransitionNavigation> navigation() const { return m_navigation; }
     ViewTransitionNavigation computedNavigation() const { return navigation().value_or(ViewTransitionNavigation::None); }
-    Vector<AtomString> types() const { return m_types; }
+    const Vector<AtomString>& types() const { return m_types; }
+    bool explicitlySetTypes() const { return m_explicitlySetTypes; }
 
 private:
     explicit StyleRuleViewTransition(Ref<StyleProperties>&&);
     StyleRuleViewTransition(const StyleRuleViewTransition&) = default;
 
     std::optional<ViewTransitionNavigation> m_navigation;
+
+    // Set if 'types' is explicit set in the CSS rule. Used to determine
+    // whether to serialize 'types' in cssText.
+    bool m_explicitlySetTypes { false };
     Vector<AtomString> m_types;
 };
 
@@ -68,7 +73,7 @@ public:
     StyleRuleType styleRuleType() const final { return StyleRuleType::ViewTransition; }
 
     AtomString navigation() const;
-    Vector<AtomString> types() const { return protect(m_viewTransitionRule)->types(); }
+    const Vector<AtomString>& types() const { return protect(m_viewTransitionRule)->types(); }
 
 private:
     CSSViewTransitionRule(StyleRuleViewTransition&, CSSStyleSheet* parent);


### PR DESCRIPTION
#### 3e14f0ac6667bf77dab8dd3290f17fdd07439af0
<pre>
Fix serialization of CSSViewTransitionRule
<a href="https://rdar.apple.com/180170814">rdar://180170814</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317520">https://bugs.webkit.org/show_bug.cgi?id=317520</a>

Reviewed by Tim Nguyen.

Fix some issues with the serialization (cssText) of @view-transition at-rule:

1. View transition type identifiers aren&apos;t escaped for serialization.
   e.g: &quot;types: abc\ def&quot; has one type &quot;abc def&quot; (&apos;\&apos; is the escape character),
        but is serialized as &quot;types: abc def&quot;, which means two types.

2. If any types are specified, the serialization contains an extra bracket
   e.g: &quot;@view-transition { types: abc }&quot; is serialized as
        &quot;@view-transition { types: abc}}&quot;

3. &apos;types&apos; is not serialized if it&apos;s &apos;none&apos;
   e.g: &quot;@view-transition { types: none; }&quot; is serialized as
        &quot;@view-transition { }&quot;

Test: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-with-types-parsing.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-with-types-parsing-expected.txt:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
(WebCore::StyleRuleViewTransition::StyleRuleViewTransition):
(WebCore::CSSViewTransitionRule::cssText const):
* Source/WebCore/css/CSSViewTransitionRule.h:

Canonical link: <a href="https://commits.webkit.org/315614@main">https://commits.webkit.org/315614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b2dc32cf70c0a82a5d836e10f6403c58e75ba88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127191 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03a1fadc-a3c2-4721-826e-420b163f435c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171345 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132033 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92965 "2 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8f42fbd-3761-4379-95fc-0260e94d8232) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172438 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112536 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7de24cc6-f214-4479-aca3-748659c29df6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32172 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27535 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181437 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140481 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43057 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140317 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37777 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43746 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107884 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35586 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115511 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42256 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6823 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41649 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->