### PR TITLE
[Legacy SVG] A foreignObject's x/y is missing from its objectBoundingBox()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2596,7 +2596,6 @@ imported/w3c/web-platform-tests/svg/path/distance/pathlength-rect-mutating.svg [
 imported/w3c/web-platform-tests/svg/animations/seeking-events-1.html [ Failure Pass ]
 imported/w3c/web-platform-tests/svg/animations/pruning-first-interval.html [ Failure Pass ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-scale-scroll.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-with-position-under-clip-path.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/scroll-transform-nested-stacked-children.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/will-change-in-foreign-object-paint-order.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/isolation-with-html.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05-expected.txt
@@ -25,7 +25,7 @@ FAIL path with stroke assert_approx_equals: path1.getBBox().x {"fill":false,"str
 FAIL path with markers assert_approx_equals: path1.getBBox().width {"fill":false,"stroke":false,"markers":true,"clipped":false} expected 112 +/- 0.1 but got 100
 PASS use with fill
 FAIL use with fill, stroke, markers and clipping assert_approx_equals: use1.getBBox().y {"fill":true,"stroke":true,"markers":true,"clipped":true} expected 66 +/- 0.1 but got 70
-FAIL foreignObject with fill assert_approx_equals: fo1.getBBox().x {"fill":true,"stroke":false,"markers":false,"clipped":false} expected 2 +/- 0.1 but got 0
-FAIL foreignObject with fill, stroke, markers and clipping assert_approx_equals: fo1.getBBox().x {"fill":true,"stroke":true,"markers":true,"clipped":true} expected 53 +/- 0.1 but got 0
+PASS foreignObject with fill
+FAIL foreignObject with fill, stroke, markers and clipping assert_approx_equals: fo1.getBBox().x {"fill":true,"stroke":true,"markers":true,"clipped":true} expected 53 +/- 0.1 but got 2
 FAIL masking-path-07-b.html with fill, stroke, markers and clipping assert_approx_equals: rect-1.getBBox().x {"fill":true,"stroke":true,"markers":true,"clipped":true} expected 10 +/- 0.1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-10-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-10-expected.txt
@@ -4,5 +4,5 @@ There are issues of dynamic loading required for tiling. According to 'postpone'
 PASS text with zoom
 PASS image with zoom
 PASS path with zoom
-FAIL foreignObject with zoom assert_approx_equals: fo1.getBBox().x expected 2 +/- 0.1 but got 0
+PASS foreignObject with zoom
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -139,6 +139,7 @@
 #include "SVGDocumentExtensions.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGNames.h"
+#include "SVGRenderSupport.h"
 #include "SVGSVGElement.h"
 #include "SVGScriptElement.h"
 #include "ScriptDisallowedScope.h"
@@ -1941,7 +1942,7 @@ IntRect Element::boundsInRootViewSpace()
 
     if (RefPtr svgElement = elementWithSVGLayoutBox(*this)) {
         if (auto localRect = svgElement->getBoundingBox())
-            quads.append(protect(renderer())->localToAbsoluteQuad(*localRect));
+            quads.append(SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad(*protect(renderer()), *localRect));
     } else if (shouldObtainBoundsFromBoxModel(this)) {
         // Get the bounding rectangle from the box model.
         protect(renderer())->absoluteQuads(quads);
@@ -2005,7 +2006,7 @@ LayoutRect Element::absoluteEventBounds(bool& boundsIncludeAllDescendantElements
     LayoutRect result;
     if (RefPtr svgElement = elementWithSVGLayoutBox(*this)) {
         if (auto localRect = svgElement->getBoundingBox())
-            result = LayoutRect(protect(renderer())->localToAbsoluteQuad(*localRect, MapCoordinatesMode::UseTransforms, &includesFixedPositionElements).boundingBox());
+            result = LayoutRect(SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad(*protect(renderer()), *localRect, MapCoordinatesMode::UseTransforms, &includesFixedPositionElements).boundingBox());
     } else {
         CheckedPtr renderer = this->renderer();
         if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer.get())) {
@@ -2101,7 +2102,7 @@ Ref<DOMRectList> Element::getClientRects()
 
     if (RefPtr svgElement = elementWithSVGLayoutBox(*this)) {
         if (auto localRect = svgElement->getBoundingBox())
-            quads.append(renderer->localToAbsoluteQuad(*localRect));
+            quads.append(SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad(*renderer, *localRect));
     } else if (auto pair = listBoxElementBoundingBox(*this)) {
         renderer = WTF::move(pair.value().first);
         quads.append(renderer->localToAbsoluteQuad(FloatQuad { pair.value().second }));
@@ -2126,7 +2127,7 @@ std::optional<std::pair<CheckedPtr<RenderElement>, FloatRect>> Element::bounding
     Vector<FloatQuad> quads;
     if (RefPtr svgElement = elementWithSVGLayoutBox(*this)) {
         if (auto localRect = svgElement->getBoundingBox())
-            quads.append(renderer->localToAbsoluteQuad(*localRect));
+            quads.append(SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad(*renderer, *localRect));
     } else if (auto pair = listBoxElementBoundingBox(*this)) {
         renderer = WTF::move(pair.value().first);
         quads.append(renderer->localToAbsoluteQuad(FloatQuad { pair.value().second }));

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2083,7 +2083,7 @@ const Style::ComputedStyle* RenderElement::targetTextPseudoStyle() const
 bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
 {
     if (isSVGRenderer()) {
-        point = localToAbsoluteQuad(strokeBoundingBox(), MapCoordinatesMode::UseTransforms).boundingBox().minXMinYCorner();
+        point = SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad(*this, strokeBoundingBox()).boundingBox().minXMinYCorner();
         return true;
     }
 
@@ -2147,7 +2147,7 @@ bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
 bool RenderElement::getTrailingCorner(FloatPoint& point, bool& insideFixed) const
 {
     if (isSVGRenderer()) {
-        point = localToAbsoluteQuad(strokeBoundingBox(), MapCoordinatesMode::UseTransforms).boundingBox().maxXMaxYCorner();
+        point = SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad(*this, strokeBoundingBox()).boundingBox().maxXMaxYCorner();
         return true;
     }
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -173,6 +173,15 @@ static bool hasValidBoundingBoxForContainer(const RenderObject& object)
     return false;
 }
 
+// Maps a child's bounding boxes into the container's coordinate space. See LegacyRenderSVGForeignObject.h for
+// why a <foreignObject> uses localTransform() rather than localToParentTransform() here.
+static AffineTransform boundingBoxToParentTransform(const RenderObject& renderer)
+{
+    if (is<LegacyRenderSVGForeignObject>(renderer))
+        return renderer.localTransform();
+    return renderer.localToParentTransform();
+}
+
 auto SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& container, RepaintRectCalculation repaintRectCalculation) -> ContainerBoundingBoxes
 {
     ContainerBoundingBoxes result;
@@ -195,8 +204,9 @@ auto SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& contai
             continue;
 
         auto objectBounds = current->objectBoundingBox();
-        if (!transform.isIdentity())
-            objectBounds = transform.mapRect(objectBounds);
+        auto boundingBoxTransform = boundingBoxToParentTransform(current);
+        if (!boundingBoxTransform.isIdentity())
+            objectBounds = boundingBoxTransform.mapRect(objectBounds);
 
         if (!result.objectBoundingBox)
             result.objectBoundingBox = objectBounds;
@@ -226,7 +236,7 @@ FloatRect SVGRenderSupport::computeContainerStrokeBoundingBox(const RenderElemen
 
         if (auto* currentElement = dynamicDowncast<RenderElement>(current.get()))
             SVGRenderSupport::intersectRepaintRectWithResources(*currentElement, childStrokeBoundingBox, RepaintRectCalculation::Accurate);
-        const AffineTransform& transform = current->localToParentTransform();
+        auto transform = boundingBoxToParentTransform(current);
         if (!transform.isIdentity())
             childStrokeBoundingBox = transform.mapRect(childStrokeBoundingBox);
 
@@ -401,7 +411,7 @@ FloatRect SVGRenderSupport::computeContainerDecoratedBoundingBox(const RenderEle
 
         FloatRect childDecoratedBox = current.decoratedBoundingBox();
 
-        const AffineTransform& transform = current.localToParentTransform();
+        auto transform = boundingBoxToParentTransform(current);
         if (!transform.isIdentity())
             childDecoratedBox = transform.mapRect(childDecoratedBox);
 
@@ -426,18 +436,17 @@ bool SVGRenderSupport::filtersForceContainerLayout(const RenderElement& renderer
     return true;
 }
 
-FloatSize SVGRenderSupport::svgContentLocationOffset(const RenderObject& renderer)
+FloatQuad SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad(const RenderElement& renderer, FloatRect boundingBox, OptionSet<MapCoordinatesMode> mode, bool* wasFixed)
 {
-    // A <foreignObject> keeps its bounding boxes origin-relative, but paints its content at location().
     if (CheckedPtr foreignObject = dynamicDowncast<LegacyRenderSVGForeignObject>(renderer))
-        return toFloatSize(FloatPoint { foreignObject->location() });
-    return { };
+        boundingBox.moveBy(-foreignObject->objectBoundingBox().location());
+
+    return renderer.localToAbsoluteQuad(boundingBox, mode, wasFixed);
 }
 
 inline FloatRect clipPathReferenceBox(const RenderElement& renderer, CSSBoxType boxType)
 {
     FloatRect referenceBox;
-    bool isBoxRelativeToRendererGeometry = true;
     switch (boxType) {
     case CSSBoxType::BorderBox:
     case CSSBoxType::MarginBox:
@@ -451,7 +460,6 @@ inline FloatRect clipPathReferenceBox(const RenderElement& renderer, CSSBoxType 
             auto viewportSize = SVGLengthContext(downcast<SVGElement>(renderer.element())).viewportSize();
             if (viewportSize) {
                 referenceBox.setSize(*viewportSize);
-                isBoxRelativeToRendererGeometry = false;
                 break;
             }
         }
@@ -462,9 +470,6 @@ inline FloatRect clipPathReferenceBox(const RenderElement& renderer, CSSBoxType 
         referenceBox = renderer.objectBoundingBox();
         break;
     }
-
-    if (isBoxRelativeToRendererGeometry)
-        referenceBox.move(SVGRenderSupport::svgContentLocationOffset(renderer));
 
     return referenceBox;
 }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -111,8 +111,9 @@ public:
 
     static void clipContextToCSSClippingArea(GraphicsContext&, const RenderElement& renderer);
 
-    // Offset from a renderer's origin-relative bounding box to where it actually paints its content.
-    static FloatSize svgContentLocationOffset(const RenderObject&);
+    // Like RenderObject::localToAbsoluteQuad(), but takes a rect in SVG bounding box space rather than CSS box
+    // space. The two only differ for a <foreignObject> - see LegacyRenderSVGForeignObject.h.
+    static FloatQuad mapSVGBoundingBoxToAbsoluteQuad(const RenderElement&, FloatRect boundingBox, OptionSet<MapCoordinatesMode> = MapCoordinatesMode::UseTransforms, bool* wasFixed = nullptr);
 
     static void styleChanged(RenderElement&, const Style::ComputedStyle*);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
@@ -29,6 +29,19 @@ namespace WebCore {
 
 class SVGForeignObjectElement;
 
+// A <foreignObject> sits on the SVG/HTML boundary and therefore lives in two coordinate spaces at once:
+//
+//  - As an SVG graphics element its geometry is positioned by x/y, exactly like a <rect> or an <image>.
+//    x/y is part of objectBoundingBox() (and so of getBBox(), and of everything resolved against
+//    *Units="objectBoundingBox"), and paint() / nodeAtFloatPoint() only apply localTransform().
+//  - As a CSS box hosting an HTML subtree its border box origin is at location(), which is set to x/y so
+//    that the hosted content lays out in the right place. The RenderBox repaint and coordinate-mapping
+//    machinery hands us rects in that space, i.e. relative to the border box origin and excluding x/y.
+//
+// The two spaces differ by exactly x/y, which is why localToParentTransform() carries the x/y translation
+// (for repaintRectInLocalCoordinates() and for HTML descendants walking up through SVGRenderSupport) while
+// the bounding boxes below carry x/y themselves. SVGRenderSupport maps them with localTransform() alone, so
+// that x/y is not counted twice - see boundingBoxToParentTransform() in SVGRenderSupport.cpp.
 class LegacyRenderSVGForeignObject final : public RenderSVGBlock {
     WTF_MAKE_TZONE_ALLOCATED(LegacyRenderSVGForeignObject);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGForeignObject);
@@ -43,12 +56,13 @@ public:
     bool requiresLayer() const override { return false; }
     void layout() override;
 
-    FloatRect objectBoundingBox() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
+    FloatRect objectBoundingBox() const override { return m_viewport; }
     bool isObjectBoundingBoxValid() const { return !m_viewport.isEmpty(); }
     bool objectBoundingBoxIsEmpty() const final { return !isObjectBoundingBoxValid(); }
-    FloatRect strokeBoundingBox() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
+    FloatRect strokeBoundingBox() const override { return m_viewport; }
+    // Unlike the bounding boxes, this one is in CSS box space - see the class comment.
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const override { return FloatRect(FloatPoint(), m_viewport.size()); }
-    FloatRect decoratedBoundingBox() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
+    FloatRect decoratedBoundingBox() const override { return m_viewport; }
 
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
 


### PR DESCRIPTION
#### a2fad73b3c2974dea6e8b6811cea5b475954f349
<pre>
[Legacy SVG] A foreignObject&apos;s x/y is missing from its objectBoundingBox()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317525">https://bugs.webkit.org/show_bug.cgi?id=317525</a>
<a href="https://rdar.apple.com/180188422">rdar://180188422</a>

Reviewed by NOBODY (OOPS!).

LegacyRenderSVGForeignObject keeps every bounding box origin-relative and puts x/y into
localToParentTransform() instead, so that one transform can serve both the SVG bounding box
math and the RenderBox coordinate mapping of the HTML subtree it hosts. Container bounds do
come out right that way, but the choice leaks into everything that resolves against the
object bounding box, which lands at (0, 0) rather than at the content: getBBox() reports
0,0,w,h where every other graphics element - and RenderSVGForeignObject, which returns
m_viewport - reports x,y,w,h; clipPathUnits, maskUnits and filterUnits=&quot;objectBoundingBox&quot;
resolve one x/y off; transform-origin resolves against a box at the wrong origin. Each has
been fixed in isolation so far - 319856 taught the CSS clip-path reference box to add
location() back - and the SVG clipper and masker were about to grow the same graft.

Put the x/y in the bounding boxes instead, matching RenderSVGForeignObject as well as Gecko
/ Firefox and Blink / Chromium. The two coordinate spaces a &lt;foreignObject&gt; lives in are
now described once, in LegacyRenderSVGForeignObject.h, and reconciled in the two places
that bridge them: boundingBoxToParentTransform(), used by the three container bounding box
computations, and SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad(), used by the
getBoundingClientRect() / getClientRects() family and by the SVG branch of
RenderElement::getLeadingCorner() / getTrailingCorner(). 319856&apos;s svgContentLocationOffset()
is no longer needed and is removed.

localToParentTransform() keeps the x/y translation and repaintRectInLocalCoordinates() stays
relative to the border box origin, so the repaint and coordinate mapping paths for the hosted
HTML subtree are untouched. This mirrors how LBSE already works, where objectBoundingBox() is
spec-correct and nominalSVGLayoutLocation() corrects the plumbing.

* LayoutTests/TestExpectations: Progression
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-05-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-10-expected.txt: Progression
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::boundsInRootViewSpace):
(WebCore::Element::absoluteEventBounds):
(WebCore::Element::getClientRects):
(WebCore::Element::boundingAbsoluteRectWithoutLayout const):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::getLeadingCorner const):
(WebCore::RenderElement::getTrailingCorner const):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::boundingBoxToParentTransform):
(WebCore::SVGRenderSupport::computeContainerBoundingBoxes):
(WebCore::SVGRenderSupport::computeContainerStrokeBoundingBox):
(WebCore::SVGRenderSupport::computeContainerDecoratedBoundingBox):
(WebCore::SVGRenderSupport::mapSVGBoundingBoxToAbsoluteQuad):
(WebCore::SVGRenderSupport::svgContentLocationOffset): Deleted.
(WebCore::clipPathReferenceBox):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::applyResource):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2fad73b3c2974dea6e8b6811cea5b475954f349

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144947 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b285c6e-0d61-49e5-b839-9a5e71052014) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140881 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97606 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8b2c1a9-6461-445d-8f6d-75ec24a2814d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121333 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84f5fa14-7b04-4fb7-94f2-f176d706d785) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43225 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41510 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41185 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1996 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192772 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150257 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54924 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149975 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44593 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127189 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122404 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53441 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16178 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52823 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53060 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->