### PR TITLE
[JSC] Compute dominance frontier of each block once in the entire graph instead of computing for each SSA variable

### DIFF
--- a/Source/JavaScriptCore/b3/B3SSACalculator.cpp
+++ b/Source/JavaScriptCore/b3/B3SSACalculator.cpp
@@ -65,6 +65,32 @@ SSACalculator::SSACalculator(Procedure& proc)
 
 SSACalculator::~SSACalculator() = default;
 
+void SSACalculator::ensureDominanceFrontiers()
+{
+    if (m_dominanceFrontiersComputed)
+        return;
+    m_dominanceFrontiersComputed = true;
+
+    m_dominanceFrontiers = IndexMap<BasicBlock*, Vector<BasicBlock*>>(m_proc.size());
+
+    // "A Simple, Fast Dominance Algorithm", Cooper, Harvey, and Kennedy, 2001.
+    // https://www.cs.tufts.edu/~nr/cs257/archive/keith-cooper/dom14.pdf
+    for (BasicBlock* block : m_proc) {
+        if (block->numPredecessors() < 2)
+            continue;
+        BasicBlock* idom = m_dominators->idom(block);
+        for (BasicBlock* predecessor : block->predecessors()) {
+            BasicBlock* runner = predecessor;
+            while (runner && runner != idom) {
+                auto& frontier = m_dominanceFrontiers[runner];
+                if (frontier.isEmpty() || frontier.last() != block)
+                    frontier.append(block);
+                runner = m_dominators->idom(runner);
+            }
+        }
+    }
+}
+
 void SSACalculator::reset()
 {
     m_variables.clear();
@@ -74,6 +100,7 @@ void SSACalculator::reset()
         m_data[blockIndex].m_defs.clear();
         m_data[blockIndex].m_phis.clear();
     }
+    m_dominanceFrontiersComputed = false;
 }
 
 SSACalculator::Variable* SSACalculator::newVariable()
@@ -102,7 +129,7 @@ SSACalculator::Def* SSACalculator::reachingDefAtTail(BasicBlock* startingBlock, 
     for (BasicBlock* block = startingBlock; block; block = m_dominators->idom(block)) {
         if (Def* def = m_data[block].m_defs.get(variable)) {
             for (BasicBlock* otherBlock = startingBlock; otherBlock != block; otherBlock = m_dominators->idom(otherBlock))
-                m_data[block].m_defs.add(variable, def);
+                m_data[otherBlock].m_defs.add(variable, def);
             return def;
         }
     }

--- a/Source/JavaScriptCore/b3/B3SSACalculator.h
+++ b/Source/JavaScriptCore/b3/B3SSACalculator.h
@@ -111,21 +111,36 @@ public:
     void computePhis(const Functor& functor)
     {
         m_dominators = &m_proc.dominators();
-        for (Variable& variable : m_variables) {
-            m_dominators->forAllBlocksInPrunedIteratedDominanceFrontierOf(
-                variable.m_blocksWithDefs,
-                [&] (BasicBlock* block) -> bool {
-                    Value* phi = functor(&variable, block);
-                    if (!phi)
-                        return false;
+        ensureDominanceFrontiers();
 
-                    BlockData& data = m_data[block];
-                    Def* phiDef = m_phis.add(Def(&variable, block, phi));
+        // Iterated dominance frontier per variable, computed over the shared per-block
+        // dominance-frontier cache. The per-variable "visited" set is tracked with
+        // an epoch stamp so we don't allocate a fresh set for every variable.
+        Vector<BasicBlock*, 16> worklist;
+        IndexMap<BasicBlock*, unsigned> visited(m_proc.size(), 0);
+        for (SSACalculator::Variable& variable : m_variables) {
+            unsigned epoch = variable.index() + 1;
+            worklist.shrink(0);
+            worklist.appendVector(variable.m_blocksWithDefs);
+            while (!worklist.isEmpty()) {
+                BasicBlock* block = worklist.takeLast();
+                for (BasicBlock* to : m_dominanceFrontiers[block]) {
+                    if (visited[to] == epoch)
+                        continue;
+                    visited[to] = epoch;
+
+                    Value* phi = functor(&variable, to);
+                    if (!phi)
+                        continue;
+
+                    BlockData& data = m_data[to];
+                    Def* phiDef = m_phis.add(Def(&variable, to, phi));
                     data.m_phis.append(phiDef);
 
                     data.m_defs.add(&variable, phiDef);
-                    return true;
-                });
+                    worklist.append(to);
+                }
+            }
         }
     }
 
@@ -148,17 +163,22 @@ public:
     void dump(PrintStream&) const;
     
 private:
+    void ensureDominanceFrontiers();
+
     SegmentedVector<Variable> m_variables;
     Bag<Def> m_defs;
-    
+
     Bag<Def> m_phis;
-    
+
     struct BlockData {
         UncheckedKeyHashMap<Variable*, Def*> m_defs;
         Vector<Def*> m_phis;
     };
-    
+
     IndexMap<BasicBlock*, BlockData> m_data;
+
+    IndexMap<BasicBlock*, Vector<BasicBlock*>> m_dominanceFrontiers;
+    bool m_dominanceFrontiersComputed { false };
 
     Dominators* m_dominators { nullptr };
     Procedure& m_proc;

--- a/Source/JavaScriptCore/dfg/DFGBlockMap.h
+++ b/Source/JavaScriptCore/dfg/DFGBlockMap.h
@@ -98,6 +98,12 @@ public:
         return m_vector[block->index];
     }
 
+    template<typename... Args>
+    void clear(Args&&... args)
+    {
+        m_vector.fill(T(std::forward<Args>(args)...), m_vector.size());
+    }
+
 private:
     Vector<T> m_vector;
 };

--- a/Source/JavaScriptCore/dfg/DFGSSACalculator.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSACalculator.cpp
@@ -64,6 +64,33 @@ SSACalculator::SSACalculator(Graph& graph)
 
 SSACalculator::~SSACalculator() = default;
 
+void SSACalculator::ensureDominanceFrontiers()
+{
+    if (m_dominanceFrontiersComputed)
+        return;
+    m_dominanceFrontiersComputed = true;
+
+    // "A Simple, Fast Dominance Algorithm", Cooper, Harvey, and Kennedy, 2001.
+    // https://www.cs.tufts.edu/~nr/cs257/archive/keith-cooper/dom14.pdf
+    m_dominanceFrontiers = BlockMap<Vector<BasicBlock*>>(m_graph);
+    auto& dominators = *m_graph.m_ssaDominators;
+    for (BlockIndex blockIndex = m_graph.numBlocks(); blockIndex--;) {
+        BasicBlock* block = m_graph.block(blockIndex);
+        if (!block || block->predecessors.size() < 2)
+            continue;
+        BasicBlock* idom = dominators.idom(block);
+        for (BasicBlock* predecessor : block->predecessors) {
+            BasicBlock* runner = predecessor;
+            while (runner && runner != idom) {
+                auto& frontier = m_dominanceFrontiers[runner];
+                if (frontier.isEmpty() || frontier.last() != block)
+                    frontier.append(block);
+                runner = dominators.idom(runner);
+            }
+        }
+    }
+}
+
 void SSACalculator::reset()
 {
     m_variables.clear();
@@ -73,6 +100,7 @@ void SSACalculator::reset()
         m_data[blockIndex].m_defs.clear();
         m_data[blockIndex].m_phis.clear();
     }
+    m_dominanceFrontiersComputed = false;
 }
 
 SSACalculator::Variable* SSACalculator::newVariable()

--- a/Source/JavaScriptCore/dfg/DFGSSACalculator.h
+++ b/Source/JavaScriptCore/dfg/DFGSSACalculator.h
@@ -29,6 +29,7 @@
 
 #include "DFGDominators.h"
 #include "DFGGraph.h"
+#include <wtf/IndexMap.h>
 
 namespace JSC { namespace DFG {
 
@@ -175,19 +176,34 @@ public:
     void computePhis(const Invocable<Node*(Variable*, BasicBlock*)> auto& functor)
     {
         DFG_ASSERT(m_graph, nullptr, m_graph.m_ssaDominators);
-        
+
+        ensureDominanceFrontiers();
+
+        // Iterated dominance frontier per variable, computed over the shared per-block
+        // dominance-frontier cache. The per-variable "visited" set is tracked with
+        // an epoch stamp so we don't allocate a fresh set for every variable.
+        Vector<BasicBlock*, 16> worklist;
+        BlockMap<unsigned> visited(m_graph);
+        visited.clear(0);
         for (Variable& variable : m_variables) {
-            m_graph.m_ssaDominators->forAllBlocksInPrunedIteratedDominanceFrontierOf(
-                variable.m_blocksWithDefs,
-                [&] (BasicBlock* block) -> bool {
-                    Node* phiNode = functor(&variable, block);
+            unsigned epoch = variable.index() + 1;
+            worklist.shrink(0);
+            worklist.appendVector(variable.m_blocksWithDefs);
+            while (!worklist.isEmpty()) {
+                BasicBlock* block = worklist.takeLast();
+                for (BasicBlock* to : m_dominanceFrontiers[block]) {
+                    if (visited[to] == epoch)
+                        continue;
+                    visited[to] = epoch;
+
+                    Node* phiNode = functor(&variable, to);
                     if (!phiNode)
-                        return false;
-                    
-                    BlockData& data = m_data[block];
-                    Def* phiDef = m_phis.add(Def(&variable, block, phiNode));
+                        continue;
+
+                    BlockData& data = m_data[to];
+                    Def* phiDef = m_phis.add(Def(&variable, to, phiNode));
                     data.m_phis.append(phiDef);
-                    
+
                     // Note that it's possible to have a block that looks like this before SSA
                     // conversion:
                     //
@@ -214,8 +230,9 @@ public:
                     // So, we rely on the fact that UncheckedKeyHashMap::add() does nothing if the key was
                     // already present.
                     data.m_defs.add(&variable, phiDef);
-                    return true;
-                });
+                    worklist.append(to);
+                }
+            }
         }
     }
     
@@ -238,18 +255,23 @@ public:
     void dump(PrintStream&) const;
     
 private:
+    void ensureDominanceFrontiers();
+
     SegmentedVector<Variable> m_variables;
     Bag<Def> m_defs;
-    
+
     Bag<Def> m_phis;
-    
+
     struct BlockData {
         UncheckedKeyHashMap<Variable*, Def*> m_defs;
         Vector<Def*> m_phis;
     };
-    
+
     BlockMap<BlockData> m_data;
-    
+
+    BlockMap<Vector<BasicBlock*>> m_dominanceFrontiers;
+    bool m_dominanceFrontiersComputed { false };
+
     Graph& m_graph;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
@@ -30,6 +30,7 @@
 
 #include "DFGBasicBlockInlines.h"
 #include "DFGBlockInsertionSet.h"
+#include "DFGBlockMapInlines.h"
 #include "DFGGraph.h"
 #include "DFGInsertionSet.h"
 #include "DFGPhase.h"


### PR DESCRIPTION
#### a929c7e65180305fdd0d1ae606a2e1001a717b61
<pre>
[JSC] Compute dominance frontier of each block once in the entire graph instead of computing for each SSA variable
<a href="https://bugs.webkit.org/show_bug.cgi?id=317527">https://bugs.webkit.org/show_bug.cgi?id=317527</a>
<a href="https://rdar.apple.com/180197031">rdar://180197031</a>

Reviewed by Yijia Huang.

Right now, SSACalculator is computing iterated dominance frontier for
each variable, and it is taking too long time. Given the graph, for each
block, let&apos;s compute dominance frontier via single path algorithm and
use it to compute iterated dominance frontier for each SSA variable.

We also fix B3SSACalculator&apos;s reachingDefAtTail, which didn&apos;t update defs
up to found block to compress the path finding.

Right now DFG and B3 BasicBlocks are having subtle difference, so making
both unified causes massive refactoring. I don&apos;t  do it in this change
since that&apos;s not the scope of this patch.

* Source/JavaScriptCore/b3/B3SSACalculator.cpp:
(JSC::B3::SSACalculator::ensureDominanceFrontiers):
(JSC::B3::SSACalculator::reset):
(JSC::B3::SSACalculator::reachingDefAtTail):
* Source/JavaScriptCore/b3/B3SSACalculator.h:
(JSC::B3::SSACalculator::computePhis):
* Source/JavaScriptCore/dfg/DFGBlockMap.h:
(JSC::DFG::BlockMap::clear):
* Source/JavaScriptCore/dfg/DFGSSACalculator.cpp:
(JSC::DFG::SSACalculator::ensureDominanceFrontiers):
(JSC::DFG::SSACalculator::reset):
* Source/JavaScriptCore/dfg/DFGSSACalculator.h:
(JSC::DFG::SSACalculator::computePhis):
* Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp:

Canonical link: <a href="https://commits.webkit.org/315623@main">https://commits.webkit.org/315623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31feb67b5a39c8bdb3d97c0f60d8ad755784ea68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127169 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc740c41-e1de-4ed5-b301-040b52482519) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132010 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92942 "10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/159ad43a-c499-48cc-8229-bfc51dca9cfa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172416 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34938 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112513 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdd39e29-bf60-4424-904d-e77b7b3f441a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32149 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27513 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/748 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181415 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30712 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140459 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43035 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140295 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107850 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35569 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115489 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202136 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42234 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6795 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54206 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41627 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41882 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41770 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->