### PR TITLE
[Legacy SVG] mask is mispositioned on a foreignObject with non-zero x/y

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-foreignobject-non-zero-xy-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-foreignobject-non-zero-xy-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-foreignobject-non-zero-xy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-foreignobject-non-zero-xy.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>CSS Masking: mask with maskContentUnits="objectBoundingBox" on a foreignObject with non-zero 'x' and 'y' renders correctly</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-maskcontentunits">
+<link rel="match" href="reference/green-100x100.html">
+<!--
+  The mask content is in objectBoundingBox units, so the white rect (width 0.5)
+  covers the left half (100px) of the foreignObject's 200x100 bounding box. The
+  bounding box is positioned at the foreignObject's x/y, so the mask must align
+  with the painted content there: the green 100x100 div must remain and its
+  100px red border must be masked out, leaving a 100x100 green square.
+-->
+<svg viewBox="25 50 200 100" width="200">
+  <rect x="25" y="50" width="100" height="100" fill="red"/>
+  <mask id="m" maskContentUnits="objectBoundingBox">
+    <rect width="0.5" height="1" fill="white"/>
+  </mask>
+  <foreignObject x="25" y="50" width="200" height="100" mask="url(#m)">
+    <div style="width: 100px; height: 100px; background-color: green; border-right: 100px solid red"></div>
+  </foreignObject>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-userspace-foreignobject-non-zero-xy-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-userspace-foreignobject-non-zero-xy-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-userspace-foreignobject-non-zero-xy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-userspace-foreignobject-non-zero-xy.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>CSS Masking: mask with maskContentUnits="userSpaceOnUse" on a foreignObject with non-zero 'x' and 'y' renders correctly</title>
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-mask">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-maskcontentunits">
+<link rel="match" href="reference/green-100x100.html">
+<!--
+  The mask content is in userSpaceOnUse units, so the white rect is authored in the
+  foreignObject's user coordinate system at (25,50) - the same place its x/y position
+  the content. It must cover the green 100x100 div and mask out the 100px red border,
+  leaving a 100x100 green square.
+-->
+<svg viewBox="25 50 200 100" width="200">
+  <rect x="25" y="50" width="100" height="100" fill="red"/>
+  <mask id="m" maskContentUnits="userSpaceOnUse">
+    <rect x="25" y="50" width="100" height="100" fill="white"/>
+  </mask>
+  <foreignObject x="25" y="50" width="200" height="100" mask="url(#m)">
+    <div style="width: 100px; height: 100px; background-color: green; border-right: 100px solid red"></div>
+  </foreignObject>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/reference/green-100x100.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/reference/green-100x100.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -27,6 +27,7 @@
 #include "FloatPoint.h"
 #include "Image.h"
 #include "IntRect.h"
+#include "LegacyRenderSVGForeignObject.h"
 #include "LegacyRenderSVGResourceMaskerInlines.h"
 #include "SVGRenderingContext.h"
 #include "StyleComputedStyle+GettersInlines.h"
@@ -35,6 +36,20 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyRenderSVGResourceMasker);
+
+// <foreignObject> paints its content at the box location() (its x/y) instead of baking x/y into the
+// origin-relative objectBoundingBox()/decoratedBoundingBox(), so the mask geometry (region, image
+// buffer and objectBoundingBox content units) must be positioned at the content origin to line up
+// with what is actually painted. This is safe for the repaint path: a <foreignObject> never expands
+// its repaint rect through the masker (it has no intersectRepaintRectWithResources caller), so this
+// only affects mask painting.
+static FloatRect maskTargetBoundingBox(const RenderObject& renderer)
+{
+    auto boundingBox = renderer.objectBoundingBox();
+    if (CheckedPtr foreignObject = dynamicDowncast<LegacyRenderSVGForeignObject>(renderer))
+        boundingBox.setLocation(foreignObject->location());
+    return boundingBox;
+}
 
 LegacyRenderSVGResourceMasker::LegacyRenderSVGResourceMasker(SVGMaskElement& element, Style::ComputedStyle&& style)
     : LegacyRenderSVGResourceContainer(Type::LegacySVGResourceMasker, element, WTF::move(style))
@@ -67,6 +82,11 @@ auto LegacyRenderSVGResourceMasker::applyResource(RenderElement& renderer, const
     MaskerData* maskerData = result.iterator->value.get();
     AffineTransform absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
     FloatRect decoratedBounds = renderer.decoratedBoundingBox();
+
+    // Position the mask region at the content origin for a <foreignObject> (see maskTargetBoundingBox);
+    // do this before intersecting with the mask's region so the effective area is not clipped away.
+    if (CheckedPtr foreignObject = dynamicDowncast<LegacyRenderSVGForeignObject>(renderer))
+        decoratedBounds.setLocation(foreignObject->location());
 
     // Masks define a clipping region via x/y/width/height attributes.
     // We need to get the effective area to mask.
@@ -108,7 +128,7 @@ bool LegacyRenderSVGResourceMasker::drawContentIntoMaskImage(MaskerData* maskerD
 {
     RefPtr maskImage = maskerData->maskImage;
     auto& maskImageContext = maskImage->context();
-    auto objectBoundingBox = object->objectBoundingBox();
+    auto objectBoundingBox = maskTargetBoundingBox(*object);
 
     if (!drawContentIntoContext(maskImageContext, objectBoundingBox))
         return false;
@@ -185,7 +205,7 @@ void LegacyRenderSVGResourceMasker::calculateMaskContentRepaintRect(RepaintRectC
 
 FloatRect LegacyRenderSVGResourceMasker::resourceBoundingBox(const RenderObject& object, RepaintRectCalculation repaintRectCalculation)
 {
-    FloatRect objectBoundingBox = object.objectBoundingBox();
+    FloatRect objectBoundingBox = maskTargetBoundingBox(object);
     Ref maskElement = this->maskElement();
     FloatRect maskBoundaries = SVGLengthContext::resolveRectangle(maskElement.get(), maskElement->maskUnits(), objectBoundingBox);
 


### PR DESCRIPTION
#### 4713e7e22ff1c2efc0d86e8383005f6af62018a9
<pre>
[Legacy SVG] mask is mispositioned on a foreignObject with non-zero x/y
<a href="https://bugs.webkit.org/show_bug.cgi?id=317528">https://bugs.webkit.org/show_bug.cgi?id=317528</a>
<a href="https://rdar.apple.com/180199105">rdar://180199105</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

A legacy &lt;foreignObject&gt; paints its content at the box location() (its x/y), while
objectBoundingBox()/decoratedBoundingBox() are intentionally origin-relative (0,0,w,h)
so they compose with localToParentTransform() for container bounds. The masker builds
the mask region (resourceBoundingBox), the image buffer / composite target (applyResource),
and the objectBoundingBox content-units transform (drawContentIntoMaskImage) from those
origin-relative boxes, so for a foreignObject with non-zero x/y the whole mask was offset
from the content by x/y. In addition, the default mask region (maskUnits=&quot;objectBoundingBox&quot;)
is derived from the origin-relative bounding box, which clipped userSpaceOnUse mask content
authored at the (x,y) position.

Add maskTargetBoundingBox(), which returns the content-positioned bounding box for a
foreignObject (location()-inclusive) and the unmodified objectBoundingBox() otherwise, and
use it for the mask region, the image buffer / composite bounds, and the objectBoundingBox
content-units transform. The foreignObject offset is applied to decoratedBounds before
intersecting with the mask region so the effective area is not clipped away.

This is paint-only and safe for the repaint path: a foreignObject never expands its repaint
rect through the masker (no intersectRepaintRectWithResources caller), so resourceBoundingBox()
is only reached during mask painting for it. The change is gated on foreignObject; the x=0,y=0
case and non-foreignObject renderers are unchanged.

Test: imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-foreignobject-non-zero-xy.html
      imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-userspace-foreignobject-non-zero-xy.html

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::maskTargetBoundingBox):
(WebCore::LegacyRenderSVGResourceMasker::applyResource):
(WebCore::LegacyRenderSVGResourceMasker::drawContentIntoMaskImage):
(WebCore::LegacyRenderSVGResourceMasker::resourceBoundingBox):

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-foreignobject-non-zero-xy.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-foreignobject-non-zero-xy-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-userspace-foreignobject-non-zero-xy.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/mask-userspace-foreignobject-non-zero-xy-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-svg-content/reference/green-100x100.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4713e7e22ff1c2efc0d86e8383005f6af62018a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/180534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/54479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/190745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/144856 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f30326a-288f-4242-9d7b-2b84fcc0dbda) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/55777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/140811 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/97547 "1 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71dcd1d5-3b76-4571-abd8-47ae404c93e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/183489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/161590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121263 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/56791ced-b2c8-4171-bf87-9c19098f944b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41436 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/153557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41119 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/1904 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/45691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/192681 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150177 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/54833 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/37734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/149898 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/44520 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127096 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/122299 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53350 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16108 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/52732 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/52969 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/52797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->