### PR TITLE
[HTML Tracks] Add tests for untested areas of the HTML TextTrack specification

### DIFF
--- a/LayoutTests/media/track/text-track-cuelist-identity-expected.txt
+++ b/LayoutTests/media/track/text-track-cuelist-identity-expected.txt
@@ -1,0 +1,5 @@
+
+PASS cues: same TextTrackCueList instance returned across calls
+PASS activeCues: same TextTrackCueList instance returned across calls
+PASS getCueById: returns first match, null on miss, null on empty-string arg
+

--- a/LayoutTests/media/track/text-track-cuelist-identity.html
+++ b/LayoutTests/media/track/text-track-cuelist-identity.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+    <title>TextTrackCueList identity and getCueById</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard §4.8.13.10 "Text track API":
+//   https://html.spec.whatwg.org/multipage/media.html#text-track-api
+//
+// - TextTrack.cues / TextTrack.activeCues must return the same
+//   TextTrackCueList object on each access (while non-null).
+// - TextTrackCueList.getCueById(id) returns the first cue whose identifier
+//   matches id, or null if there is no match or the argument is the empty
+//   string.
+
+function makeTrackWithCues() {
+    const video = document.createElement("video");
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+    return { video, tt };
+}
+
+test(() => {
+    const { tt } = makeTrackWithCues();
+    const a = tt.cues;
+    const b = tt.cues;
+    assert_equals(a, b, "tt.cues returns the same TextTrackCueList instance");
+
+    const c1 = new VTTCue(0, 1, "a");
+    tt.addCue(c1);
+    assert_equals(tt.cues, a, "tt.cues identity stable across addCue");
+
+    tt.removeCue(c1);
+    assert_equals(tt.cues, a, "tt.cues identity stable across removeCue");
+}, "cues: same TextTrackCueList instance returned across calls");
+
+test(() => {
+    const { tt } = makeTrackWithCues();
+    // activeCues should also be stable while non-null.
+    const first = tt.activeCues;
+    const second = tt.activeCues;
+    assert_equals(first, second,
+        "activeCues returns the same TextTrackCueList instance across calls (while non-null)");
+}, "activeCues: same TextTrackCueList instance returned across calls");
+
+test(() => {
+    const { tt } = makeTrackWithCues();
+    const cueA = new VTTCue(0, 1, "alpha");
+    cueA.id = "a";
+    const cueB = new VTTCue(1, 2, "beta");
+    cueB.id = "b";
+    const cueAnon = new VTTCue(2, 3, "gamma");
+    // cueAnon.id stays empty
+    const cueDup = new VTTCue(3, 4, "alpha-dup");
+    cueDup.id = "a";
+
+    tt.addCue(cueA);
+    tt.addCue(cueB);
+    tt.addCue(cueAnon);
+    tt.addCue(cueDup);
+
+    assert_equals(tt.cues.getCueById("a"), cueA,
+        "getCueById returns the first matching cue");
+    assert_equals(tt.cues.getCueById("b"), cueB,
+        "getCueById returns a non-first match by id");
+    assert_equals(tt.cues.getCueById("nonexistent"), null,
+        "getCueById returns null when no cue matches");
+    assert_equals(tt.cues.getCueById(""), null,
+        "getCueById returns null for the empty string");
+}, "getCueById: returns first match, null on miss, null on empty-string arg");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/text-track-disabled-mode-expected.txt
+++ b/LayoutTests/media/track/text-track-disabled-mode-expected.txt
@@ -1,0 +1,8 @@
+
+PASS disabled mode: activeCues returns null
+PASS disabled mode: UA does not attempt to obtain cues
+PASS active-flag clears synchronously when cue is removed from track
+PASS active-flag clears synchronously when mode changes to disabled
+PASS active-flag clears when track is removed from media element
+PASS active-flag clears synchronously when readyState reverts to HAVE_NOTHING
+

--- a/LayoutTests/media/track/text-track-disabled-mode.html
+++ b/LayoutTests/media/track/text-track-disabled-mode.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html>
+<head>
+    <title>TextTrack disabled mode and cue active-flag clearing</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.7 "Text tracks" — text track mode, cue active flag
+//     https://html.spec.whatwg.org/multipage/media.html#text-track-mode
+//     https://html.spec.whatwg.org/multipage/media.html#text-track-cue-active-flag
+//   §4.8.13.10 "Text track API" — TextTrack.activeCues
+//     https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-activecues
+//
+// In disabled mode: no cues are active, no events are fired, and the user
+// agent does not attempt to obtain cues.
+//
+// A cue's active flag is initially unset; it must be unset synchronously when:
+//   (a) the cue is removed from its track's list of cues
+//   (b) the track is removed from the media element's list of text tracks
+//   (c) the mode changes to disabled
+//   (d) readyState reverts to HAVE_NOTHING
+//
+// We observe the active flag through TextTrack.activeCues (a cue is in
+// activeCues iff its active flag is set).
+//
+// Cue activation requires the media element's readiness to be at least
+// HAVE_METADATA so time-marches-on can run. We attach a small video file
+// and seek to a known time, then assert against the cues active there.
+
+const MEDIA_SRC = "../content/test-25fps.mp4";
+
+function makeReadyVideo(t) {
+    const video = document.createElement("video");
+    video.muted = true;
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    video.src = MEDIA_SRC;
+    return video;
+}
+
+function whenSeekedTo(video, time) {
+    return new Promise(resolve => {
+        const handler = () => {
+            video.removeEventListener("seeked", handler);
+            resolve();
+        };
+        video.addEventListener("seeked", handler);
+        if (video.readyState >= video.HAVE_METADATA)
+            video.currentTime = time;
+        else
+            video.addEventListener("loadedmetadata", () => { video.currentTime = time; }, { once: true });
+    });
+}
+
+function addShowingTrackWithCue(video, startTime, endTime, text) {
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+    const cue = new VTTCue(startTime, endTime, text);
+    tt.addCue(cue);
+    return { tt, cue };
+}
+
+test(() => {
+    // activeCues is null when mode is disabled. addTextTrack creates the
+    // track with mode="hidden" per spec; we set it to disabled.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    try {
+        const tt = video.addTextTrack("captions", "test", "en");
+        tt.mode = "disabled";
+        assert_equals(tt.activeCues, null,
+            "TextTrack.activeCues is null when mode is disabled");
+    } finally {
+        video.remove();
+    }
+}, "disabled mode: activeCues returns null");
+
+async_test(t => {
+    // In disabled mode, the UA does not "attempt to obtain cues".
+    // For a track-element-backed track at default mode=disabled, no fetch
+    // should happen.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = "data:text/vtt;charset=utf-8,"
+        + encodeURIComponent("WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nx\n");
+    video.appendChild(track);
+    assert_equals(track.track.mode, "disabled", "default mode is disabled");
+
+    let loadFired = false;
+    track.onload = () => { loadFired = true; };
+    track.onerror = t.unreached_func("unexpected error");
+
+    t.step_timeout(t.step_func_done(() => {
+        assert_false(loadFired,
+            "disabled track must not trigger a fetch");
+        assert_equals(track.readyState, track.NONE);
+    }), 100);
+}, "disabled mode: UA does not attempt to obtain cues");
+
+promise_test(async t => {
+    // Per spec, removing a cue from its track's list must synchronously
+    // unset the cue's active flag.
+    //
+    // We can't observe `tt.activeCues` after removal (the cue is no longer
+    // in tt.cues, so it can never be in activeCues regardless of flag
+    // state). Instead, re-add the cue at a time outside its range and
+    // observe whether time-marches-on queues an 'exit' event: if the
+    // flag was preserved, the cue would be in "other cues" with active
+    // flag set, and time-marches-on (step 11) would queue exit. If the
+    // flag was correctly cleared, the cue is in "other cues" without
+    // active flag set, and no exit is queued.
+    const video = makeReadyVideo(t);
+    const { tt, cue } = addShowingTrackWithCue(video, 0, 0.5, "in-range");
+    await whenSeekedTo(video, 0.1);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_array_equals([...tt.activeCues], [cue], "cue is active at t=0.1");
+
+    let exitAfterRemove = false;
+    cue.onexit = () => { exitAfterRemove = true; };
+
+    tt.removeCue(cue);
+    // Move currentTime outside the cue's range, then re-add the cue.
+    // If the active flag survived removeCue, the next time-marches-on
+    // would queue exit (cue is in "other cues" with flag set).
+    await whenSeekedTo(video, 0.8);
+    await new Promise(r => t.step_timeout(r, 50));
+    tt.addCue(cue);
+    await new Promise(r => t.step_timeout(r, 100));
+
+    assert_false(exitAfterRemove,
+        "no 'exit' fires after removeCue + re-add at out-of-range time " +
+        "(active flag was correctly cleared on removeCue)");
+}, "active-flag clears synchronously when cue is removed from track");
+
+promise_test(async t => {
+    // mode->disabled -> activeCues becomes null and on re-enabling,
+    // time-marches-on recomputes the list from scratch.
+    const video = makeReadyVideo(t);
+    const { tt, cue } = addShowingTrackWithCue(video, 0, 1000, "always-on");
+    await whenSeekedTo(video, 0.1);
+
+    const before = tt.activeCues;
+    assert_not_equals(before, null);
+    assert_array_equals([...before], [cue], "cue active before mode flip");
+
+    tt.mode = "disabled";
+    assert_equals(tt.activeCues, null, "activeCues null while disabled");
+
+    // Re-enable. The active flag must have been cleared by the mode flip;
+    // a subsequent recomputation re-adds the cue based on currentTime.
+    tt.mode = "hidden";
+    // Recomputation happens off the next time-marches-on tick — wait a bit.
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_array_equals([...tt.activeCues], [cue],
+        "after mode->hidden, activeCues recomputed from currentTime");
+}, "active-flag clears synchronously when mode changes to disabled");
+
+promise_test(async t => {
+    // Track removed from media element -> cue active flag is unset.
+    // <track> element removal is the only way to remove a text track
+    // from a media element's list of text tracks.
+    //
+    // Use addTextTrack (not a <track> element) plus removal-via-cleanup:
+    // we instead test cue active-flag clearing via the equivalent code path
+    // of marking the track as no-longer-attached. Since the spec gives no
+    // way to remove an addTextTrack-created TextTrack from textTracks
+    // either, we test the <track>-removal path but skip the activeCues
+    // assertion if it's null (which also satisfies the spec).
+    const video = makeReadyVideo(t);
+    const trackEl = document.createElement("track");
+    trackEl.kind = "subtitles";
+    trackEl.src = "data:text/vtt;charset=utf-8,"
+        + encodeURIComponent("WEBVTT\n\n00:00:00.000 --> 00:01:00.000\nalways-on\n");
+    video.appendChild(trackEl);
+    const tt = trackEl.track;
+    tt.mode = "showing";
+
+    // Wait for both the video to be seekable and the track to be loaded.
+    await new Promise(resolve => {
+        if (trackEl.readyState === trackEl.LOADED)
+            resolve();
+        else
+            trackEl.addEventListener("load", resolve, { once: true });
+    });
+    await whenSeekedTo(video, 0.1);
+    // Give time-marches-on a tick to populate activeCues.
+    await new Promise(r => t.step_timeout(r, 50));
+
+    assert_equals(tt.activeCues.length, 1, "one cue active before removal");
+    const cue = tt.activeCues[0];
+
+    video.removeChild(trackEl);
+    // Per spec §4.8.13.7 "text track cue active flag", the flag must be
+    // synchronously unset when the track is removed from the media
+    // element's list of text tracks. The track's mode is preserved
+    // (still "showing"), so per §4.8.13.10 `activeCues` should still
+    // return a TextTrackCueList (not null — null is reserved for
+    // mode=disabled). The list must be empty since the flag was cleared.
+    assert_not_equals(tt.activeCues, null,
+        "activeCues is non-null (mode is still 'showing' on detached track)");
+    assert_equals(tt.activeCues.length, 0,
+        "cue active flag was synchronously cleared on track removal");
+}, "active-flag clears when track is removed from media element");
+
+promise_test(async t => {
+    // readyState reverts to HAVE_NOTHING -> cue active flag is unset.
+    // Triggered by reassigning video.src; the in-flight tracks' cues
+    // should lose their active flag synchronously.
+    const video = makeReadyVideo(t);
+    const { tt, cue } = addShowingTrackWithCue(video, 0, 1000, "always-on");
+    await whenSeekedTo(video, 0.1);
+
+    assert_array_equals([...tt.activeCues], [cue], "cue active before reload");
+
+    // Reassigning src triggers a load and resets readyState to HAVE_NOTHING.
+    video.src = "about:blank";
+    // Per spec §4.8.13.7 "text track cue active flag", the cue's active
+    // flag must be synchronously cleared when readyState reverts to
+    // HAVE_NOTHING. Track mode is still "showing" (a property of the
+    // TextTrack itself, not the media element), so activeCues must return
+    // a non-null list and that list must be empty.
+    assert_not_equals(tt.activeCues, null,
+        "activeCues is non-null after readyState->HAVE_NOTHING (mode still 'showing')");
+    assert_equals(tt.activeCues.length, 0,
+        "cue active flag was synchronously cleared on readyState->HAVE_NOTHING");
+}, "active-flag clears synchronously when readyState reverts to HAVE_NOTHING");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/text-track-list-events-expected.txt
+++ b/LayoutTests/media/track/text-track-list-events-expected.txt
@@ -1,0 +1,7 @@
+
+PASS TextTrackList: onaddtrack and onremovetrack IDL attributes exist
+PASS TrackEvent: .track returns the initialized value (null by default)
+PASS addTextTrack: fires 'addtrack' with TrackEvent.track == new TextTrack
+PASS track element removal: fires 'removetrack' with TrackEvent.track == removed TextTrack
+PASS onaddtrack IDL handler and addEventListener both fire
+

--- a/LayoutTests/media/track/text-track-list-events.html
+++ b/LayoutTests/media/track/text-track-list-events.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html>
+<head>
+    <title>TextTrackList addtrack/removetrack events and TrackEvent</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.10 "Text track API" -- TextTrackList interface, addtrack/
+//   removetrack events, TrackEvent interface:
+//     https://html.spec.whatwg.org/multipage/media.html#texttracklist
+//     https://html.spec.whatwg.org/multipage/media.html#trackevent
+//     https://html.spec.whatwg.org/multipage/media.html#dom-trackevent-track
+//
+// - TextTrackList exposes `onaddtrack` (event type 'addtrack') and
+//   `onremovetrack` (event type 'removetrack') event handler IDL attrs.
+// - The 'addtrack' / 'removetrack' events are TrackEvent instances; their
+//   `track` property returns the track the event relates to (the value it
+//   was initialized to).
+// - addTextTrack() fires 'addtrack' on TextTrackList; removing a <track>
+//   element from its media-element parent fires 'removetrack'.
+
+test(() => {
+    const video = document.createElement("video");
+    assert_true("onaddtrack" in video.textTracks,
+        "TextTrackList exposes onaddtrack");
+    assert_true("onremovetrack" in video.textTracks,
+        "TextTrackList exposes onremovetrack");
+    assert_equals(video.textTracks.onaddtrack, null,
+        "onaddtrack default is null");
+    assert_equals(video.textTracks.onremovetrack, null,
+        "onremovetrack default is null");
+}, "TextTrackList: onaddtrack and onremovetrack IDL attributes exist");
+
+test(() => {
+    // TrackEvent interface: constructor accepts a `track` init dict member;
+    // the .track property returns whatever it was initialized to.
+    const dummy = document.createElement("video").addTextTrack("captions");
+    const ev = new TrackEvent("addtrack", { track: dummy });
+    assert_equals(ev.type, "addtrack");
+    assert_equals(ev.track, dummy,
+        "TrackEvent.track returns the value it was initialized to");
+
+    const evNullDefault = new TrackEvent("removetrack");
+    assert_equals(evNullDefault.track, null,
+        "TrackEvent.track defaults to null when not initialized");
+}, "TrackEvent: .track returns the initialized value (null by default)");
+
+async_test(t => {
+    // addTextTrack must fire 'addtrack' on the TextTrackList, with a
+    // TrackEvent whose .track is the new TextTrack.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    video.textTracks.addEventListener("addtrack", t.step_func_done(ev => {
+        assert_true(ev instanceof TrackEvent, "event is a TrackEvent");
+        assert_equals(ev.type, "addtrack");
+        assert_equals(ev.track, video.textTracks[0],
+            "TrackEvent.track is the newly-added TextTrack");
+    }), { once: true });
+
+    video.addTextTrack("captions", "test", "en");
+}, "addTextTrack: fires 'addtrack' with TrackEvent.track == new TextTrack");
+
+async_test(t => {
+    // Removing a <track> child from its media-element parent must fire
+    // 'removetrack' with the TextTrack that was removed.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const trackEl = document.createElement("track");
+    trackEl.kind = "subtitles";
+    video.appendChild(trackEl);
+    const tt = trackEl.track;
+    assert_equals(video.textTracks.length, 1, "track is in TextTrackList");
+
+    video.textTracks.addEventListener("removetrack", t.step_func_done(ev => {
+        assert_true(ev instanceof TrackEvent, "event is a TrackEvent");
+        assert_equals(ev.type, "removetrack");
+        assert_equals(ev.track, tt,
+            "TrackEvent.track is the removed TextTrack");
+        assert_equals(video.textTracks.length, 0,
+            "TextTrackList no longer contains the removed track");
+    }), { once: true });
+
+    video.removeChild(trackEl);
+}, "track element removal: fires 'removetrack' with TrackEvent.track == removed TextTrack");
+
+async_test(t => {
+    // The IDL onaddtrack handler should receive the same event as a
+    // capturing addEventListener.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    let listenerEvent = null;
+    let handlerEvent = null;
+    video.textTracks.addEventListener("addtrack", ev => { listenerEvent = ev; });
+    video.textTracks.onaddtrack = ev => { handlerEvent = ev; };
+
+    video.addTextTrack("captions");
+
+    // Both should see the event after the queued task runs.
+    t.step_timeout(t.step_func_done(() => {
+        assert_not_equals(listenerEvent, null,
+            "addEventListener received the event");
+        assert_not_equals(handlerEvent, null,
+            "onaddtrack received the event");
+        assert_equals(handlerEvent, listenerEvent,
+            "both observers see the same event");
+    }), 50);
+}, "onaddtrack IDL handler and addEventListener both fire");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/track-element-idl-attributes-expected.txt
+++ b/LayoutTests/media/track/track-element-idl-attributes-expected.txt
@@ -1,0 +1,12 @@
+
+PASS kind: missing value default is 'subtitles'
+PASS kind: empty value reflects as 'metadata' (invalid value default, not missing value default)
+PASS kind: IDL getter canonicalizes known values (case-insensitive)
+PASS kind: invalid value reflects as 'metadata' (invalid value default)
+PASS kind: IDL setter writes through to content attribute
+PASS label: IDL attribute reflects content attribute
+PASS default: IDL attribute reflects boolean content attribute
+PASS track.track returns the corresponding TextTrack object (stable identity)
+PASS each text track has its own TextTrack object
+PASS TextTrack.kind/.label update when the track element's attributes change
+

--- a/LayoutTests/media/track/track-element-idl-attributes.html
+++ b/LayoutTests/media/track/track-element-idl-attributes.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html>
+<head>
+    <title>track element IDL attribute reflection and canonicalization</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.3 "The track element"
+//     https://html.spec.whatwg.org/multipage/media.html#the-track-element
+//   §4.8.13.7 "Text tracks" -> text track model
+//     https://html.spec.whatwg.org/multipage/media.html#text-track-model
+//
+// Covers:
+//   - kind content attribute: missing-value default "subtitles",
+//     invalid-value default "metadata", IDL reflection (limited to known values)
+//   - label IDL attribute reflects label content attribute
+//   - default IDL attribute reflects default boolean content attribute
+//   - track.track returns the corresponding TextTrack object (stable identity)
+//   - TextTrack.kind/.label update dynamically when the backing track
+//     element's attributes change
+const KNOWN_KINDS = ["subtitles", "captions", "descriptions", "chapters", "metadata"];
+
+test(() => {
+    const track = document.createElement("track");
+    assert_equals(track.kind, "subtitles", "missing kind reflects as 'subtitles'");
+}, "kind: missing value default is 'subtitles'");
+
+test(() => {
+    // Missing value default only applies when the attribute is absent.
+    // An empty-string attribute is "present, no keyword match" -> invalid
+    // value default ("metadata").
+    const track = document.createElement("track");
+    track.setAttribute("kind", "");
+    assert_equals(track.kind, "metadata", "empty kind reflects as 'metadata' (invalid value default)");
+}, "kind: empty value reflects as 'metadata' (invalid value default, not missing value default)");
+
+test(() => {
+    for (const kind of KNOWN_KINDS) {
+        const track = document.createElement("track");
+        track.setAttribute("kind", kind);
+        assert_equals(track.kind, kind, kind);
+        // Case insensitivity per HTML enumerated-attribute rules.
+        track.setAttribute("kind", kind.toUpperCase());
+        assert_equals(track.kind, kind, kind.toUpperCase() + " canonicalizes to " + kind);
+    }
+}, "kind: IDL getter canonicalizes known values (case-insensitive)");
+
+test(() => {
+    const track = document.createElement("track");
+    track.setAttribute("kind", "bogus");
+    // "limited to only known values" -> invalid value defaults to "metadata"
+    // (the kind state's invalid value default per HTML spec).
+    assert_equals(track.kind, "metadata", "invalid kind reflects as 'metadata'");
+}, "kind: invalid value reflects as 'metadata' (invalid value default)");
+
+test(() => {
+    const track = document.createElement("track");
+    track.kind = "captions";
+    assert_equals(track.getAttribute("kind"), "captions", "IDL setter writes content attribute");
+    assert_equals(track.kind, "captions", "IDL getter reads back");
+}, "kind: IDL setter writes through to content attribute");
+
+test(() => {
+    const track = document.createElement("track");
+    assert_equals(track.label, "", "no label attribute -> empty string");
+    track.setAttribute("label", "");
+    assert_equals(track.label, "", "empty label attribute -> empty string");
+    track.setAttribute("label", "English");
+    assert_equals(track.label, "English", "non-empty reflects verbatim");
+    track.label = "Français";
+    assert_equals(track.getAttribute("label"), "Français", "IDL setter writes content attribute");
+}, "label: IDL attribute reflects content attribute");
+
+test(() => {
+    const track = document.createElement("track");
+    assert_equals(track.default, false, "missing default attribute -> false");
+    track.setAttribute("default", "");
+    assert_equals(track.default, true, "present default attribute -> true");
+    track.default = false;
+    assert_false(track.hasAttribute("default"), "setter false removes attribute");
+    track.default = true;
+    assert_true(track.hasAttribute("default"), "setter true adds attribute");
+}, "default: IDL attribute reflects boolean content attribute");
+
+test(() => {
+    const track = document.createElement("track");
+    const t = track.track;
+    assert_true(t instanceof TextTrack, ".track is a TextTrack");
+    assert_equals(track.track, t, ".track returns the same TextTrack across calls");
+}, "track.track returns the corresponding TextTrack object (stable identity)");
+
+test(() => {
+    const a = document.createElement("track");
+    const b = document.createElement("track");
+    assert_not_equals(a.track, b.track, "distinct track elements have distinct TextTrack objects");
+}, "each text track has its own TextTrack object");
+
+test(() => {
+    const track = document.createElement("track");
+    // Default kind state ("subtitles") + empty label + empty srclang
+    // ⇒ TextTrack.kind/.label/.language reflect those.
+    assert_equals(track.track.kind, "subtitles", "default TextTrack.kind");
+    assert_equals(track.track.label, "", "default TextTrack.label");
+
+    track.kind = "captions";
+    assert_equals(track.track.kind, "captions", "TextTrack.kind tracks track-element kind change");
+
+    track.label = "Closed captions";
+    assert_equals(track.track.label, "Closed captions", "TextTrack.label tracks track-element label change");
+
+    track.label = "";
+    assert_equals(track.track.label, "", "label cleared -> TextTrack.label empty");
+}, "TextTrack.kind/.label update when the track element's attributes change");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/track-element-load-conditions-expected.txt
+++ b/LayoutTests/media/track/track-element-load-conditions-expected.txt
@@ -1,0 +1,6 @@
+
+PASS processing model: returns early when track has no media element parent
+PASS processing model: returns early when mode is disabled
+PASS processing model: unsupported resource fails to load and fires error
+PASS processing model: load fires once per src settle; src change re-triggers load
+

--- a/LayoutTests/media/track/track-element-load-conditions.html
+++ b/LayoutTests/media/track/track-element-load-conditions.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html>
+<head>
+    <title>track element load conditions and processing model guards</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard §4.8.13.7 "Text tracks",
+// "Sourcing out-of-band text tracks" — track processing model:
+//   https://html.spec.whatwg.org/multipage/media.html#sourcing-out-of-band-text-tracks
+//
+// The processing model returns early when:
+//   - another instance is already running for this element
+//   - the text track's mode is not hidden or showing
+//   - the track element's parent is not a media element
+//
+// If the resource is of an unsupported type or processing fails, the
+// readiness state is set to "failed to load" and an 'error' event fires.
+// While loading, if the track URL changes (while mode is hidden/showing),
+// the in-flight fetch is aborted and the algorithm is re-run.
+//
+// Re-entrancy and URL-change re-entry are internal invariants observable
+// only as "no extra load events for the same src" and "exactly one load
+// event after a settled URL". We assert what we can see.
+
+const validVtt = "data:text/vtt;charset=utf-8,"
+    + encodeURIComponent("WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n");
+const otherVtt = "data:text/vtt;charset=utf-8,"
+    + encodeURIComponent("WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nworld\n");
+
+async_test(t => {
+    // A track element with no media-element parent must not load. Set
+    // mode=showing on a detached track and verify no fetch happens.
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = validVtt;
+    track.track.mode = "showing";
+
+    track.onload = t.unreached_func("detached track must not fire load");
+    track.onerror = t.unreached_func("detached track must not fire error");
+
+    t.step_timeout(() => {
+        assert_equals(track.readyState, track.NONE,
+            "detached track readyState stays NONE");
+        t.done();
+    }, 100);
+}, "processing model: returns early when track has no media element parent");
+
+async_test(t => {
+    // With mode=disabled and a media-element parent, no load.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = validVtt;
+    video.appendChild(track);
+    // Default mode is "disabled" — do not flip it.
+    assert_equals(track.track.mode, "disabled", "default mode is disabled");
+
+    track.onload = t.unreached_func("disabled track must not fire load");
+    track.onerror = t.unreached_func("disabled track must not fire error");
+
+    t.step_timeout(() => {
+        assert_equals(track.readyState, track.NONE,
+            "disabled track readyState stays NONE");
+        t.done();
+    }, 100);
+}, "processing model: returns early when mode is disabled");
+
+async_test(t => {
+    // Unsupported / processing-failed -> readiness=ERROR + 'error'.
+    // text/plain (not text/vtt) is the simplest "unsupported type" trigger.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = "data:text/plain;charset=utf-8,not%20vtt";
+
+    track.onload = t.unreached_func("unsupported MIME must not fire load");
+    track.onerror = t.step_func_done(() => {
+        assert_equals(track.readyState, track.ERROR,
+            "unsupported MIME -> readyState ERROR");
+    });
+
+    video.appendChild(track);
+    track.track.mode = "showing";
+}, "processing model: unsupported resource fails to load and fires error");
+
+async_test(t => {
+    // Re-entrancy guard: load is triggered exactly once per settled src.
+    // Combined with: loader waits for readiness to leave LOADING, and a
+    // URL change while loading re-runs the algorithm.
+    //
+    // We can't directly observe re-entry, but we can observe:
+    //   (a) flipping mode twice in the same tick produces exactly one load
+    //   (b) changing src after a successful load produces a second load
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = validVtt;
+
+    let loadCount = 0;
+    track.onload = t.step_func(() => {
+        loadCount++;
+        if (loadCount === 1) {
+            // First settle. Re-flipping mode (without changing src) must not
+            // cause another load.
+            track.track.mode = "disabled";
+            track.track.mode = "showing";
+            t.step_timeout(() => {
+                assert_equals(loadCount, 1,
+                    "mode toggle on a loaded track must not re-trigger load");
+                // Now change src; that *should* trigger another load.
+                track.src = otherVtt;
+            }, 50);
+        } else if (loadCount === 2) {
+            assert_equals(track.readyState, track.LOADED);
+            t.done();
+        }
+    });
+    track.onerror = t.unreached_func("unexpected error");
+
+    video.appendChild(track);
+    // Flip mode twice in the same task; only one load should result.
+    track.track.mode = "showing";
+    track.track.mode = "hidden";
+    track.track.mode = "showing";
+}, "processing model: load fires once per src settle; src change re-triggers load");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/track-element-src-url-parsing-expected.txt
+++ b/LayoutTests/media/track/track-element-src-url-parsing-expected.txt
@@ -1,0 +1,6 @@
+
+PASS src: missing attribute -> IDL getter returns empty string
+PASS src: relative URL resolves against document base URL
+PASS src: surrounding whitespace stripped before URL parse
+PASS src: empty value fires 'error' and sets readyState to ERROR
+

--- a/LayoutTests/media/track/track-element-src-url-parsing.html
+++ b/LayoutTests/media/track/track-element-src-url-parsing.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html>
+<head>
+    <title>track element src attribute URL parsing</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard §4.8.13.3 "The track element", src attribute
+// and "track URL" determination algorithm:
+//   https://html.spec.whatwg.org/multipage/media.html#the-track-element
+//   https://html.spec.whatwg.org/multipage/media.html#sourcing-out-of-band-text-tracks
+//
+// The src attribute, if present, must be a valid non-empty URL potentially
+// surrounded by spaces. The track URL determination algorithm:
+//   - Let trackURL be failure.
+//   - Let value be the src attribute value.
+//   - If value is not the empty string, set trackURL to the result of
+//     encoding-parsing-and-serializing a URL given value, relative to the
+//     node document.
+//   - Set the element's track URL to trackURL if trackURL is not failure;
+//     otherwise to the empty string.
+//
+// Per the sourcing-out-of-band-text-tracks algorithm, when the track URL is
+// the empty string the user agent must queue a task to set the readiness
+// state to "failed to load" and fire 'error' at the track element.
+//
+// The "track URL" is not directly exposed via API. We verify the algorithm
+// indirectly through:
+//   (1) the src IDL getter (a ReflectURL-typed reflection of the content
+//       attribute), and
+//   (2) the load behavior — empty src must result in readiness=ERROR and
+//       an 'error' event (not a successful load).
+
+test(() => {
+    const track = document.createElement("track");
+    assert_equals(track.src, "", "no src attribute -> src IDL is empty string");
+}, "src: missing attribute -> IDL getter returns empty string");
+
+// Note: an *empty* src attribute resolves through ReflectURL against the
+// document base URL and returns the document URL, not empty. That's a
+// separate behavior from the "track URL" algorithm above, which sets the
+// track URL to the empty string in this case. The "track URL" is not
+// exposed via API; we verify it indirectly through the error-event test below.
+
+test(() => {
+    const track = document.createElement("track");
+    track.setAttribute("src", "resources/track.vtt");
+    // Should resolve against the document's base URL.
+    assert_equals(track.src, new URL("resources/track.vtt", document.baseURI).href,
+        "relative src resolves against document baseURI");
+}, "src: relative URL resolves against document base URL");
+
+test(() => {
+    const track = document.createElement("track");
+    track.setAttribute("src", "  https://example.com/t.vtt  ");
+    // "potentially surrounded by spaces" -> whitespace stripped before parsing.
+    assert_equals(track.src, "https://example.com/t.vtt",
+        "leading/trailing ASCII whitespace stripped during URL parse");
+}, "src: surrounding whitespace stripped before URL parse");
+
+async_test(t => {
+    // Per spec, empty src triggers: readiness state -> "failed to load",
+    // and an 'error' event at the track element. Specifically the
+    // sourcing-out-of-band-text-tracks algorithm says:
+    //   "If fetching fails for any reason ..., or if URL is the empty
+    //    string, then queue an element task on the DOM manipulation task
+    //    source given the media element to first change the text track
+    //    readiness state to 'failed to load' and then fire an event named
+    //    'error' at the track element."
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = "";
+    track.onload = t.unreached_func("empty src must not fire 'load'");
+    track.onerror = t.step_func_done(() => {
+        assert_equals(track.readyState, track.ERROR,
+            "empty src -> readyState is ERROR when error event fires");
+    });
+    video.appendChild(track);
+    track.track.mode = "showing";
+}, "src: empty value fires 'error' and sets readyState to ERROR");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/track-readiness-state-expected.txt
+++ b/LayoutTests/media/track/track-readiness-state-expected.txt
@@ -1,0 +1,6 @@
+
+PASS readyState: constants exposed and initial value is NONE
+PASS readyState: transitions NONE -> LOADING -> LOADED for a valid VTT resource
+PASS readyState: transitions to ERROR for an unfetchable src
+PASS readyState: LOADED is preserved across mode toggles after load
+

--- a/LayoutTests/media/track/track-readiness-state.html
+++ b/LayoutTests/media/track/track-readiness-state.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html>
+<head>
+    <title>track element readiness state transitions</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.3 "The track element" — readyState IDL attribute
+//     https://html.spec.whatwg.org/multipage/media.html#the-track-element
+//   §4.8.13.7 "Text tracks" — text track readiness state
+//     https://html.spec.whatwg.org/multipage/media.html#text-track-readiness-state
+//
+// HTMLTrackElement.readyState constants:
+//   NONE    = 0   (not loaded)
+//   LOADING = 1
+//   LOADED  = 2
+//   ERROR   = 3   (failed to load)
+//
+// The element starts at NONE; the track processing model is triggered when
+// the track's mode is hidden/showing and the track is in a media element.
+// Valid transitions: NONE -> LOADING -> LOADED, or NONE -> LOADING -> ERROR.
+
+test(() => {
+    const track = document.createElement("track");
+    assert_equals(track.NONE, 0);
+    assert_equals(track.LOADING, 1);
+    assert_equals(track.LOADED, 2);
+    assert_equals(track.ERROR, 3);
+    assert_equals(track.readyState, track.NONE, "newly-created track has readyState NONE");
+}, "readyState: constants exposed and initial value is NONE");
+
+async_test(t => {
+    // NONE -> LOADING -> LOADED happy path.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    // data: URL avoids any network dependency / flakiness.
+    track.src = "data:text/vtt;charset=utf-8,"
+        + encodeURIComponent("WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n");
+
+    let sawLoading = false;
+    // Poll readyState a few times between mode-set and load to catch LOADING.
+    // The transition through LOADING is synchronous from the script's POV
+    // once the processing model starts in parallel, so polling on a timer
+    // is the most portable way to observe it.
+    const probe = () => {
+        if (track.readyState === track.LOADING)
+            sawLoading = true;
+    };
+
+    track.onload = t.step_func_done(() => {
+        assert_equals(track.readyState, track.LOADED, "readyState is LOADED on load event");
+        assert_true(sawLoading, "saw readyState=LOADING at some point before LOADED");
+    });
+    track.onerror = t.unreached_func("unexpected error event");
+
+    video.appendChild(track);
+    track.track.mode = "showing";
+    probe();
+    t.step_timeout(probe, 0);
+    t.step_timeout(probe, 5);
+    t.step_timeout(probe, 20);
+}, "readyState: transitions NONE -> LOADING -> LOADED for a valid VTT resource");
+
+async_test(t => {
+    // NONE -> LOADING -> ERROR (failed to load) arc.
+    // An unsupported URL scheme reliably triggers the failed-to-load path.
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = "javascript:'network error'";
+
+    track.onload = t.unreached_func("unexpected load event");
+    track.onerror = t.step_func_done(() => {
+        assert_equals(track.readyState, track.ERROR, "readyState is ERROR on error event");
+    });
+
+    video.appendChild(track);
+    track.track.mode = "showing";
+    // Spec doesn't guarantee an observable LOADING here (the error may be
+    // detected synchronously during scheme processing), so we don't assert it.
+}, "readyState: transitions to ERROR for an unfetchable src");
+
+async_test(t => {
+    // Verify the loaded state is sticky: once we reach LOADED, it stays
+    // LOADED across subsequent mode changes (without changing src).
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = "data:text/vtt;charset=utf-8,"
+        + encodeURIComponent("WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhi\n");
+
+    track.onload = t.step_func_done(() => {
+        assert_equals(track.readyState, track.LOADED);
+        // Flipping back to disabled should not regress the readiness state.
+        track.track.mode = "disabled";
+        assert_equals(track.readyState, track.LOADED, "mode=disabled preserves LOADED");
+        track.track.mode = "showing";
+        assert_equals(track.readyState, track.LOADED, "mode=showing preserves LOADED");
+    });
+    track.onerror = t.unreached_func("unexpected error event");
+
+    video.appendChild(track);
+    track.track.mode = "showing";
+}, "readyState: LOADED is preserved across mode toggles after load");
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 79fc25fbf815dccabbde0e5c77c3ebda7d379eb0
<pre>
[HTML Tracks] Add tests for untested areas of the HTML TextTrack specification
<a href="https://rdar.apple.com/180205095">rdar://180205095</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317529">https://bugs.webkit.org/show_bug.cgi?id=317529</a>

Reviewed by Eric Carlson.

Add new tests covering previously untested areas of the TextTrack specification, including
disabled track behavior, the identity property of cuelist, default and empty mapping of
IDL attributes to the DOM, track loading, URL parsing, and ready state transitions.

* LayoutTests/media/track/text-track-cuelist-identity-expected.txt: Added.
* LayoutTests/media/track/text-track-cuelist-identity.html: Added.
* LayoutTests/media/track/text-track-disabled-mode-expected.txt: Added.
* LayoutTests/media/track/text-track-disabled-mode.html: Added.
* LayoutTests/media/track/track-element-idl-attributes-expected.txt: Added.
* LayoutTests/media/track/track-element-idl-attributes.html: Added.
* LayoutTests/media/track/track-element-load-conditions-expected.txt: Added.
* LayoutTests/media/track/track-element-load-conditions.html: Added.
* LayoutTests/media/track/track-element-src-url-parsing-expected.txt: Added.
* LayoutTests/media/track/track-element-src-url-parsing.html: Added.
* LayoutTests/media/track/track-readiness-state-expected.txt: Added.
* LayoutTests/media/track/track-readiness-state.html: Added.
* LayoutTests/platform/mac/media/track/track-element-src-url-parsing-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/315604@main">https://commits.webkit.org/315604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83141a999cf58f32cf720da2a12cf6a80390a44a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43467 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178904 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127257 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b435c20f-83d6-4682-ae15-9e2123390b3b) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132095 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93029 "11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9124b10-0836-4463-83f2-29b1510e62cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172504 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112598 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51d64433-c531-48cf-aa7d-f1f4ff41833f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32234 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27601 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143924 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/31862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181503 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36400 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140543 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests; Uploaded test results; 2 failures; Compiled WebKit; 2 failures; Passed layout tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43123 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140379 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43812 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108009 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35648 "Passed tests") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42322 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41715 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41858 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->