### PR TITLE
[JSC] Implement Semi-NCA for WTF::Dominators

### DIFF
--- a/Source/JavaScriptCore/b3/B3Procedure.cpp
+++ b/Source/JavaScriptCore/b3/B3Procedure.cpp
@@ -42,6 +42,7 @@
 #include "B3ValueInlines.h"
 #include "B3Variable.h"
 #include "JITOpaqueByproducts.h"
+#include <wtf/GraphOrdering.h>
 #include <wtf/ListDump.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WTF/wtf/Dominators.h
+++ b/Source/WTF/wtf/Dominators.h
@@ -30,7 +30,6 @@
 #include <wtf/DataLog.h>
 #include <wtf/FastBitVector.h>
 #include <wtf/GraphNodeWorklist.h>
-#include <wtf/GraphOrdering.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -46,22 +45,24 @@ class Dominators {
 public:
     using List = typename Graph::List;
 
-    constexpr static unsigned maxNodesForIterativeDominance = 20000;
+    // Above this many nodes we switch from Semi-NCA to Lengauer-Tarjan. Semi-NCA has better
+    // constant factors on real CFGs, but uses 16-bit DFS numbering, so it is also bounded by that.
+    constexpr static unsigned maxNodesForSemiNCADominance = 20000;
 
     Dominators(Graph& graph, bool selfCheck = false)
         : m_graph(graph)
         , m_data(graph.template newMap<BlockData>())
     {
-        if (m_graph.numNodes() <= maxNodesForIterativeDominance) [[likely]] {
-            IterativeDominance iterativeDominance(m_graph);
-            iterativeDominance.compute();
+        if (m_graph.numNodes() <= maxNodesForSemiNCADominance) [[likely]] {
+            SemiNCA semiNCA(m_graph);
+            semiNCA.compute();
 
             for (unsigned blockIndex = m_graph.numNodes(); blockIndex--;) {
                 typename Graph::Node block = m_graph.node(blockIndex);
                 if (!block)
                     continue;
 
-                typename Graph::Node idomBlock = iterativeDominance.immediateDominator(block);
+                typename Graph::Node idomBlock = semiNCA.immediateDominator(block);
                 m_data[block].idomParent = idomBlock;
                 if (idomBlock)
                     m_data[idomBlock].idomKids.append(block);
@@ -315,105 +316,153 @@ public:
     }
     
 private:
-    // This implements Cooper, Harvey, and Kennedy's iterative dominance algorithm as described in
-    // "A Simple, Fast Dominance Algorithm" (2001). Compared to Lengauer and Tarjan's method, which is
-    // O(n log n), the iterative method is O(N + E * D), where D is the size of the set of dominators
-    // for a particular node. This is worst-case quadratic, but likely better in practice for real code
-    // where the average number of dominators does not grow nearly as fast as the number of nodes.
-    // Moreover, this algorithm is much simpler, requiring very little auxiliary data and generally
-    // having substantially better constant factors. We prefer this algorithm for most graphs, the
-    // asymptotic complexity only becoming an issue for very large functions (10000s of blocks).
-    // https://www.clear.rice.edu/comp512/Lectures/Papers/TR06-33870-Dom.pdf
+    // This implements the Semi-NCA dominator algorithm, the same approach used by LLVM.
+    // Like Lengauer-Tarjan it computes semidominators using a depth-first spanning tree and
+    // a path-compressing EVAL, but it replaces Lengauer-Tarjan's bucket/LINK machinery for
+    // deriving immediate dominators with a simple "nearest common ancestor" walk over the
+    // partially-built dominator tree. This is near-linear in practice, and due to simplicity,
+    // this is in general faster than Lengauer-Tarjan. However since this is *near-linear*,
+    // pathological graph can explode the computation. Thus for large graph, we fall back to
+    // Lengauer-Tarjan to avoid too-long computation time.
+    //
+    // Semi-NCA is described in "Linear-Time Algorithms for Dominators and Related Problems", 2005, Georgiadis, Loukas.
+    // https://www.cs.princeton.edu/research/techreps/432
 
-    class IterativeDominance {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(IterativeDominance);
-        constexpr static uint16_t undefinedIdom = std::numeric_limits<uint16_t>::max();
+    class SemiNCA {
+        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SemiNCA);
+        // 0 is reserved as "no DFS number" / "no ancestor", so DFS numbers are 1-based.
+        constexpr static uint16_t noDFSNumber = 0;
     public:
-        IterativeDominance(Graph& graph)
+        SemiNCA(Graph& graph)
             : m_graph(graph)
         {
-            // We only use this for small-ish graphs. So, we exploit that to use
-            // smaller integers for idom information. We mostly use uint16_t for
-            // our analysis, but we exploit int16_t when computing reverse
-            // postorder. We expect Lengauer-Tarjan to beat us beyond a few ten
-            // thousand blocks anyway so this should be fine.
-            RELEASE_ASSERT(graph.numNodes() < std::numeric_limits<int16_t>::max());
-            m_idoms.fill(undefinedIdom, graph.numNodes());
-        }
-
-        void computeReversePostorder()
-        {
-            // Any valid DFS reverse-post-order works for the iterative dominance fixpoint: a node's
-            // dominator always precedes it. We reuse the shared graph-ordering utility rather than
-            // hand-rolling the traversal.
-            BitVector visited(m_graph.numNodes());
-            appendNodeIndicesInOrder(m_graph, GraphOrder::PostOrder, visited, m_reversePostorderedNodes);
-
-            // postorder number = position in post-order = mirror of the position in reverse-post-order.
-            m_postorderNumbers.fill(0, m_graph.numNodes());
-            for (unsigned i = 0; i < m_reversePostorderedNodes.size(); i ++)
-                m_postorderNumbers[m_reversePostorderedNodes[i]] = i;
-            m_reversePostorderedNodes.reverse();
-        }
-
-        uint16_t intersect(uint16_t a, uint16_t b)
-        {
-            while (a != b) {
-                while (m_postorderNumbers[a] < m_postorderNumbers[b])
-                    a = m_idoms[a];
-                while (m_postorderNumbers[b] < m_postorderNumbers[a])
-                    b = m_idoms[b];
-            }
-            return a;
+            // We only use this for small-ish graphs (Lengauer-Tarjan handles the rest), so we can use
+            // 16-bit DFS numbers. With 1-based numbering we need numNodes() + 1 to be representable.
+            RELEASE_ASSERT(graph.numNodes() < std::numeric_limits<uint16_t>::max());
         }
 
         void compute()
         {
-            computeReversePostorder();
+            unsigned numNodes = m_graph.numNodes();
+            // node index -> DFS number, initialized to noDFSNumber (0) for every node.
+            m_nodeToDFS.fill(noDFSNumber, numNodes);
+            // All per-DFS-number state lives in one array for locality. noDFSNumber is 0, so a
+            // zero-initialized BlockData is the correct starting state for every field.
+            m_data.fill(BlockData { }, numNodes + 1);
 
-            bool changed = true;
-            int16_t rootIndex = m_graph.index(m_graph.root());
-            m_idoms[rootIndex] = rootIndex;
-            ASSERT(m_reversePostorderedNodes[0] == rootIndex);
-            while (changed) {
-                changed = false;
-                for (unsigned i = 1; i < m_reversePostorderedNodes.size(); i ++) {
-                    uint16_t node = m_reversePostorderedNodes[i];
-                    uint16_t newIdom = m_idoms[node];
-                    bool isFirstProcessed = true;
-                    const typename Graph::Node& block = m_graph.node(node);
-                    for (auto pred : m_graph.predecessors(block)) {
-                        uint16_t predIndex = m_graph.index(pred);
-                        uint16_t predIdom = m_idoms[predIndex];
-                        if (predIdom == undefinedIdom)
-                            continue;
-                        if (isFirstProcessed) {
-                            newIdom = predIndex;
-                            isFirstProcessed = false;
-                        } else
-                            newIdom = intersect(newIdom, predIndex);
-                    }
-                    if (m_idoms[node] != newIdom) {
-                        ASSERT(newIdom != undefinedIdom);
-                        changed = true;
-                        m_idoms[node] = newIdom;
+            // Step 1: assign DFS numbers and record each node's parent in the DFS spanning tree.
+            uint16_t count = 0;
+            {
+                struct WorklistItem {
+                    uint16_t nodeIndex;
+                    uint16_t parentDFS;
+                };
+                uint16_t nextDFSNumber = 0;
+                Vector<WorklistItem, 64> worklist;
+                worklist.append({ static_cast<uint16_t>(m_graph.index(m_graph.root())), noDFSNumber });
+                while (!worklist.isEmpty()) {
+                    auto item = worklist.takeLast();
+                    if (m_nodeToDFS[item.nodeIndex] != noDFSNumber)
+                        continue;
+                    uint16_t dfs = ++nextDFSNumber;
+                    m_nodeToDFS[item.nodeIndex] = dfs;
+                    BlockData& data = m_data[dfs];
+                    data.nodeIndex = item.nodeIndex;
+                    data.parent = item.parentDFS;
+                    data.semi = dfs;
+                    data.label = dfs;
+                    for (auto successor : m_graph.successors(m_graph.node(item.nodeIndex))) {
+                        uint16_t successorIndex = m_graph.index(successor);
+                        if (m_nodeToDFS[successorIndex] == noDFSNumber)
+                            worklist.append({ successorIndex, dfs });
                     }
                 }
+                count = nextDFSNumber;
+            }
+
+            // Step 2: compute semidominators in reverse DFS order, then LINK each node to its parent.
+            // Semidominator means, let's avoid the normal dfs path, and what the earliest (small DFS num)
+            // point can start reaching to the node without using the normal dfs path, like a shortcut.
+            //
+            // The intent of Semi-NCA algorithm is, idom(w) = NearestCommonAncestor(parent(w), semi(w)).
+            {
+                // Path-compressing EVAL: returns the node on the ancestor path from v with minimum
+                // semidominator. We compress the path iteratively to avoid deep recursion.
+                Vector<uint16_t, 64> compressStack;
+                auto eval = [&](uint16_t v) -> uint16_t {
+                    if (m_data[v].ancestor == noDFSNumber)
+                        return m_data[v].label;
+
+                    compressStack.shrink(0);
+                    uint16_t u = v;
+                    while (m_data[m_data[u].ancestor].ancestor != noDFSNumber) {
+                        compressStack.append(u);
+                        u = m_data[u].ancestor;
+                    }
+                    for (unsigned i = compressStack.size(); i--;) {
+                        BlockData& data = m_data[compressStack[i]];
+                        uint16_t ancestor = data.ancestor;
+                        if (m_data[m_data[ancestor].label].semi < m_data[data.label].semi)
+                            data.label = m_data[ancestor].label;
+                        data.ancestor = m_data[ancestor].ancestor;
+                    }
+                    return m_data[v].label;
+                };
+
+                for (uint16_t w = count; w >= 2; --w) {
+                    BlockData& wData = m_data[w];
+                    for (auto predecessor : m_graph.predecessors(m_graph.node(wData.nodeIndex))) {
+                        uint16_t v = m_nodeToDFS[m_graph.index(predecessor)];
+                        if (v == noDFSNumber)
+                            continue; // Predecessor not reachable from the root.
+                        uint16_t u = eval(v);
+                        wData.semi = std::min(wData.semi, m_data[u].semi);
+                    }
+                    wData.ancestor = wData.parent;
+                }
+            }
+
+            // Step 3: derive immediate dominators. Start each node's idom at its DFS parent and walk
+            // it up the (already-computed) dominator tree until it is an ancestor of the node's
+            // semidominator. This is the "nearest common ancestor" refinement.
+            //
+            // We do not need to walk up in semidominator side. This is because semidominator is guaranteed
+            // to be on the path between idom(w) -> ... -> parent(w).
+            if (count >= 1)
+                m_data[1].idom = 1;
+            for (uint16_t w = 2; w <= count; ++w) {
+                uint16_t idom = m_data[w].parent;
+                while (idom > m_data[w].semi)
+                    idom = m_data[idom].idom;
+                m_data[w].idom = idom;
             }
         }
 
         typename Graph::Node immediateDominator(typename Graph::Node block)
         {
-            if (block == m_graph.root())
+            uint16_t dfs = m_nodeToDFS[m_graph.index(block)];
+            // The root (DFS number 1) and any node unreachable from the root have no idom.
+            if (dfs <= 1)
                 return nullptr;
-            return m_graph.node(m_idoms[m_graph.index(block)]);
+            return m_graph.node(m_data[m_data[dfs].idom].nodeIndex);
         }
 
     private:
+        // All numeric fields are indexed by DFS number. noDFSNumber (0) is the value-initialized
+        // default. We keep nodeIndex as a uint16_t (not a Graph::Node pointer) so BlockData stays
+        // compact at 12 bytes; the node is reconstructed via m_graph.node() at the few boundaries.
+        struct BlockData {
+            uint16_t nodeIndex { 0 };  // DFS number -> node index
+            uint16_t parent { 0 };     // DFS-tree parent's DFS number
+            uint16_t semi { 0 };       // semidominator (DFS number)
+            uint16_t label { 0 };      // EVAL label
+            uint16_t ancestor { 0 };   // forest ancestor (noDFSNumber if none)
+            uint16_t idom { 0 };       // immediate dominator (DFS number)
+        };
+
         Graph& m_graph;
-        Vector<uint16_t, 64> m_idoms;
-        Vector<uint16_t, 64> m_reversePostorderedNodes;
-        Vector<uint16_t, 64> m_postorderNumbers;
+        Vector<uint16_t, 64> m_nodeToDFS;  // node index -> DFS number (noDFSNumber if unreachable)
+        Vector<BlockData, 64> m_data;      // DFS number -> per-node Semi-NCA state
     };
 
     // This implements Lengauer and Tarjan's "A Fast Algorithm for Finding Dominators in a Flowgraph"


### PR DESCRIPTION
#### 5e66de200545adb37f2a61b13893b22505143f8c
<pre>
[JSC] Implement Semi-NCA for WTF::Dominators
<a href="https://bugs.webkit.org/show_bug.cgi?id=317531">https://bugs.webkit.org/show_bug.cgi?id=317531</a>
<a href="https://rdar.apple.com/180210650">rdar://180210650</a>

Reviewed by Yijia Huang.

This patch implements Semi-NCA algorithm to compute Dominators
efficiently. Previously, we were using iterative dominance computation
algorithm for smaller graph (and for larger graph, using Lengauer-Tarjan
algorithm), but Semi-NCA is faster than iterative dominance computation
and in general it is near-linear complexity. This algorithm is used in
LLVM as well.

Empirically, we observed Semi-NCA is 1.4x - 2.0x faster than iterative
dominance and it is in general 1.4x faster than Lengauer-Tarjan. However
since it has still pathological case which causes O(N^2), we are falling
back to Lengauer-Tarjan for large graph as a safety measure.

* Source/JavaScriptCore/b3/B3Procedure.cpp:
* Source/WTF/wtf/Dominators.h:
(WTF::Dominators::Dominators):
(WTF::Dominators::SemiNCA::SemiNCA):
(WTF::Dominators::SemiNCA::compute):
(WTF::Dominators::SemiNCA::immediateDominator):
(WTF::Dominators::IterativeDominance::IterativeDominance): Deleted.
(WTF::Dominators::IterativeDominance::computeReversePostorder): Deleted.
(WTF::Dominators::IterativeDominance::intersect): Deleted.
(WTF::Dominators::IterativeDominance::compute): Deleted.
(WTF::Dominators::IterativeDominance::immediateDominator): Deleted.

Canonical link: <a href="https://commits.webkit.org/315938@main">https://commits.webkit.org/315938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/807653b27c3223bb329c07ca0a89dc13847725fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170502 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179879 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128215 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f538a6d-8141-49ed-a016-c22893f89ef5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132960 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf0fbaab-dd0b-4ae1-af70-a90f6965f76c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36145 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153396 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113458 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b7d3df55-0848-4fc1-a492-f0e2b4cfbfda) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28560 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1806 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182462 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31757 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37282 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44083 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141230 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44772 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109272 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36496 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116661 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203181 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43282 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7878 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54411 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42687 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42928 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42818 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->