### PR TITLE
exp: text-autospace: allow normal initial value by gating fast paths on ideographic content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-autospace-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-autospace-computed-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Property text-autospace value 'initial' assert_equals: expected "normal" but got "no-autospace"
+PASS Property text-autospace value 'initial'
 PASS Property text-autospace value 'normal'
 PASS Property text-autospace value 'no-autospace'
 PASS Property text-autospace value 'auto'

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1551,8 +1551,7 @@
         "text-autospace": {
             "animation-type": "discrete",
             "inherited": true,
-            "initial": "no-autospace",
-            "initial-comment": "Current spec initial value is 'normal'",
+            "initial": "normal",
             "values": [
                 "auto",
                 "normal",

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -129,13 +129,13 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
         breakAndComputeBidiLevels(inlineItemList);
     }
 
-    if (contentRequiresVisualReordering() || m_hasTextAutospace)
+    if (contentRequiresVisualReordering() || hasTextAutospace())
         computeInlineTextItemWidthsAndTextSpacing(inlineItemList);
 
     auto adjustInlineContentCacheWithNewInlineItems = [&] {
         ASSERT(!startPosition || startPosition.index < inlineContentCache().inlineItems().content().size());
 
-        auto contentAttributes = InlineContentCache::InlineItems::ContentAttributes { m_contentRequiresVisualReordering, m_hasTextAndLineBreakOnlyContent, m_hasTextAutospace, m_inlineBoxCount };
+        auto contentAttributes = InlineContentCache::InlineItems::ContentAttributes { m_contentRequiresVisualReordering, m_hasTextAndLineBreakOnlyContent, hasTextAutospace(), m_inlineBoxCount };
         auto isPopulatedFromCache = m_textContentPopulatedFromCache && *m_textContentPopulatedFromCache ? InlineContentCache::InlineItems::IsPopulatedFromCache::Yes : InlineContentCache::InlineItems::IsPopulatedFromCache::No;
         auto& inlineItemCache = inlineContentCache().inlineItems();
         if (!startPosition || startPosition.index >= inlineItemCache.content().size())
@@ -172,7 +172,7 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
 
 void InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings(const InlineItemList& inlineItemList)
 {
-    ASSERT(m_hasTextAutospace);
+    ASSERT(hasTextAutospace());
     char32_t lastCharacterFromPreviousRun = 0;
     size_t lastCharacterDepth = 0;
     size_t currentCharacterDepth = 0;
@@ -806,7 +806,7 @@ void InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing(InlineItemLis
     if (inlineItemList.isEmpty())
         return;
 
-    if (m_hasTextAutospace)
+    if (hasTextAutospace())
         computeInlineBoxBoundaryTextSpacings(inlineItemList);
 
     TextSpacing::SpacingState spacingState;
@@ -929,6 +929,7 @@ void InlineItemsBuilder::handleTextContent(const InlineTextBox& inlineTextBox, I
         return inlineItemList.append(InlineTextItem::createEmptyItem(inlineTextBox));
 
     m_contentRequiresVisualReordering = m_contentRequiresVisualReordering || requiresVisualReordering(inlineTextBox);
+    m_mayHaveIdeographicContent = m_mayHaveIdeographicContent || inlineTextBox.mayHaveIdeographicContent();
 
     if (inlineTextBox.isCombined())
         return inlineItemList.append(InlineTextItem::createNonWhitespaceItem(inlineTextBox, { }, contentLength, UBIDI_DEFAULT_LTR, { }));
@@ -1054,7 +1055,7 @@ void InlineItemsBuilder::handleInlineBoxStart(const Box& inlineBox, InlineItemLi
 {
     inlineItemList.append({ inlineBox, InlineItem::Type::InlineBoxStart });
     m_contentRequiresVisualReordering |= requiresVisualReordering(inlineBox);
-    m_hasTextAutospace |= !inlineBox.style().textAutospace().isNoAutospace();
+    m_autospaceEnabled |= !inlineBox.style().textAutospace().isNoAutospace();
     ++m_inlineBoxCount;
 }
 
@@ -1149,7 +1150,7 @@ void InlineItemsBuilder::populateBreakingPositionCache(const InlineItemList& inl
 
 std::pair<bool, bool> InlineItemsBuilder::shouldDeferTextMeasurement(const InlineTextBox& inlineTextBox) const
 {
-    auto shouldDefer = contentRequiresVisualReordering() || m_hasTextAutospace;
+    auto shouldDefer = contentRequiresVisualReordering() || hasTextAutospace();
     return { shouldDefer || !canCacheWidthOnInlineTextItem(inlineTextBox, false), shouldDefer || !canCacheWidthOnInlineTextItem(inlineTextBox, true) };
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h
@@ -71,6 +71,8 @@ private:
     const ElementBox& root() const { return m_root; }
     InlineContentCache& inlineContentCache() { return m_inlineContentCache; }
 
+    bool hasTextAutospace() const { return m_autospaceEnabled && m_mayHaveIdeographicContent; }
+
 private:
     InlineContentCache& m_inlineContentCache;
     const ElementBox& m_root;
@@ -79,7 +81,8 @@ private:
     size_t m_inlineBoxCount { 0 };
     bool m_hasTextAndLineBreakOnlyContent { true }; // Note that this is true for cases like <span>text content</span>
     bool m_contentRequiresVisualReordering { false };
-    bool m_hasTextAutospace { !root().style().textAutospace().isNoAutospace() };
+    bool m_autospaceEnabled { !root().style().textAutospace().isNoAutospace() };
+    bool m_mayHaveIdeographicContent { false };
     std::optional<bool> m_textContentPopulatedFromCache { };
 };
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -88,6 +88,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
         CheckedRef style = inlineTextBox.style();
         auto directionalOverride = isOverride(style->unicodeBidi());
         auto run = WebCore::TextRun { StringView(text).substring(from, to - from), contentLogicalLeft, { }, ExpansionBehavior::defaultBehavior(), directionalOverride ? style->writingMode().bidiDirection() : TextDirection::LTR, directionalOverride };
+        run.setMayHaveIdeographicContent(inlineTextBox.mayHaveIdeographicContent());
         if (!style->collapseWhiteSpace() && !style->tabSize().isZero())
             run.setTabSize(true, Style::toPlatform(style->tabSize()));
         // FIXME: consider moving this to TextRun ctor
@@ -749,6 +750,18 @@ bool TextUtil::hasPositionDependentContentWidth(StringView textContent)
     if (textContent.is8Bit())
         return charactersContain<Latin1Character, tabCharacter>(textContent.span8());
     return charactersContain<char16_t, tabCharacter>(textContent.span16());
+}
+
+bool TextUtil::mayHaveIdeographicContent(StringView textContent)
+{
+    // Ideographs are never Latin-1, so 8-bit content can never produce text-autospace spacing.
+    if (textContent.is8Bit())
+        return false;
+    for (char32_t character : textContent.codePoints()) {
+        if (TextSpacing::isIdeograph(character))
+            return true;
+    }
+    return false;
 }
 
 SUPPRESS_NODELETE char32_t TextUtil::lastBaseCharacterFromText(StringView string)

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -116,6 +116,7 @@ public:
 
     static bool canUseSimplifiedTextMeasuring(StringView, const FontCascade&, bool whitespaceIsCollapsed, const Style::ComputedStyle* firstLineStyle);
     static bool hasPositionDependentContentWidth(StringView);
+    static bool mayHaveIdeographicContent(StringView);
 
     static char32_t NODELETE lastBaseCharacterFromText(StringView);
 };

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -276,6 +276,12 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
             textRenderer->setHasStrongDirectionalityContent(*hasStrongDirectionalityContent);
         }
 
+        auto mayHaveIdeographicContent = textRenderer->mayHaveIdeographicContent();
+        if (!mayHaveIdeographicContent) {
+            mayHaveIdeographicContent = Layout::TextUtil::mayHaveIdeographicContent(text);
+            textRenderer->setMayHaveIdeographicContent(mayHaveIdeographicContent);
+        }
+
         auto contentCharacteristic = EnumSet<Layout::InlineTextBox::ContentCharacteristic> { };
         if (canUseSimpleFontCodePath)
             contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimpleFontCodepath);
@@ -287,6 +293,8 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
             contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasPositionDependentContentWidth);
         if (*hasStrongDirectionalityContent)
             contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasStrongDirectionalityContent);
+        if (mayHaveIdeographicContent)
+            contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::MayHaveIdeographicContent);
 
         return makeUniqueRef<Layout::InlineTextBox>(text, isCombinedText, contentCharacteristic, WTF::move(style), WTF::move(firstLineStyle));
     }
@@ -367,6 +375,8 @@ static void updateContentCharacteristic(const RenderText& rendererText, Layout::
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasPositionDependentContentWidth);
     if (inlineTextBox.hasStrongDirectionalityContent())
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasStrongDirectionalityContent);
+    if (inlineTextBox.mayHaveIdeographicContent())
+        contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::MayHaveIdeographicContent);
 
     if (inlineTextBox.canUseSimpleFontCodePath() && Layout::TextUtil::canUseSimplifiedTextMeasuring(inlineTextBox.content(), rendererStyle->fontCascade(), rendererStyle->collapseWhiteSpace(), &rendererText.firstLineStyle()))
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimplifiedContentMeasuring);
@@ -432,6 +442,13 @@ void BoxTreeUpdater::updateContent(const RenderText& textRenderer)
     }
     if (*hasStrongDirectionalityContent)
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasStrongDirectionalityContent);
+    auto mayHaveIdeographicContent = textRenderer.mayHaveIdeographicContent();
+    if (!mayHaveIdeographicContent) {
+        mayHaveIdeographicContent = Layout::TextUtil::mayHaveIdeographicContent(text);
+        const_cast<RenderText&>(textRenderer).setMayHaveIdeographicContent(mayHaveIdeographicContent);
+    }
+    if (mayHaveIdeographicContent)
+        contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::MayHaveIdeographicContent);
 
     inlineTextBox->setContent(text, contentCharacteristic);
 }

--- a/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
@@ -42,7 +42,8 @@ public:
         CanUseSimpleFontCodepath,
         ShouldUseSimpleGlyphOverflowCodePath,
         HasPositionDependentContentWidth,
-        HasStrongDirectionalityContent
+        HasStrongDirectionalityContent,
+        MayHaveIdeographicContent
     };
     InlineTextBox(String, bool isCombined, EnumSet<ContentCharacteristic>, Style::ComputedStyle&&, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle = nullptr);
     virtual ~InlineTextBox() = default;
@@ -55,6 +56,7 @@ public:
     bool shouldUseSimpleGlyphOverflowCodePath() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::ShouldUseSimpleGlyphOverflowCodePath); }
     bool hasPositionDependentContentWidth() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::HasPositionDependentContentWidth); }
     bool hasStrongDirectionalityContent() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::HasStrongDirectionalityContent); }
+    bool mayHaveIdeographicContent() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::MayHaveIdeographicContent); }
 
     void setContent(String newContent, EnumSet<ContentCharacteristic>);
     void setContentCharacteristic(EnumSet<ContentCharacteristic> contentCharacteristicSet) { m_contentCharacteristicSet = contentCharacteristicSet; }

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -174,7 +174,7 @@ private:
 
     FontSelectionRequest m_fontSelectionRequest;
     TextSpacingTrim m_textSpacingTrim;
-    TextAutospace m_textAutospace;
+    TextAutospace m_textAutospace { TextAutospace::Options { TextAutospace::Type::Normal } };
     float m_computedSize { 0 }; // Computed size adjusted for the minimum font size and the zoom factor.
     float m_usedZoomFactor { 1.0 };
 

--- a/Source/WebCore/platform/graphics/TextMeasurementCache.h
+++ b/Source/WebCore/platform/graphics/TextMeasurementCache.h
@@ -232,6 +232,8 @@ private:
     {
         if (m_hasSeenIdeograph)
             return true;
+        if (!textRun.mayHaveIdeographicContent())
+            return false;
         const auto& text = textRun.textAsString();
         for (unsigned index = 0; index < text.length(); ++index) {
             if (TextSpacing::isIdeograph(text.codeUnitAt(index))) {

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -58,6 +58,7 @@ public:
         , m_directionalOverride(directionalOverride)
         , m_characterScanForCodePath(characterScanForCodePath)
         , m_disableSpacing(false)
+        , m_mayHaveIdeographicContent(true)
     {
         ASSERT(!m_text.isNull());
     }
@@ -79,6 +80,7 @@ public:
         , m_directionalOverride(0)
         , m_characterScanForCodePath(0)
         , m_disableSpacing(0)
+        , m_mayHaveIdeographicContent(0)
     {
     }
 
@@ -94,6 +96,7 @@ public:
         , m_directionalOverride(0)
         , m_characterScanForCodePath(0)
         , m_disableSpacing(0)
+        , m_mayHaveIdeographicContent(0)
     {
     }
 
@@ -159,6 +162,9 @@ public:
     void setTextSpacingState(TextSpacing::SpacingState spacingState) { m_textSpacingState = spacingState; }
     TextSpacing::SpacingState textSpacingState() const { return m_textSpacingState; }
 
+    bool mayHaveIdeographicContent() const { return m_mayHaveIdeographicContent; }
+    void setMayHaveIdeographicContent(bool value) { m_mayHaveIdeographicContent = value; }
+
 private:
     String m_text;
 
@@ -181,6 +187,7 @@ private:
     unsigned m_directionalOverride : 1; // Was this direction set by an override character.
     unsigned m_characterScanForCodePath : 1;
     unsigned m_disableSpacing : 1;
+    unsigned m_mayHaveIdeographicContent : 1;
 };
 
 inline void TextRun::setTabSize(bool allow, const TabSize& size)

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -872,7 +872,9 @@ void WidthIterator::advance(unsigned offset, GlyphBuffer& glyphBuffer)
         m_leftoverJustificationWidth = 0;
     }
 
-    if (hasExtraSpacing() || m_containsTabs || m_run->horizontalGlyphStretch() != 1 || !m_fontCascade->textAutospace().isNoAutospace())
+    auto needsAutospaceSpacing = !m_fontCascade->textAutospace().isNoAutospace()
+        && (m_run->mayHaveIdeographicContent() || m_run->textSpacingState().lastCharacterClassFromPreviousRun != TextSpacing::CharacterClass::Undefined);
+    if (hasExtraSpacing() || m_containsTabs || m_run->horizontalGlyphStretch() != 1 || needsAutospaceSpacing)
         applyExtraSpacingAfterShaping(glyphBuffer, characterStartIndex, glyphBufferStartIndex, offset, startingRunWidth);
 
     applyCSSVisibilityRules(glyphBuffer, glyphBufferStartIndex);

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -65,6 +65,7 @@
 #include "SurrogatePairAwareTextIterator.h"
 #include "Text.h"
 #include "TextResourceDecoder.h"
+#include "TextSpacing.h"
 #include "TextTransform.h"
 #include "TextUtil.h"
 #include "VisiblePosition.h"
@@ -107,7 +108,7 @@ struct SameSizeAsRenderText : public RenderObject {
     std::optional<bool> canUseSimplifiedTextMeasuring;
     std::optional<bool> hasPositionDependentContentWidth;
     std::optional<bool> m_hasStrongDirectionalityContent;
-    uint32_t bitfields : 14;
+    uint32_t bitfields : 15;
 };
 
 static_assert(sizeof(RenderText) == sizeof(SameSizeAsRenderText), "RenderText should stay small");
@@ -507,6 +508,8 @@ void RenderText::initiateFontLoadingByAccessingGlyphDataAndComputeCanUseSimplifi
     m_hasPositionDependentContentWidth = false;
     m_hasStrongDirectionalityContent = false;
     auto mayHaveStrongDirectionalityContent = !textContent.is8Bit();
+    auto mayHaveIdeographicContentCandidate = !textContent.is8Bit();
+    auto mayHaveIdeographicContent = false;
     // FIXME: Pre-warm glyph loading in FontCascade with the most common range.
     WTF::BitSet<256> hasSeen;
     for (char32_t character : StringView(textContent).codePoints()) {
@@ -517,7 +520,9 @@ void RenderText::initiateFontLoadingByAccessingGlyphDataAndComputeCanUseSimplifi
         m_canUseSimplifiedTextMeasuring = *m_canUseSimplifiedTextMeasuring && fontCascade.canUseSimplifiedTextMeasuring(character, fontVariant, whitespaceIsCollapsed, primaryFont);
         m_hasPositionDependentContentWidth = *m_hasPositionDependentContentWidth || character == tabCharacter;
         m_hasStrongDirectionalityContent = *m_hasStrongDirectionalityContent || (mayHaveStrongDirectionalityContent && Layout::TextUtil::isStrongDirectionalityCharacter(character));
+        mayHaveIdeographicContent = mayHaveIdeographicContent || (mayHaveIdeographicContentCandidate && TextSpacing::isIdeograph(character));
     }
+    setMayHaveIdeographicContent(mayHaveIdeographicContent);
 }
 
 void RenderText::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)
@@ -1835,6 +1840,7 @@ void RenderText::setRenderedText(const String& newText)
     m_canUseSimplifiedTextMeasuring = { };
     m_hasPositionDependentContentWidth = { };
     m_hasStrongDirectionalityContent = { };
+    m_mayHaveIdeographicContent = false;
 
     if (m_text != originalText) {
         originalTextMap().set(*this, originalText);

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -190,6 +190,8 @@ public:
     std::optional<bool> hasPositionDependentContentWidth() const { return m_hasPositionDependentContentWidth; }
     void setHasStrongDirectionalityContent(bool hasStrongDirectionalityContent) { m_hasStrongDirectionalityContent = hasStrongDirectionalityContent; }
     std::optional<bool> hasStrongDirectionalityContent() const { return m_hasStrongDirectionalityContent; }
+    void setMayHaveIdeographicContent(bool mayHaveIdeographicContent) { m_mayHaveIdeographicContent = mayHaveIdeographicContent; }
+    bool mayHaveIdeographicContent() const { return m_mayHaveIdeographicContent; }
 
 protected:
     virtual void computeMinMaxIntrinsicLogicalWidths(float leadingWidth, bool forcedMinMaxWidthComputation = false);
@@ -263,6 +265,7 @@ private:
     unsigned m_originalTextDiffersFromRendered : 1 { false };
     unsigned m_hasInlineWrapperForDisplayContents : 1 { false };
     unsigned m_hasSecureTextTimer : 1 { false };
+    unsigned m_mayHaveIdeographicContent : 1 { false };
     FontCascade::CodePath m_fontCodePath : 2;
 };
 


### PR DESCRIPTION
#### 42db22c1aed3071fb8de911424d5cd1d190fd872
<pre>
exp: text-autospace: allow normal initial value by gating fast paths on ideographic content

Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::build):
(WebCore::Layout::InlineItemsBuilder::computeInlineBoxBoundaryTextSpacings):
(WebCore::Layout::InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing):
(WebCore::Layout::InlineItemsBuilder::handleTextContent):
(WebCore::Layout::InlineItemsBuilder::handleInlineBoxStart):
(WebCore::Layout::InlineItemsBuilder::shouldDeferTextMeasurement const):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.h:
(WebCore::Layout::InlineItemsBuilder::hasTextAutospace const):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::mayHaveIdeographicContent):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::createLayoutBox):
(WebCore::LayoutIntegration::updateContentCharacteristic):
(WebCore::LayoutIntegration::BoxTreeUpdater::updateContent):
* Source/WebCore/layout/layouttree/LayoutInlineTextBox.h:
(WebCore::Layout::InlineTextBox::mayHaveIdeographicContent const):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::initiateFontLoadingByAccessingGlyphDataAndComputeCanUseSimplifiedTextMeasuring):
(WebCore::RenderText::setRenderedText):
* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::setMayHaveIdeographicContent):
(WebCore::RenderText::mayHaveIdeographicContent const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42db22c1aed3071fb8de911424d5cd1d190fd872

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127215 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/231f785d-c2b0-478d-93b6-31b5842484d7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43054 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132056 "Found 22 new test failures: css3/font-feature-font-face-local.html fast/dynamic/text-combine.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html fast/text/decorations-with-text-combine.html fast/text/emphasis-combined-text.html fast/text/font-fallback.html fast/text/international/synthesized-italic-vertical-latin.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92988 "1 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86992201-d023-42ba-af7a-adf0d1ba6c38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172462 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35732 "Found 17 new test failures: css3/font-feature-font-face-local.html fast/text/font-fallback.html fast/text/international/synthesized-italic-vertical-latin.html fast/text/international/text-combine-image-test.html fast/text/ruby-justify-tatechuyoko.html fast/text/text-combine-placement.html http/tests/canvas/color-fonts/ctm-sbix.html http/tests/canvas/color-fonts/fill-color-sbix.html http/tests/canvas/color-fonts/fill-color-shadow-ctm-sbix.html http/tests/canvas/color-fonts/fill-color-shadow-sbix.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112559 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e779ded-e280-42a3-bd8a-d438b65c7bba) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34323 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-ruby/block-ruby-003.html imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html imported/w3c/web-platform-tests/css/css-text/word-break/word-break-keep-all-011.html imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32194 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27559 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144806 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31791 "Found 35 new test failures: css3/font-feature-font-face-local.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/rtl-content-selection-hairline-gap.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html fast/ruby/ruby-expansion-cjk-3.html fast/ruby/ruby-expansion-cjk.html fast/ruby/ruby-justification.html fast/text/decorations-with-text-combine.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181461 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34169 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36361 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Skipped layout-tests; 344 new passes 19 flakes 40 failures; Uploaded test results; 344 new passes 14 flakes 39 failures; Compiled WebKit (warnings); layout-tests; Found 35 new test failures: css3/font-feature-font-face-local.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/rtl-content-selection-hairline-gap.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html fast/ruby/ruby-expansion-cjk-3.html fast/ruby/ruby-expansion-cjk.html fast/ruby/ruby-justification.html fast/text/decorations-with-text-combine.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140504 "Found 22 new test failures: css3/font-feature-font-face-local.html fast/dynamic/text-combine.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html fast/text/decorations-with-text-combine.html fast/text/emphasis-combined-text.html fast/text/font-fallback.html fast/text/international/synthesized-italic-vertical-latin.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43081 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140340 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43770 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28770 "Found 39 new test failures: css3/font-feature-font-face-local.html fast/css/text-overflow-ellipsis-text-align-center.html fast/css/text-overflow-ellipsis-text-align-justify.html fast/css/text-overflow-ellipsis-text-align-left.html fast/css/text-overflow-ellipsis-text-align-right.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/rtl-content-selection-hairline-gap.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107927 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35611 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115535 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42280 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6856 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41673 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41928 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->