### PR TITLE
REGRESSION(307136@main): crash adding multiple attribute to appearance: base <select>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-add-multiple-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-add-multiple-crash.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html class=test-wait>
+
+<style>
+select { appearance: base-select; }
+</style>
+
+<select></select>
+
+<script>
+requestAnimationFrame(() => {
+  document.querySelector('select').setAttribute('multiple', '');
+  document.documentElement.classList.remove('test-wait');
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-multiple-keydown-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-multiple-keydown-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html class=test-wait>
+<style>select { appearance: base-select; }</style>
+<select><option></select>
+<script>
+requestAnimationFrame(() => {
+  const select = document.querySelector('select');
+  select.setAttribute('multiple', '');
+  // Renderer rebuild is scheduled but has not happened yet; the renderer is
+  // still the generic base-appearance one rather than RenderListBox.
+  select.dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, keyIdentifier: 'Down'}));
+  document.documentElement.classList.remove('test-wait');
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-multiple-mousemove-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-multiple-mousemove-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html class=test-wait>
+<style>select { appearance: base-select; }</style>
+<select></select>
+<script>
+requestAnimationFrame(() => {
+  const select = document.querySelector('select');
+  select.setAttribute('multiple', '');
+  // Renderer rebuild is scheduled but has not happened yet; the renderer is
+  // still the generic base-appearance one rather than RenderListBox.
+  select.dispatchEvent(new MouseEvent('mousemove', {bubbles: true}));
+  document.documentElement.classList.remove('test-wait');
+});
+</script>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1210,8 +1210,8 @@ void HTMLSelectElement::setOptionsChangedOnRenderer()
     if (auto* renderer = this->renderer()) {
         if (auto* renderMenuList = dynamicDowncast<RenderMenuList>(*renderer))
             renderMenuList->setOptionsChanged(true);
-        else if (!usesMenuList())
-            downcast<RenderListBox>(*renderer).setOptionsChanged(true);
+        else if (auto* renderListBox = dynamicDowncast<RenderListBox>(*renderer))
+            renderListBox->setOptionsChanged(true);
     }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -1912,7 +1912,9 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
             mouseEvent->setDefaultHandled();
         }
     } else if (event.type() == eventNames.mousemoveEvent && mouseEvent) {
-        CheckedRef renderListBox = downcast<RenderListBox>(*renderer());
+        CheckedPtr renderListBox = dynamicDowncast<RenderListBox>(*renderer());
+        if (!renderListBox)
+            return;
         if (renderListBox->canBeScrolledAndHasScrollableArea())
             return;
 
@@ -2043,7 +2045,8 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
                 setActiveSelectionAnchorIndex(m_activeSelectionEndIndex);
             }
 
-            downcast<RenderListBox>(*renderer).scrollToRevealElementAtListIndex(endIndex);
+            if (auto* renderListBox = dynamicDowncast<RenderListBox>(*renderer))
+                renderListBox->scrollToRevealElementAtListIndex(endIndex);
             if (selectNewItem) {
                 updateListBoxSelection(deselectOthers);
                 listBoxOnChange();


### PR DESCRIPTION
#### 810f13a41f203822a3bab0e23374dcea46ad9531
<pre>
REGRESSION(307136@main): crash adding multiple attribute to appearance: base &lt;select&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=317533">https://bugs.webkit.org/show_bug.cgi?id=317533</a>

Reviewed by Tim Nguyen.

An appearance: base &lt;select&gt; uses a generic renderer. Setting a
multiple attribute makes it so that m_multiple is true, but the
renderer is still generic. This causes crashes in points that
unconditionally downcast to RenderListBox.

Now we no-op when casting fails.

Thanks to Keith Cirkel for mentioning this to me.

Tests: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-add-multiple-crash.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-multiple-keydown-crash.html
       imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-multiple-mousemove-crash.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/60774">https://github.com/web-platform-tests/wpt/pull/60774</a>
Canonical link: <a href="https://commits.webkit.org/315575@main">https://commits.webkit.org/315575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6188c9e1fe35904752fe35acdc46b07e79f4a0b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127158 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84647dc0-4c0b-4137-b3de-12d8aae69618) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132000 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92933 "4 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/faf0d017-2490-46f7-a842-06835819cf60) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112503 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/828de6fe-93f6-460a-a130-b7287c77b26e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32140 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27502 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181404 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140450 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140286 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37751 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43713 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107830 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35560 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115478 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42223 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6783 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41616 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41871 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->