### PR TITLE
[JSC] `Intl.PluralRules` should reflect `compactDisplay` in skeleton and `resolvedOptions`

### DIFF
--- a/JSTests/stress/intl-pluralrules-compactdisplay.js
+++ b/JSTests/stress/intl-pluralrules-compactdisplay.js
@@ -1,0 +1,43 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+// resolvedOptions should expose compactDisplay only when notation is "compact".
+{
+    let pr = new Intl.PluralRules("en", { notation: "compact", compactDisplay: "long" });
+    let resolved = pr.resolvedOptions();
+    shouldBe(resolved.notation, "compact");
+    shouldBe(resolved.compactDisplay, "long");
+}
+{
+    let pr = new Intl.PluralRules("en", { notation: "compact", compactDisplay: "short" });
+    let resolved = pr.resolvedOptions();
+    shouldBe(resolved.notation, "compact");
+    shouldBe(resolved.compactDisplay, "short");
+}
+{
+    let pr = new Intl.PluralRules("en", { notation: "compact" });
+    let resolved = pr.resolvedOptions();
+    shouldBe(resolved.notation, "compact");
+    shouldBe(resolved.compactDisplay, "short");
+}
+{
+    let pr = new Intl.PluralRules("en", { notation: "standard", compactDisplay: "long" });
+    let resolved = pr.resolvedOptions();
+    shouldBe(resolved.notation, "standard");
+    shouldBe("compactDisplay" in resolved, false);
+}
+{
+    let pr = new Intl.PluralRules("en");
+    let resolved = pr.resolvedOptions();
+    shouldBe(resolved.notation, "standard");
+    shouldBe("compactDisplay" in resolved, false);
+}
+
+// resolvedOptions property order: compactDisplay must come right after notation.
+{
+    let resolved = new Intl.PluralRules("en", { notation: "compact", compactDisplay: "long" }).resolvedOptions();
+    let keys = Object.keys(resolved);
+    shouldBe(keys.indexOf("compactDisplay"), keys.indexOf("notation") + 1);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -67,9 +67,6 @@ test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js:
 test/intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js:
   default: 'Test262Error: undefined: length Expected SameValue(«3», «4») to be true'
   strict mode: 'Test262Error: undefined: length Expected SameValue(«3», «4») to be true'
-test/intl402/PluralRules/compactDisplay-undefined-unless-notation-compact.js:
-  default: 'Test262Error: compactDisplay (compact, long) Expected SameValue(«undefined», «"long"») to be true'
-  strict mode: 'Test262Error: compactDisplay (compact, long) Expected SameValue(«undefined», «"long"») to be true'
 test/language/destructuring/binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js:
   default: 'Test262Error: Actual [binding::source, binding::sourceKey, sourceKey, get source, binding::defaultValue, binding::varTarget] and expected [binding::source, binding::sourceKey, sourceKey, binding::varTarget, get source, binding::defaultValue] should have the same contents. '
 test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -301,19 +301,13 @@ void appendNumberFormatNotationOptionsToSkeleton(IntlType* intlInstance, StringB
         skeletonBuilder.append(" engineering"_s);
         break;
     case IntlNotation::Compact:
-        if constexpr (std::is_same_v<IntlType, JSC::IntlPluralRules>) {
-            // Intl.PluralRules does not support `compactDisplay` option
-            // https://github.com/tc39/ecma402/issues/1013
+        switch (intlInstance->m_compactDisplay) {
+        case CompactDisplay::Short:
             skeletonBuilder.append(" compact-short"_s);
-        } else {
-            switch (intlInstance->m_compactDisplay) {
-            case CompactDisplay::Short:
-                skeletonBuilder.append(" compact-short"_s);
-                break;
-            case CompactDisplay::Long:
-                skeletonBuilder.append(" compact-long"_s);
-                break;
-            }
+            break;
+        case CompactDisplay::Long:
+            skeletonBuilder.append(" compact-long"_s);
+            break;
         }
         break;
     }

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -182,6 +182,8 @@ JSObject* IntlPluralRules::resolvedOptions(JSGlobalObject* globalObject) const
     options->putDirect(vm, vm.propertyNames->locale, jsNontrivialString(vm, m_locale));
     options->putDirect(vm, vm.propertyNames->type, jsNontrivialString(vm, m_type == Type::Ordinal ? "ordinal"_s : "cardinal"_s));
     options->putDirect(vm, Identifier::fromString(vm, "notation"_s), jsNontrivialString(vm, IntlNumberFormat::notationString(m_notation)));
+    if (m_notation == IntlNotation::Compact)
+        options->putDirect(vm, Identifier::fromString(vm, "compactDisplay"_s), jsNontrivialString(vm, IntlNumberFormat::compactDisplayString(m_compactDisplay)));
     options->putDirect(vm, vm.propertyNames->minimumIntegerDigits, jsNumber(m_minimumIntegerDigits));
     switch (m_roundingType) {
     case IntlRoundingType::FractionDigits:


### PR DESCRIPTION
#### efcd683a93b8d90dc6cdf372c37fd2b406b1cfc3
<pre>
[JSC] `Intl.PluralRules` should reflect `compactDisplay` in skeleton and `resolvedOptions`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317534">https://bugs.webkit.org/show_bug.cgi?id=317534</a>

Reviewed by Yusuke Suzuki.

315426@main added m_compactDisplay to IntlPluralRules and read the
&quot;compactDisplay&quot; option in initializePluralRules, but the value was never
used: appendNumberFormatNotationOptionsToSkeleton still hardcoded
&quot;compact-short&quot; for IntlPluralRules, and resolvedOptions() did not expose
the property.

This patch removes the IntlPluralRules special case from
appendNumberFormatNotationOptionsToSkeleton so that m_compactDisplay is
passed to ICU, and emits &quot;compactDisplay&quot; from resolvedOptions() right
after &quot;notation&quot; when notation is &quot;compact&quot;, per the Resolved Options of
PluralRules Instances table.

Test: JSTests/stress/intl-pluralrules-compactdisplay.js

* JSTests/stress/intl-pluralrules-compactdisplay.js: Added.
(shouldBe):
(throw.new.Error):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::appendNumberFormatNotationOptionsToSkeleton):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::resolvedOptions const):

Canonical link: <a href="https://commits.webkit.org/315566@main">https://commits.webkit.org/315566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0ae70e87a82e2c2efdcd36e86893b02974017ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178805 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127160 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132002 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92935 "3 flakes 10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172407 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112505 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32142 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27504 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/739 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181406 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30703 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140452 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43026 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/151792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140288 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37742 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43715 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107838 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35562 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115480 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42225 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6786 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54202 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41618 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->