### PR TITLE
[AppKit Gestures] Clicking and dragging text selection to the edge of the window does not autoscroll

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1112,6 +1112,14 @@ void EventHandler::updateSelectionForMouseDrag()
     if (!supportsSelectionUpdatesOnMouseDrag())
         return;
 
+#if PLATFORM(COCOA)
+    // During a selection-drag, the UI process re-extends the selection as the page
+    // autoscrolls (preserving the selection granularity), so don't also re-extend here using the
+    // stale last-known mouse position.
+    if (m_isAutoscrolling)
+        return;
+#endif
+
     RefPtr view = m_frame->view();
     if (!view)
         return;
@@ -3483,7 +3491,7 @@ bool EventHandler::shouldUpdateAutoscroll()
     return mousePressed();
 }
     
-#endif // !PLATFORM(IOS_FAMILY)
+#endif // !PLATFORM(COCOA)
 
 Widget* EventHandler::widgetForEventTarget(Element* eventTarget)
 {

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -399,6 +399,16 @@ public:
     WEBCORE_EXPORT void cancelSelectionAutoscroll();
 #endif
 
+#if PLATFORM(MAC)
+    // Whether a root-view point sits in the edge band where a selection-extend drag should autoscroll.
+    // Shares the band geometry with `targetPositionInWindowForSelectionAutoscroll` so the start/cancel
+    // decision and the pushed autoscroll target can never disagree. An edge only arms once the drag has
+    // moved toward it from `dragOriginInRootView` (the drag's first extent) by at least half the band, so
+    // a selection that merely originates near an edge (a short drag) doesn't autoscroll - matching the
+    // inset threshold iOS applies in `adjustAutoscrollDestinationForInsetEdges`.
+    WEBCORE_EXPORT bool isPointNearSelectionAutoscrollEdge(const IntPoint& positionInRootView, const IntPoint& dragOriginInRootView) const;
+#endif
+
     WEBCORE_EXPORT std::optional<Cursor> selectCursor(const HitTestResult&, bool shiftKey);
 
 #if ENABLE(KINETIC_SCROLLING)

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "AXObjectCache.h"
+#import "AutoscrollController.h"
 #import "Chrome.h"
 #import "ChromeClient.h"
 #import "DataTransfer.h"
@@ -1004,8 +1005,148 @@ IntSize EventHandler::autoscrollAdjustmentFactorForScreenBoundaries(const FloatP
     return adjustmentFactor;
 }
 
+// Selection-drag autoscroll on macOS is split into two decisions that share one edge-band geometry
+// (`selectionAutoscrollGeometry`):
+//
+//   - The gate (`isPointNearSelectionAutoscrollEdge`) runs on each extent-point update from the UI
+//     process and decides *whether* to autoscroll - including the drag-distance threshold.
+//   - The push (`pushSelectionAutoscrollTargetPastVisibleEdges`, via
+//     `targetPositionInWindowForSelectionAutoscroll`) runs on each 50ms autoscroll-timer tick and
+//     decides *how far* past the edge to aim the target so the scroll velocity stays steady.
+//
+// Both reason about the same edge band, but for different purposes; the threshold lives only in the
+// gate, since by the time the push runs the decision to scroll has already been made.
+//
+// The edge band both functions share (root-view coords; thickness = edgeHotZone on every side):
+//
+//     x()                               maxX()
+//      +---------------------------------+  y()
+//      |#################################|
+//      |##                             ##|
+//      |##   interior: no autoscroll   ##|
+//      |##                             ##|
+//      |#################################|
+//      +---------------------------------+  maxY()
+//       \/                           \/
+//      edgeHotZone              edgeHotZone
+//
+// A point in the '#' band that is dragged toward that edge past the threshold autoscrolls toward it.
+
+// Pushes a selection-autoscroll target that sits within the edge hot-zone of (or past)
+// `visibleRect` to a point just outside the nearest edge, scaling how far outside by how deep into
+// the hot-zone the point is so the scroll speed ramps up toward the edge. Input and output are in
+// the same root-view coordinate space, so the autoscroll timer's windowToContents mapping keeps the
+// target a fixed distance past the visible content each tick — a stable scroll velocity for as long
+// as the gesture holds near (or past) the edge, with no need for the UI process to re-push a target.
+// `zoomScale` is the page scale factor (magnification); dividing the hot-zone and speed by it keeps
+// both a constant on-screen size while the page is magnified, matching iOS.
+//
+// Ramp (schematic) - how far the target is pushed past the edge vs. how deep the point is in the band:
+//
+//   push past edge
+//   (per-tick speed)
+//        ^
+//    max |- - - - - - - - - .__________   clamped at / beyond the visible edge
+//        |                 /
+//        |               /       slope = maxSpeed / edgeHotZone
+//        |             /
+//        |           /
+//        |         /
+//      0 +-------/-----------------------> depth into band
+//        0                  edgeHotZone
+//   (band inner boundary)   (= visible edge)
+//
+//   pushDistance = (min(depth, edgeHotZone) / edgeHotZone) * maxSpeed
+static IntPoint pushSelectionAutoscrollTargetPastVisibleEdges(IntPoint point, FloatRect visibleRect, float zoomScale)
+{
+    const float edgeHotZone = AutoscrollController::selectionAutoscrollEdgeDistance / zoomScale;
+    const float maximumScrollingSpeed = AutoscrollController::selectionAutoscrollMaximumSpeed / zoomScale;
+
+    auto pushedCoordinate = [&](float position, float minEdge, float maxEdge) -> float {
+        if (position < minEdge + edgeHotZone) {
+            float depth = std::min<float>((minEdge + edgeHotZone) - position, edgeHotZone);
+            return minEdge - AutoscrollController::rampedSelectionAutoscrollDistance(depth, edgeHotZone, maximumScrollingSpeed);
+        }
+        if (position > maxEdge - edgeHotZone) {
+            float depth = std::min<float>(position - (maxEdge - edgeHotZone), edgeHotZone);
+            return maxEdge + AutoscrollController::rampedSelectionAutoscrollDistance(depth, edgeHotZone, maximumScrollingSpeed);
+        }
+        return position;
+    };
+
+    return roundedIntPoint(FloatPoint {
+        pushedCoordinate(point.x(), visibleRect.x(), visibleRect.maxX()),
+        pushedCoordinate(point.y(), visibleRect.y(), visibleRect.maxY()),
+    });
+}
+
+// The visible-content rect (in root-view coordinates) and zoom scale used to size the selection
+// autoscroll edge band. Shared by the start/cancel predicate and the target-push so they agree.
+static std::optional<std::pair<FloatRect, float>> selectionAutoscrollGeometry(const LocalFrame& frame)
+{
+    RefPtr frameView = frame.view();
+    if (!frameView)
+        return std::nullopt;
+    RefPtr page = frame.page();
+    float zoomScale = page ? page->pageScaleFactor() : 1;
+    return std::make_pair(frameView->contentsToRootView(frameView->unobscuredContentRect()), zoomScale);
+}
+
+bool EventHandler::isPointNearSelectionAutoscrollEdge(const IntPoint& positionInRootView, const IntPoint& dragOriginInRootView) const
+{
+    // Require the drag to have moved toward an edge before that edge autoscrolls, so a selection that
+    // merely originates near an edge (a short drag) doesn't scroll the page out from under the user. The
+    // delta is measured from the drag's first extent (`dragOriginInRootView`): a drag that starts in the
+    // interior has already crossed `dragThreshold` by the time it reaches the band, so it stays as
+    // responsive as before, while a drag that starts inside the band must be pushed deliberately toward
+    // the edge. This is the macOS counterpart to iOS's `insetDistanceThreshold` (also half the band).
+    //
+    // Toward the max edge (the min edge is the mirror image):
+    //
+    //   |<----------- interior ----------->|<------ edge band ------>|
+    //   +----------------------------------+-------------------------+ maxEdge
+    //        origin                            p
+    //          o . . . . . . . . . . . . . . . *
+    //          |<--------- p - origin -------->|
+    //                must exceed dragThreshold (= edgeHotZone / 2)
+    //
+    // Arms only when BOTH hold: p is in the band, and (p - origin) toward the edge > dragThreshold.
+    auto geometry = selectionAutoscrollGeometry(m_frame.get());
+    if (!geometry)
+        return false;
+
+    auto [visibleRect, zoomScale] = *geometry;
+    const float edgeHotZone = AutoscrollController::selectionAutoscrollEdgeDistance / zoomScale;
+    const float dragThreshold = edgeHotZone / 2;
+
+    auto dragOffset = positionInRootView - dragOriginInRootView;
+
+    // Per axis, an edge arms only when the point is within its hot zone and the drag points toward it
+    // past the threshold. Mirrors the per-axis `pushedCoordinate` lambda in the target-push below.
+    auto draggingTowardArmedEdge = [&](float position, float dragComponent, float minEdge, float maxEdge) {
+        bool towardMinEdge = position < minEdge + edgeHotZone && dragComponent < -dragThreshold;
+        bool towardMaxEdge = position > maxEdge - edgeHotZone && dragComponent > dragThreshold;
+        return towardMinEdge || towardMaxEdge;
+    };
+
+    return draggingTowardArmedEdge(positionInRootView.x(), dragOffset.width(), visibleRect.x(), visibleRect.maxX())
+        || draggingTowardArmedEdge(positionInRootView.y(), dragOffset.height(), visibleRect.y(), visibleRect.maxY());
+}
+
 IntPoint EventHandler::targetPositionInWindowForSelectionAutoscroll() const
 {
+    // During a selection-drag, autoscrolling is driven by the UI process pushing a target
+    // point (in root-view coordinates) as the selection is extended.
+    // Push that point past the nearest visible-content edge so the autoscroll timer keeps scrolling
+    // at a stable velocity while the gesture holds near (or past) the edge.
+    if (m_isAutoscrolling) {
+        auto geometry = selectionAutoscrollGeometry(m_frame.get());
+        if (!geometry)
+            return m_targetAutoscrollPositionInRootView;
+        auto [visibleRect, zoomScale] = *geometry;
+        return pushSelectionAutoscrollTargetPastVisibleEdges(m_targetAutoscrollPositionInRootView, visibleRect, zoomScale);
+    }
+
     RefPtr page = m_frame->page();
     if (!page)
         return flooredIntPoint(valueOrDefault(m_lastKnownMousePosition));

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
@@ -44,6 +44,8 @@ NS_SWIFT_UI_ACTOR
 
 - (void)selectionDidChange;
 
+- (void)reextendSelectionForAutoscrollIfNeeded;
+
 @end
 
 @interface WKTextSelectionController (NSTextSelectionManagerDelegate)

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -37,6 +37,11 @@ extension WKTextSelectionController {
     @nonobjc
     private var currentRangeSelectionGranularity: NSTextSelection.Granularity? = nil
 
+    // The most recent extent point of an ongoing range-selection drag, in view coordinates. Used to
+    // re-extend the selection as the page autoscrolls while the gesture holds near the window edge.
+    @nonobjc
+    private var lastRangeSelectionExtentPoint: NSPoint? = nil
+
     init(view: WKWebView) {
         self.view = view
         super.init()
@@ -70,6 +75,30 @@ extension WKTextSelectionController {
         let editorState = page.editorState
         view.textSelectionManager?.textSelectionMode =
             editorState.isContentEditable || editorState.isContentRichlyEditable ? .editable : .selectable
+    }
+
+    // Re-extends the selection toward the last drag point as the page autoscrolls. Invoked when the
+    // page scrolls so the selection keeps growing into the newly revealed content, mirroring the iOS
+    // `-updateSelection` re-extension. The web process decides when to start/stop autoscrolling (see
+    // `updateSelectionWithExtentPointAndBoundary` in WebPageCocoa.mm); here we only need to know a
+    // range-selection drag is in flight, which `lastRangeSelectionExtentPoint` tracks.
+    func reextendSelectionForAutoscrollIfNeeded() {
+        guard let page = view?._protectedPage().get() else {
+            return
+        }
+
+        guard let currentRangeSelectionGranularity, let point = lastRangeSelectionExtentPoint else {
+            return
+        }
+
+        Task.immediate {
+            await page.updateSelection(
+                withExtentPoint: WebCore.IntPoint(point),
+                by: .init(currentRangeSelectionGranularity),
+                isInteractingWithFocusedElement: true, // FIXME: Properly handle the case where this isn't actually true.
+                source: .Mouse
+            )
+        }
     }
 }
 
@@ -306,6 +335,11 @@ extension WKTextSelectionController {
 
         currentRangeSelectionGranularity = granularity
 
+        // Start each gesture from a clean slate: if a previous gesture ended abnormally (no
+        // endRangeSelection), a stale extent point or live autoscroll could otherwise leak into this one.
+        lastRangeSelectionExtentPoint = nil
+        page.cancelAutoscroll()
+
         impl.beginSuppressingSingleClickGestureForTextSelection()
 
         Task.immediate {
@@ -319,7 +353,7 @@ extension WKTextSelectionController {
 
     @objc(continueRangeSelectionAtPoint:)
     func continueRangeSelection(at point: NSPoint) {
-        guard let view, let page = view._protectedPage().get() else {
+        guard let page = view?._protectedPage().get() else {
             return
         }
 
@@ -329,6 +363,8 @@ extension WKTextSelectionController {
             assertionFailure("continueRangeSelection was called with a nil currentRangeSelectionGranularity")
             return
         }
+
+        lastRangeSelectionExtentPoint = point
 
         Task.immediate {
             await page.updateSelection(
@@ -349,6 +385,9 @@ extension WKTextSelectionController {
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
 
         impl.endSuppressingSingleClickGestureForTextSelection()
+
+        page.cancelAutoscroll()
+        lastRangeSelectionExtentPoint = nil
 
         guard currentRangeSelectionGranularity != nil else {
             assertionFailure("endRangeSelection was called with a nil currentRangeSelectionGranularity")

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2523,6 +2523,12 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollOffset)
     m_lastPageScrollOffset = scrollOffset;
     m_pageScrollingHysteresis->impulse();
 
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    // While a selection-drag is autoscrolling, keep extending the selection toward the
+    // last drag point as the content scrolls underneath it.
+    [m_textSelectionController reextendSelectionForAutoscrollIfNeeded];
+#endif
+
 #if ENABLE(HORIZONTAL_BANNER_VIEW_OVERLAYS)
     updateWebContentDistancesFromEdges();
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2795,6 +2795,28 @@ void WebPage::updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint point,
     if (auto range = makeSimpleRange(selectionStart, selectionEnd))
         protect(frame->selection())->setSelectedRange(range, Affinity::Upstream, WebCore::FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes);
 
+#if PLATFORM(MAC)
+    // AppKit's selection gesture has no edge-autoscroll equivalent to UIKit's `UITextAutoscrolling`,
+    // so the web process owns the decision: start autoscrolling toward `point` while it sits in the
+    // visible-edge band, and stop once the drag returns to the middle. Re-evaluated on every extent
+    // update (including the re-extensions the UI process issues as the page scrolls), so holding near
+    // the edge keeps scrolling and dragging back stops it.
+    //
+    // Capture the drag's first extent as its origin (cleared in `cancelAutoscroll` at gesture begin/end)
+    // and pass it to the edge check, which only autoscrolls once the drag has moved toward an edge by a
+    // threshold - so a selection that merely originates near an edge doesn't scroll. The origin survives
+    // hot-zone enter/exit within a drag because the else branch cancels via the EventHandler, not
+    // `WebPage::cancelAutoscroll`.
+    if (!m_selectionAutoscrollDragOrigin)
+        m_selectionAutoscrollDragOrigin = point;
+
+    if (frame->eventHandler().isPointNearSelectionAutoscrollEdge(point, *m_selectionAutoscrollDragOrigin)) {
+        if (CheckedPtr renderer = rendererForSelectionAutoscroll(*frame))
+            frame->eventHandler().startSelectionAutoscroll(renderer.get(), point);
+    } else
+        frame->eventHandler().cancelSelectionAutoscroll();
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     if (!m_hasAnyActiveTouchPoints) {
         // Ensure that `Touch` doesn't linger around in `m_activeTextInteractionSources` after
@@ -2862,36 +2884,41 @@ void WebPage::updateSelectionWithExtentPoint(WebCore::IntPoint point, bool isInt
 #endif
 }
 
+RenderObject* WebPage::rendererForSelectionAutoscroll(LocalFrame& frame) const
+{
+    if (m_focusedElement && m_focusedElement->renderer())
+        return m_focusedElement->renderer();
+
+    auto& selection = frame.selection().selection();
+    if (!selection.isRange())
+        return nullptr;
+
+    auto range = selection.toNormalizedRange();
+    if (!range)
+        return nullptr;
+
+    return range->start.container->renderer();
+}
+
 void WebPage::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
 {
     RefPtr frame = m_page->focusController().focusedOrMainFrame();
     if (!frame)
         return;
 
-    if (m_focusedElement && m_focusedElement->renderer()) {
-        frame->eventHandler().startSelectionAutoscroll(protect(m_focusedElement->renderer()), positionInWindow);
-        return;
-    }
-
-    auto& selection = frame->selection().selection();
-    if (!selection.isRange())
-        return;
-
-    auto range = selection.toNormalizedRange();
-    if (!range)
-        return;
-
-    CheckedPtr renderer = range->start.container->renderer();
-    if (!renderer)
-        return;
-
-    frame->eventHandler().startSelectionAutoscroll(renderer, positionInWindow);
+    if (CheckedPtr renderer = rendererForSelectionAutoscroll(*frame))
+        frame->eventHandler().startSelectionAutoscroll(renderer.get(), positionInWindow);
 }
 
 void WebPage::cancelAutoscroll()
 {
     if (RefPtr frame = m_page->focusController().focusedOrMainFrame())
         frame->eventHandler().cancelSelectionAutoscroll();
+
+#if PLATFORM(MAC)
+    // Reset the drag-origin so the next gesture's edge check starts measuring from its own first extent.
+    m_selectionAutoscrollDragOrigin = std::nullopt;
+#endif
 }
 
 void WebPage::selectTextWithGranularityAtPoint(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -219,6 +219,7 @@ class Range;
 class RegistrableDomain;
 class RemoteFrameGeometryTransformer;
 class RenderImage;
+class RenderObject;
 class Report;
 class ResourceRequest;
 class ResourceResponse;
@@ -1239,6 +1240,7 @@ public:
 #endif // PLATFORM(IOS_FAMILY)
 
 #if PLATFORM(COCOA)
+    WebCore::RenderObject* rendererForSelectionAutoscroll(WebCore::LocalFrame&) const;
     void startAutoscrollAtPosition(const WebCore::FloatPoint&);
     void cancelAutoscroll();
 #endif
@@ -3088,6 +3090,12 @@ private:
 
 #if PLATFORM(MAC)
     double m_overflowHeightForTopScrollEdgeEffect { 0 };
+
+    // Root-view origin of the in-flight selection-extend drag: captured on the first extent update and
+    // cleared by `cancelAutoscroll` (which the UI process calls at gesture begin/end). Lets the edge check
+    // require a minimum drag toward an edge before selection autoscroll engages, so a selection that merely
+    // originates near an edge doesn't scroll. Persists across hot-zone enter/exit within a single drag.
+    std::optional<WebCore::IntPoint> m_selectionAutoscrollDragOrigin;
 #endif
 
     bool m_needsScrollGeometryUpdates { false };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -161,6 +161,285 @@ struct AppKitGesturesTests {
     }
 
     @Test(
+        arguments: [true, false]
+    )
+    func draggingSelectionToWindowEdgeAutoscrolls(dragPastEdge: Bool) async throws {
+        let lines = (0..<100)
+            .reversed()
+            .map { "<p id='line\($0)'>\($0) bottles of beer on the wall</p>" }
+            .joined(separator: "\n")
+
+        let html = """
+            <div id="text" style="font-size: 60px; margin: 0;">\(lines)</div>
+            """
+        try await page.load(html: html).wait()
+
+        await page.waitForNextPresentationUpdate()
+
+        let startViewportCoordinates = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "line97"))
+        let startBounds = convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: startViewportCoordinates, window: window)
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(CGPoint(initialScrollPosition) == .zero)
+
+        // Arbitrarily chosen to be close to the edge of the window.
+        let dragEndYInWindow: CGFloat = dragPastEdge ? -20 : 20
+        let dragEnd = convertToCoreGraphicsScreenCoordinates(
+            pointInWindowCoordinates: CGPoint(x: window.frame.width / 2, y: dragEndYInWindow),
+            window: window
+        )
+
+        await recap.play { composer in
+            // Click-and-hold to begin a range selection, then drag to the bottom edge and hold.
+            composer._wk_click(at: startBounds.center, for: .seconds(0.5))
+            composer.advanceTime(0.1)
+            composer._wk_drag(withStart: startBounds.center, end: dragEnd, duration: .seconds(1), release: false)
+
+            // Hold at the edge so the autoscroll timer fires repeatedly.
+            // The longer the duration the further down the scroll goes.
+            composer.advanceTime(0.5)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let finalScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(finalScrollPosition.x == 0)
+        #expect(finalScrollPosition.y > 0)
+
+        let expectedEndPosition: JavaScriptSelection.Position = dragPastEdge ? .init(in: "line90", at: 18) : .init(in: "line91", at: 2)
+
+        let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+        #expect(selection == .range(base: .init(in: "line97", at: 14), extent: expectedEndPosition))
+    }
+
+    @Test
+    func holdingSelectionDragNearEdgeKeepsScrolling() async throws {
+        try await loadScrollableText()
+        await page.waitForNextPresentationUpdate()
+
+        let startBounds = try await screenBounds(ofElementWithID: "line297")
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        // Record (timestamp, scrollY) on every scroll event so we can observe that scrolling continues
+        // throughout the hold, rather than scrolling in one burst and stopping early (the pre-fix bug).
+        try await page.callJavaScript {
+            """
+            window.__wkScrollLog = [];
+            window.addEventListener("scroll", () => window.__wkScrollLog.push(performance.now(), window.scrollY));
+            """
+        }
+
+        // Just inside the bottom edge of the window (window coordinates have a bottom-left origin).
+        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 20)
+
+        await recap.play { composer in
+            composer._wk_click(at: startBounds.center, for: .seconds(0.5))
+            composer.advanceTime(0.1)
+            composer._wk_drag(withStart: startBounds.center, end: dragEnd, duration: .seconds(1), release: false)
+
+            // Hold near the edge for a couple of seconds so the autoscroll timer fires many times.
+            composer.advanceTime(2.0)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let log = try await page.callJavaScript(returning: [Double].self) { "return window.__wkScrollLog;" }
+        let timestamps = stride(from: 0, to: log.count, by: 2).map { log[$0] }
+        let offsets = stride(from: 1, to: log.count, by: 2).map { log[$0] }
+
+        let firstTimestamp = try #require(timestamps.first)
+        let lastTimestamp = try #require(timestamps.last)
+        let lastOffset = try #require(offsets.last)
+
+        // The page actually scrolled...
+        #expect(lastOffset > 0)
+        // ...and kept scrolling across most of the ~2s hold instead of bursting then stopping early.
+        // `performance.now()` is in milliseconds.
+        #expect(lastTimestamp - firstTimestamp > 1000)
+    }
+
+    @Test
+    func holdingSelectionDragMidContentDoesNotAutoscroll() async throws {
+        try await loadScrollableText()
+        await page.waitForNextPresentationUpdate()
+
+        let startBounds = try await screenBounds(ofElementWithID: "line297")
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(CGPoint(initialScrollPosition) == .zero)
+
+        let contentHeight = try #require(window.contentViewController?.view.frame.height)
+        let midContent = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: contentHeight / 2)
+
+        await recap.play { composer in
+            composer._wk_click(at: startBounds.center, for: .seconds(0.5))
+            composer.advanceTime(0.1)
+            composer._wk_drag(withStart: startBounds.center, end: midContent, duration: .seconds(1), release: false)
+            composer.advanceTime(1.0)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let finalScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(CGPoint(finalScrollPosition) == .zero)
+    }
+
+    @Test
+    func selectionAutoscrollStopsAfterGestureEnds() async throws {
+        try await loadScrollableText()
+        await page.waitForNextPresentationUpdate()
+
+        let startBounds = try await screenBounds(ofElementWithID: "line297")
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 20)
+
+        await recap.play { composer in
+            composer._wk_click(at: startBounds.center, for: .seconds(0.5))
+            composer.advanceTime(0.1)
+            composer._wk_drag(withStart: startBounds.center, end: dragEnd, duration: .seconds(1), release: false)
+            composer.advanceTime(0.5)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let scrollAfterLift = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(scrollAfterLift.y > 0)
+
+        // Ending the gesture cancels autoscroll, so the page must not keep scrolling afterwards.
+        try await Task.sleep(for: .seconds(0.5))
+
+        let scrollLater = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(scrollLater.y == scrollAfterLift.y)
+    }
+
+    @Test()
+    func draggingSelectionToTopEdgeScrollsUp() async throws {
+        try await loadScrollableText()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        // Start partway down the page so there is room to scroll back up.
+        try await page.callJavaScript { "window.scrollTo(0, 3000);" }
+        await page.waitForNextPresentationUpdate()
+
+        let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(initialScrollPosition.y > 0)
+
+        // Begin a selection on the visible text at the window's center, then drag up to the top edge.
+        let contentHeight = try #require(window.contentViewController?.view.frame.height)
+        let start = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: contentHeight / 2)
+        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: contentHeight - 20)
+
+        await recap.play { composer in
+            composer._wk_click(at: start, for: .seconds(0.5))
+            composer.advanceTime(0.1)
+            composer._wk_drag(withStart: start, end: dragEnd, duration: .seconds(1), release: false)
+            composer.advanceTime(0.5)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let finalScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(finalScrollPosition.y < initialScrollPosition.y)
+    }
+
+    @Test
+    func selectionOriginatingNearEdgeWithShortDragDoesNotAutoscroll() async throws {
+        try await loadScrollableText()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(CGPoint(initialScrollPosition) == .zero)
+
+        // Begin the selection inside the bottom edge band (~70pt from the bottom; the band is 100pt) and
+        // drag only a short distance toward the edge - less than the ~50pt threshold. The selection
+        // originates near the edge but the drag is too small to be a deliberate "scroll past the edge"
+        // gesture, so the page must not autoscroll. (Pre-fix, being in the band alone started autoscroll.)
+        let start = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 70)
+        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 45)
+
+        await recap.play { composer in
+            composer._wk_click(at: start, for: .seconds(0.5))
+            composer.advanceTime(0.1)
+            composer._wk_drag(withStart: start, end: dragEnd, duration: .seconds(1), release: false)
+
+            // Hold so the autoscroll timer would fire repeatedly if it were going to.
+            composer.advanceTime(1.0)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let finalScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(CGPoint(finalScrollPosition) == .zero)
+    }
+
+    @Test
+    func selectionOriginatingNearEdgeAutoscrollsAfterDraggingPastThreshold() async throws {
+        try await loadScrollableText()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(CGPoint(initialScrollPosition) == .zero)
+
+        // Same near-edge origin as the short-drag test, but now drag well past the threshold (and past the
+        // window edge) and hold, so the deliberate gesture engages autoscroll.
+        let start = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 70)
+        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: -40)
+
+        await recap.play { composer in
+            composer._wk_click(at: start, for: .seconds(0.5))
+            composer.advanceTime(0.1)
+            composer._wk_drag(withStart: start, end: dragEnd, duration: .seconds(1), release: false)
+            composer.advanceTime(0.5)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let finalScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
+        #expect(finalScrollPosition.y > 0)
+    }
+
+    @Test(
         .bug("rdar://176117750"),
         arguments: [true, false]
     )
@@ -889,6 +1168,29 @@ extension AppKitGesturesTests {
         )
 
         return screenCoordinates
+    }
+
+    // Loads a tall column of identified lines (`line0` at the bottom, `line<count - 1>` at the top) so a
+    // selection drag has somewhere to autoscroll.
+    private func loadScrollableText(lineCount: Int = 300) async throws {
+        let lines = (0..<lineCount)
+            .reversed()
+            .map { "<p id='line\($0)'>\($0) bottles of beer on the wall</p>" }
+            .joined(separator: "\n")
+
+        let html = """
+            <div id="text" style="font-size: 60px; margin: 0;">\(lines)</div>
+            """
+        try await page.load(html: html).wait()
+    }
+
+    private func screenBounds(ofElementWithID id: String) async throws -> CGRect {
+        let viewportCoordinates = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: id))
+        return convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: viewportCoordinates, window: window)
+    }
+
+    private func windowEdgePointInScreenCoordinates(x: CGFloat, y: CGFloat) -> CGPoint {
+        convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: CGPoint(x: x, y: y), window: window)
     }
 }
 


### PR DESCRIPTION
#### 17c30e3cfa7cb856ba46e621918774758aab0da3
<pre>
[AppKit Gestures] Clicking and dragging text selection to the edge of the window does not autoscroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=317717">https://bugs.webkit.org/show_bug.cgi?id=317717</a>
<a href="https://rdar.apple.com/176424187">rdar://176424187</a>

Reviewed by Abrar Rahman Protyasha.

On macOS, when using the AppKit-gestures text interaction path (driven by
NSTextSelectionManager), click-dragging a selection to the edge of the window
did not autoscroll the page. The selection stopped growing at whatever was
already on screen, so it was impossible to select past the visible content
without manually scrolling first. iOS already supports this via UIKit&apos;s
UITextAutoscrolling protocol, which performs edge detection and drives the
web process&apos;s autoscroll timer; AppKit has no equivalent, so nothing started
or sustained the scroll.

Implement selection-drag autoscroll for macOS by reusing the existing
selection-autoscroll machinery that iOS relies on (EventHandler&apos;s
m_isAutoscrolling / m_targetAutoscrollPositionInRootView, AutoscrollController&apos;s
50ms Selection timer, and the WebPage StartAutoscrollAtPosition /
CancelAutoscroll messages). The decision of when to autoscroll lives entirely
in the web process, which already computes the visible content rect and owns
the edge-band constants, so the UI process does not duplicate that geometry.

How it works:

  - On each extent-point update during a range-selection drag (the messages
    the UI process already sends as the cursor moves, and re-sends as the page
    scrolls), WebPage::updateSelectionWithExtentPointAndBoundary asks the
    EventHandler whether the point sits within the visible-edge band. If so it
    starts (or keeps) selection autoscroll targeting that point; otherwise it
    cancels. This is re-evaluated every update, so holding the cursor near the
    edge keeps scrolling and dragging back toward the middle stops it -- the
    macOS counterpart to UIKit&apos;s UITextAutoscrolling edge detection.

  - While autoscrolling, EventHandler::targetPositionInWindowForSelectionAutoscroll
    pushes the target point past the nearest visible-content edge, scaling the
    push by how deep into the edge band the point is. Because the push is a fixed
    distance past the edge in root-view coordinates, the autoscroll timer&apos;s
    windowToContents mapping yields a stable per-tick scroll delta, so the page
    keeps scrolling at a constant velocity for as long as the gesture holds near
    (or past) the edge -- without the UI process having to re-push a target.

  - As the page scrolls, WebViewImpl::pageDidScroll asks the text selection
    controller to re-extend the selection toward the last drag point, so the
    selection keeps growing into the newly revealed content. This mirrors the
    iOS -updateSelection re-extension.

The edge-detection predicate (isPointNearSelectionAutoscrollEdge) and the
target-push (pushSelectionAutoscrollTargetPastVisibleEdges) share a single
helper, selectionAutoscrollGeometry, for the visible rect and page-scale
factor. Sharing one source of truth guarantees the &quot;should we scroll&quot; decision
and &quot;how far past the edge&quot; computation use the same edge band, so they cannot
disagree (e.g. when the page is magnified to a scale below 1).

While autoscrolling on Cocoa, EventHandler::updateSelectionForMouseDrag is
suppressed: the selection is re-extended by the UI process toward the live drag
point as the page scrolls, so re-extending here from the stale last-known mouse
position would fight that. This is a no-op on iOS, where
supportsSelectionUpdatesOnMouseDrag() already returns false; the corresponding
preprocessor guard is widened from !PLATFORM(IOS_FAMILY) to !PLATFORM(COCOA) to
match.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateSelectionForMouseDrag): Bail during autoscroll on
Cocoa so the UI-process-driven re-extension is authoritative.

* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::selectionAutoscrollGeometry): Added; shared visible-rect + zoom scale.
(WebCore::EventHandler::isPointNearSelectionAutoscrollEdge): Added.
(WebCore::EventHandler::targetPositionInWindowForSelectionAutoscroll): Push the
target past the nearest visible edge while autoscrolling.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::rendererForSelectionAutoscroll): Added; factored out renderer
resolution shared by the start path and the extent-point edge check.

(WebKit::WebPage::startAutoscrollAtPosition): Use the shared helper.

(WebKit::WebPage::updateSelectionWithExtentPointAndBoundary): On macOS, start or
cancel selection autoscroll based on edge proximity.

* Source/WebKit/UIProcess/mac/WKTextSelectionController.h:
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(reextendSelectionForAutoscrollIfNeeded): Re-extend toward the last drag point
on scroll; gated on an in-flight drag rather than UI-cached autoscroll state.
(beginRangeSelection / continueRangeSelection / endRangeSelection): Track the
last extent point; cancel autoscroll at gesture begin/end as a safety net.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::pageDidScroll): Re-extend the selection as the page
autoscrolls.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(draggingSelectionToWindowEdgeAutoscrolls): Added.

(holdingSelectionDragNearEdgeKeepsScrolling): Added; verifies the scroll
continues across the hold rather than bursting and stopping early.

(holdingSelectionDragMidContentDoesNotAutoscroll): Added.
(selectionAutoscrollStopsAfterGestureEnds): Added.
(draggingSelectionToTopEdgeScrollsUp): Added.

Canonical link: <a href="https://commits.webkit.org/315834@main">https://commits.webkit.org/315834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16a557214c1e6212b96990f2c8b1d5bc86c45d87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170123 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44046 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127835 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f9392f3-1bb3-478b-ac1b-ede60ea65210) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45289 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132608 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed892c88-ae90-4137-a648-ae183343ddf3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173082 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113110 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8df8cbf5-0522-4b3c-8b90-1a2140118c39) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28181 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182082 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34871 "Found 139 new failures in platform/graphics/IntRect.cpp, css/typedom/transform/CSSTransformValue.cpp, runtime/IndexingType.cpp, WebProcess/WebPage/Cocoa/WebPageCocoa.mm, dom/EventPath.cpp, dom/ImageOverlay.cpp, Modules/webauthn/fido/U2fResponseConverter.cpp, Modules/webauthn/apdu/ApduCommand.cpp, svg/SVGSVGElement.cpp, rendering/cocoa/RenderThemeCocoa.mm ...") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36916 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141062 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43702 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37956 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44391 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108752 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36158 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116272 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42902 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7579 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42294 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42548 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->