### PR TITLE
[SVG] clip-path/mask/filter referencing a <text> is not updated when the text content changes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2955,7 +2955,6 @@ imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-strokeBox-1a.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-viewBox-1c.html [ ImageOnlyFailure ]
 webkit.org/b/104442 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-url-reference-change-from-empty.html [ ImageOnlyFailure ]
-webkit.org/b/229510 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-scaled-video.html [ Skip ]
 
 imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-fixed-position-rounding-error.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -294,6 +294,12 @@ void RenderSVGText::subtreeTextDidChange(RenderSVGInlineText* text)
     checkLayoutAttributesConsistency(this, m_layoutAttributes);
     setNeedsPositioningValuesUpdate();
     setNeedsLayout();
+
+    // Invalidate any SVG resource (clip-path, mask, filter) referencing this text subtree so its cached output is flushed and clients repaint.
+    if (document().settings().layerBasedSVGEngineEnabled())
+        repaintClientsOfReferencedSVGResources();
+    else
+        LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(*this);
 }
 
 static inline void updateFontInAllDescendants(RenderSVGText& text)


### PR DESCRIPTION
#### e020ddcaefe638eb10f0dfd784262b85917d340f
<pre>
[SVG] clip-path/mask/filter referencing a &lt;text&gt; is not updated when the text content changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=317536">https://bugs.webkit.org/show_bug.cgi?id=317536</a>
<a href="https://rdar.apple.com/180221695">rdar://180221695</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Mutating a &lt;text&gt; descendant of a clipPath (e.g. text.firstChild.data = &apos;X&apos;)
did not invalidate the resource&apos;s clients, so the clipped element kept showing
the stale result until an unrelated repaint (e.g. occluding and revealing the
window) forced an update.

Element/attribute changes inside a resource go through
RenderTreeUpdater::updateSVGRenderer(), which invalidates the enclosing
resource for both engines (legacy:
LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(), which
walks to the LegacyRenderSVGResourceContainer, flushes its ClipperData cache
and repaints clients; LBSE: setNeedsLayout(), whose
RenderSVGResourceContainer::layout() calls repaintAllClients()). Text content
changes take a different path
(RenderSVGInlineText::setTextInternal -&gt; RenderSVGText::subtreeTextDidChange)
that only called setNeedsLayout() on the text, which neither flushes the legacy
clipper cache (its cache key is the clipped element&apos;s geometry, unaffected by a
clip-content change) nor reliably reaches the resource container&apos;s layout()
to repaint clients.

Invalidate the referencing resource from RenderSVGText::subtreeTextDidChange()
using the same engine split SVGClipPathElement already uses:
repaintClientsOfReferencedSVGResources() under LBSE and
markForLayoutAndParentResourceInvalidation() in the legacy engine.

* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::subtreeTextDidChange):
* LayoutTests/TestExpectations: Unskip the now-passing test.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e020ddcaefe638eb10f0dfd784262b85917d340f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178813 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127167 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1e4b4e5-8c49-4974-9c19-ebc2fb40d5e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132009 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92941 "10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f99979a-67d2-4eae-9796-a8b5177f37e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112512 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a84dc545-b2b9-451e-a003-08d4f159f26f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34314 "Found 10 new test failures: imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/report-only-frame.sub.html imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-cross-origin-same-document-navigation.window.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-with-x-frame-options.sub.html imported/w3c/web-platform-tests/content-security-policy/sandbox/meta-element.sub.html imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053.html imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative.html?type=text imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative.html?type=textarea imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html?rest imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer.html?rest (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32148 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27511 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181413 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140458 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140294 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43722 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107848 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35568 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115487 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42232 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6794 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41625 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41880 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41768 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->