### PR TITLE
[JSC] Inline `NumericStrings` int cache lookup in DFG and FTL `ToString(Int32)`

### DIFF
--- a/JSTests/microbenchmarks/int32-to-string-int-cache-hit.js
+++ b/JSTests/microbenchmarks/int32-to-string-int-cache-hit.js
@@ -1,0 +1,11 @@
+function test(i)
+{
+    return ("" + (1000000 + (i & 7))).length;
+}
+noInline(test);
+
+let acc = 0;
+for (let i = 0; i < 5e6; ++i)
+    acc += test(i);
+if (acc !== 35000000)
+    throw new Error("bad result: " + acc);

--- a/JSTests/stress/to-string-int32-int-cache.js
+++ b/JSTests/stress/to-string-int32-int-cache.js
@@ -1,0 +1,34 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error(`bad value: expected:(${expected}),actual:(${actual})`);
+}
+
+function toString10(value)
+{
+    return `${value | 0}`;
+}
+noInline(toString10);
+
+function test()
+{
+    shouldBe(toString10(1023), "1023");
+    shouldBe(toString10(1024), "1024");
+    shouldBe(toString10(1025), "1025");
+    shouldBe(toString10(123456), "123456");
+    shouldBe(toString10(1000000), "1000000");
+    shouldBe(toString10(-1), "-1");
+    shouldBe(toString10(-1024), "-1024");
+    shouldBe(toString10(-123456), "-123456");
+    shouldBe(toString10(2147483647), "2147483647");
+    shouldBe(toString10(-2147483648), "-2147483648");
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i)
+    test();
+
+fullGC();
+
+for (let i = 0; i < testLoopCount; ++i)
+    test();

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -235,6 +235,7 @@ namespace JSC::B3 {
     macro(variables, 0, sizeof(Register)) \
     macro(HasOwnPropertyCache, 0, sizeof(HasOwnPropertyCache::Entry)) \
     macro(SmallIntCache, 0, sizeof(NumericStrings::StringWithJSString)) \
+    macro(IntCache, 0, sizeof(NumericStrings::CacheEntryWithJSString<int>)) \
     macro(WasmRTT_data, Wasm::RTT::offsetOfData(), sizeof(RefPtr<const Wasm::RTT>)) \
     macro(WebAssemblyGCStructure_inlinedDisplay, WebAssemblyGCStructure::offsetOfInlinedDisplay(), sizeof(WriteBarrierStructureID)) \
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -11843,32 +11843,7 @@ void SpeculativeJIT::compileNumberToStringWithValidRadixConstant(Node* node, int
     switch (node->child1().useKind()) {
     case Int32Use: {
         if (radix == 10) {
-            SpeculateStrictInt32Operand value(this, node->child1());
-            GPRTemporary result(this);
-
-            GPRReg valueGPR = value.gpr();
-            GPRReg resultGPR = result.gpr();
-
-            flushRegisters();
-
-            JumpList slowCases;
-            JumpList doneCases;
-
-            slowCases.append(branch32(AboveOrEqual, valueGPR, TrustedImm32(NumericStrings::cacheSize)));
-
-            move(valueGPR, resultGPR);
-            static_assert(hasOneBitSet(sizeof(NumericStrings::StringWithJSString)), "size should be a power of two.");
-            lshiftPtr(TrustedImm32(WTF::fastLog2(static_cast<unsigned>(sizeof(NumericStrings::StringWithJSString)))), resultGPR);
-            addPtr(TrustedImmPtr(vm().numericStrings.smallIntCache()), resultGPR);
-            loadPtr(Address(resultGPR, NumericStrings::StringWithJSString::offsetOfJSString()), resultGPR);
-            doneCases.append(branchTestPtr(NonZero, resultGPR));
-            // Fall-through.
-
-            slowCases.link(this);
-            callOperation(operationInt32ToStringWithValidRadix, resultGPR, LinkableConstant::globalObject(*this, node), valueGPR, TrustedImm32(10));
-
-            doneCases.link(this);
-            cellResult(resultGPR, node);
+            compileInt32ToStringRadix10(node);
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1481,6 +1481,7 @@ public:
     void compileNumberToStringWithRadix(Node*);
     void compileNumberToStringWithValidRadixConstant(Node*);
     void compileNumberToStringWithValidRadixConstant(Node*, int32_t radix);
+    void compileInt32ToStringRadix10(Node*);
     void compileNewStringObject(Node*);
     void compileNewSymbol(Node*);
     void compileNewMap(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2145,6 +2145,30 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
     } }
 }
 
+void SpeculativeJIT::compileInt32ToStringRadix10(Node* node)
+{
+    SpeculateStrictInt32Operand value(this, node->child1());
+    GPRTemporary result(this);
+
+    GPRReg valueGPR = value.gpr();
+    GPRReg resultGPR = result.gpr();
+
+    JumpList slowCases;
+
+    slowCases.append(branch32(AboveOrEqual, valueGPR, TrustedImm32(NumericStrings::cacheSize)));
+
+    move(valueGPR, resultGPR);
+    static_assert(hasOneBitSet(sizeof(NumericStrings::StringWithJSString)), "size should be a power of two.");
+    lshiftPtr(TrustedImm32(WTF::fastLog2(static_cast<unsigned>(sizeof(NumericStrings::StringWithJSString)))), resultGPR);
+    addPtr(TrustedImmPtr(vm().numericStrings.smallIntCache()), resultGPR);
+    loadPtr(Address(resultGPR, NumericStrings::StringWithJSString::offsetOfJSString()), resultGPR);
+    slowCases.append(branchTestPtr(Zero, resultGPR));
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationInt32ToStringWithValidRadix, resultGPR, LinkableConstant::globalObject(*this, node), valueGPR, TrustedImm32(10)));
+
+    cellResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compile(Node* node)
 {
     NodeType op = node->op();

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3310,6 +3310,51 @@ void SpeculativeJIT::compileGetTypedArrayByteOffsetAsInt52(Node* node)
 }
 #endif // USE(LARGE_TYPED_ARRAYS)
 
+void SpeculativeJIT::compileInt32ToStringRadix10(Node* node)
+{
+    SpeculateStrictInt32Operand value(this, node->child1());
+    GPRTemporary result(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
+    GPRReg valueGPR = value.gpr();
+    GPRReg resultGPR = result.gpr();
+    GPRReg scratch1GPR = scratch1.gpr();
+    GPRReg scratch2GPR = scratch2.gpr();
+
+    JumpList slowCases;
+    JumpList doneCases;
+
+    Jump notSmallInt = branch32(AboveOrEqual, valueGPR, TrustedImm32(NumericStrings::cacheSize));
+
+    move(valueGPR, resultGPR);
+    static_assert(hasOneBitSet(sizeof(NumericStrings::StringWithJSString)), "size should be a power of two.");
+    lshiftPtr(TrustedImm32(WTF::fastLog2(static_cast<unsigned>(sizeof(NumericStrings::StringWithJSString)))), resultGPR);
+    addPtr(TrustedImmPtr(vm().numericStrings.smallIntCache()), resultGPR);
+    loadPtr(Address(resultGPR, NumericStrings::StringWithJSString::offsetOfJSString()), resultGPR);
+    doneCases.append(branchTestPtr(NonZero, resultGPR));
+    slowCases.append(jump());
+
+    notSmallInt.link(this);
+    zeroExtend32ToWord(valueGPR, resultGPR);
+    rapidHashMix64(resultGPR, scratch1GPR, scratch2GPR);
+    and32(TrustedImm32(NumericStrings::cacheSize - 1), resultGPR);
+    if (hasOneBitSet(sizeof(NumericStrings::CacheEntryWithJSString<int>)))
+        lshift32(TrustedImm32(getLSBSet(sizeof(NumericStrings::CacheEntryWithJSString<int>))), resultGPR);
+    else
+        mul32(TrustedImm32(sizeof(NumericStrings::CacheEntryWithJSString<int>)), resultGPR, resultGPR);
+    addPtr(TrustedImmPtr(vm().numericStrings.intCache()), resultGPR);
+    slowCases.append(branch32(NotEqual, Address(resultGPR, NumericStrings::CacheEntryWithJSString<int>::offsetOfKey()), valueGPR));
+    loadPtr(Address(resultGPR, NumericStrings::CacheEntryWithJSString<int>::offsetOfJSString()), resultGPR);
+    slowCases.append(branchTestPtr(Zero, resultGPR));
+
+    doneCases.link(this);
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationInt32ToStringWithValidRadix, resultGPR, LinkableConstant::globalObject(*this, node), valueGPR, TrustedImm32(10)));
+
+    cellResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compile(Node* node)
 {
     NodeType op = node->op();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -20911,25 +20911,39 @@ IGNORE_CLANG_WARNINGS_END
         switch (child1.useKind()) {
         case Int32Use: {
             if (radix == 10) {
-                LBasicBlock cacheCase = m_out.newBlock();
+                LBasicBlock smallIntCase = m_out.newBlock();
+                LBasicBlock intCacheCase = m_out.newBlock();
+                LBasicBlock intCacheKeyMatchCase = m_out.newBlock();
                 LBasicBlock slowCase = m_out.newBlock();
                 LBasicBlock continuation = m_out.newBlock();
 
                 LValue int32Value = lowInt32(child1);
-                m_out.branch(m_out.aboveOrEqual(int32Value, m_out.constInt32(NumericStrings::cacheSize)), unsure(slowCase), unsure(cacheCase));
+                m_out.branch(m_out.aboveOrEqual(int32Value, m_out.constInt32(NumericStrings::cacheSize)), unsure(intCacheCase), unsure(smallIntCase));
 
-                LBasicBlock lastNext = m_out.appendTo(cacheCase, slowCase);
+                LBasicBlock lastNext = m_out.appendTo(smallIntCase, intCacheCase);
                 LValue cache = m_out.constIntPtr(vm().numericStrings.smallIntCache());
                 LValue result = m_out.loadPtr(baseIndexWithProvenValue(m_heaps.SmallIntCache, cache, int32Value, child1, NumericStrings::StringWithJSString::offsetOfJSString()));
-                ValueFromBlock fastResult = m_out.anchor(result);
+                ValueFromBlock smallIntResult = m_out.anchor(result);
                 m_out.branch(m_out.isNull(result), unsure(slowCase), unsure(continuation));
+
+                m_out.appendTo(intCacheCase, intCacheKeyMatchCase);
+                LValue hash = rapidHashMix64(m_out.zeroExt(int32Value, Int64));
+                LValue slotIndex = m_out.zeroExtPtr(m_out.bitAnd(hash, m_out.constInt32(NumericStrings::cacheSize - 1)));
+                LValue intCacheBase = m_out.constIntPtr(vm().numericStrings.intCache());
+                LValue entryKey = m_out.load32(m_out.baseIndex(m_heaps.IntCache, intCacheBase, slotIndex, JSValue(), NumericStrings::CacheEntryWithJSString<int>::offsetOfKey()));
+                LValue entryJSString = m_out.loadPtr(m_out.baseIndex(m_heaps.IntCache, intCacheBase, slotIndex, JSValue(), NumericStrings::CacheEntryWithJSString<int>::offsetOfJSString()));
+                m_out.branch(m_out.equal(entryKey, int32Value), unsure(intCacheKeyMatchCase), unsure(slowCase));
+
+                m_out.appendTo(intCacheKeyMatchCase, slowCase);
+                ValueFromBlock intCacheResult = m_out.anchor(entryJSString);
+                m_out.branch(m_out.isNull(entryJSString), unsure(slowCase), unsure(continuation));
 
                 m_out.appendTo(slowCase, continuation);
                 ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationInt32ToStringWithValidRadix, weakPointer(globalObject), int32Value, m_out.constInt32(radix)));
                 m_out.jump(continuation);
 
                 m_out.appendTo(continuation, lastNext);
-                return m_out.phi(pointerType(), fastResult, slowResult);
+                return m_out.phi(pointerType(), smallIntResult, intCacheResult, slowResult);
             }
             return vmCall(pointerType(), operationInt32ToStringWithValidRadix, weakPointer(globalObject), lowInt32(child1), m_out.constInt32(radix));
         }

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -52,6 +52,9 @@ public:
         T key;
         String value;
         JSString* jsString { nullptr };
+
+        static constexpr ptrdiff_t offsetOfKey() { return OBJECT_OFFSETOF(CacheEntryWithJSString, key); }
+        static constexpr ptrdiff_t offsetOfJSString() { return OBJECT_OFFSETOF(CacheEntryWithJSString, jsString); }
     };
 
     struct StringWithJSString {
@@ -136,6 +139,7 @@ public:
     }
 
     const StringWithJSString* smallIntCache() LIFETIME_BOUND { return m_smallIntCache.data(); }
+    const CacheEntryWithJSString<int>* intCache() LIFETIME_BOUND { return m_intCache.data(); }
 
     void initializeSmallIntCache(VM&);
 


### PR DESCRIPTION
#### 186e2a91934e2dd2fe1f4e21b46c2135cca0fcbe
<pre>
[JSC] Inline `NumericStrings` int cache lookup in DFG and FTL `ToString(Int32)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317537">https://bugs.webkit.org/show_bug.cgi?id=317537</a>

Reviewed by Yusuke Suzuki.

DFG and FTL already inline the NumericStrings small-int cache lookup
(values 0..1023) for ToString(Int32) with radix 10, but values outside
that range always take a vmCall to operationInt32ToStringWithValidRadix
even when the int cache would hit. The hash used by the int cache is
WTF::IntHash&lt;int&gt;, which is the rapidhash mum mixer that DFG/FTL already
emit inline for Map/Set hashing via rapidHashMix64.

Emit the same hash inline, index into m_intCache, and return the cached
JSString directly when the slot&apos;s key matches and its jsString is
non-null. Only the miss path (collision or empty slot) calls into the
runtime.

The radix-10 Int32 case is split out into compileInt32ToStringRadix10 so
that the 64-bit and 32-bit DFG backends can diverge cleanly: the 64-bit
backend adds the int-cache lookup (rapidHashMix64 needs 128-bit multiply)
while the 32-bit backend keeps the existing small-int-only path.

                                        baseline                  patched

int32-to-string-int-cache-hit       27.1492+-0.3189     ^     11.4171+-0.1587        ^ definitely 2.3779x faster

* JSTests/microbenchmarks/int32-to-string-int-cache-hit.js: Added.
* JSTests/stress/to-string-int32-int-cache.js: Added.
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
* Source/JavaScriptCore/runtime/NumericStrings.h:

Canonical link: <a href="https://commits.webkit.org/315805@main">https://commits.webkit.org/315805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0658e773b18158a48134a556df734ae2dabda797

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170147 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44070 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127859 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173106 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113137 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28205 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/1487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182106 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31402 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43727 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140913 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37935 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44416 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108782 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36183 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116296 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202826 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42926 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7552 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54359 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->