### PR TITLE
Add test coverage for valid Punycode but invalid UTS46

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -308,6 +308,22 @@ TEST(URLExtras, URLExtras_PercentEncodedIDN)
     EXPECT_STREQ("http://xn--mnchen-3ya.de/", originalDataAsString(WTF::URLWithUserTypedString(@"http://m%C3%BCnchen.de/", nil)));
 }
 
+TEST(URLExtras, URLExtras_InvalidACELabel)
+{
+    // xn--8i7caa Punycode-decodes to U+FF57 U+FF57 U+FF57 (FULLWIDTH LATIN SMALL LETTER W),
+    // which has UTS#46 "mapped" status — so the post-decode label fails validation. ASCII
+    // inputs are nevertheless accepted as-is.
+
+    EXPECT_STREQ("http://xn--8i7caa.example/", originalDataAsString(WTF::URLWithUserTypedString(@"http://xn--8i7caa.example/", nil)));
+    EXPECT_STREQ("http://xn--8i7caa.example/", userVisibleString(WTF::URLWithUserTypedString(@"http://xn--8i7caa.example/", nil)));
+
+    EXPECT_STREQ("http://xn--8i7caa.example/", originalDataAsString(literalURL("http://xn--8i7caa.example/")));
+    EXPECT_STREQ("http://xn--8i7caa.example/", userVisibleString(literalURL("http://xn--8i7caa.example/")));
+
+    EXPECT_STREQ("xn--8i7caa.example", [WTF::encodeHostName(@"xn--8i7caa.example") UTF8String]);
+    EXPECT_NULL([@"xn--8i7caa.example" _wk_decodeHostName]);
+}
+
 TEST(URLExtras, URLExtras_IPv6)
 {
     // IPv6 hosts pass through unchanged.


### PR DESCRIPTION
#### ab38c23be42b9326eebf262fea403151aa380a32
<pre>
Add test coverage for valid Punycode but invalid UTS46
<a href="https://bugs.webkit.org/show_bug.cgi?id=317539">https://bugs.webkit.org/show_bug.cgi?id=317539</a>

Reviewed by Alex Christensen.

A potential roundtripping issue surfaced in
<a href="https://github.com/whatwg/url/pull/914">https://github.com/whatwg/url/pull/914</a> that we did not have test
coverage for. In particular because after 314820@main to ASCII succeeds
more often, there&apos;s a risk that ToUnicode returns something that does
not roundtrip.

We do not have this issue because when to Unicode records an error, we
return the input as-is. Document this with a test so we won&apos;t
accidentally regress it.

This is an API test because to Unicode is not exposed to the web at
the moment.

Canonical link: <a href="https://commits.webkit.org/315690@main">https://commits.webkit.org/315690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b77240d8f605508abb113da89150189f3c3c166c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127414 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba0a3a59-26c9-4eae-b3a1-474b79f211eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171568 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68f3d144-7267-4444-8f59-d9b1ffd8b1f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172661 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112752 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/735ad59b-4bf0-4c33-8afc-17865e9520ed) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32387 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27758 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181660 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140694 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43280 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140529 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43969 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108229 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25862 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35797 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42480 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7126 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41872 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42127 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->