### PR TITLE
Digital credentials: resync upstream WPT tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8067,6 +8067,13 @@ webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/create.t
 webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/create.disabled-by-permissions-policy.https.sub.html [ Skip ]
 webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/create-enabled-on-self-origin-by-permissions-policy.https.sub.html [ Skip ]
 webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-create.https.html [ Skip ]
+webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/webdriver/create.https.html [ Skip ]
+webkit.org/b/306292 imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html [ Skip ]
+webkit.org/b/306292 imported/w3c/web-platform-tests/digital-credentials/mdoc/valid-roundtrip.https.html [ Skip ]
+webkit.org/b/306292 imported/w3c/web-platform-tests/digital-credentials/mdoc/response-handling.https.html [ Skip ]
+webkit.org/b/306292 imported/w3c/web-platform-tests/digital-credentials/mdoc/origin-binding.https.html [ Skip ]
+webkit.org/b/306292 imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html [ Skip ]
+webkit.org/b/317545 imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-openid4vp.https.html [ Skip ]
 
 # Hits assert in debug, tracked by https://bugs.webkit.org/show_bug.cgi?id=303414
 [ Debug ] fullscreen/fullscreen-grid-item-container-type-crash.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/META.yml
@@ -1,8 +1,5 @@
 spec: https://github.com/w3c-fedid/digital-credentials/
 suggested_reviewers:
   - marcoscaceres
-  - samuelgoto
-  - tplooker
-  - pkotwicz
   - mohamedamir
   - timcappalli

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Digital Credential concurrent request rejection tests</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body></body>
+<script type="module">
+  import { makeGetOptions } from "./support/helper.js";
+
+  promise_test(async (t) => {
+    const abortController = new AbortController();
+    const firstOptions = makeGetOptions({ signal: abortController.signal });
+    const secondOptions = makeGetOptions();
+
+    await test_driver.bless("user activation for first request");
+    const firstRequest = navigator.credentials.get(firstOptions);
+
+    // Use bless's action callback so the second get() is called within
+    // the same microtask as activation grant. This prevents the first
+    // request's IPC response from completing (clearing the pending state
+    // in the browser process) before the second call is dispatched.
+    let secondRequest;
+    await test_driver.bless("user activation for second request", () => {
+      assert_true(navigator.userActivation.isActive);
+      secondRequest = navigator.credentials.get(secondOptions);
+    });
+
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      secondRequest,
+      "Second concurrent request should be rejected with NotAllowedError"
+    );
+
+    abortController.abort();
+    await promise_rejects_dom(
+      t,
+      "AbortError",
+      firstRequest,
+      "First request should be aborted"
+    );
+  }, "A second get() call while another is pending should reject with NotAllowedError.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.tentative.https.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>Digital Credential API tests for create.</title>
 <link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
 <script src="/common/get-host-info.sub.js"></script>
@@ -13,7 +14,7 @@
 </body>
 
 <script type="module">
-  import { makeCreateOptions, sendMessage, loadIframe } from "./support/helper.js";
+  import { makeCreateOptions, makeCanonicalCreateRequest, sendMessage, loadIframe } from "./support/helper.js";
 
   const iframeSameOrigin = document.querySelector("iframe#same-origin");
   const iframeCrossOrigin = document.querySelector("iframe#cross-origin");
@@ -229,9 +230,9 @@
 
   promise_test(async (t) => {
     const throwingValues = [
-      BigInt(123),
+      { val: BigInt(123) },
       (() => { const o = {}; o.self = o; return o; })(),
-      Symbol("foo")
+      { toJSON() { throw new TypeError("toJSON throws"); } }
     ];
 
     for (const badValue of throwingValues) {
@@ -267,7 +268,7 @@
         requests: [
           {
             protocol: "unknown-protocol",
-            data: BigInt(1), // malformed/non-serializable
+            data: { val: BigInt(1) }, // malformed/non-serializable
           },
           {
             protocol: "openid4vci",
@@ -283,4 +284,78 @@
     controller.abort();
     await promise_rejects_dom(t, "AbortError", promise);
   }, "navigator.credentials.create() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail.");
+
+  promise_test(async (t) => {
+    const options = {
+      digital: {
+        requests: [{ protocol: "unknown-protocol", data: {} }]
+      }
+    };
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.create(options)
+    );
+  }, "All unsupported protocols filtered results in TypeError.");
+
+  promise_test(async (t) => {
+    const options = {
+      digital: {
+        requests: [
+          { protocol: "fake-protocol-1", data: {} },
+          { protocol: "fake-protocol-2", data: {} },
+          { protocol: "another-unknown", data: {} }
+        ]
+      }
+    };
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.create(options)
+    );
+  }, "Multiple unsupported protocols all filtered results in TypeError.");
+
+  promise_test(async (t) => {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    const options = {
+      digital: {
+        requests: [makeCanonicalCreateRequest("openid4vci")]
+      },
+      signal
+    };
+    await test_driver.bless("user activation");
+    const promise = navigator.credentials.create(options);
+    abortController.abort();
+    await promise_rejects_dom(
+      t,
+      "AbortError",
+      promise,
+      "Valid 'openid4vci' protocol should not be filtered out"
+    );
+  }, "Valid 'openid4vci' protocol passes through filtering.");
+
+  promise_test(async (t) => {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    const options = {
+      digital: {
+        requests: [
+          { protocol: "unknown-protocol", data: {} },
+          makeCanonicalCreateRequest("openid4vci"),
+          { protocol: "another-fake", data: {} }
+        ]
+      },
+      signal
+    };
+    await test_driver.bless("user activation");
+    const promise = navigator.credentials.create(options);
+    abortController.abort();
+    await promise_rejects_dom(
+      t,
+      "AbortError",
+      promise,
+      "Valid protocol among invalid ones should survive filtering"
+    );
+  }, "Mix of valid and invalid protocols - valid survives filtering.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.https.html
@@ -236,9 +236,9 @@
 
 promise_test(async t => {
   const throwingValues = [
-    BigInt(123),
+    { val: BigInt(123) },
     (() => { const o = {}; o.self = o; return o; })(),
-    Symbol("foo")
+    { toJSON() { throw new TypeError("toJSON throws"); } }
   ];
 
   for (const badValue of throwingValues) {
@@ -270,7 +270,7 @@ promise_test(async (t) => {
       requests: [
         {
           protocol: "unknown-protocol",
-          data: BigInt(1), // malformed/non-serializable
+          data: { val: BigInt(1) }, // malformed/non-serializable
         },
       ],
       signal,
@@ -286,9 +286,9 @@ promise_test(async (t) => {
     const options = {
       digital: {
         requests: [
-          { protocol: "bogus-1", data: BigInt(1) },
-          { protocol: "bogus-2", data: BigInt(2) },
-          { protocol: "bogus-3", data: BigInt(3) },
+          { protocol: "bogus-1", data: { val: BigInt(1) } },
+          { protocol: "bogus-2", data: { val: BigInt(2) } },
+          { protocol: "bogus-3", data: { val: BigInt(3) } },
         ],
       },
     };
@@ -308,8 +308,8 @@ promise_test(async (t) => {
       protocol: [], // disable defaults
       requests: [
         openidReq,
-        { protocol: "bogus-1", data: BigInt(1) },
-        { protocol: "bogus-2", data: BigInt(2) },
+        { protocol: "bogus-1", data: { val: BigInt(1) } },
+        { protocol: "bogus-2", data: { val: BigInt(2) } },
         mdocReq,
       ],
       signal,
@@ -331,10 +331,10 @@ promise_test(async (t) => {
     const options = makeGetOptions({
       protocol: [], // disable automatic protocol requests
       requests: [
-        { protocol: "bogus-1", data: BigInt(1) },
+        { protocol: "bogus-1", data: { val: BigInt(1) } },
         openidReq,
         mdocReq,
-        { protocol: "bogus-2", data: BigInt(2) },
+        { protocol: "bogus-2", data: { val: BigInt(2) } },
       ],
       signal,
     });
@@ -344,4 +344,20 @@ promise_test(async (t) => {
     controller.abort();
     await promise_rejects_dom(t, "AbortError", promise);
   }, "navigator.credentials.get() with bogus requests at both ends should skip them and not fail.");
+
+  // State machine: after a mid-flight abort via AbortSignal, the coordinator
+  // must return to the idle state so a subsequent get() works.
+  promise_test(async (t) => {
+    const ac1 = new AbortController();
+    await test_driver.bless("user activation");
+    const p1 = navigator.credentials.get(makeGetOptions({ signal: ac1.signal }));
+    ac1.abort();
+    await promise_rejects_dom(t, "AbortError", DOMException, p1);
+
+    const ac2 = new AbortController();
+    await test_driver.bless("user activation");
+    const p2 = navigator.credentials.get(makeGetOptions({ signal: ac2.signal }));
+    ac2.abort();
+    await promise_rejects_dom(t, "AbortError", DOMException, p2);
+  }, "navigator.credentials.get() returns coordinator to idle after mid-flight abort.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/encryption-info-validation.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/encryption-info-validation.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS EncryptionInfo protocol tag 'evil' instead of 'dcapi' is rejected.
+PASS EncryptionInfo with empty protocol tag is rejected.
+PASS EncryptionInfo missing nonce field is rejected.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/encryption-info-validation.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/encryption-info-validation.https.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<title>Digital Credential API: org-iso-mdoc EncryptionInfo validation</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body></body>
+<script type="module">
+
+// Tests for ISO 18013-7 Annex C EncryptionInfo structure validation.
+// EncryptionInfo = ["dcapi", {"nonce": bstr(>=16), "recipientPublicKey": COSE_Key}]
+
+// Minimal CBOR encoder (inline for test self-containment)
+function cborHead(mt, val) {
+  const m = mt << 5;
+  if (val < 24) return [m | val];
+  if (val < 256) return [m | 24, val];
+  if (val < 65536) return [m | 25, val >> 8, val & 0xff];
+  return [m | 26, (val >> 24) & 0xff, (val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff];
+}
+function cborUint(v) { return cborHead(0, v); }
+function cborNegInt(v) { return cborHead(1, -1 - v); }
+function cborBstr(bytes) { return [...cborHead(2, bytes.length), ...bytes]; }
+function cborTstr(s) { const b = new TextEncoder().encode(s); return [...cborHead(3, b.length), ...b]; }
+function cborArray(items) { return [...cborHead(4, items.length), ...items.flat()]; }
+function cborMapFromPairs(pairs) {
+  return [...cborHead(5, pairs.length), ...pairs.flatMap(([k, v]) => [...k, ...v])];
+}
+function toBase64url(bytes) {
+  return btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+// Valid P-256 point (from Martijn's Annex C reference vectors, verified on curve)
+function validCoseKey() {
+  const x = [0x60,0xe3,0x39,0x23,0x85,0x04,0x1f,0x51,0x40,0x30,0x51,0xf2,0x41,0x55,0x31,0xcb,
+             0x56,0xdd,0x3f,0x99,0x9c,0x71,0x68,0x70,0x13,0xaa,0xc6,0x76,0x8b,0xc8,0x18,0x7e];
+  const y = [0xe5,0x8d,0xeb,0x8f,0xdb,0xe9,0x07,0xf7,0xdd,0x53,0x68,0x24,0x55,0x51,0xa3,0x47,
+             0x96,0xf7,0xd2,0x21,0x5c,0x44,0x0c,0x33,0x9b,0xb0,0xf7,0xb6,0x7b,0xec,0xcd,0xfa];
+  return cborMapFromPairs([
+    [cborUint(1), cborUint(2)],
+    [cborNegInt(-1), cborUint(1)],
+    [cborNegInt(-2), cborBstr(x)],
+    [cborNegInt(-3), cborBstr(y)],
+  ]);
+}
+
+function validNonce(len = 16) {
+  return new Array(len).fill(0xab);
+}
+
+function makeEncryptionInfo(protocolTag, params) {
+  return cborArray([cborTstr(protocolTag), params]);
+}
+
+// Valid DeviceRequest (ISO 18013-7 Annex C reference vector)
+const VALID_DR = "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWFyiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4xomtmYW1pbHlfbmFtZfRvZG9jdW1lbnRfbnVtYmVy9A";
+
+async function assertRejectsGracefully(t, deviceRequest, encryptionInfo) {
+  const options = {
+    digital: {
+      requests: [{
+        protocol: "org-iso-mdoc",
+        data: { deviceRequest, encryptionInfo }
+      }]
+    },
+  };
+
+  await test_driver.bless("user activation");
+  try {
+    await navigator.credentials.get(options);
+    assert_unreached("Should not resolve with malformed EncryptionInfo");
+  } catch (e) {
+    // An immediate abort would mask whether the malformed request was actually
+    // rejected (AbortError is a DOMException), so exclude AbortError here.
+    assert_true(
+      e instanceof TypeError || (e instanceof DOMException && e.name !== "AbortError"),
+      `Expected a non-abort rejection, got: ${e.constructor.name}: ${e.name}`
+    );
+  }
+}
+
+// --- Protocol tag tests ---
+
+promise_test(async (t) => {
+  const params = cborMapFromPairs([
+    [cborTstr("nonce"), cborBstr(validNonce())],
+    [cborTstr("recipientPublicKey"), validCoseKey()],
+  ]);
+  const ei = toBase64url(makeEncryptionInfo("evil", params));
+  await assertRejectsGracefully(t, VALID_DR, ei);
+}, "EncryptionInfo protocol tag 'evil' instead of 'dcapi' is rejected.");
+
+promise_test(async (t) => {
+  const params = cborMapFromPairs([
+    [cborTstr("nonce"), cborBstr(validNonce())],
+    [cborTstr("recipientPublicKey"), validCoseKey()],
+  ]);
+  const ei = toBase64url(makeEncryptionInfo("", params));
+  await assertRejectsGracefully(t, VALID_DR, ei);
+}, "EncryptionInfo with empty protocol tag is rejected.");
+
+// --- Nonce tests (spec: minimum entropy 16 bytes) ---
+
+promise_test(async (t) => {
+  const params = cborMapFromPairs([
+    [cborTstr("recipientPublicKey"), validCoseKey()],
+  ]);
+  const ei = toBase64url(makeEncryptionInfo("dcapi", params));
+  await assertRejectsGracefully(t, VALID_DR, ei);
+}, "EncryptionInfo missing nonce field is rejected.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/malformed-requests.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/malformed-requests.https-expected.txt
@@ -1,0 +1,13 @@
+
+PASS Empty deviceRequest and encryptionInfo are handled gracefully.
+PASS Single-character base64url strings are handled gracefully.
+PASS Base64 with padding characters (invalid base64url) is handled gracefully.
+PASS Standard base64 characters (+/) instead of base64url (-_) are handled gracefully.
+PASS Truncated CBOR (incomplete array header) is handled gracefully.
+PASS CBOR unsigned integer (wrong major type) is handled gracefully.
+PASS Indefinite-length CBOR array is handled gracefully.
+PASS CBOR with reserved additional information (28) is handled gracefully.
+PASS EncryptionInfo with protocol tag != 'dcapi' is handled gracefully.
+PASS EncryptionInfo that is a CBOR map instead of array is handled gracefully.
+PASS Very large (1MB) deviceRequest is handled gracefully without hanging.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/malformed-requests.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/malformed-requests.https.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<title>Digital Credential API: org-iso-mdoc malformed request robustness</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body></body>
+<script type="module">
+
+// These tests verify that malformed org-iso-mdoc requests are handled
+// gracefully (no crash, no hang, deterministic rejection).
+
+// When ALL requests have invalid data, the browser should reject.
+// We pair the malformed org-iso-mdoc with no other protocols,
+// so the browser has zero valid requests and must reject.
+
+async function assertMalformedMdocRequestRejects(t, deviceRequest, encryptionInfo) {
+  const options = {
+    digital: {
+      requests: [{
+        protocol: "org-iso-mdoc",
+        data: { deviceRequest, encryptionInfo }
+      }]
+    },
+  };
+
+  await test_driver.bless("user activation");
+  try {
+    await navigator.credentials.get(options);
+    assert_unreached("Malformed request should not resolve successfully");
+  } catch (e) {
+    // An immediate abort would mask whether the malformed request was actually
+    // rejected (AbortError is a DOMException), so exclude AbortError here.
+    assert_true(
+      e instanceof TypeError || (e instanceof DOMException && e.name !== "AbortError"),
+      `Expected a non-abort rejection, got ${e.constructor.name}: ${e.name}`
+    );
+  }
+}
+
+// --- Base64url malformation ---
+
+promise_test(async (t) => {
+  await assertMalformedMdocRequestRejects(t, "", "");
+}, "Empty deviceRequest and encryptionInfo are handled gracefully.");
+
+promise_test(async (t) => {
+  await assertMalformedMdocRequestRejects(t, "A", "A");
+}, "Single-character base64url strings are handled gracefully.");
+
+promise_test(async (t) => {
+  await assertMalformedMdocRequestRejects(t, "aGVsbG8=", "aGVsbG8=");
+}, "Base64 with padding characters (invalid base64url) is handled gracefully.");
+
+promise_test(async (t) => {
+  await assertMalformedMdocRequestRejects(t, "aGVs+G8/", "aGVs+G8/");
+}, "Standard base64 characters (+/) instead of base64url (-_) are handled gracefully.");
+
+// --- Valid base64url but not valid CBOR ---
+
+promise_test(async (t) => {
+  // 0x83 = CBOR array(3) with no items following (truncated)
+  await assertMalformedMdocRequestRejects(t, "gw", "gw");
+}, "Truncated CBOR (incomplete array header) is handled gracefully.");
+
+promise_test(async (t) => {
+  // 0x01 = CBOR unsigned integer 1 (not a map)
+  await assertMalformedMdocRequestRejects(t, "AQ", "AQ");
+}, "CBOR unsigned integer (wrong major type) is handled gracefully.");
+
+promise_test(async (t) => {
+  // 0x9F 0x01 0x02 0xFF = indefinite-length array (not allowed in ISO 18013)
+  await assertMalformedMdocRequestRejects(t, "nwEC_w", "nwEC_w");
+}, "Indefinite-length CBOR array is handled gracefully.");
+
+promise_test(async (t) => {
+  // 0x1C = CBOR with reserved additional information value 28
+  await assertMalformedMdocRequestRejects(t, "HA", "HA");
+}, "CBOR with reserved additional information (28) is handled gracefully.");
+
+// --- Valid CBOR but wrong EncryptionInfo structure ---
+
+promise_test(async (t) => {
+  // ["evil", {}] encoded as CBOR
+  const wrongTag = "gmRldmlsoA";
+  await assertMalformedMdocRequestRejects(t, wrongTag, wrongTag);
+}, "EncryptionInfo with protocol tag != 'dcapi' is handled gracefully.");
+
+promise_test(async (t) => {
+  // {"protocol": "dcapi"} encoded as CBOR (map instead of array)
+  const notArray = "oWhwcm90b2NvbGVkY2FwaQ";
+  await assertMalformedMdocRequestRejects(t, notArray, notArray);
+}, "EncryptionInfo that is a CBOR map instead of array is handled gracefully.");
+
+// --- Resource exhaustion ---
+
+promise_test(async (t) => {
+  const huge = "A".repeat(1048576);
+  await assertMalformedMdocRequestRejects(t, huge, huge);
+}, "Very large (1MB) deviceRequest is handled gracefully without hanging.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/mixed-requests.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/mixed-requests.https-expected.txt
@@ -1,0 +1,9 @@
+
+PASS All org-iso-mdoc requests invalid: API rejects (no valid request survives).
+PASS Invalid org-iso-mdoc + valid openid4vp: openid4vp request proceeds (abort confirms it was accepted).
+PASS One valid org-iso-mdoc among garbage: valid request survives, flow proceeds.
+PASS Failed request does not poison the coordinator state for subsequent valid requests.
+PASS 100 invalid org-iso-mdoc requests are handled without hanging.
+PASS Numeric values in deviceRequest/encryptionInfo are coerced to strings and handled gracefully.
+PASS Object/Array values in deviceRequest/encryptionInfo are handled gracefully.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/mixed-requests.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/mixed-requests.https.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Digital Credential API: org-iso-mdoc mixed valid/invalid request handling</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+
+// Tests that verify behavior when multiple org-iso-mdoc requests are sent
+// with a mix of valid and invalid data. Per the WebKit implementation,
+// invalid requests are silently dropped; if at least one survives validation,
+// the flow proceeds. If ALL fail, the request should reject.
+//
+// These tests also cover the case where org-iso-mdoc is mixed with other
+// protocols (openid4vp) to verify cross-protocol isolation.
+
+import { makeGetOptions } from "../support/helper.js";
+
+// Valid ISO 18013-7 Annex C reference vectors (proven to trigger wallet prompt)
+const VALID_DR = "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWFyiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4xomtmYW1pbHlfbmFtZfRvZG9jdW1lbnRfbnVtYmVy9A";
+const VALID_EI = "gmVkY2FwaaJlbm9uY2VQuTBR9ybYyMxHk586vsBGt3JyZWNpcGllbnRQdWJsaWNLZXmkAQIgASFYIGDjOSOFBB9RQDBR8kFVMctW3T-ZnHFocBOqxnaLyBh-Ilgg5Y3rj9vpB_fdU2gkVVGjR5b30iFcRAwzm7D3tnvszfo";
+const GARBAGE_DR = "not-valid-cbor-at-all";
+const GARBAGE_EI = "also-not-valid";
+
+// --- All invalid org-iso-mdoc requests should reject ---
+
+promise_test(async (t) => {
+  const options = {
+    digital: {
+      requests: [
+        { protocol: "org-iso-mdoc", data: { deviceRequest: GARBAGE_DR, encryptionInfo: GARBAGE_EI } },
+        { protocol: "org-iso-mdoc", data: { deviceRequest: "", encryptionInfo: "" } },
+        { protocol: "org-iso-mdoc", data: { deviceRequest: "AQ", encryptionInfo: "AQ" } },
+      ]
+    }
+  };
+  await test_driver.bless("user activation");
+  // All requests fail validation and are dropped, leaving an empty set of
+  // validated requests; per the get() algorithm an empty set rejects with a
+  // TypeError, not a DOMException.
+  await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
+}, "All org-iso-mdoc requests invalid: API rejects (no valid request survives).");
+
+// --- Mix of invalid org-iso-mdoc with valid openid4vp should still work ---
+
+promise_test(async (t) => {
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  const [openidReq] = makeGetOptions({ protocol: "openid4vp-v1-unsigned" }).digital.requests;
+
+  const options = {
+    digital: {
+      requests: [
+        { protocol: "org-iso-mdoc", data: { deviceRequest: GARBAGE_DR, encryptionInfo: GARBAGE_EI } },
+        openidReq,
+      ]
+    },
+    signal,
+  };
+
+  await test_driver.bless("user activation");
+  const promise = navigator.credentials.get(options);
+  controller.abort();
+  await promise_rejects_dom(t, "AbortError", promise);
+}, "Invalid org-iso-mdoc + valid openid4vp: openid4vp request proceeds (abort confirms it was accepted).");
+
+// --- Multiple org-iso-mdoc requests: one valid, others garbage ---
+
+promise_test(async (t) => {
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  const options = {
+    digital: {
+      requests: [
+        { protocol: "org-iso-mdoc", data: { deviceRequest: GARBAGE_DR, encryptionInfo: GARBAGE_EI } },
+        { protocol: "org-iso-mdoc", data: { deviceRequest: VALID_DR, encryptionInfo: VALID_EI } },
+        { protocol: "org-iso-mdoc", data: { deviceRequest: "", encryptionInfo: "" } },
+      ]
+    },
+    signal,
+  };
+
+  await test_driver.bless("user activation");
+  const promise = navigator.credentials.get(options);
+  // If the valid request survived validation, the promise should be pending
+  // (waiting for wallet interaction). Abort to confirm it proceeded.
+  controller.abort();
+  await promise_rejects_dom(t, "AbortError", promise);
+}, "One valid org-iso-mdoc among garbage: valid request survives, flow proceeds.");
+
+// --- Invalid request should not poison subsequent valid request ---
+
+promise_test(async (t) => {
+  // First: a request with all garbage (should reject)
+  const garbageOptions = {
+    digital: {
+      requests: [
+        { protocol: "org-iso-mdoc", data: { deviceRequest: GARBAGE_DR, encryptionInfo: GARBAGE_EI } },
+      ]
+    }
+  };
+  await test_driver.bless("user activation");
+  await promise_rejects_js(t, TypeError, navigator.credentials.get(garbageOptions));
+
+  // Second: a request with valid data (should proceed)
+  const controller = new AbortController();
+  const { signal } = controller;
+  const validOptions = {
+    digital: {
+      requests: [
+        { protocol: "org-iso-mdoc", data: { deviceRequest: VALID_DR, encryptionInfo: VALID_EI } },
+      ]
+    },
+    signal,
+  };
+  await test_driver.bless("user activation");
+  const promise = navigator.credentials.get(validOptions);
+  controller.abort();
+  await promise_rejects_dom(t, "AbortError", promise);
+}, "Failed request does not poison the coordinator state for subsequent valid requests.");
+
+// --- Extremely large number of invalid requests in one call ---
+
+promise_test(async (t) => {
+  const requests = [];
+  for (let i = 0; i < 100; i++) {
+    requests.push({
+      protocol: "org-iso-mdoc",
+      data: { deviceRequest: `garbage-${i}`, encryptionInfo: `garbage-${i}` }
+    });
+  }
+  const options = { digital: { requests } };
+  await test_driver.bless("user activation");
+
+  // Should reject without hanging (all 100 fail validation)
+  const startTime = performance.now();
+  try {
+    await navigator.credentials.get(options);
+    assert_unreached("100 invalid requests should not succeed");
+  } catch (e) {
+    const elapsed = performance.now() - startTime;
+    assert_less_than(elapsed, 10000, "Should reject within 10 seconds (no hang)");
+  }
+}, "100 invalid org-iso-mdoc requests are handled without hanging.");
+
+// --- Data field type coercion edge cases ---
+
+promise_test(async (t) => {
+  // data.deviceRequest and data.encryptionInfo are required DOMStrings
+  // What happens with numeric values that coerce to strings?
+  const options = {
+    digital: {
+      requests: [{
+        protocol: "org-iso-mdoc",
+        data: { deviceRequest: 12345, encryptionInfo: 67890 }
+      }]
+    }
+  };
+  await test_driver.bless("user activation");
+  // Number coerces to string "12345" which is not valid base64url CBOR
+  try {
+    await navigator.credentials.get(options);
+    assert_unreached("Numeric deviceRequest should not succeed");
+  } catch (e) {
+    assert_true(
+      e instanceof TypeError || e instanceof DOMException,
+      "Numeric coercion handled gracefully"
+    );
+  }
+}, "Numeric values in deviceRequest/encryptionInfo are coerced to strings and handled gracefully.");
+
+promise_test(async (t) => {
+  // Object values that would stringify to "[object Object]"
+  const options = {
+    digital: {
+      requests: [{
+        protocol: "org-iso-mdoc",
+        data: { deviceRequest: {nested: "object"}, encryptionInfo: [1,2,3] }
+      }]
+    }
+  };
+  await test_driver.bless("user activation");
+  try {
+    await navigator.credentials.get(options);
+    assert_unreached("Object deviceRequest should not succeed");
+  } catch (e) {
+    assert_true(
+      e instanceof TypeError || e instanceof DOMException,
+      "Object coercion handled gracefully"
+    );
+  }
+}, "Object/Array values in deviceRequest/encryptionInfo are handled gracefully.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/origin-binding.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/origin-binding.https.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Digital Credential API: org-iso-mdoc origin binding scenarios</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body>
+  <iframe id="cross-origin" allow="digital-credentials-get"></iframe>
+  <iframe id="sandboxed" sandbox="allow-scripts" allow="digital-credentials-get"></iframe>
+  <iframe id="same-origin"></iframe>
+</body>
+<script type="module">
+import { makeGetOptions, sendMessage, loadIframe } from "../support/helper.js";
+
+// Tests for origin binding behavior with org-iso-mdoc.
+//
+// ISO 18013-7 C.5 specifies:
+//   dcapiInfo = [Base64EncryptionInfo, SerializedOrigin]
+//   The mdoc shall use the origin received from the API.
+//   If the mdoc does not receive the origin, it shall abort.
+//
+// The browser passes the TOP-LEVEL origin to the framework.
+// These tests verify that origin handling is correct across
+// iframe, cross-origin, and sandbox scenarios.
+
+const iframeCrossOrigin = document.querySelector("#cross-origin");
+const iframeSandboxed = document.querySelector("#sandboxed");
+const iframeSameOrigin = document.querySelector("#same-origin");
+
+promise_setup(async () => {
+  const hostInfo = get_host_info();
+  await Promise.all([
+    loadIframe(
+      iframeCrossOrigin,
+      `${hostInfo.HTTPS_REMOTE_ORIGIN}/digital-credentials/support/iframe.html`
+    ),
+    loadIframe(
+      iframeSandboxed,
+      "/digital-credentials/support/iframe.html"
+    ),
+    loadIframe(
+      iframeSameOrigin,
+      "/digital-credentials/support/iframe.html"
+    ),
+  ]);
+});
+
+// --- Sandboxed iframe with opaque origin ---
+
+promise_test(async (t) => {
+  // A sandboxed iframe has an opaque origin.
+  // The DC API should either reject (no valid origin to pass to wallet)
+  // or the wallet should abort (origin is "null").
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+  const result = await sendMessage(iframeSandboxed, {
+    action: "get",
+    needsActivation: true,
+    options,
+  });
+
+  // Expect rejection: either NotAllowedError (permissions policy blocks it
+  // because sandboxed iframe without allow-same-origin can't use the feature)
+  // or TypeError (opaque origin)
+  assert_true(
+    result.constructor === "DOMException" || result.constructor === "TypeError",
+    `Sandboxed iframe should fail, got: ${result.constructor} ${result.name || ''}`
+  );
+}, "org-iso-mdoc request from sandboxed iframe (opaque origin) is rejected.");
+
+// --- Cross-origin iframe (allowed via permissions policy) ---
+
+promise_test(async (t) => {
+  // Cross-origin iframe with digital-credentials-get permission.
+  // The request should proceed, using the TOP-LEVEL origin for the
+  // SessionTranscript (not the iframe's origin).
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+
+  const result = await sendMessage(iframeCrossOrigin, {
+    abort: "after",
+    action: "get",
+    needsActivation: true,
+    options,
+  });
+
+  // Should get AbortError (meaning the request was accepted and was pending
+  // before we aborted). NotAllowedError would mean it was rejected outright.
+  assert_equals(result.constructor, "DOMException");
+  assert_equals(result.name, "AbortError",
+    "Cross-origin iframe request should proceed (then abort), not be rejected");
+}, "org-iso-mdoc request from cross-origin iframe (with permission) proceeds with top-level origin.");
+
+// --- Same-origin iframe ---
+
+promise_test(async (t) => {
+  // Same-origin iframe: origin should match top-level (they're the same).
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+
+  const result = await sendMessage(iframeSameOrigin, {
+    abort: "after",
+    action: "get",
+    needsActivation: true,
+    options,
+  });
+
+  assert_equals(result.constructor, "DOMException");
+  assert_equals(result.name, "AbortError",
+    "Same-origin iframe request should proceed (then abort)");
+}, "org-iso-mdoc request from same-origin iframe proceeds normally.");
+
+// --- Cross-origin iframe WITHOUT permission policy ---
+
+promise_test(async (t) => {
+  // Create a cross-origin iframe without the allow attribute
+  const hostInfo = get_host_info();
+  const iframe = document.createElement("iframe");
+  // No allow="digital-credentials-get"
+  document.body.appendChild(iframe);
+  t.add_cleanup(() => iframe.remove());
+
+  await loadIframe(iframe, `${hostInfo.HTTPS_REMOTE_ORIGIN}/digital-credentials/support/iframe.html`);
+
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+  const result = await sendMessage(iframe, {
+    action: "get",
+    needsActivation: true,
+    options,
+  });
+
+  assert_equals(result.constructor, "DOMException");
+  assert_equals(result.name, "NotAllowedError",
+    "Cross-origin iframe without permission policy should be rejected with NotAllowedError");
+}, "org-iso-mdoc request from cross-origin iframe WITHOUT permission is rejected.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/response-handling.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/response-handling.https.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Digital Credential API: org-iso-mdoc response handling</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+import { makeGetOptions } from "../support/helper.js";
+
+// Tests for org-iso-mdoc response handling.
+// Uses the WebDriver BiDi virtual wallet to inject mock responses.
+//
+// Key architectural fact: the browser does NOT validate the Annex C
+// EncryptedResponse CBOR. It passes the response object through to
+// the site as credential.data. The site (as the verifier) is responsible
+// for base64url decoding, CBOR parsing, and HPKE decryption.
+//
+// These tests verify:
+// 1. The browser correctly passes through response data
+// 2. The credential.protocol is set correctly
+// 3. The response shape matches what the site expects
+
+async function setMockResponse(t, responseObj) {
+  await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", responseObj);
+  t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+}
+
+// --- Response passthrough tests ---
+
+promise_test(async (t) => {
+  // ISO 18013-7 Annex C.3: { "response": Base64EncryptedResponse }
+  const responseData = { response: "gmVkY2FwaaJjZW5jWEEEAAAAAAAA" };
+  await setMockResponse(t, responseData);
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+  const result = await navigator.credentials.get(options);
+
+  assert_equals(result.protocol, "org-iso-mdoc");
+  assert_equals(result.data.response, "gmVkY2FwaaJjZW5jWEEEAAAAAAAA");
+}, "org-iso-mdoc response is passed through with correct protocol and data.");
+
+promise_test(async (t) => {
+  // Response with the full Annex C structure as the site would receive it
+  const responseData = { response: "gmVkY2FwaaJjZW5jWCEEq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6tqY2lwaGVyVGV4dFhAq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urqw" };
+  await setMockResponse(t, responseData);
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+  const result = await navigator.credentials.get(options);
+
+  assert_equals(result.protocol, "org-iso-mdoc");
+  assert_true("response" in result.data, "Response object has 'response' field");
+  assert_equals(typeof result.data.response, "string", "Response field is a string");
+}, "org-iso-mdoc response with Annex C shaped data preserves the response string.");
+
+promise_test(async (t) => {
+  // Verify the browser doesn't modify the response data
+  const originalResponse = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  const responseData = { response: originalResponse };
+  await setMockResponse(t, responseData);
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+  const result = await navigator.credentials.get(options);
+
+  assert_equals(result.data.response, originalResponse,
+    "Browser must not modify the response string (no re-encoding, no validation)");
+}, "Response data is passed through byte-for-byte without modification.");
+
+promise_test(async (t) => {
+  // Empty response string (site would fail to decode, but browser should pass through)
+  const responseData = { response: "" };
+  await setMockResponse(t, responseData);
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+  const result = await navigator.credentials.get(options);
+
+  assert_equals(result.protocol, "org-iso-mdoc");
+  assert_equals(result.data.response, "");
+}, "Empty response string is passed through (validation is the site's responsibility).");
+
+promise_test(async (t) => {
+  // Extra fields beyond 'response' (future extensibility)
+  const responseData = { response: "gmVkY2FwaQ", extra: "field", version: 2 };
+  await setMockResponse(t, responseData);
+  await test_driver.bless("user activation");
+
+  const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+  const result = await navigator.credentials.get(options);
+
+  assert_equals(result.protocol, "org-iso-mdoc");
+  assert_equals(result.data.response, "gmVkY2FwaQ");
+  assert_equals(result.data.extra, "field");
+  assert_equals(result.data.version, 2);
+}, "Additional fields in the response object are preserved.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/valid-roundtrip.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/valid-roundtrip.https.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Digital Credential API: org-iso-mdoc valid request/response (ISO 18013-7 Annex C)</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+
+// Golden-path tests using ISO/IEC 18013-7 2nd edition Annex C reference vectors.
+// These prove a correctly-formed org-iso-mdoc request/response round-trip works.
+//
+// Vectors provided by Martijn Haring (ISO/IEC JTC 1/SC 17/WG 10).
+// Origin: https://example.com
+// DocType: org.iso.18013.5.1.mDL
+// Elements: family_name ("Doe"), document_number ("123456789")
+//
+// Requires: WebDriver BiDi virtual wallet (PR #381)
+
+// --- Reference vectors (ISO 18013-7 Annex C example) ---
+
+const VALID_REQUEST = {
+  deviceRequest: "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWFyiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4xomtmYW1pbHlfbmFtZfRvZG9jdW1lbnRfbnVtYmVy9A",
+  encryptionInfo: "gmVkY2FwaaJlbm9uY2VQuTBR9ybYyMxHk586vsBGt3JyZWNpcGllbnRQdWJsaWNLZXmkAQIgASFYIGDjOSOFBB9RQDBR8kFVMctW3T-ZnHFocBOqxnaLyBh-Ilgg5Y3rj9vpB_fdU2gkVVGjR5b30iFcRAwzm7D3tnvszfo",
+};
+
+const VALID_RESPONSE = {
+  response: "gmVkY2FwaaJjZW5jWEEEWojRgrzl9C76WZQ_MzWdLoqWj_KJ2T5fpES2JDQxZ_6xboz4WN3HaQQHumHUwzgjeoz8895qpnL8YKVXqjL8Z2pjaXBoZXJUZXh0WQZ0BAaypQYA8xz2vVLOT99canhuSsGJgQnuxY3DjkvXz14-8lRNZqdh3Y3znCLw3sJLnylnAAhLiOA_X0sRnwkOkQjFT4PWzkyARAPcW7B35URx1de1rdSV-t5-Ei9v1oRGuvzDHrXRwOHhSaXolE4Sv5O_kSsYscfBcAj2jD6mQRqjND0UDFozBZdZzlCuESx5yoz6bWMGSjiM5iixj6Q0XhJ1WMZX9p-b6xLcNxxDXpZyVVJAmLeBWkT4qKwQyf40NlMRBC6hDsRcQB7dwnZUKowyNY8jaSwjLbdToYtJ-dPQ5vXuf9gmYVsDsm5AYCX-udOhnz70oJyLtkyu5wvRE8BCRrbZiwPPcZjx1JU7ARM7Sf_P3qfyxNDO7HlxVdBOAIColO20_kxmyU-FBTGeRknXHwf4VJY9Fw8wf0sawmjycNgx1lS471cQbZBjkscpBLmtorAsSHfA-Be-8EnSqwRLgWqQe0SjW3p6vMicTKx27x8N74P-4KqwiVAVbUQNFioWtBd5ipiDHs8fpGvB3yBiAoSQzCN32Ax0-cXhzocQdeOM5N4F_abDNV_R01ucVMV6RpK2dBHQEIpmyvBUwgxJi4uMCsuFi43Vw5cuJUOZCap-G1n7MngDMsfZmHq2DxWso9qaYI-NkxddWS_nGMEByzbLIud_OfKzzbr6HRkiy-XWnPLOTEw7q9nbv4z4dIBD4eKeH3TOz1V8WjHlxZi1oowIy-GSh0lenVyeZinizCcVyY8a_CnKngP4X6fjSDRS9hB5v1pcyiR6PpdUr3Ui9A1m4W3DxJCxAl0LvtvASmUDpR_R38RUYXx46VD3cU_r-j7oEcc121zTq0aO-VRwOCj0OTAtS2Z_LxR6wjHvKXP0XAyNcm1PX12kf3eeD6edPVOEnJ11iJ-pNe5uGuTbpLSIjpG1J3qv0YukHvPj74rSRpU4J7mpGJRDnJqb7v_XTqTUFO2OPm-UsmwBfxVg5zqXtmoVXFsZZ9s7izTx-gdQaKdrKXrftEPvKoi4mb4Z_jamrSHhw70fieF9wKwMaeH8ih-fLF6jN5go4s-GRigA_JVEASGO4vwZ3TQPgo20ij8z-mbbZonOkbeyZZA4FIHkuwovft1lPSzecaTeljqE7ntJhmxMzM9c8jGcbq5PxmmnvV53JhOupXzeOu8pre6_k_YWWH0LV-IbUWo4twjGre-OhhmseUPoqCMjDPW9lxJ_mnCyD_EPvdRChOwaRxdfFacIDIE39-qPHrQhZVXhiIMhJlLenBFRbgolfUATS2KuiKNy9PvhFlGdZ_pBfBgPIj3iZBq3Tdr9dTJt_HRDsUZ7Gg15vbQvx3QrKa_NLkMUDRoVtLz0ir3d15pMc3K3GrD6JI8RcfGx4ILbrwbMUgUv-7iBVmf3VNTfTbTXnx0vclGiB69bREb5lJz3zPVw_SIPpc_n79JKyYwpcFZsGeyeo1oCtLYXrSjzsokm-H6QJW462ASkfM6Qy3ww45boPriWnKRzakWi6W8K3ujIBszG1jvkxzwlJS1TcHjTyamBSCOJ5213l0wak8Gfg2dN-eq157ZxqtJ-DDw8c1JtOTg7dLyykQp2re8LfHbUdAkxgccO89u6eyL4_ifGFiUpO4wcx_URQ-hINLSCfbti2jp8946uQn2BByzBWHXS_RZ7bH9vdHukUOMNuTjmgDmpp84z3EuOOTdlbEGB01avgbk4s3APKDwhcvE-YttKkvT7s040KyWqItzxkuA3uJtu6b9z98bonLAjZlNYqvZOVvuwo3VT0D4kqsPbKeKzBPy-pDPpM5eDPrgsZdBRQDxJtyrPYqh0wwtDGEk2VDsa-taG6_pWC-YHTZeGd6WP5zZvZ8HsJeWhzhgmGj9QE-vCDguyhHHgSRRYzIwHLfRGdKTFxRdQ6nG_6fx7criSK-RljLv0i7ETheMGAlAqk3rajCGYZRYEa-qrhoCpYFZJEf92yI65iqYcJJScgg6fVZ4yc7U2F-LTywuufOKA0flzGIFmD-01qzw1xaw3SsQwAwgdWT7Hvwc8TwbJ2NpFwiREUtD37k_TV5s1HLxZP9GCQgPzMvO3rxmf1w5yslTjth86XK-oF5q7G8LqxThLL8mq4pct8Kbj_OHRrVvmClnIrewOybtW1CYrXNIeNE5ld8sItpGe0yTN2gHZ_ct2llLJidFf0rEeuz63q3lnVl0",
+};
+
+// --- Tests ---
+
+promise_test(async (t) => {
+  await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", VALID_RESPONSE);
+  t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+  await test_driver.bless("user activation");
+
+  const options = {
+    digital: {
+      requests: [{
+        protocol: "org-iso-mdoc",
+        data: VALID_REQUEST,
+      }]
+    }
+  };
+
+  const credential = await navigator.credentials.get(options);
+
+  assert_equals(credential.protocol, "org-iso-mdoc",
+    "Protocol should be org-iso-mdoc");
+  assert_equals(credential.type, "digital",
+    "Credential type should be 'digital'");
+  assert_true(credential.data !== null && credential.data !== undefined,
+    "Credential data should be present");
+  assert_equals(credential.data.response, VALID_RESPONSE.response,
+    "Response data should match what the wallet returned");
+}, "Valid ISO 18013-7 Annex C request/response round-trip succeeds.");
+
+promise_test(async (t) => {
+  await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", VALID_RESPONSE);
+  t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+  await test_driver.bless("user activation");
+
+  const options = {
+    digital: {
+      requests: [{
+        protocol: "org-iso-mdoc",
+        data: VALID_REQUEST,
+      }]
+    }
+  };
+
+  const credential = await navigator.credentials.get(options);
+
+  // Verify the response contains the expected structure:
+  // EncryptedResponse = ["dcapi", {"enc": bstr, "cipherText": bstr}]
+  // encoded as base64url CBOR
+  const responseStr = credential.data.response;
+  assert_equals(typeof responseStr, "string", "Response should be a string");
+  assert_greater_than(responseStr.length, 0, "Response should not be empty");
+
+  // The response starts with the CBOR encoding of ["dcapi", ...]
+  // (array(2) + text string "dcapi"); its leading base64url chars are "gmVkY2Fwa".
+  assert_true(responseStr.startsWith("gmVkY2Fwa"),
+    "Response should start with CBOR-encoded ['dcapi', ...] prefix");
+}, "Valid response contains expected Annex C EncryptedResponse structure prefix.");
+
+promise_test(async (t) => {
+  await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", VALID_RESPONSE);
+  t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+  await test_driver.bless("user activation");
+
+  // Request with both org-iso-mdoc and openid4vp protocols
+  const options = {
+    digital: {
+      requests: [
+        { protocol: "org-iso-mdoc", data: VALID_REQUEST },
+        { protocol: "openid4vp-v1-unsigned", data: { dcql_query: { credentials: [] }, nonce: "test" } },
+      ]
+    }
+  };
+
+  const credential = await navigator.credentials.get(options);
+
+  // The wallet responded with org-iso-mdoc, so that's what we should get
+  assert_equals(credential.protocol, "org-iso-mdoc");
+  assert_equals(credential.data.response, VALID_RESPONSE.response);
+}, "Valid org-iso-mdoc request alongside other protocols: wallet response selects org-iso-mdoc.");
+
+promise_test(async (t) => {
+  await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", VALID_RESPONSE);
+  t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+  await test_driver.bless("user activation");
+
+  // Two identical org-iso-mdoc requests (e.g., different document types in real use)
+  const options = {
+    digital: {
+      requests: [
+        { protocol: "org-iso-mdoc", data: VALID_REQUEST },
+        { protocol: "org-iso-mdoc", data: VALID_REQUEST },
+      ]
+    }
+  };
+
+  const credential = await navigator.credentials.get(options);
+  assert_equals(credential.protocol, "org-iso-mdoc");
+  assert_equals(credential.data.response, VALID_RESPONSE.response);
+}, "Multiple valid org-iso-mdoc requests in a single call: succeeds.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/w3c-import.log
@@ -1,0 +1,22 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/encryption-info-validation.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/malformed-requests.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/mixed-requests.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/origin-binding.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/response-handling.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/valid-roundtrip.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-mdoc.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-mdoc.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Valid protocol 'org-iso-mdoc' passes through filtering
+PASS Protocol matching is case sensitive - 'ORG-ISO-MDOC' filtered
+PASS Empty protocol string is filtered out
+PASS Protocol with leading whitespace is filtered out
+PASS Protocol with trailing whitespace is filtered out
+PASS Partial protocol match 'org-iso' is filtered out
+PASS Protocol with invalid characters 'org_iso_mdoc' is filtered out
+PASS Unknown protocol 'unknown-protocol' is filtered out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-mdoc.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-mdoc.https.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Digital Credential API: Protocol Filtering (org-iso-mdoc)</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import { makeGetOptions, makeGetOptionsWithArbitraryProtocol } from "./support/helper.js";
+
+  promise_test(async (t) => {
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    const options = makeGetOptions({ protocol: "org-iso-mdoc", signal });
+    await test_driver.bless("user activation");
+    const promise = navigator.credentials.get(options);
+    abortController.abort();
+    await promise_rejects_dom(
+      t,
+      "AbortError",
+      promise,
+      "Valid protocol should not throw TypeError"
+    );
+  }, "Valid protocol 'org-iso-mdoc' passes through filtering");
+
+  promise_test(async (t) => {
+    const options = makeGetOptionsWithArbitraryProtocol("ORG-ISO-MDOC");
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.get(options)
+    );
+  }, "Protocol matching is case sensitive - 'ORG-ISO-MDOC' filtered");
+
+  promise_test(async (t) => {
+    const options = makeGetOptionsWithArbitraryProtocol("");
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.get(options)
+    );
+  }, "Empty protocol string is filtered out");
+
+  promise_test(async (t) => {
+    const options = makeGetOptionsWithArbitraryProtocol(" org-iso-mdoc");
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.get(options)
+    );
+  }, "Protocol with leading whitespace is filtered out");
+
+  promise_test(async (t) => {
+    const options = makeGetOptionsWithArbitraryProtocol("org-iso-mdoc ");
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.get(options)
+    );
+  }, "Protocol with trailing whitespace is filtered out");
+
+  promise_test(async (t) => {
+    const options = makeGetOptionsWithArbitraryProtocol("org-iso");
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.get(options)
+    );
+  }, "Partial protocol match 'org-iso' is filtered out");
+
+  promise_test(async (t) => {
+    const options = makeGetOptionsWithArbitraryProtocol("org_iso_mdoc");
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.get(options)
+    );
+  }, "Protocol with invalid characters 'org_iso_mdoc' is filtered out");
+
+  promise_test(async (t) => {
+    const options = makeGetOptionsWithArbitraryProtocol("unknown-protocol");
+    await promise_rejects_js(
+      t,
+      TypeError,
+      navigator.credentials.get(options)
+    );
+  }, "Unknown protocol 'unknown-protocol' is filtered out");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-openid4vp.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-openid4vp.https.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Digital Credential API: Protocol Filtering (openid4vp)</title>
+<link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import {
+    makeGetOptions,
+    makeGetOptionsWithArbitraryProtocol,
+  } from "./support/helper.js";
+
+  const validProtocols = [
+    "openid4vp-v1-unsigned",
+    "openid4vp-v1-signed",
+    "openid4vp-v1-multisigned",
+  ];
+
+  for (const protocol of validProtocols) {
+    promise_test(async (t) => {
+      const abortController = new AbortController();
+      const { signal } = abortController;
+      const options = makeGetOptions({ protocol, signal });
+      await test_driver.bless("user activation");
+      const promise = navigator.credentials.get(options);
+      abortController.abort();
+      await promise_rejects_dom(
+        t,
+        "AbortError",
+        promise,
+        `Valid protocol '${protocol}' should not throw TypeError`
+      );
+    }, `Valid protocol '${protocol}' passes through filtering`);
+  }
+
+  const filteredProtocols = [
+    ["openid4vp", "bare identifier without version or mode"],
+    ["openid4vp-v1", "version without mode"],
+    ["openid4vp-v2-unsigned", "wrong version number"],
+    ["openid4vp-v1-unknown", "valid prefix with unknown mode"],
+    ["OPENID4VP-V1-UNSIGNED", "uppercase variant"],
+    ["Openid4vp-V1-Unsigned", "mixed case variant"],
+    [" openid4vp-v1-unsigned", "leading whitespace"],
+    ["openid4vp-v1-unsigned ", "trailing whitespace"],
+    ["openid4vp-v1-unsigned\t", "trailing tab"],
+    ["openid4vp_v1_unsigned", "underscores instead of hyphens"],
+  ];
+
+  for (const [protocol, description] of filteredProtocols) {
+    promise_test(async (t) => {
+      const options = makeGetOptionsWithArbitraryProtocol(protocol);
+      await promise_rejects_js(
+        t,
+        TypeError,
+        navigator.credentials.get(options)
+      );
+    }, `Filtered: '${protocol}' (${description})`);
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
@@ -126,9 +126,9 @@ const CANONICAL_REQUEST_OBJECTS = {
   /** @type MobileDocumentRequest **/
   "org-iso-mdoc": {
     deviceRequest:
-      "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWIKiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4x9pWthZ2Vfb3Zlcl8yMfRqZ2l2ZW5fbmFtZfRrZmFtaWx5X25hbWX0cmRyaXZpbmdfcHJpdmlsZWdlc_RocG9ydHJhaXT0",
+      "omd2ZXJzaW9uYzEuMGtkb2NSZXF1ZXN0c4GhbGl0ZW1zUmVxdWVzdNgYWFyiZ2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4xomtmYW1pbHlfbmFtZfRvZG9jdW1lbnRfbnVtYmVy9A",
     encryptionInfo:
-      "gmVkY2FwaaJlbm9uY2VYICBetSsDkKlE_G9JSIHwPzr3ctt6Ol9GgmCH8iGdGQNJcnJlY2lwaWVudFB1YmxpY0tleaQBAiABIVggKKm1iPeuOb9bDJeeJEL4QldYlWvY7F_K8eZkmYdS9PwiWCCm9PLEmosiE_ildsE11lqq4kDkjhfQUKPpbX-Hm1ZSLg",
+      "gmVkY2FwaaJlbm9uY2VQuTBR9ybYyMxHk586vsBGt3JyZWNpcGllbnRQdWJsaWNLZXmkAQIgASFYIGDjOSOFBB9RQDBR8kFVMctW3T-ZnHFocBOqxnaLyBh-Ilgg5Y3rj9vpB_fdU2gkVVGjR5b30iFcRAwzm7D3tnvszfo",
   },
 };
 
@@ -211,6 +211,40 @@ const allMappings = {
     },
   },
 };
+
+/**
+ * Internal helper to handle the shared logic for creating and getting credentials.
+ * @param {"get" | "create"} type
+ * @param {Protocol} protocol
+ * @returns {DigitalCredentialGetRequest | DigitalCredentialCreateRequest}
+ */
+function makeCanonicalRequest(type, protocol) {
+  const mapping = allMappings[type];
+  if (protocol in mapping) {
+    return mapping[/** @type {keyof typeof mapping} */ (protocol)]();
+  }
+  throw new Error(`Unknown ${type} protocol: ${protocol}`);
+}
+
+/**
+ * Creates a single canonical create request for a protocol.
+ * @export
+ * @param {CreateProtocol} protocol
+ * @returns {DigitalCredentialCreateRequest}
+ */
+export function makeCanonicalCreateRequest(protocol) {
+  return makeCanonicalRequest('create', protocol);
+}
+
+/**
+ * Creates a single canonical get request for a protocol.
+ * @export
+ * @param {GetProtocol} protocol
+ * @returns {DigitalCredentialGetRequest}
+ */
+export function makeCanonicalGetRequest(protocol) {
+  return makeCanonicalRequest('get', protocol);
+}
 
 /**
  * Generic helper to create credential options from config with protocol already set.
@@ -324,4 +358,30 @@ export function loadIframe(iframe, url) {
     }
     iframe.src = url.toString();
   });
+}
+
+/**
+ * Creates options for getting credentials with an arbitrary protocol string.
+ * Unlike makeGetOptions, this doesn't validate the protocol - useful for testing
+ * invalid/unknown protocols that should be filtered out by the browser.
+ *
+ * @export
+ * @param {string} protocol - The protocol string (can be invalid/unknown)
+ * @param {object} [data={}] - The request data
+ * @param {AbortSignal} [signal] - Optional abort signal
+ * @returns {CredentialRequestOptions}
+ */
+export function makeGetOptionsWithArbitraryProtocol(protocol, data = {}, signal) {
+  /** @type {CredentialRequestOptions} */
+  const options = {
+    digital: {
+      requests: [{ protocol, data }]
+    }
+  };
+
+  if (signal) {
+    options.signal = signal;
+  }
+
+  return options;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-create.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-create.tentative.https.html
@@ -27,7 +27,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active",
     );
-    const options = makeCreateOptions({ data: BigInt(1) });
+    const options = makeCreateOptions({ data: { val: BigInt(1) } });
     await promise_rejects_dom(
       t,
       "NotAllowedError",

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS navigator.credentials.get() calling the API without user activation should reject with NotAllowedError.
-FAIL navigator.credentials.get() with non-serializable data and no user activation should reject with NotAllowedError. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
+FAIL navigator.credentials.get() with non-serializable data and no user activation should reject with NotAllowedError. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: JSON.stringify cannot serialize BigInt." that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
 PASS navigator.credentials.get() with empty protocol array and no user activation needed should reject with TypeError.
 PASS navigator.credentials.get() with early abort does not consume user activation.
 PASS navigator.credentials.get() with late abort consumes user activation.

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https.html
@@ -27,7 +27,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active",
     );
-    const options = makeGetOptions({ data: BigInt(1) });
+    const options = makeGetOptions({ data: { val: BigInt(1) } });
     await promise_rejects_dom(
       t,
       "NotAllowedError",

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/w3c-import.log
@@ -17,6 +17,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-create.https.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create-enabled-on-self-origin-by-permissions-policy.https.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create-enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create-non-fully-active.https.html
@@ -35,6 +36,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.https.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/historical.any.js
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-secure-contexts.http.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-mdoc.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-openid4vp.https.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/tsconfig.json
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-create.tentative.https.html
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/create.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/create.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>Digital Credential API: create() webdriver tests.</title>
+<link rel="help" href="https://wicg.github.io/digital-credentials/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import { makeCreateOptions } from "../support/helper.js";
+
+  promise_test(async (t) => {
+    const responseData = "test-create-response-data";
+    await test_driver.set_virtual_wallet_behavior("respond", "openid4vci", { "value": responseData });
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeCreateOptions({ protocol: "openid4vci" });
+    const result = await navigator.credentials.create(options);
+
+    assert_equals(result.protocol, "openid4vci");
+    assert_equals(result.data.value, responseData);
+  }, "navigator.credentials.create() with respond mode should resolve with the specified data.");
+
+  promise_test(async (t) => {
+    const complexData = { "a": 1, "b": [2, 3], "c": { "d": 4 } };
+    await test_driver.set_virtual_wallet_behavior("respond", "openid4vci", complexData);
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeCreateOptions({ protocol: "openid4vci" });
+    const result = await navigator.credentials.create(options);
+
+    assert_equals(result.protocol, "openid4vci");
+    assert_equals(result.data.a, 1);
+    assert_array_equals(result.data.b, [2, 3]);
+    assert_equals(result.data.c.d, 4);
+  }, "navigator.credentials.create() with complex data response should resolve with structured data.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("decline");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeCreateOptions({ protocol: "openid4vci" });
+    await promise_rejects_dom(t, "NotAllowedError", navigator.credentials.create(options));
+  }, "navigator.credentials.create() with decline mode should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const controller = new AbortController();
+    const options = makeCreateOptions({ protocol: "openid4vci", signal: controller.signal });
+    const promise = navigator.credentials.create(options);
+
+    // Give it some time to make sure it's pending.
+    await new Promise(resolve => t.step_timeout(resolve, 100));
+
+    controller.abort();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "navigator.credentials.create() with wait mode should remain pending until aborted.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>Digital Credential API: get() webdriver tests.</title>
+<link rel="help" href="https://wicg.github.io/digital-credentials/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import { makeGetOptions } from "../support/helper.js";
+
+  promise_test(async (t) => {
+    const responseData = "test-response-data";
+    await test_driver.set_virtual_wallet_behavior("respond", "openid4vp-v1-unsigned", { "value": responseData });
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned" });
+    const result = await navigator.credentials.get(options);
+
+    assert_equals(result.protocol, "openid4vp-v1-unsigned");
+    assert_equals(result.data.value, responseData);
+  }, "navigator.credentials.get() with respond mode should resolve with the specified data.");
+
+  promise_test(async (t) => {
+    const complexData = { "a": 1, "b": [2, 3], "c": { "d": 4 } };
+    await test_driver.set_virtual_wallet_behavior("respond", "openid4vp-v1-unsigned", complexData);
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned" });
+    const result = await navigator.credentials.get(options);
+
+    assert_equals(result.protocol, "openid4vp-v1-unsigned");
+    assert_equals(result.data.a, 1);
+    assert_array_equals(result.data.b, [2, 3]);
+    assert_equals(result.data.c.d, 4);
+  }, "navigator.credentials.get() with complex data response should resolve with structured data.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("decline");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned" });
+    await promise_rejects_dom(t, "NotAllowedError", navigator.credentials.get(options));
+  }, "navigator.credentials.get() with decline mode should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const controller = new AbortController();
+    const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned", signal: controller.signal });
+    const promise = navigator.credentials.get(options);
+
+    // Give it some time to make sure it's pending.
+    await new Promise(resolve => t.step_timeout(resolve, 100));
+
+    controller.abort();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "navigator.credentials.get() with wait mode should remain pending until aborted.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/create.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/lint.ignore
+++ b/LayoutTests/imported/w3c/web-platform-tests/lint.ignore
@@ -9,6 +9,7 @@
 
 INDENT TABS: conformance-checkers/*
 INDENT TABS: encoding/legacy*/*
+INDENT TABS: *w3c-import.log
 
 TRAILING WHITESPACE: html/canvas/tools/current-work-canvas.xhtml
 TRAILING WHITESPACE: conformance-checkers/*

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt
@@ -15,8 +15,9 @@ PASS navigator.credentials.get() promise is rejected if abort controller is abor
 PASS Mediation is implicitly required and hence ignored. Request is aborted regardless.
 PASS Throws TypeError when request data is not JSON stringifiable.
 PASS `requests` field is required in the options object.
-FAIL navigator.credentials.get() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+FAIL navigator.credentials.get() with one unknown protocol with malformed data and one known protocol with proper data should skip the unknown one and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: JSON.stringify cannot serialize BigInt." that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
 PASS navigator.credentials.get() with only bogus requests should reject with TypeError.
-FAIL navigator.credentials.get() with good requests at the start and end should skip the bogus ones and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
-FAIL navigator.credentials.get() with bogus requests at both ends should skip them and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: Type error" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+FAIL navigator.credentials.get() with good requests at the start and end should skip the bogus ones and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: JSON.stringify cannot serialize BigInt." that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+FAIL navigator.credentials.get() with bogus requests at both ends should skip them and not fail. promise_rejects_dom: function "function() { throw e; }" threw object "TypeError: JSON.stringify cannot serialize BigInt." that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+PASS navigator.credentials.get() returns coordinator to idle after mid-flight abort.
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1854,6 +1854,8 @@ webkit.org/b/295743 [ Debug ] media/video-display-aspect-ratio.html [ Pass Failu
 [ Sequoia ] imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html [ Skip ]
 [ Sequoia ] imported/w3c/web-platform-tests/digital-credentials/get.https.html [ Skip ]
 [ Sequoia ] imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https.html [ Skip ]
+# FIXME: Needs bug. On arm64 Debug (internal DC UI), non-fully-active get() returns UnknownError instead of AbortError.
+[ arm64 Debug ] imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https.html [ Pass Failure ]
 
 # FIXME: Needs bug.
 http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html [ Failure ]


### PR DESCRIPTION
#### ba944f4309541ac66b7eea048e23168ad2602be1
<pre>
Digital credentials: resync upstream WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=317541">https://bugs.webkit.org/show_bug.cgi?id=317541</a>
<a href="https://rdar.apple.com/180236211">rdar://180236211</a>

Reviewed by BJ Burg.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/fa3b32ced60d1099cd9dc4757ef43ce7e3df55ec">https://github.com/web-platform-tests/wpt/commit/fa3b32ced60d1099cd9dc4757ef43ce7e3df55ec</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/create.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/encryption-info-validation.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/encryption-info-validation.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/malformed-requests.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/malformed-requests.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/mixed-requests.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/mixed-requests.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/origin-binding.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/response-handling.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/valid-roundtrip.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/mdoc/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-mdoc.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-mdoc.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-openid4vp.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-create.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation-get.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/create.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/lint.ignore:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.https-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/315658@main">https://commits.webkit.org/315658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/277b5ee5deef711b62566119c6297f9035785117

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127267 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00502e6d-f9b5-468e-9c4d-42fabe4afc27) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132104 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93038 "1 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b948d67-acd2-4d18-9934-2f0cdbeba2da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172514 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112607 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49f76bf4-cd2b-4489-b9ed-19679eb21370) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32242 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27611 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181513 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140553 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140389 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37818 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43822 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28836 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108027 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35657 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42332 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6921 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41725 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41980 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41868 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->