### PR TITLE
Changing presentation attributes of shape referenced by <use> in <clipPath> breaks clipping

### DIFF
--- a/LayoutTests/svg/clip-path/clip-path-use-dynamic-update-expected.html
+++ b/LayoutTests/svg/clip-path/clip-path-use-dynamic-update-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="250" height="150">
+  <rect id="clipSource" width="50" height="100" x="100" y="25" fill="none"/>
+  <g clip-path="url(#clip)"><rect x="25" y="25" width="200" height="100" fill="#3333ff"/></g>
+  <clipPath id="clip"><use xlink:href="#clipSource"/></clipPath>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/clip-path/clip-path-use-dynamic-update.html
+++ b/LayoutTests/svg/clip-path/clip-path-use-dynamic-update.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="250" height="150">
+  <rect id="clipSource" width="150" height="100" x="50" y="25" fill="none"/>
+  <g clip-path="url(#clip)"><rect x="25" y="25" width="200" height="100" fill="#3333ff"/></g>
+  <clipPath id="clip"><use xlink:href="#clipSource"/></clipPath>
+</svg>
+<script>
+// Mutate only after the initial layout & paint, so the clipper has cached its
+// state and must be invalidated by the change to the use-referenced element.
+requestAnimationFrame(() => requestAnimationFrame(() => {
+    const source = document.getElementById("clipSource");
+    source.setAttribute("width", "50");
+    source.setAttribute("x", "100");
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        document.documentElement.classList.remove("reftest-wait");
+    }));
+}));
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -86,7 +86,7 @@ public:
     inline SVGUnitTypes::SVGUnitType clipPathUnits() const;
 
 private:
-    bool selfNeedsClientInvalidation() const override { return (everHadLayout() || !m_clipperMap.isEmptyIgnoringNullReferences()) && selfNeedsLayout(); }
+    bool selfNeedsClientInvalidation() const override { return (everHadLayout() || !m_clipperMap.isEmptyIgnoringNullReferences()) && needsLayout(); }
 
     void element() const = delete;
 


### PR DESCRIPTION
#### b063740f5ce693cadd2f12d9947094572a616800
<pre>
Changing presentation attributes of shape referenced by &lt;use&gt; in &lt;clipPath&gt; breaks clipping
<a href="https://bugs.webkit.org/show_bug.cgi?id=141929">https://bugs.webkit.org/show_bug.cgi?id=141929</a>
<a href="https://rdar.apple.com/97101827">rdar://97101827</a>

Reviewed by NOBODY (OOPS!).

Mutating a basic shape referenced by a &lt;use&gt; inside a &lt;clipPath&gt; after the
initial paint made the clipped content disappear in the legacy SVG engine.
The change rebuilds the &lt;use&gt; shadow tree, so the clip child&apos;s renderer is
recreated. Resources lay out after their clients, and the freshly created
clone has no bounds yet when the client computes its clipped bounds, leaving
the client with an empty clip that never repaints.

The clipper only opted into LegacyRenderSVGRoot&apos;s deferred client
re-invalidation (m_resourcesNeedingToInvalidateClients) when its own box
changed (selfNeedsLayout()). A rebuilt clone is a descendant change, so the
clipper&apos;s clients were never re-evaluated after the clone was laid out.

Use needsLayout() instead of selfNeedsLayout() in
selfNeedsClientInvalidation(), since the clip output depends on the whole
subtree. Clients are then re-invalidated and re-laid-out once the content is
up to date and pick up the new clip.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* LayoutTests/svg/clip-path/clip-path-use-dynamic-update-expected.html: Added.
* LayoutTests/svg/clip-path/clip-path-use-dynamic-update.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b063740f5ce693cadd2f12d9947094572a616800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127188 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0be6f826-bd71-4292-ba1d-b906d32fe8e2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43026 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132029 "Found 1 new test failure: css3/masking/reference-clip-path-change-repaint.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92962 "1 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d023c6b-bd39-425d-ad47-a5f7750ea92d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172435 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35371 "Found 1 new test failure: css3/masking/reference-clip-path-change-repaint.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112532 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebf464ef-b7c5-4dda-895e-6e404f958cc9) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34308 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/sandbox/meta-element.sub.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32168 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27532 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144446 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31756 "Found 1 new test failure: css3/masking/reference-clip-path-change-repaint.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181434 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34142 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36335 "Found 1 new test failure: css3/masking/reference-clip-path-change-repaint.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140478 "Found 1 new test failure: css3/masking/reference-clip-path-change-repaint.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140314 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43743 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28734 "Found 1 new test failure: css3/masking/reference-clip-path-change-repaint.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107879 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35582 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115508 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42253 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6821 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41646 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41901 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->