### PR TITLE
Web Inspector: Media Logging setting does not persist across page loads

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -99,6 +99,9 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         // See WI.Target.prototype.initialize.
 
         this._setConsoleClearAPIEnabled(target);
+
+        for (let channel of this._customLoggingChannels)
+            target.ConsoleAgent.setLoggingChannelLevel(channel.source, channel.level);
     }
 
     // Public

--- a/Source/WebInspectorUI/UserInterface/Models/LoggingChannel.js
+++ b/Source/WebInspectorUI/UserInterface/Models/LoggingChannel.js
@@ -47,7 +47,22 @@ WI.LoggingChannel = class LoggingChannel
     // Public
 
     get source() { return this._source; }
+
     get level() { return this._level; }
+    set level(level)
+    {
+        console.assert(Object.values(WI.LoggingChannel.Level).includes(level), level);
+
+        if (level === this._level)
+            return;
+
+        this._level = level;
+
+        for (let target of WI.targets) {
+            if (target.hasDomain("Console"))
+                target.ConsoleAgent.setLoggingChannelLevel(this._source, this._level);
+        }
+    }
 };
 
 WI.LoggingChannel.Level = {

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -390,10 +390,7 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
                 let logEditor = consoleSettingsView.addGroupWithCustomSetting(label, WI.SettingEditor.Type.Select, {values: logLevels});
                 logEditor.value = channel.level;
                 logEditor.addEventListener(WI.SettingEditor.Event.ValueDidChange, function(event) {
-                    for (let target of WI.targets) {
-                        if (target.hasDomain("Console"))
-                            target.ConsoleAgent.setLoggingChannelLevel(channel.source, this.value);
-                    }
+                    channel.level = this.value;
                 }, logEditor);
             }
         }


### PR DESCRIPTION
#### 51c7591a14137e0426162a388d52fa77bcf08ed9
<pre>
Web Inspector: Media Logging setting does not persist across page loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=294908">https://bugs.webkit.org/show_bug.cgi?id=294908</a>
&lt;<a href="https://rdar.apple.com/problem/154766890">rdar://problem/154766890</a>&gt;

Reviewed by Qianlang Chen.

* Source/WebInspectorUI/UserInterface/Models/LoggingChannel.js:
(WI.LoggingChannel.prototype.set level): Added.
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createConsoleSettingsView):
Modify the actual model object when changing instead of just invoking `Console.setLoggingChannelLevel`.

* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.initializeTarget):
Invoke `Console.setLoggingChannelLevel` for each new `WI.Target` based on the current saved value.

Canonical link: <a href="https://commits.webkit.org/315758@main">https://commits.webkit.org/315758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6d52e936f2a887c00b4ea28e88e345ecd7b5ca9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127234 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132071 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93013 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112574 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32214 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27578 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181480 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140522 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43100 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140358 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37902 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Reviewed by Qianlang Chen; Compiled WebKit (warnings); Skipped layout-tests; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43789 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107975 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35627 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115554 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 33017 issues") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42299 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6881 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->