### PR TITLE
Uncaught Exception: TypeError: undefined is not an object (evaluating 'style of orderedStyles')

### DIFF
--- a/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html
@@ -45,7 +45,7 @@ function test()
             InspectorTest.expectFalse(styles.pseudoElements.has(WI.CSSManager.PseudoSelectorNames.Backdrop), "Expected no rules entry for selector `*::backdrop` before showing the dialog.");
             await InspectorTest.evaluateInPage(`openDialog()`);
             await styles.refresh();
-            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Backdrop).matchedRules.length, 3, "Expected exactly 3 rules for selector `*::backdrop` after showing the dialog.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Backdrop).length, 3, "Expected exactly 3 rules for selector `*::backdrop` after showing the dialog.");
         }
     });
 

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeMarkerPseudoId.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeMarkerPseudoId.html
@@ -42,7 +42,7 @@ function test()
         description: "A list item should have both the User Agent and authored `::marker` rules.",
         selector: "#listItem",
         async domNodeStylesHandler(styles) {
-            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Marker).matchedRules.length, 2, "Expected exactly 2 rules for selector `*::marker`.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Marker).length, 2, "Expected exactly 2 rules for selector `*::marker`.");
         }
     });
 
@@ -63,7 +63,7 @@ function test()
             InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Marker), undefined, "Expected no rules entry for selector `*::marker`.");
             await changeElementDisplayValue("nonListItemWithMarkerSpecified", "list-item");
             await styles.refresh();
-            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Marker).matchedRules.length, 3, "Expected 3 rules for selector `*::marker`.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.Marker).length, 3, "Expected 3 rules for selector `*::marker`.");
         }
     });
 

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html
@@ -47,7 +47,7 @@ function test()
 
             await InspectorTest.evaluateInPage(`startViewTransition()`);
             await styles.refresh();
-            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransition).matchedRules.length, 2, "Expected entry for selector `*::view-transition` after starting the view transition.");
+            InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransition).length, 2, "Expected entry for selector `*::view-transition` after starting the view transition.");
 
             // FIXME: These should use the correct values when adding support for named pseudo-elements. We'll also want to test different names individually. (webkit.org/b/283951)
             InspectorTest.expectEqual(styles.pseudoElements.get(WI.CSSManager.PseudoSelectorNames.ViewTransitionGroup), undefined, "No crash");

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -221,7 +221,8 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
             this._pseudoElements.clear();
             for (let {pseudoId, matches} of pseudoElementRulesPayload) {
                 let pseudoElementRules = parseRuleMatchArrayPayload(matches, this._node, false, pseudoId);
-                this._pseudoElements.set(pseudoId, {matchedRules: pseudoElementRules});
+                let pseudoElementOrderedStyles = this._collectStylesInCascadeOrder(pseudoElementRules, null, null);
+                this._pseudoElements.set(pseudoId, WI.DOMNodeStyles.uniqueOrderedStyles(pseudoElementOrderedStyles));
             }
 
             this._inheritedRules = [];
@@ -836,10 +837,9 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         this._markOverriddenProperties(cascadeOrderedStyleDeclarations, this._propertyNameToEffectivePropertyMap);
         this._collectCSSVariables(cascadeOrderedStyleDeclarations);
 
-        for (let pseudoElementInfo of this._pseudoElements.values()) {
-            pseudoElementInfo.orderedStyles = this._collectStylesInCascadeOrder(pseudoElementInfo.matchedRules, null, null);
-            this._associateRelatedProperties(pseudoElementInfo.orderedStyles);
-            this._markOverriddenProperties(pseudoElementInfo.orderedStyles);
+        for (let pseudoElementOrderedStyles of this._pseudoElements.values()) {
+            this._associateRelatedProperties(pseudoElementOrderedStyles);
+            this._markOverriddenProperties(pseudoElementOrderedStyles);
         }
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js
@@ -308,23 +308,25 @@ WI.SpreadsheetRulesStyleDetailsPanel = class SpreadsheetRulesStyleDetailsPanel e
 
             // Add all pseudo styles before any inherited rules.
 
-            for (let [pseudoId, pseudoElementInfo] of this.nodeStyles.pseudoElements) {
+            for (let [pseudoId, uniqueOrderedStyles] of this.nodeStyles.pseudoElements) {
                 let pseudoElement = null;
                 if (pseudoId === WI.CSSManager.PseudoSelectorNames.Before)
                     pseudoElement = this.nodeStyles.node.beforePseudoElement();
                 else if (pseudoId === WI.CSSManager.PseudoSelectorNames.After)
                     pseudoElement = this.nodeStyles.node.afterPseudoElement();
 
-                let orderedPseudoStyles = WI.DOMNodeStyles.uniqueOrderedStyles(pseudoElementInfo.orderedStyles).filter((style) => this._shouldIncludeStyle(style));
+                let didAddHeader = false;
+                for (let style of uniqueOrderedStyles) {
+                    if (!this._shouldIncludeStyle(style))
+                        continue;
 
-                // Don't show an empty "Pseudo-Element..." header
-                if (!orderedPseudoStyles.length)
-                    continue;
+                    if (!didAddHeader) {
+                        didAddHeader = true;
+                        addHeader(WI.UIString("Pseudo-Element"), pseudoElement || pseudoId);
+                    }
 
-                addHeader(WI.UIString("Pseudo-Element"), pseudoElement || pseudoId);
-
-                for (let style of orderedPseudoStyles)
                     createSection(style);
+                }
             }
 
             addedPseudoStyles = true;


### PR DESCRIPTION
#### aeccc1a965fcd8cd5c69eaa7ea1532fad549cba6
<pre>
Uncaught Exception: TypeError: undefined is not an object (evaluating &apos;style of orderedStyles&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=289172">https://bugs.webkit.org/show_bug.cgi?id=289172</a>
&lt;<a href="https://rdar.apple.com/problem/146863680">rdar://problem/146863680</a>&gt;

Reviewed by Qianlang Chen.

There&apos;s no reason to delay calculating the ordering of pseudo-element styles until after inline styles are fetched.

* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.prototype.refresh.fetchedMatchedStyles):
(WI.DOMNodeStyles.prototype._updateStyleCascade):

* Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js:
(WI.SpreadsheetRulesStyleDetailsPanel.prototype.layout):

* LayoutTests/inspector/css/getMatchedStylesForNodeBackdropPseudoId.html:
* LayoutTests/inspector/css/getMatchedStylesForNodeMarkerPseudoId.html:
* LayoutTests/inspector/css/getMatchedStylesForNodeViewTransitionPseudoElements.html:

Canonical link: <a href="https://commits.webkit.org/316071@main">https://commits.webkit.org/316071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3376000020c058babb205a39ea948426fd7ba5d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127192 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132034 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92966 "2 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112537 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34312 "Found 2 new test failures: imported/w3c/web-platform-tests/content-security-policy/sandbox/meta-element.sub.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number-constraint-validation.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32173 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27536 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181438 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140482 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38146 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43747 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28772 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 344 new passes 9 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107885 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35588 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115512 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42257 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->