### PR TITLE
Web Inspector: timeline exports/imports wrong timestamp for performance.mark()

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.js
@@ -343,24 +343,8 @@ WI.TimelineRuler = class TimelineRuler extends WI.View
 
         marker.addEventListener(WI.TimelineMarker.Event.TimeChanged, this._timelineMarkerTimeChanged, this);
 
-        let markerTime = marker.time - this._startTime;
         let markerElement = document.createElement("div");
         markerElement.classList.add(marker.type, "marker");
-
-        switch (marker.type) {
-        case WI.TimelineMarker.Type.LoadEvent:
-            markerElement.title = WI.UIString("Load \u2014 %s").format(Number.secondsToString(markerTime));
-            break;
-        case WI.TimelineMarker.Type.DOMContentEvent:
-            markerElement.title = WI.UIString("DOM Content Loaded \u2014 %s").format(Number.secondsToString(markerTime));
-            break;
-        case WI.TimelineMarker.Type.TimeStamp:
-            if (marker.details)
-                markerElement.title = WI.UIString("%s \u2014 %s").format(marker.details, Number.secondsToString(markerTime));
-            else
-                markerElement.title = WI.UIString("Timestamp \u2014 %s").format(Number.secondsToString(markerTime));
-            break;
-        }
 
         this._markerElementMap.set(marker, markerElement);
 
@@ -648,9 +632,24 @@ WI.TimelineRuler = class TimelineRuler extends WI.View
                 continue;
             }
 
-            let newPosition = (marker.time - this._startTime) / duration;
+            let markerTime = marker.time - this._startTime;
             let property = WI.resolvedLayoutDirection() === WI.LayoutDirection.RTL ? "right" : "left";
-            this._updatePositionOfElement(markerElement, newPosition, visibleWidth, property);
+            this._updatePositionOfElement(markerElement, markerTime / duration, visibleWidth, property);
+
+            switch (marker.type) {
+            case WI.TimelineMarker.Type.LoadEvent:
+                markerElement.title = WI.UIString("Load \u2014 %s").format(Number.secondsToString(markerTime));
+                break;
+            case WI.TimelineMarker.Type.DOMContentEvent:
+                markerElement.title = WI.UIString("DOM Content Loaded \u2014 %s").format(Number.secondsToString(markerTime));
+                break;
+            case WI.TimelineMarker.Type.TimeStamp:
+                if (marker.details)
+                    markerElement.title = WI.UIString("%s \u2014 %s").format(marker.details, Number.secondsToString(markerTime));
+                else
+                    markerElement.title = WI.UIString("Timestamp \u2014 %s").format(Number.secondsToString(markerTime));
+                break;
+            }
 
             if (!markerElement.parentNode)
                 this._markersElement.appendChild(markerElement);


### PR DESCRIPTION
#### 39abc0748ebf842bfc66a51c49419cfd2bb7353e
<pre>
Web Inspector: timeline exports/imports wrong timestamp for performance.mark()
<a href="https://bugs.webkit.org/show_bug.cgi?id=287639">https://bugs.webkit.org/show_bug.cgi?id=287639</a>
&lt;<a href="https://rdar.apple.com/problem/145226764">rdar://problem/145226764</a>&gt;

Reviewed by Qianlang Chen.

Wait to set the `title` of the `WI.TimelineMarker` until when it&apos;s added to the DOM as it&apos;s not needed until then.
As a byproduct, this is after the `_startTime` is set, which is needed to ensure the right timestamp is shown.

* Source/WebInspectorUI/UserInterface/Views/TimelineRuler.js:
(WI.TimelineRuler.prototype.addMarker):
(WI.TimelineRuler.prototype._updateMarkers):

Canonical link: <a href="https://commits.webkit.org/316073@main">https://commits.webkit.org/316073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/869931c8a6885d1a19e8f9457dca5d9957a97a7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178842 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127196 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132037 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92969 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112540 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33854 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32176 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27540 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181442 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140485 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43062 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140321 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38147 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43751 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107892 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35592 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115516 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42261 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6831 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->