### PR TITLE
EWS counts a build as a "failure" if its log contains "error:" even if it's not actually an error

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3312,9 +3312,22 @@ class BuildLogLineObserver(ParseByLineLogObserver):
         self.includeRelatedLines = includeRelatedLines
         self.error_context_buffer = []
         self.whitespace_re = re.compile(r'^[\s]*$')
+        # Match the search string only when it is a standalone diagnostic
+        # severity token, i.e. the word containing it is preceded by whitespace
+        # or the start of the line (`Foo.cpp:10:5: error: ...`). A run of
+        # letters can precede the search string (so `rror:` still matches both
+        # `error:` and `Error:`), but the run may not begin mid-token: this
+        # deliberately does not match `error:` embedded in a longer
+        # colon-separated token such as the Objective-C selector
+        # `unarchivedObjectOfClass:fromData:error:` referenced by a deprecation
+        # warning.
+        self.error_re = re.compile(r'(?:^|\s)[A-Za-z]*' + re.escape(searchString))
         self.line_count = 0
         self.thresholdExceedCallBack = thresholdExceedCallBack
         super().__init__(self.parseOutputLine)
+
+    def lineIndicatesError(self, line):
+        return self.error_re.search(line) is not None
 
     def parseOutputLine(self, line):
         self.line_count += 1
@@ -3326,7 +3339,7 @@ class BuildLogLineObserver(ParseByLineLogObserver):
             return
 
         if not self.includeRelatedLines:
-            if self.searchString in line:
+            if self.lineIndicatesError(line):
                 self.errorReceived(line)
             return
 
@@ -3336,7 +3349,7 @@ class BuildLogLineObserver(ParseByLineLogObserver):
         else:
             self.error_context_buffer.append(line)
 
-        if self.searchString in line:
+        if self.lineIndicatesError(line):
             for log in self.error_context_buffer[-50:]:
                 self.errorReceived(log)
             self.error_context_buffer = []

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -1362,6 +1362,45 @@ class TestCompileWebKit(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=FAILURE, state_string='Failed to compile WebKit')
         return self.run_step()
 
+    def test_success_with_warning_containing_error_substring(self):
+        self.setup_step(CompileWebKit())
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        timeout=3600,
+                        log_environ=False,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'perl Tools/Scripts/build-webkit --release -hideShellScriptEnvironment WK_VALIDATE_DEPENDENCIES=YES WK_ENABLE_SLOW_BUILD_VERIFICATION=YES 2>&1 | perl Tools/Scripts/filter-build-webkit -logfile build-log.txt'],
+                        )
+            # A deprecation warning whose message references an Objective-C selector
+            # ending in `error:` must not be misread as a compile error.
+            .log('stdio', stdout="CodingTests.swift:164:52: warning: 'unarchiveObject(with:)' was deprecated in macOS 10.14: Use +unarchivedObjectOfClass:fromData:error: instead")
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Compiled WebKit')
+        return self.run_step()
+
+    def test_failure_from_log_on_clean_exit(self):
+        self.setup_step(CompileWebKit())
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        timeout=3600,
+                        log_environ=False,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'perl Tools/Scripts/build-webkit --release -hideShellScriptEnvironment WK_VALIDATE_DEPENDENCIES=YES WK_ENABLE_SLOW_BUILD_VERIFICATION=YES 2>&1 | perl Tools/Scripts/filter-build-webkit -logfile build-log.txt'],
+                        )
+            # A genuine error diagnostic must still fail the build even when the
+            # process exits 0 (the silent-failure workaround), including when its
+            # message text mentions another severity such as `note:`.
+            .log('stdio', stdout='CodingTests.swift:164:52: error: redefinition of Foo; see note: previous definition here')
+            .exit(0),
+        )
+        self.expect_outcome(result=FAILURE, state_string='Failed to compile WebKit')
+        return self.run_step()
+
     def test_skip_for_revert_patches_on_commit_queue(self):
         self.setup_step(CompileWebKit())
         self.setProperty('buildername', 'Commit-Queue')


### PR DESCRIPTION
#### b08877e45b015ae8425b6347c6e64e44dd77d730
<pre>
EWS counts a build as a &quot;failure&quot; if its log contains &quot;error:&quot; even if it&apos;s not actually an error
<a href="https://bugs.webkit.org/show_bug.cgi?id=317550">https://bugs.webkit.org/show_bug.cgi?id=317550</a>
<a href="https://rdar.apple.com/180248076">rdar://180248076</a>

Reviewed by NOBODY (OOPS!).

Use a regex to make matching an actual error line more strict.

* Tools/CISupport/ews-build/steps.py:
(BuildLogLineObserver.__init__):
(BuildLogLineObserver.lineIndicatesError):
(BuildLogLineObserver.parseOutputLine):
* Tools/CISupport/ews-build/steps_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b08877e45b015ae8425b6347c6e64e44dd77d730

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127199 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/714ac216-0939-4e2c-8762-c3b3d2bc96a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132040 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92972 "2 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cdb9ebf-e8f9-46b4-bbbe-395bf743c4ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112543 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a322477b-22b6-41e1-8868-d836285c72be) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32179 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27543 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181445 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140488 "Passed tests") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/168887 "Failed EWS unit tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43065 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140324 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43754 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28741 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107895 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35595 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42264 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6828 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41657 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41912 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->