### PR TITLE
[JSC][WTF] WTF::Liveness should use BitVector / SparseBitVector for the external workset

### DIFF
--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -26,12 +26,13 @@
 #pragma once
 
 #include <algorithm>
-#include <ranges>
+#include <bit>
+#include <span>
 #include <wtf/BitVector.h>
 #include <wtf/GraphOrdering.h>
-#include <wtf/IndexSparseSet.h>
 #include <wtf/SparseBitVector.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Vector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -44,19 +45,214 @@ class Liveness : public Adapter {
 public:
     typedef typename Adapter::CFG CFG;
     typedef typename Adapter::Thing Thing;
-    typedef Vector<unsigned, 4, UnsafeVectorOverflow> IndexVector;
-    typedef IndexSparseSet<unsigned, DefaultIndexSparseSetTraits<unsigned>, UnsafeVectorOverflow> Workset;
-    
+
     template<typename... Arguments>
     Liveness(CFG& cfg, Arguments&&... arguments)
         : Adapter(std::forward<Arguments>(arguments)...)
         , m_cfg(cfg)
-        , m_workset(Adapter::numIndices())
-        , m_liveAtHead(cfg.template newMap<IndexVector>())
-        , m_liveAtTail(cfg.template newMap<IndexVector>())
     {
     }
-    
+
+private:
+    static constexpr unsigned wordBits = 64;
+    enum class Storage : uint8_t { Dense, Sparse };
+
+    static size_t wordsForBits(unsigned numBits)
+    {
+        return (numBits + wordBits - 1) / wordBits;
+    }
+
+    class Workset {
+    public:
+        void initialize(Storage storage, size_t wordsPerSet)
+        {
+            m_storage = storage;
+            if (storage == Storage::Dense)
+                m_dense.fill(0, wordsPerSet);
+            else
+                m_dense.clear();
+            m_sparse.clear();
+        }
+
+        void clear()
+        {
+            if (m_storage == Storage::Dense)
+                std::ranges::fill(m_dense, 0);
+            else
+                m_sparse.clear();
+        }
+
+        bool add(unsigned bit)
+        {
+            if (m_storage == Storage::Dense) {
+                ASSERT(bit / wordBits < m_dense.size());
+                uint64_t mask = static_cast<uint64_t>(1) << (bit % wordBits);
+                uint64_t& word = m_dense[bit / wordBits];
+                bool wasSet = word & mask;
+                word |= mask;
+                return !wasSet;
+            }
+            return m_sparse.set(bit);
+        }
+
+        bool remove(unsigned bit)
+        {
+            if (m_storage == Storage::Dense) {
+                ASSERT(bit / wordBits < m_dense.size());
+                uint64_t mask = static_cast<uint64_t>(1) << (bit % wordBits);
+                uint64_t& word = m_dense[bit / wordBits];
+                bool wasSet = word & mask;
+                word &= ~mask;
+                return wasSet;
+            }
+            return m_sparse.reset(bit);
+        }
+
+        bool contains(unsigned bit) const
+        {
+            if (m_storage == Storage::Dense) {
+                if (bit / wordBits >= m_dense.size())
+                    return false;
+                return m_dense[bit / wordBits] & (static_cast<uint64_t>(1) << (bit % wordBits));
+            }
+            return m_sparse.contains(bit);
+        }
+
+        void copyFromDense(std::span<const uint64_t> source)
+        {
+            ASSERT(m_storage == Storage::Dense);
+            ASSERT(source.size() == m_dense.size());
+            memcpySpan(m_dense.mutableSpan(), source);
+        }
+
+        void copyFromSparse(const SparseBitVector<>& source)
+        {
+            ASSERT(m_storage == Storage::Sparse);
+            m_sparse = source;
+        }
+
+        Storage storage() const { return m_storage; }
+        std::span<const uint64_t> denseSpan() const LIFETIME_BOUND { return m_dense.span(); }
+        const SparseBitVector<>& sparse() const LIFETIME_BOUND { return m_sparse; }
+
+    private:
+        Vector<uint64_t> m_dense;
+        SparseBitVector<> m_sparse;
+        Storage m_storage { Storage::Dense };
+    };
+
+    class Iterator {
+        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Iterator);
+    public:
+        Iterator() = default;
+
+        static Iterator makeBegin(Liveness& liveness, std::span<const uint64_t> dense, const SparseBitVector<>* sparse, Storage storage)
+        {
+            Iterator iter;
+            iter.m_liveness = &liveness;
+            iter.m_storage = storage;
+            if (storage == Storage::Dense) {
+                iter.m_denseSpan = dense;
+                iter.m_wordIndex = 0;
+                iter.m_currentWord = dense.empty() ? 0 : dense[0];
+                iter.advanceDense();
+            } else
+                iter.m_sparseIter = sparse->begin();
+            return iter;
+        }
+
+        static Iterator makeEnd(Liveness& liveness, std::span<const uint64_t> dense, const SparseBitVector<>* sparse, Storage storage)
+        {
+            Iterator iter;
+            iter.m_liveness = &liveness;
+            iter.m_storage = storage;
+            if (storage == Storage::Dense) {
+                iter.m_denseSpan = dense;
+                iter.m_wordIndex = dense.size();
+                iter.m_currentWord = 0;
+            } else
+                iter.m_sparseIter = sparse->end();
+            return iter;
+        }
+
+        Thing operator*() const
+        {
+            if (m_storage == Storage::Dense) {
+                unsigned bit = static_cast<unsigned>(m_wordIndex * wordBits + std::countr_zero(m_currentWord));
+                return m_liveness->indexToValue(bit);
+            }
+            return m_liveness->indexToValue(*m_sparseIter);
+        }
+
+        Iterator& operator++()
+        {
+            if (m_storage == Storage::Dense) {
+                m_currentWord &= m_currentWord - 1;
+                advanceDense();
+            } else
+                ++m_sparseIter;
+            return *this;
+        }
+
+        bool operator==(const Iterator& other) const
+        {
+            if (m_storage == Storage::Dense)
+                return m_wordIndex == other.m_wordIndex && m_currentWord == other.m_currentWord;
+            return m_sparseIter == other.m_sparseIter;
+        }
+
+    private:
+        void advanceDense()
+        {
+            while (!m_currentWord && m_wordIndex + 1 < m_denseSpan.size()) {
+                ++m_wordIndex;
+                m_currentWord = m_denseSpan[m_wordIndex];
+            }
+            if (!m_currentWord)
+                m_wordIndex = m_denseSpan.size();
+        }
+
+        Liveness* m_liveness { nullptr };
+        Storage m_storage { Storage::Dense };
+        std::span<const uint64_t> m_denseSpan;
+        size_t m_wordIndex { 0 };
+        uint64_t m_currentWord { 0 };
+        typename SparseBitVector<>::iterator m_sparseIter;
+    };
+
+public:
+    class Iterable {
+        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Iterable);
+    public:
+        Iterable(Liveness& liveness, std::span<const uint64_t> dense, const SparseBitVector<>* sparse, Storage storage)
+            : m_liveness(liveness)
+            , m_dense(dense)
+            , m_sparse(sparse)
+            , m_storage(storage)
+        {
+        }
+
+        Iterator begin() const LIFETIME_BOUND { return Iterator::makeBegin(m_liveness, m_dense, m_sparse, m_storage); }
+        Iterator end() const LIFETIME_BOUND { return Iterator::makeEnd(m_liveness, m_dense, m_sparse, m_storage); }
+
+        bool contains(const Thing& thing) const
+        {
+            unsigned bit = m_liveness.valueToIndex(thing);
+            if (m_storage == Storage::Dense) {
+                if (bit / wordBits >= m_dense.size())
+                    return false;
+                return m_dense[bit / wordBits] & (static_cast<uint64_t>(1) << (bit % wordBits));
+            }
+            return m_sparse->contains(bit);
+        }
+
+    private:
+        Liveness& m_liveness;
+        std::span<const uint64_t> m_dense;
+        const SparseBitVector<>* m_sparse { nullptr };
+        Storage m_storage { Storage::Dense };
+    };
+
     // This calculator has to be run in reverse.
     class LocalCalc {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(LocalCalc);
@@ -65,11 +261,11 @@ public:
             : m_liveness(liveness)
             , m_block(block)
         {
-            auto& workset = liveness.m_workset;
-            workset.clear();
-            IndexVector& liveAtTail = liveness.m_liveAtTail[block];
-            for (unsigned index : liveAtTail)
-                workset.add(index);
+            Workset& workset = liveness.m_workset;
+            if (liveness.m_storage == Storage::Dense)
+                workset.copyFromDense(liveness.denseTailSlice(block->index()));
+            else
+                workset.copyFromSparse(liveness.sparseTail(block->index()));
         }
 
         class Iterable {
@@ -80,37 +276,18 @@ public:
             {
             }
 
-            class iterator {
-                WTF_DEPRECATED_MAKE_FAST_ALLOCATED(iterator);
-            public:
-                iterator(Adapter& adapter, Workset::const_iterator sparceSetIterator)
-                    : m_adapter(adapter)
-                    , m_sparceSetIterator(sparceSetIterator)
-                {
-                }
+            Iterator begin() const LIFETIME_BOUND
+            {
+                const Workset& workset = m_liveness.m_workset;
+                return Iterator::makeBegin(m_liveness, workset.denseSpan(), &workset.sparse(), workset.storage());
+            }
+            Iterator end() const LIFETIME_BOUND
+            {
+                const Workset& workset = m_liveness.m_workset;
+                return Iterator::makeEnd(m_liveness, workset.denseSpan(), &workset.sparse(), workset.storage());
+            }
 
-                iterator& operator++()
-                {
-                    ++m_sparceSetIterator;
-                    return *this;
-                }
-
-                typename Adapter::Thing operator*() const
-                {
-                    return m_adapter.indexToValue(*m_sparceSetIterator);
-                }
-
-                bool operator==(const iterator& other) const { return m_sparceSetIterator == other.m_sparceSetIterator; }
-
-            private:
-                Adapter& m_adapter;
-                Workset::const_iterator m_sparceSetIterator;
-            };
-
-            iterator begin() const LIFETIME_BOUND { return iterator(m_liveness, m_liveness.m_workset.begin()); }
-            iterator end() const LIFETIME_BOUND { return iterator(m_liveness, m_liveness.m_workset.end()); }
-            
-            bool contains(const typename Adapter::Thing& thing) const
+            bool contains(const Thing& thing) const
             {
                 return m_liveness.m_workset.contains(m_liveness.valueToIndex(thing));
             }
@@ -119,146 +296,75 @@ public:
             Liveness& m_liveness;
         };
 
-        Iterable live() const
+        Iterable live() const LIFETIME_BOUND
         {
             return Iterable(m_liveness);
         }
 
-        bool isLive(const typename Adapter::Thing& thing) const
+        bool isLive(const Thing& thing) const
         {
-            return live().contains(thing);
+            return m_liveness.m_workset.contains(m_liveness.valueToIndex(thing));
         }
 
         void execute(unsigned instIndex)
         {
-            auto& workset = m_liveness.m_workset;
-
-            // Want an easy example to help you visualize how this works?
-            // Check out B3VariableLiveness.h.
-            //
-            // Want a hard example to help you understand the hard cases?
-            // Check out AirLiveness.h.
-            
+            Workset& workset = m_liveness.m_workset;
             m_liveness.forEachDef(
                 m_block, instIndex + 1,
                 [&] (unsigned index) {
                     workset.remove(index);
                 });
-            
             m_liveness.forEachUse(
                 m_block, instIndex,
                 [&] (unsigned index) {
                     workset.add(index);
                 });
         }
-        
+
     private:
         Liveness& m_liveness;
         typename CFG::Node m_block;
     };
 
-    const IndexVector& rawLiveAtHead(typename CFG::Node block)
+    Iterable liveAtHead(typename CFG::Node block) LIFETIME_BOUND
     {
-        return m_liveAtHead[block];
+        if (m_storage == Storage::Dense)
+            return Iterable(*this, denseHeadSlice(block->index()), nullptr, Storage::Dense);
+        return Iterable(*this, { }, &sparseHead(block->index()), Storage::Sparse);
     }
 
-    template<typename UnderlyingIterable>
-    class Iterable {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Iterable);
-    public:
-        Iterable(Liveness& liveness, const UnderlyingIterable& iterable)
-            : m_liveness(liveness)
-            , m_iterable(iterable)
-        {
-        }
-
-        class iterator {
-            WTF_DEPRECATED_MAKE_FAST_ALLOCATED(iterator);
-        public:
-            iterator()
-                : m_liveness(nullptr)
-                , m_iter()
-            {
-            }
-            
-            iterator(Liveness& liveness, typename UnderlyingIterable::const_iterator iter)
-                : m_liveness(&liveness)
-                , m_iter(iter)
-            {
-            }
-
-            typename Adapter::Thing operator*()
-            {
-                return m_liveness->indexToValue(*m_iter);
-            }
-
-            iterator& operator++()
-            {
-                ++m_iter;
-                return *this;
-            }
-
-            bool operator==(const iterator& other) const
-            {
-                ASSERT(m_liveness == other.m_liveness);
-                return m_iter == other.m_iter;
-            }
-
-        private:
-            Liveness* m_liveness;
-            typename UnderlyingIterable::const_iterator m_iter;
-        };
-
-        iterator begin() const LIFETIME_BOUND { return iterator(m_liveness, m_iterable.begin()); }
-        iterator end() const LIFETIME_BOUND { return iterator(m_liveness, m_iterable.end()); }
-
-        bool contains(const typename Adapter::Thing& thing) const
-        {
-            return m_liveness.m_workset.contains(m_liveness.valueToIndex(thing));
-        }
-
-    private:
-        Liveness& m_liveness;
-        const UnderlyingIterable& m_iterable;
-    };
-
-    Iterable<IndexVector> liveAtHead(typename CFG::Node block)
+    Iterable liveAtTail(typename CFG::Node block) LIFETIME_BOUND
     {
-        return Iterable<IndexVector>(*this, m_liveAtHead[block]);
+        if (m_storage == Storage::Dense)
+            return Iterable(*this, denseTailSlice(block->index()), nullptr, Storage::Dense);
+        return Iterable(*this, { }, &sparseTail(block->index()), Storage::Sparse);
     }
 
-    Iterable<IndexVector> liveAtTail(typename CFG::Node block)
-    {
-        return Iterable<IndexVector>(*this, m_liveAtTail[block]);
-    }
-
-    Workset& workset() LIFETIME_BOUND { return m_workset; }
-    
     class LiveAtHead {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(LiveAtHead);
     public:
         LiveAtHead(Liveness& liveness)
             : m_liveness(liveness)
         {
-            for (unsigned blockIndex = m_liveness.m_cfg.numNodes(); blockIndex--;) {
-                typename CFG::Node block = m_liveness.m_cfg.node(blockIndex);
-                if (!block)
-                    continue;
-                
-                std::ranges::sort(m_liveness.m_liveAtHead[block]);
-            }
         }
-        
-        bool isLiveAtHead(typename CFG::Node block, const typename Adapter::Thing& thing)
+
+        bool isLiveAtHead(typename CFG::Node block, const Thing& thing)
         {
-            return !!tryBinarySearch<unsigned>(m_liveness.m_liveAtHead[block], m_liveness.m_liveAtHead[block].size(), m_liveness.valueToIndex(thing), [] (unsigned* value) { return *value; });
+            unsigned bit = m_liveness.valueToIndex(thing);
+            if (m_liveness.m_storage == Storage::Dense) {
+                std::span<const uint64_t> set = m_liveness.denseHeadSlice(block->index());
+                if (bit / wordBits >= set.size())
+                    return false;
+                return set[bit / wordBits] & (static_cast<uint64_t>(1) << (bit % wordBits));
+            }
+            return m_liveness.sparseHead(block->index()).contains(bit);
         }
-        
+
     private:
         Liveness& m_liveness;
     };
-    
-    LiveAtHead liveAtHead() { return LiveAtHead(*this); }
+
+    LiveAtHead liveAtHead() LIFETIME_BOUND { return LiveAtHead(*this); }
 
 protected:
     void compute()
@@ -267,9 +373,8 @@ protected:
         constexpr uint64_t denseMatrixBitBudget = 32 * 1024 * 1024; // 4 MB per live-set matrix.
         bool useSparse = denseMatrixBits > denseMatrixBitBudget;
 #if ASSERT_ENABLED
-        // Most JSC stress test functions are small enough that the dense path would always win.
-        // Force the sparse path on roughly half of them in debug builds so the sparse implementation
-        // gets meaningful coverage from the regular test suite.
+        // Force the sparse storage on roughly half of the otherwise-dense functions in debug builds so
+        // the sparse implementation gets coverage from the regular test suite.
         if (!useSparse && (m_cfg.numNodes() & 1))
             useSparse = true;
 #endif
@@ -286,33 +391,26 @@ protected:
         unsigned numNodes = m_cfg.numNodes();
         unsigned numIndices = Adapter::numIndices();
 
-        // Per-block live sets are stored as a flat bit-matrix: a single Vector<uint64_t> of
-        // numNodes * wordsPerSet words, where block b's set occupies the contiguous slice
-        // [b * wordsPerSet, (b + 1) * wordsPerSet). Keeping each set as a span of machine words lets
-        // the whole dataflow run as plain word loops, with one allocation per matrix (rather than
-        // one per block) and no inline/out-of-line special-casing. This is what makes liveness fast
-        // on the very large functions (e.g. SQLite's VDBE) that dominate its cost.
-        constexpr unsigned wordBits = 64;
-        size_t wordsPerSet = (numIndices + wordBits - 1) / wordBits;
-        size_t matrixWords = static_cast<size_t>(numNodes) * wordsPerSet;
+        m_storage = Storage::Dense;
+        m_wordsPerSet = wordsForBits(numIndices);
 
-        Vector<uint64_t> liveInStore(matrixWords);
-        Vector<uint64_t> liveOutStore(matrixWords);
+        size_t matrixWords = static_cast<size_t>(numNodes) * m_wordsPerSet;
+        m_denseStore.fill(0, 2 * matrixWords);
         Vector<uint64_t> genStore(matrixWords);
         Vector<uint64_t> killStore(matrixWords);
-        // Vector's sized constructor does not zero POD storage, and the dataflow ORs into these
-        // sets, so they must start empty.
-        std::ranges::fill(liveInStore, 0);
-        std::ranges::fill(liveOutStore, 0);
+        // Vector's sized constructor does not zero POD storage, and the dataflow ORs into these.
         std::ranges::fill(genStore, 0);
         std::ranges::fill(killStore, 0);
-        std::span<uint64_t> liveInMatrix = liveInStore.mutableSpan();
-        std::span<uint64_t> liveOutMatrix = liveOutStore.mutableSpan();
+        std::span<uint64_t> store = m_denseStore.mutableSpan();
+        std::span<uint64_t> liveInMatrix = store.subspan(0, matrixWords);
+        std::span<uint64_t> liveOutMatrix = store.subspan(matrixWords, matrixWords);
         std::span<uint64_t> genMatrix = genStore.mutableSpan();
         std::span<uint64_t> killMatrix = killStore.mutableSpan();
 
+        m_workset.initialize(Storage::Dense, m_wordsPerSet);
+
         auto setFor = [&] (std::span<uint64_t> matrix, unsigned blockIndex) -> std::span<uint64_t> {
-            return matrix.subspan(static_cast<size_t>(blockIndex) * wordsPerSet, wordsPerSet);
+            return matrix.subspan(static_cast<size_t>(blockIndex) * m_wordsPerSet, m_wordsPerSet);
         };
         auto setBit = [] (std::span<uint64_t> set, unsigned index) {
             set[index / wordBits] |= static_cast<uint64_t>(1) << (index % wordBits);
@@ -328,24 +426,24 @@ protected:
             auto genSet = setFor(genMatrix, blockIndex);
             auto liveOutSet = setFor(liveOutMatrix, blockIndex);
 
-            // kill: every value defined anywhere in the block.
             for (size_t boundary = 0; boundary <= Adapter::blockSize(block); ++boundary) {
                 Adapter::forEachDef(block, boundary, [&] (unsigned index) {
                     setBit(killSet, index);
                 });
             }
 
-            // gen: the block's transfer function applied to an empty live-out, i.e. the uses that
-            // are exposed at the head. This is the only place we walk instructions; the fixpoint
-            // below works purely on gen/kill/liveOut.
+            // gen = transfer function applied to an empty live-out: the uses exposed at the head.
+            // The fixpoint below works purely on gen/kill/liveOut, so this is the only place that
+            // walks instructions.
             m_workset.clear();
             for (size_t instIndex = Adapter::blockSize(block); instIndex--;) {
                 Adapter::forEachDef(block, instIndex + 1, [&] (unsigned index) { m_workset.remove(index); });
                 Adapter::forEachUse(block, instIndex, [&] (unsigned index) { m_workset.add(index); });
             }
             Adapter::forEachDef(block, 0, [&] (unsigned index) { m_workset.remove(index); });
-            for (unsigned index : m_workset)
-                setBit(genSet, index);
+            std::span<const uint64_t> worksetSpan = m_workset.denseSpan();
+            for (size_t i = 0; i < m_wordsPerSet; ++i)
+                genSet[i] = worksetSpan[i];
 
             // liveOut automatically contains the LateUse's of the terminal.
             Adapter::forEachUse(block, Adapter::blockSize(block), [&] (unsigned index) {
@@ -355,16 +453,13 @@ protected:
             ++numActiveBlocks;
         }
 
-        // Seed the worklist in reverse post-order so the backward dataflow processes a block after
-        // its successors. This minimizes re-visits -- in particular the high-fan-in switch-dispatch
-        // block is finalized in one pass instead of once per contributing case, which also avoids
-        // repeating its expensive many-predecessor propagation.
+        // Reverse-post-order seed so the backward dataflow processes a block after its successors.
         Vector<unsigned, 64> worklist;
         worklist.reserveInitialCapacity(numActiveBlocks);
         BitVector dirtyBlocks(numNodes);
         appendNodeIndicesInOrder(m_cfg, GraphOrder::PostOrder, dirtyBlocks, worklist);
         worklist.reverse();
-        // Queue any active block the DFS did not reach (e.g. unreachable but not yet pruned).
+        // Active blocks the DFS did not reach (e.g. unreachable but not yet pruned).
         for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
             if (m_cfg.node(blockIndex) && !dirtyBlocks.quickSet(blockIndex))
                 worklist.append(blockIndex);
@@ -385,7 +480,7 @@ protected:
 
             // liveIn = gen | (liveOut & ~kill)
             uint64_t changed = 0;
-            for (size_t i = 0; i < wordsPerSet; ++i) {
+            for (size_t i = 0; i < m_wordsPerSet; ++i) {
                 uint64_t newLiveIn = genSet[i] | (liveOutSet[i] & ~killSet[i]);
                 uint64_t oldLiveIn = liveInSet[i];
                 liveInSet[i] = newLiveIn;
@@ -394,12 +489,10 @@ protected:
             if (!changed)
                 continue;
 
-            // Propagate this block's liveIn into each predecessor's liveOut, re-queuing a predecessor
-            // only when its liveOut actually grew.
             for (auto predecessor : m_cfg.predecessors(block)) {
                 auto predLiveOut = setFor(liveOutMatrix, predecessor->index());
                 uint64_t predChanged = 0;
-                for (size_t i = 0; i < wordsPerSet; ++i) {
+                for (size_t i = 0; i < m_wordsPerSet; ++i) {
                     uint64_t oldLiveOut = predLiveOut[i];
                     uint64_t newLiveOut = oldLiveOut | liveInSet[i];
                     predLiveOut[i] = newLiveOut;
@@ -409,28 +502,20 @@ protected:
                     worklist.append(predecessor->index());
             }
         }
-
-        // Materialize the sorted IndexVector representation that the public API uses. WTF::forEachSetBit
-        // yields ascending indices, so the resulting vectors are already sorted.
-        for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
-            auto block = m_cfg.node(blockIndex);
-            if (!block)
-                continue;
-            WTF::forEachSetBit(std::span<const uint64_t> { setFor(liveInMatrix, blockIndex) }, [&] (size_t index) { m_liveAtHead[block].append(index); });
-            WTF::forEachSetBit(std::span<const uint64_t> { setFor(liveOutMatrix, blockIndex) }, [&] (size_t index) { m_liveAtTail[block].append(index); });
-        }
     }
 
-    // Sparse fallback for functions whose dense matrices would be too large. Memory is proportional
-    // to live values, at the cost of working bit by bit (SparseBitVector has no bulk word ops).
+    // Sparse fallback for functions whose dense matrices would exceed the budget.
     void computeSparse()
     {
         Adapter::prepareToCompute();
 
         unsigned numNodes = m_cfg.numNodes();
 
-        Vector<SparseBitVector<>> tailBits(numNodes);
-        Vector<SparseBitVector<>> headBits(numNodes);
+        m_storage = Storage::Sparse;
+        m_wordsPerSet = 0;
+        m_sparseStore.clear();
+        m_sparseStore.grow(2 * numNodes);
+        m_workset.initialize(Storage::Sparse, 0);
 
         BitVector dirtyBlocks(numNodes);
         Vector<unsigned, 64> worklist;
@@ -439,8 +524,8 @@ protected:
             if (!block)
                 continue;
 
-            // The liveAtTail of each block automatically contains the LateUse's of the terminal.
-            auto& liveAtTail = tailBits[blockIndex];
+            // liveAtTail automatically contains the LateUse's of the terminal.
+            auto& liveAtTail = sparseTail(blockIndex);
             Adapter::forEachUse(
                 block, Adapter::blockSize(block),
                 [&] (unsigned index) {
@@ -461,8 +546,8 @@ protected:
             ASSERT(block);
 
             m_workset.clear();
-            tailBits[blockIndex].forEachSetBit(
-                [&] (size_t index) {
+            sparseTail(blockIndex).forEachSetBit(
+                [&] (unsigned index) {
                     m_workset.add(index);
                 });
             for (size_t instIndex = Adapter::blockSize(block); instIndex--;) {
@@ -471,18 +556,18 @@ protected:
             }
             Adapter::forEachDef(block, 0, [&] (unsigned index) { m_workset.remove(index); });
 
-            auto& liveAtHead = headBits[blockIndex];
+            auto& liveAtHead = sparseHead(blockIndex);
             delta.shrink(0);
-            for (unsigned index : m_workset) {
+            m_workset.sparse().forEachSetBit([&] (unsigned index) {
                 if (liveAtHead.set(index))
                     delta.append(index);
-            }
+            });
 
             if (delta.isEmpty())
                 continue;
 
             for (auto predecessor : m_cfg.predecessors(block)) {
-                auto& predTail = tailBits[predecessor->index()];
+                auto& predTail = sparseTail(predecessor->index());
                 bool changed = false;
                 for (unsigned index : delta) {
                     if (predTail.set(index))
@@ -492,24 +577,36 @@ protected:
                     worklist.append(predecessor->index());
             }
         }
-
-        for (unsigned blockIndex = 0; blockIndex < numNodes; ++blockIndex) {
-            auto block = m_cfg.node(blockIndex);
-            if (!block)
-                continue;
-            headBits[blockIndex].forEachSetBit([&] (size_t index) { m_liveAtHead[block].append(index); });
-            tailBits[blockIndex].forEachSetBit([&] (size_t index) { m_liveAtTail[block].append(index); });
-        }
     }
 
 private:
     friend class LocalCalc;
     friend class LocalCalc::Iterable;
+    friend class Iterable;
+    friend class LiveAtHead;
+
+    size_t denseHalfWords() const { return m_denseStore.size() / 2; }
+    std::span<const uint64_t> denseHeadSlice(unsigned blockIndex) const LIFETIME_BOUND
+    {
+        return m_denseStore.span().subspan(static_cast<size_t>(blockIndex) * m_wordsPerSet, m_wordsPerSet);
+    }
+    std::span<const uint64_t> denseTailSlice(unsigned blockIndex) const LIFETIME_BOUND
+    {
+        return m_denseStore.span().subspan(denseHalfWords() + static_cast<size_t>(blockIndex) * m_wordsPerSet, m_wordsPerSet);
+    }
+
+    size_t sparseHalfSize() const { return m_sparseStore.size() / 2; }
+    SparseBitVector<>& sparseHead(unsigned blockIndex) LIFETIME_BOUND { return m_sparseStore[blockIndex]; }
+    const SparseBitVector<>& sparseHead(unsigned blockIndex) const LIFETIME_BOUND { return m_sparseStore[blockIndex]; }
+    SparseBitVector<>& sparseTail(unsigned blockIndex) LIFETIME_BOUND { return m_sparseStore[sparseHalfSize() + blockIndex]; }
+    const SparseBitVector<>& sparseTail(unsigned blockIndex) const LIFETIME_BOUND { return m_sparseStore[sparseHalfSize() + blockIndex]; }
 
     CFG& m_cfg;
     Workset m_workset;
-    typename CFG::template Map<IndexVector> m_liveAtHead;
-    typename CFG::template Map<IndexVector> m_liveAtTail;
+    Vector<uint64_t> m_denseStore;
+    Vector<SparseBitVector<>> m_sparseStore;
+    size_t m_wordsPerSet { 0 };
+    Storage m_storage { Storage::Dense };
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/SparseBitVector.h
+++ b/Source/WTF/wtf/SparseBitVector.h
@@ -103,6 +103,57 @@ public:
         }
     }
 
+    class iterator {
+    public:
+        iterator() = default;
+
+        iterator(const SparseBitVector& owner, bool isEnd)
+            : m_owner(&owner)
+        {
+            if (isEnd || owner.m_elements.isEmpty()) {
+                m_elementIndex = owner.m_elements.size();
+                return;
+            }
+            m_bitIter = owner.m_elements[0].bits.begin();
+        }
+
+        unsigned operator*() const
+        {
+            const Element& element = m_owner->m_elements[m_elementIndex];
+            return element.index * elementBits + static_cast<unsigned>(*m_bitIter);
+        }
+
+        iterator& operator++()
+        {
+            ++m_bitIter;
+            if (m_bitIter == m_owner->m_elements[m_elementIndex].bits.end()) {
+                ++m_elementIndex;
+                if (m_elementIndex < m_owner->m_elements.size())
+                    m_bitIter = m_owner->m_elements[m_elementIndex].bits.begin();
+                else
+                    m_bitIter = { };
+            }
+            return *this;
+        }
+
+        bool operator==(const iterator& other) const
+        {
+            if (m_elementIndex != other.m_elementIndex)
+                return false;
+            if (!m_owner || m_elementIndex == m_owner->m_elements.size())
+                return true;
+            return m_bitIter == other.m_bitIter;
+        }
+
+    private:
+        const SparseBitVector* m_owner { nullptr };
+        size_t m_elementIndex { 0 };
+        typename BitSet<elementBits>::iterator m_bitIter;
+    };
+
+    iterator begin() const LIFETIME_BOUND { return iterator(*this, false); }
+    iterator end() const LIFETIME_BOUND { return iterator(*this, true); }
+
 private:
     struct Element {
         unsigned index { 0 };

--- a/Tools/TestWebKitAPI/Tests/WTF/SparseBitVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SparseBitVector.cpp
@@ -213,5 +213,74 @@ TEST(WTF_SparseBitVector, RandomizedAddRemoveAgainstReference)
     EXPECT_EQ(collect(bits), expected);
 }
 
+template<unsigned elementBits>
+static Vector<unsigned> collectViaIterator(const SparseBitVector<elementBits>& bits)
+{
+    Vector<unsigned> result;
+    for (unsigned index : bits)
+        result.append(index);
+    return result;
+}
+
+TEST(WTF_SparseBitVector, IteratorEmpty)
+{
+    SparseBitVector<> bits;
+    EXPECT_TRUE(bits.begin() == bits.end());
+    EXPECT_TRUE(collectViaIterator(bits).isEmpty());
+}
+
+TEST(WTF_SparseBitVector, IteratorSingleBit)
+{
+    SparseBitVector<> bits;
+    bits.set(42);
+    EXPECT_FALSE(bits.begin() == bits.end());
+
+    auto it = bits.begin();
+    EXPECT_EQ(*it, 42u);
+    ++it;
+    EXPECT_TRUE(it == bits.end());
+    EXPECT_EQ(collectViaIterator(bits), (Vector<unsigned> { 42 }));
+}
+
+TEST(WTF_SparseBitVector, IteratorWithinSingleElement)
+{
+    // All set bits live in the same element, exercising bit-iterator advancement only.
+    SparseBitVector<128> bits;
+    for (unsigned value : { 0u, 5u, 63u, 64u, 127u })
+        bits.set(value);
+    EXPECT_EQ(collectViaIterator(bits), (Vector<unsigned> { 0, 5, 63, 64, 127 }));
+}
+
+TEST(WTF_SparseBitVector, IteratorCrossesElementBoundaries)
+{
+    // Bits spread across multiple elements exercise the element-advance branch in operator++.
+    SparseBitVector<128> bits;
+    for (unsigned value : { 0u, 127u, 128u, 200u, 255u, 1000u, 100000u })
+        bits.set(value);
+    EXPECT_EQ(collectViaIterator(bits), (Vector<unsigned> { 0, 127, 128, 200, 255, 1000, 100000 }));
+}
+
+TEST(WTF_SparseBitVector, IteratorMatchesForEachSetBit)
+{
+    // The iterator must yield exactly the same sequence as forEachSetBit.
+    SparseBitVector<> bits;
+    for (unsigned value : { 5000u, 3u, 4999u, 200u, 0u, 127u, 128u, 129u, 1u, 1000003u })
+        bits.set(value);
+    EXPECT_EQ(collectViaIterator(bits), collect(bits));
+}
+
+TEST(WTF_SparseBitVector, IteratorAfterClear)
+{
+    SparseBitVector<> bits;
+    bits.set(1);
+    bits.set(100000);
+    bits.clear();
+    EXPECT_TRUE(bits.begin() == bits.end());
+    EXPECT_TRUE(collectViaIterator(bits).isEmpty());
+
+    bits.set(7);
+    EXPECT_EQ(collectViaIterator(bits), (Vector<unsigned> { 7 }));
+}
+
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### c8778c2d099048be132c7168cd11f20c58212ead
<pre>
[JSC][WTF] WTF::Liveness should use BitVector / SparseBitVector for the external workset
<a href="https://bugs.webkit.org/show_bug.cgi?id=317551">https://bugs.webkit.org/show_bug.cgi?id=317551</a>
<a href="https://rdar.apple.com/180251801">rdar://180251801</a>

Reviewed by Marcus Plutowski.

We use BitVector (internally Vector&lt;uint64_t&gt; for direct bulk access) and
SparseBitVector in WTF::Liveness. But for the external interface, we are
converting them to Vector to expose. But this is wasteful. Let&apos;s just
expose these BitVector as a result. Wrap them with common interface not
to switch BitVector v.s. SparseBitVector from the client side.

* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::Liveness):
(WTF::Liveness::wordsForBits):
(WTF::Liveness::Workset::initialize):
(WTF::Liveness::Workset::clear):
(WTF::Liveness::Workset::add):
(WTF::Liveness::Workset::remove):
(WTF::Liveness::Workset::contains const):
(WTF::Liveness::Workset::copyFromDense):
(WTF::Liveness::Workset::copyFromSparse):
(WTF::Liveness::Workset::storage const):
(WTF::Liveness::Iterator::makeBegin):
(WTF::Liveness::Iterator::makeEnd):
(WTF::Liveness::Iterator::operator* const):
(WTF::Liveness::Iterator::operator++):
(WTF::Liveness::Iterator::operator== const):
(WTF::Liveness::Iterator::advanceDense):
(WTF::Liveness::Iterable::Iterable):
(WTF::Liveness::Iterable::contains const):
(WTF::Liveness::LocalCalc::LocalCalc):
(WTF::Liveness::LocalCalc::Iterable::Iterable):
(WTF::Liveness::LocalCalc::Iterable::contains const):
(WTF::Liveness::LocalCalc::isLive const):
(WTF::Liveness::LocalCalc::execute):
(WTF::Liveness::LiveAtHead::LiveAtHead):
(WTF::Liveness::LiveAtHead::isLiveAtHead):
(WTF::Liveness::compute):
(WTF::Liveness::computeDense):
(WTF::Liveness::computeSparse):
(WTF::Liveness::denseHalfWords const):
(WTF::Liveness::sparseHalfSize const):
(WTF::Liveness::LocalCalc::Iterable::iterator::iterator): Deleted.
(WTF::Liveness::LocalCalc::Iterable::iterator::operator++): Deleted.
(WTF::Liveness::LocalCalc::Iterable::iterator::operator* const): Deleted.
(WTF::Liveness::LocalCalc::Iterable::iterator::operator== const): Deleted.
(WTF::Liveness::LocalCalc::live const): Deleted.
(WTF::Liveness::rawLiveAtHead): Deleted.
(WTF::Liveness::Iterable::iterator::iterator): Deleted.
(WTF::Liveness::Iterable::iterator::operator*): Deleted.
(WTF::Liveness::Iterable::iterator::operator++): Deleted.
(WTF::Liveness::Iterable::iterator::operator== const): Deleted.
(WTF::Liveness::liveAtHead): Deleted.
(WTF::Liveness::liveAtTail): Deleted.
* Source/WTF/wtf/SparseBitVector.h:
(WTF::SparseBitVector::iterator::iterator):
(WTF::SparseBitVector::iterator::operator* const):
(WTF::SparseBitVector::iterator::operator++):
(WTF::SparseBitVector::iterator::operator== const):
* Tools/TestWebKitAPI/Tests/WTF/SparseBitVector.cpp:
(TestWebKitAPI::collectViaIterator):
(TestWebKitAPI::TEST(WTF_SparseBitVector, IteratorEmpty)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, IteratorSingleBit)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, IteratorWithinSingleElement)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, IteratorCrossesElementBoundaries)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, IteratorMatchesForEachSetBit)):
(TestWebKitAPI::TEST(WTF_SparseBitVector, IteratorAfterClear)):

Canonical link: <a href="https://commits.webkit.org/315632@main">https://commits.webkit.org/315632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2713dccecd5780e3515726b476084267fded1691

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43418 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36731 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127208 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/666d9de4-7394-459f-a856-6a557fbc5d12) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171362 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132049 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92981 "2 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55a2396a-de84-412d-99b5-104f27ea525c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172455 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112552 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/caff5230-fd21-4fec-bd26-5c118d11347e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32187 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27552 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/798 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181454 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30751 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140497 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43074 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140333 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43763 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28758 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107912 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35603 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115528 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202175 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42273 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6845 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54217 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41921 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41809 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->