### PR TITLE
[AppKit Gestures] Expose more autoscroll logic on macOS

### DIFF
--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -51,14 +51,28 @@ enum class AutoscrollType : uint8_t {
 #endif
 };
 
-// When the autoscroll or the panScroll is triggered when do the scroll every 50ms to make it smooth.
-constexpr Seconds autoscrollInterval { 50_ms };
-
-// AutscrollController handles autoscroll and pan scroll for EventHandler.
+// AutoscrollController handles autoscroll and pan scroll for EventHandler.
 class AutoscrollController final : public CanMakeCheckedPtr<AutoscrollController> {
     WTF_MAKE_TZONE_ALLOCATED(AutoscrollController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AutoscrollController);
 public:
+    // When the autoscroll or the panScroll is triggered when do the scroll every 50ms to make it smooth.
+    constexpr static Seconds autoscrollInterval = 50_ms;
+
+    // The band, in root-view points, within which a selection-extend drag autoscrolls.
+    constexpr static float selectionAutoscrollEdgeDistance = 100;
+
+    // This bounds how far past a visible edge the autoscroll target is pushed (and thus the per-tick scroll speed.
+    constexpr static float selectionAutoscrollMaximumSpeed = 40;
+
+    // Maps how far a point reaches into the edge band (`distancePastBandEdge`, root-view points) to how far
+    // past the visible edge the autoscroll target should sit, scaling by the band size so the resulting
+    // scroll speed is independent of the band's size.
+    static inline float rampedSelectionAutoscrollDistance(float distancePastBandEdge, float edgeDistance, float maximumSpeed)
+    {
+        return (distancePastBandEdge / edgeDistance) * maximumSpeed;
+    }
+
     AutoscrollController();
     RenderBox* NODELETE autoscrollRenderer() const;
     bool NODELETE autoscrollInProgress() const;

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3475,7 +3475,7 @@ IntPoint EventHandler::targetPositionInWindowForSelectionAutoscroll() const
     
 #endif // !PLATFORM(MAC)
     
-#if !PLATFORM(IOS_FAMILY)
+#if !PLATFORM(COCOA)
     
 bool EventHandler::shouldUpdateAutoscroll()
 {

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -394,7 +394,7 @@ public:
     WEBCORE_EXPORT void tryToBeginDragAtPoint(const IntPoint& clientPosition, const IntPoint& globalPosition, CompletionHandler<void(Expected<bool, RemoteFrameGeometryTransformer>)>&&);
 #endif
     
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
     WEBCORE_EXPORT void startSelectionAutoscroll(RenderObject* renderer, const FloatPoint& positionInWindow);
     WEBCORE_EXPORT void cancelSelectionAutoscroll();
 #endif
@@ -787,10 +787,13 @@ private:
     int m_activationEventNumber { -1 };
 #endif
 
-#if PLATFORM(IOS_FAMILY)
-    bool m_shouldAllowMouseDownToStartDrag { false };
+#if PLATFORM(COCOA)
     bool m_isAutoscrolling { false };
     IntPoint m_targetAutoscrollPositionInRootView;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    bool m_shouldAllowMouseDownToStartDrag { false };
     IntPoint m_targetAutoscrollPositionInUnscrolledRootView;
     std::optional<IntPoint> m_initialAutoscrollPositionInUnscrolledRootView;
 #endif

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -500,7 +500,7 @@ void FocusController::setFocusedFrame(Frame* frame, BroadcastFocusedFrame broadc
         } while (frame);
     }
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(COCOA)
     if (oldFrame)
         oldFrame->eventHandler().cancelSelectionAutoscroll();
 #endif

--- a/Source/WebCore/page/cocoa/EventHandlerCocoa.mm
+++ b/Source/WebCore/page/cocoa/EventHandlerCocoa.mm
@@ -26,11 +26,17 @@
 #import "config.h"
 #import "EventHandler.h"
 
+#import "AutoscrollController.h"
 #import "DictionaryLookup.h"
+#import "DocumentPage.h"
+#import "DocumentView.h"
 #import "Editor.h"
 #import "EventNames.h"
 #import "HandleUserInputEventResult.h"
 #import "LocalFrameInlines.h"
+#import "LocalFrameView.h"
+#import "Page.h"
+#import "RenderObject.h"
 
 #if PLATFORM(COCOA)
 
@@ -72,6 +78,51 @@ void EventHandler::dispatchSyntheticMouseMove(const PlatformMouseEvent& platform
 }
 
 #endif // ENABLE(TWO_PHASE_CLICKS)
+
+void EventHandler::startSelectionAutoscroll(RenderObject* renderer, const FloatPoint& positionInWindow)
+{
+    Ref frame = m_frame.get();
+    RefPtr frameView = frame->view();
+    if (!frameView)
+        return;
+
+    m_targetAutoscrollPositionInRootView = roundedIntPoint(positionInWindow);
+
+#if PLATFORM(IOS_FAMILY)
+    m_targetAutoscrollPositionInUnscrolledRootView = m_targetAutoscrollPositionInRootView - toIntSize(frameView->documentScrollPositionRelativeToViewOrigin());
+
+    if (!m_isAutoscrolling)
+        m_initialAutoscrollPositionInUnscrolledRootView = m_targetAutoscrollPositionInUnscrolledRootView;
+#endif // PLATFORM(IOS_FAMILY)
+
+    m_isAutoscrolling = true;
+    m_autoscrollController->startAutoscrollForSelection(renderer);
+}
+
+void EventHandler::cancelSelectionAutoscroll()
+{
+    m_isAutoscrolling = false;
+
+#if PLATFORM(IOS_FAMILY)
+    m_initialAutoscrollPositionInUnscrolledRootView = std::nullopt;
+    m_targetAutoscrollPositionInUnscrolledRootView = { };
+#endif
+
+    m_targetAutoscrollPositionInRootView = { };
+    m_autoscrollController->stopAutoscrollTimer();
+}
+
+bool EventHandler::shouldUpdateAutoscroll()
+{
+    if (m_isAutoscrolling)
+        return true;
+
+#if PLATFORM(MAC)
+    return mousePressed();
+#else
+    return false;
+#endif
+}
 
 }
 

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -582,39 +582,13 @@ PlatformMouseEvent EventHandler::currentPlatformMouseEvent() const
 {
     return PlatformEventFactory::createPlatformMouseEvent(currentEvent());
 }
-    
-void EventHandler::startSelectionAutoscroll(RenderObject* renderer, const FloatPoint& positionInWindow)
-{
-    Ref frame = m_frame.get();
-    RefPtr frameView = frame->view();
-    if (!frameView)
-        return;
-
-    m_targetAutoscrollPositionInRootView = roundedIntPoint(positionInWindow);
-    m_targetAutoscrollPositionInUnscrolledRootView = m_targetAutoscrollPositionInRootView - toIntSize(frameView->documentScrollPositionRelativeToViewOrigin());
-
-    if (!m_isAutoscrolling)
-        m_initialAutoscrollPositionInUnscrolledRootView = m_targetAutoscrollPositionInUnscrolledRootView;
-
-    m_isAutoscrolling = true;
-    m_autoscrollController->startAutoscrollForSelection(renderer);
-}
-
-void EventHandler::cancelSelectionAutoscroll()
-{
-    m_isAutoscrolling = false;
-    m_initialAutoscrollPositionInUnscrolledRootView = std::nullopt;
-    m_targetAutoscrollPositionInRootView = { };
-    m_targetAutoscrollPositionInUnscrolledRootView = { };
-    m_autoscrollController->stopAutoscrollTimer();
-}
 
 static IntPoint adjustAutoscrollDestinationForInsetEdges(IntPoint autoscrollPoint, std::optional<IntPoint> initialAutoscrollPoint, FloatRect unobscuredRootViewRect, float zoomScale)
 {
     IntPoint resultPoint = autoscrollPoint;
 
-    const float edgeInset = 100 / zoomScale;
-    const float maximumScrollingSpeed = 40 / zoomScale;
+    const float edgeInset = AutoscrollController::selectionAutoscrollEdgeDistance / zoomScale;
+    const float maximumScrollingSpeed = AutoscrollController::selectionAutoscrollMaximumSpeed / zoomScale;
     const float insetDistanceThreshold = edgeInset / 2;
 
     // FIXME: Ideally we would only inset on edges that touch the edge of the screen,
@@ -645,21 +619,21 @@ static IntPoint adjustAutoscrollDestinationForInsetEdges(IntPoint autoscrollPoin
     if (autoscrollPoint.x() < insetUnobscuredRootViewRect.x()) {
         float distanceFromEdge = autoscrollPoint.x() - insetUnobscuredRootViewRect.x();
         if (distanceFromEdge < 0)
-            resultPoint.setX(unobscuredRootViewRect.x() + ((distanceFromEdge / edgeInset) * maximumScrollingSpeed));
+            resultPoint.setX(unobscuredRootViewRect.x() + AutoscrollController::rampedSelectionAutoscrollDistance(distanceFromEdge, edgeInset, maximumScrollingSpeed));
     } else if (autoscrollPoint.x() >= insetUnobscuredRootViewRect.maxX()) {
         float distanceFromEdge = autoscrollPoint.x() - insetUnobscuredRootViewRect.maxX();
         if (distanceFromEdge > 0)
-            resultPoint.setX(unobscuredRootViewRect.maxX() + ((distanceFromEdge / edgeInset) * maximumScrollingSpeed));
+            resultPoint.setX(unobscuredRootViewRect.maxX() + AutoscrollController::rampedSelectionAutoscrollDistance(distanceFromEdge, edgeInset, maximumScrollingSpeed));
     }
 
     if (autoscrollPoint.y() < insetUnobscuredRootViewRect.y()) {
         float distanceFromEdge = autoscrollPoint.y() - insetUnobscuredRootViewRect.y();
         if (distanceFromEdge < 0)
-            resultPoint.setY(unobscuredRootViewRect.y() + ((distanceFromEdge / edgeInset) * maximumScrollingSpeed));
+            resultPoint.setY(unobscuredRootViewRect.y() + AutoscrollController::rampedSelectionAutoscrollDistance(distanceFromEdge, edgeInset, maximumScrollingSpeed));
     } else if (autoscrollPoint.y() >= insetUnobscuredRootViewRect.maxY()) {
         float distanceFromEdge = autoscrollPoint.y() - insetUnobscuredRootViewRect.maxY();
         if (distanceFromEdge > 0)
-            resultPoint.setY(unobscuredRootViewRect.maxY() + ((distanceFromEdge / edgeInset) * maximumScrollingSpeed));
+            resultPoint.setY(unobscuredRootViewRect.maxY() + AutoscrollController::rampedSelectionAutoscrollDistance(distanceFromEdge, edgeInset, maximumScrollingSpeed));
     }
 
     return resultPoint;
@@ -689,11 +663,6 @@ IntPoint EventHandler::targetPositionInWindowForSelectionAutoscroll() const
     unobscuredContentRectInUnscrolledRootView.move(-scrollPosition);
 
     return adjustAutoscrollDestinationForInsetEdges(m_targetAutoscrollPositionInUnscrolledRootView, m_initialAutoscrollPositionInUnscrolledRootView, unobscuredContentRectInUnscrolledRootView, page->pageScaleFactor()) + scrollPosition;
-}
-
-bool EventHandler::shouldUpdateAutoscroll()
-{
-    return m_isAutoscrolling;
 }
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE_INTERACTION)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -2139,6 +2139,18 @@ void WebPageProxy::updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint p
     protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::UpdateSelectionWithExtentPointAndBoundary(point, granularity, isInteractingWithFocusedElement, source), WTF::move(callback), webPageIDInMainFrameProcess());
 }
 
+void WebPageProxy::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
+{
+    m_isAutoscrolling = true;
+    protect(m_legacyMainFrameProcess)->send(Messages::WebPage::StartAutoscrollAtPosition(positionInWindow), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::cancelAutoscroll()
+{
+    m_isAutoscrolling = false;
+    protect(m_legacyMainFrameProcess)->send(Messages::WebPage::CancelAutoscroll(), webPageIDInMainFrameProcess());
+}
+
 #if ENABLE(TWO_PHASE_CLICKS)
 
 void WebPageProxy::potentialTapAtPosition(std::optional<WebCore::FrameIdentifier> remoteFrameID, const WebCore::FloatPoint& position, bool shouldRequestMagnificationInformation, WebKit::TapIdentifier requestID, WebEventInputSource inputSource)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1277,11 +1277,8 @@ public:
     void requestRectsAtSelectionOffsetWithText(int32_t offset, const String&, CompletionHandler<void(const Vector<WebCore::SelectionGeometry>&)>&&);
     void autofillLoginCredentials(std::optional<WebCore::FrameIdentifier>, const String& username, const String& password);
     void storeSelectionForAccessibility(bool);
-    void startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow);
-    void cancelAutoscroll();
     void hardwareKeyboardAvailabilityChanged(HardwareKeyboardState);
     bool isScrollingOrZooming() const { return m_isScrollingOrZooming; }
-    bool isAutoscrolling() const { return m_isAutoscrolling; }
     void requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<WebCore::FloatRect>&)>&&);
     void updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&&);
     void requestDocumentEditingContext(DocumentEditingContextRequest&&, CompletionHandler<void(DocumentEditingContext&&)>&&);
@@ -1312,6 +1309,10 @@ public:
 #if PLATFORM(COCOA)
     void insertTextPlaceholder(const WebCore::IntSize&, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&&);
     void removeTextPlaceholder(const WebCore::ElementContext&, CompletionHandler<void()>&&);
+
+    void startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow);
+    void cancelAutoscroll();
+    bool isAutoscrolling() const { return m_isAutoscrolling; }
 #endif
 
 #if ENABLE(DATA_DETECTION)
@@ -3815,6 +3816,9 @@ private:
     bool m_hasNetworkRequestsOnSuspended { false };
     bool m_isKeyboardAnimatingIn { false };
     bool m_isScrollingOrZooming { false };
+#endif
+
+#if PLATFORM(COCOA)
     bool m_isAutoscrolling { false };
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -689,18 +689,6 @@ void WebPageProxy::storeSelectionForAccessibility(bool shouldStore)
     protect(m_legacyMainFrameProcess)->send(Messages::WebPage::StoreSelectionForAccessibility(shouldStore), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
-{
-    m_isAutoscrolling = true;
-    protect(m_legacyMainFrameProcess)->send(Messages::WebPage::StartAutoscrollAtPosition(positionInWindow), webPageIDInMainFrameProcess());
-}
-
-void WebPageProxy::cancelAutoscroll()
-{
-    m_isAutoscrolling = false;
-    protect(m_legacyMainFrameProcess)->send(Messages::WebPage::CancelAutoscroll(), webPageIDInMainFrameProcess());
-}
-
 void WebPageProxy::moveSelectionByOffset(int32_t offset, CompletionHandler<void()>&& callbackFunction)
 {
     if (!hasRunningProcess()) {

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -3284,7 +3284,7 @@ FloatRect UnifiedPDFPlugin::rectForSelectionInRootView(PDFSelection *selection) 
 void UnifiedPDFPlugin::beginAutoscroll()
 {
     if (!std::exchange(m_inActiveAutoscroll, true))
-        m_autoscrollTimer.startRepeating(WebCore::autoscrollInterval);
+        m_autoscrollTimer.startRepeating(WebCore::AutoscrollController::autoscrollInterval);
 }
 
 void UnifiedPDFPlugin::autoscrollTimerFired()

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -67,6 +67,7 @@
 #import <WebCore/CSSKeywordValue.h>
 #import <WebCore/Chrome.h>
 #import <WebCore/ChromeClient.h>
+#import <WebCore/ContainerNodeInlines.h>
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
 #import <WebCore/ContentChangeObserver.h>
 #endif
@@ -2862,6 +2863,38 @@ void WebPage::updateSelectionWithExtentPoint(WebCore::IntPoint point, bool isInt
 #else
     callback(true);
 #endif
+}
+
+void WebPage::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
+{
+    RefPtr frame = m_page->focusController().focusedOrMainFrame();
+    if (!frame)
+        return;
+
+    if (m_focusedElement && m_focusedElement->renderer()) {
+        frame->eventHandler().startSelectionAutoscroll(protect(m_focusedElement->renderer()), positionInWindow);
+        return;
+    }
+
+    auto& selection = frame->selection().selection();
+    if (!selection.isRange())
+        return;
+
+    auto range = selection.toNormalizedRange();
+    if (!range)
+        return;
+
+    CheckedPtr renderer = range->start.container->renderer();
+    if (!renderer)
+        return;
+
+    frame->eventHandler().startSelectionAutoscroll(renderer, positionInWindow);
+}
+
+void WebPage::cancelAutoscroll()
+{
+    if (RefPtr frame = m_page->focusController().focusedOrMainFrame())
+        frame->eventHandler().cancelSelectionAutoscroll();
 }
 
 void WebPage::selectTextWithGranularityAtPoint(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1212,8 +1212,6 @@ public:
     void getRectsForGranularityWithSelectionOffset(WebCore::TextGranularity, int32_t, CompletionHandler<void(const Vector<WebCore::SelectionGeometry>&)>&&);
     void getRectsAtSelectionOffsetWithText(int32_t, const String&, CompletionHandler<void(const Vector<WebCore::SelectionGeometry>&)>&&);
     void storeSelectionForAccessibility(bool);
-    void startAutoscrollAtPosition(const WebCore::FloatPoint&);
-    void cancelAutoscroll();
     void requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<WebCore::FloatRect>&)>&&);
 
     void contentSizeCategoryDidChange(const String&);
@@ -1236,6 +1234,11 @@ public:
     void requestDocumentEditingContext(WebKit::DocumentEditingContextRequest&&, CompletionHandler<void(WebKit::DocumentEditingContext&&)>&&);
     bool shouldDrawVisuallyContiguousBidiSelection() const;
 #endif // PLATFORM(IOS_FAMILY)
+
+#if PLATFORM(COCOA)
+    void startAutoscrollAtPosition(const WebCore::FloatPoint&);
+    void cancelAutoscroll();
+#endif
 
     void willChangeSelectionForAccessibility() { m_isChangingSelectionForAccessibility = true; }
     void didChangeSelectionForAccessibility() { m_isChangingSelectionForAccessibility = false; }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -150,8 +150,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
     GetRectsForGranularityWithSelectionOffset(enum:uint8_t WebCore::TextGranularity granularity, int32_t offset) -> (Vector<WebCore::SelectionGeometry> rect)
     GetRectsAtSelectionOffsetWithText(int32_t offset, String text) -> (Vector<WebCore::SelectionGeometry> rect)
     StoreSelectionForAccessibility(bool shouldStore)
-    StartAutoscrollAtPosition(WebCore::FloatPoint positionInWindow)
-    CancelAutoscroll()
     RequestFocusedElementInformation() -> (struct std::optional<WebKit::FocusedElementInformation> info)
     HardwareKeyboardAvailabilityChanged(struct WebKit::HardwareKeyboardState state)
     SetIsShowingInputViewForFocusedElement(bool showingInputView)
@@ -162,6 +160,11 @@ messages -> WebPage WantsAsyncDispatchMessage {
     TextInputContextsInRect(WebCore::FloatRect rect) -> (Vector<WebCore::ElementContext> contexts)
     FocusTextInputContextAndPlaceCaret(struct WebCore::ElementContext context, WebCore::IntPoint point) -> (bool success)
     ClearServiceWorkerEntitlementOverride() -> ()
+#endif
+
+#if PLATFORM(COCOA)
+    StartAutoscrollAtPosition(WebCore::FloatPoint positionInWindow)
+    CancelAutoscroll()
 #endif
 
     ProcessWillSuspend()

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1872,38 +1872,6 @@ void WebPage::moveSelectionByOffset(int32_t offset, CompletionHandler<void()>&& 
         protect(frame->selection())->setSelectedRange(makeSimpleRange(position), position.affinity(), WebCore::FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes);
     completionHandler();
 }
-    
-void WebPage::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
-{
-    RefPtr frame = m_page->focusController().focusedOrMainFrame();
-    if (!frame)
-        return;
-
-    if (m_focusedElement && m_focusedElement->renderer()) {
-        frame->eventHandler().startSelectionAutoscroll(protect(m_focusedElement->renderer()), positionInWindow);
-        return;
-    }
-
-    auto& selection = frame->selection().selection();
-    if (!selection.isRange())
-        return;
-
-    auto range = selection.toNormalizedRange();
-    if (!range)
-        return;
-
-    CheckedPtr renderer = range->start.container->renderer();
-    if (!renderer)
-        return;
-
-    frame->eventHandler().startSelectionAutoscroll(renderer, positionInWindow);
-}
-    
-void WebPage::cancelAutoscroll()
-{
-    if (RefPtr frame = m_page->focusController().focusedOrMainFrame())
-        frame->eventHandler().cancelSelectionAutoscroll();
-}
 
 void WebPage::requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<FloatRect>&)>&& reply)
 {


### PR DESCRIPTION
#### ade575a76c218b927e7b6fd4ece828cf4a8d5d62
<pre>
[AppKit Gestures] Expose more autoscroll logic on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=317553">https://bugs.webkit.org/show_bug.cgi?id=317553</a>
<a href="https://rdar.apple.com/180253433">rdar://180253433</a>

Reviewed by Wenson Hsieh.

No logic change.

* Source/WebCore/page/AutoscrollController.h:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):
* Source/WebCore/page/cocoa/EventHandlerCocoa.mm:
(WebCore::EventHandler::startSelectionAutoscroll):
(WebCore::EventHandler::cancelSelectionAutoscroll):
(WebCore::EventHandler::shouldUpdateAutoscroll):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::currentPlatformMouseEvent const):
(WebCore::adjustAutoscrollDestinationForInsetEdges):
(WebCore::EventHandler::startSelectionAutoscroll): Deleted.
(WebCore::EventHandler::cancelSelectionAutoscroll): Deleted.
(WebCore::EventHandler::shouldUpdateAutoscroll): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::startAutoscrollAtPosition):
(WebKit::WebPageProxy::cancelAutoscroll):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::startAutoscrollAtPosition): Deleted.
(WebKit::WebPageProxy::cancelAutoscroll): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::beginAutoscroll):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::startAutoscrollAtPosition):
(WebKit::WebPage::cancelAutoscroll):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::moveSelectionByOffset):
(WebKit::WebPage::startAutoscrollAtPosition): Deleted.
(WebKit::WebPage::cancelAutoscroll): Deleted.

Canonical link: <a href="https://commits.webkit.org/315600@main">https://commits.webkit.org/315600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a1096e4413fa1283387c380ef52df2e30003a2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127202 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/157df499-6bc7-4570-bad9-3be14a8e0020) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171356 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/43916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132043 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92975 "1 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b5f5f9c-0106-4abd-aa55-4651b5944151) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172449 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34891 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112546 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75dc48b6-2088-4bb7-9a5c-a003544379a8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32181 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27546 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181448 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140491 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43068 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140327 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37769 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28751 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107900 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35598 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115522 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42267 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6838 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41660 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41915 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->