### PR TITLE
[JSC] `IteratorClose` in `forEachInIterable` should use the Map/Set's own realm's iterator structure

### DIFF
--- a/JSTests/stress/for-each-in-iterable-cross-realm-iterator-close.js
+++ b/JSTests/stress/for-each-in-iterable-cross-realm-iterator-close.js
@@ -1,0 +1,61 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error((msg ? msg + ": " : "") + `expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(func) {
+    let threw = false;
+    try {
+        func();
+    } catch {
+        threw = true;
+    }
+    shouldBe(threw, true, "should have thrown");
+}
+
+// When forEachInIterable takes the JSSet storage fast path and the callback
+// throws, IteratorClose must look up `return` on the iterator that the spec
+// would have created, i.e. one inheriting from the *Set's own realm's*
+// %SetIteratorPrototype%, not the caller realm's.
+{
+    const other = createGlobalObject();
+    // A Set from the other realm whose iterator protocol is pristine.
+    const otherSet = new other.Set([1, 2, 3]);
+
+    let callerRealmReturnCount = 0;
+    const SetIteratorPrototype = Object.getPrototypeOf(new Set().values());
+    SetIteratorPrototype.return = function () {
+        callerRealmReturnCount++;
+        return { value: undefined, done: true };
+    };
+
+    // new WeakSet(otherSet): primitive entries cause the adder callback to
+    // throw a TypeError, which triggers IteratorClose on the (materialized)
+    // set iterator. Per spec that iterator inherits from the other realm's
+    // %SetIteratorPrototype%, which has no `return`, so nothing should run.
+    shouldThrow(() => new WeakSet(otherSet));
+    shouldBe(callerRealmReturnCount, 0, "Set: caller realm %SetIteratorPrototype%.return must not be called");
+
+    delete SetIteratorPrototype.return;
+}
+
+// Same for the JSMap storage fast path.
+{
+    const other = createGlobalObject();
+    const otherMap = new other.Map();
+    otherMap.set("k", "v");
+
+    let callerRealmReturnCount = 0;
+    const MapIteratorPrototype = Object.getPrototypeOf(new Map().entries());
+    MapIteratorPrototype.return = function () {
+        callerRealmReturnCount++;
+        return { value: undefined, done: true };
+    };
+
+    // new WeakMap(otherMap): the entry key "k" is not an object/symbol, so the
+    // adder callback throws a TypeError, which triggers IteratorClose.
+    shouldThrow(() => new WeakMap(otherMap));
+    shouldBe(callerRealmReturnCount, 0, "Map: caller realm %MapIteratorPrototype%.return must not be called");
+
+    delete MapIteratorPrototype.return;
+}

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -273,7 +273,7 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE 
             JSCell* storageCell = jsMap->storageOrSentinel(vm);
             if (storageCell != vm.orderedHashTableSentinel()) {
                 forEachInMapStorage(vm, globalObject, storageCell, 0, IterationKind::Entries, callback, [&](JSCell* currentStorageCell, JSMap::Helper::Entry entry) {
-                    JSMapIterator* iterator = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), jsMap, IterationKind::Entries);
+                    JSMapIterator* iterator = JSMapIterator::create(vm, jsMap->realm()->mapIteratorStructure(), jsMap, IterationKind::Entries);
                     iterator->setStorage(vm, currentStorageCell);
                     iterator->setEntry(vm, entry);
                     iteratorClose(globalObject, iterator);
@@ -287,7 +287,7 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE 
             JSCell* storageCell = jsSet->storageOrSentinel(vm);
             if (storageCell != vm.orderedHashTableSentinel()) {
                 forEachInSetStorage(vm, globalObject, storageCell, 0, callback, [&](JSCell* currentStorageCell, JSSet::Helper::Entry entry) {
-                    JSSetIterator* iterator = JSSetIterator::create(vm, globalObject->setIteratorStructure(), jsSet, IterationKind::Values);
+                    JSSetIterator* iterator = JSSetIterator::create(vm, jsSet->realm()->setIteratorStructure(), jsSet, IterationKind::Values);
                     iterator->setStorage(vm, currentStorageCell);
                     iterator->setEntry(vm, entry);
                     iteratorClose(globalObject, iterator);


### PR DESCRIPTION
#### b0d53a73d7eb053d4ad8228903d0298f6676459d
<pre>
[JSC] `IteratorClose` in `forEachInIterable` should use the Map/Set&apos;s own realm&apos;s iterator structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=317554">https://bugs.webkit.org/show_bug.cgi?id=317554</a>

Reviewed by Yusuke Suzuki.

When the JSMap/JSSet storage fast paths in forEachInIterable materialize a
temporary iterator for IteratorClose after the callback throws, they were
creating it with the caller realm&apos;s mapIteratorStructure()/setIteratorStructure().
However, the isIteratorProtocolFastAndNonObservable() guard only checks the
Map/Set&apos;s own realm, so we can take the fast path with a cross-realm Map/Set
and end up looking up `return` on the wrong realm&apos;s %MapIteratorPrototype% /
%SetIteratorPrototype%.

Fix this by creating the materialized iterator with the Map/Set&apos;s own realm&apos;s
structure, matching what the spec&apos;s GetIterator would have produced.

Test: JSTests/stress/for-each-in-iterable-cross-realm-iterator-close.js

* JSTests/stress/for-each-in-iterable-cross-realm-iterator-close.js: Added.
(shouldBe):
(shouldBe.SetIteratorPrototype.return):
(MapIteratorPrototype.return):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInIterable):

Canonical link: <a href="https://commits.webkit.org/315645@main">https://commits.webkit.org/315645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4009ae452e36c54a9d0b31501a57ffc84b36d75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127204 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132045 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92977 "1 flakes 10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172451 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112548 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32183 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27548 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/793 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181450 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30747 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140493 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43070 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140329 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37804 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43759 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28753 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107905 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35600 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115524 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202171 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42269 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6840 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54214 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41662 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41805 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->