### PR TITLE
[JSC] `RegExp#@@split` should not crash on huge flags string

### DIFF
--- a/JSTests/stress/regexp-symbol-split-huge-flags-string-overflow.js
+++ b/JSTests/stress/regexp-symbol-split-huge-flags-string-overflow.js
@@ -1,0 +1,26 @@
+//@ memoryHog!
+//@ runDefault
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+var hugeFlags = "a".repeat(2 ** 31 - 1);
+
+shouldThrow(() => {
+    var fakeRegExp = {
+        get flags() { return hugeFlags; },
+    };
+    RegExp.prototype[Symbol.split].call(fakeRegExp, "abc");
+}, "RangeError: Out of memory");

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -1012,7 +1012,11 @@ JSValue regExpSplitSlow(JSGlobalObject* globalObject, JSObject* thisObject, JSSt
 
     // 8. If flags contains "y", let newFlags be flags.
     // 9. Else, let newFlags be the string-concatenation of flags and "y".
-    String newFlags = flags.contains('y') ? flags : makeString(flags, 'y');
+    String newFlags = flags.contains('y') ? flags : tryMakeString(flags, 'y');
+    if (newFlags.isNull()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return { };
+    }
 
     // 10. Let splitter be ? Construct(speciesCtor, « regexp, newFlags »).
     MarkedArgumentBuffer constructorArgs;


### PR DESCRIPTION
#### fb8194b34646f00c7bbaec04c45f6944dd8b804c
<pre>
[JSC] `RegExp#@@split` should not crash on huge flags string
<a href="https://bugs.webkit.org/show_bug.cgi?id=317555">https://bugs.webkit.org/show_bug.cgi?id=317555</a>

Reviewed by Yusuke Suzuki.

When regExpSplitSlow concatenates &quot;y&quot; to a user-supplied flags string, it
used makeString, which calls WTFCrash on length overflow or allocation
failure. Since flags is obtained via Get(rx, &quot;flags&quot;) and ToString, a
custom flags getter can return a string of String::MaxLength characters,
making the concatenation crash the process instead of throwing.

Before 315243@main moved Symbol.split to C++, the JS builtin used
`flags + &quot;y&quot;`, which threw a catchable RangeError. This is a regression
from that migration.

Fix by using tryMakeString and throwing an out-of-memory error on failure,
matching the pattern used elsewhere in JSC for user-controlled string
concatenation.

Test: JSTests/stress/regexp-symbol-split-huge-flags-string-overflow.js

* JSTests/stress/regexp-symbol-split-huge-flags-string-overflow.js: Added.
(shouldThrow):
(shouldThrow.fakeRegExp.get flags):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::regExpSplitSlow):

Canonical link: <a href="https://commits.webkit.org/315644@main">https://commits.webkit.org/315644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f7cc5aff8ed3853aeb74adea1b0f7b51a853bb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127205 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132046 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92978 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172452 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112549 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32184 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27549 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/794 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181451 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30748 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140494 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43071 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37803 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43760 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28754 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107906 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35601 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115525 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202172 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42270 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6841 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54215 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->