### PR TITLE
[JSC] Avoid intermediate `StringImpl` allocation when feeding `StringBuilder` into `makeString`

### DIFF
--- a/JSTests/microbenchmarks/string-replace-string-substitution.js
+++ b/JSTests/microbenchmarks/string-replace-string-substitution.js
@@ -1,0 +1,10 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
+function test(a, b, c)
+{
+    return a.replace(b, c);
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i)
+    test("Hello World", "World", "[$&]");

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1082,7 +1082,7 @@ ResolvedLocale resolveLocale(JSGlobalObject* globalObject, const LocaleSet& avai
 
     if (supportedExtension.length() > 2) {
         StringView foundLocaleView(foundLocale);
-        foundLocale = makeString(foundLocaleView.left(matcherResult.extensionIndex), supportedExtension.toString(), foundLocaleView.substring(matcherResult.extensionIndex));
+        foundLocale = makeString(foundLocaleView.left(matcherResult.extensionIndex), StringView { supportedExtension }, foundLocaleView.substring(matcherResult.extensionIndex));
     }
 
     resolved.locale = WTF::move(foundLocale);

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -142,7 +142,7 @@ void IntlPluralRules::initializePluralRules(JSGlobalObject* globalObject, JSValu
     appendNumberFormatDigitOptionsToSkeleton(this, skeletonBuilder);
     appendNumberFormatNotationOptionsToSkeleton(this, skeletonBuilder);
 
-    StringView skeletonView { skeletonBuilder.toString() };
+    StringView skeletonView { skeletonBuilder };
     auto upconverted = skeletonView.upconvertedCharacters();
 
     m_numberFormatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), locale.data(), &status));

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -311,7 +311,7 @@ ALWAYS_INLINE String tryMakeReplacedString(const String& string, const String& r
             substituteBackreferencesSlow(builder, replacement, string, ovector, nullptr, dollarPos);
             if (builder.hasOverflowed()) [[unlikely]]
                 return { };
-            if (auto result = tryMakeString(StringView(string).substring(0, matchStart), builder.toString(), StringView(string).substring(matchEnd, string.length() - matchEnd)); !result.isNull()) [[likely]]
+            if (auto result = tryMakeString(StringView(string).substring(0, matchStart), StringView { builder }, StringView(string).substring(matchEnd, string.length() - matchEnd)); !result.isNull()) [[likely]]
                 return result;
         }
     }


### PR DESCRIPTION
#### fe4ff6d9c93646a9bdb7124a939ad0fe26451e98
<pre>
[JSC] Avoid intermediate `StringImpl` allocation when feeding `StringBuilder` into `makeString`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317556">https://bugs.webkit.org/show_bug.cgi?id=317556</a>

Reviewed by Yusuke Suzuki.

When a StringBuilder is passed to tryMakeString/makeString via toString(),
toString() shrinks the buffer and reifies a fresh StringImpl, which the
caller immediately copies from and discards. Passing StringView { builder }
lets the caller read directly from the builder&apos;s internal buffer.

Apply this in three places:

- tryMakeReplacedString (String.prototype.replace with a string search and
  a `$` substitution in the replacement). This matches what the RegExp path
  already does in replaceOneWithStringUsingRegExpSearch.
- resolveLocale, when stitching the supported -u- extension back into the
  found locale.
- IntlPluralRules::initializePluralRules, where the skeleton builder was
  reified only to be viewed as a StringView.

The Intl changes are allocation-only cleanups; ICU formatter construction
dominates those paths and the difference is below microbenchmark noise.

                                          Baseline               Fix

string-replace-string-substitution   67.4923+-0.7067  ^  57.4668+-0.5274  ^ definitely 1.1745x faster

Test: JSTests/microbenchmarks/string-replace-string-substitution.js

* JSTests/microbenchmarks/string-replace-string-substitution.js: Added.
(test):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::resolveLocale):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::initializePluralRules):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::tryMakeReplacedString):

Canonical link: <a href="https://commits.webkit.org/315643@main">https://commits.webkit.org/315643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0ae3e64a62a26a8313fe6ed55de913cec2b467e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127206 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132047 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92979 "10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112550 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32185 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27550 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/796 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181452 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30749 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140495 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43072 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140331 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37802 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43761 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107909 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35602 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115526 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202173 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42271 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6843 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54216 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41664 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->