### PR TITLE
EditingRange with an overflowing location + length crashes the UIProcess on IPC decode

### DIFF
--- a/Source/WebKit/Shared/EditingRange.h
+++ b/Source/WebKit/Shared/EditingRange.h
@@ -26,8 +26,11 @@
 #pragma once
 
 #include <WebCore/CharacterRange.h>
+#include <algorithm>
+#include <optional>
 #include <wtf/NotFound.h>
 #include <wtf/RefPtr.h>
+#include <wtf/SaturatedArithmetic.h>
 
 namespace WebCore {
 class LocalFrame;
@@ -68,6 +71,17 @@ struct EditingRange {
 
     static std::optional<WebCore::SimpleRange> toRange(WebCore::LocalFrame&, const EditingRange&, EditingRangeIsRelativeTo = EditingRangeIsRelativeTo::EditableRoot);
     static EditingRange fromRange(WebCore::LocalFrame&, const std::optional<WebCore::SimpleRange>&, EditingRangeIsRelativeTo = EditingRangeIsRelativeTo::EditableRoot);
+
+    // Returns `firstLineRange` clamped to lie within `requestedRange`. Uses saturating arithmetic
+    // so the result always satisfies isValid() (i.e. location + length never overflows), regardless
+    // of the inputs. This is sent back to the UIProcess as the "actual range".
+    static EditingRange clampedFirstLineRange(EditingRange firstLineRange, const EditingRange& requestedRange)
+    {
+        auto requestedEnd = saturatedSum<uint64_t>(requestedRange.location, requestedRange.length);
+        auto location = std::clamp(firstLineRange.location, requestedRange.location, requestedEnd);
+        auto firstLineEnd = saturatedSum<uint64_t>(location, firstLineRange.length);
+        return EditingRange(location, std::min(firstLineEnd, requestedEnd) - location);
+    }
 
 #if defined(__OBJC__)
     EditingRange(NSRange range)

--- a/Source/WebKit/Shared/EditingRange.serialization.in
+++ b/Source/WebKit/Shared/EditingRange.serialization.in
@@ -29,5 +29,5 @@ webkit_platform_headers: "EditingRange.h"
 
 [WebKitPlatform] struct WebKit::EditingRange {
     uint64_t location;
-    [Validator='!(Checked<uint64_t> { *location } + *length).hasOverflowed()'] uint64_t length;
+    [Validator='!(CheckedUint64 { *location } + *length).hasOverflowed()'] uint64_t length;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
@@ -2576,11 +2576,11 @@ struct WebCore::OrganizationStorageAccessPromptQuirk {
 };
 
 #if ENABLE(SHAREABLE_RESOURCE)
-header: <WebCore/ShareableResource.h>
-[CustomHeader, RValue] class WebCore::ShareableResourceHandle {
+webkit_platform_headers: <WebCore/ShareableResource.h>
+[CustomHeader, RValue, WebKitPlatform] class WebCore::ShareableResourceHandle {
     WebCore::SharedMemoryHandle m_handle;
     unsigned m_offset;
-    [Validator='!(Checked<unsigned> { *m_offset } + *m_size).hasOverflowed() && (*m_offset + *m_size <= m_handle->size())'] unsigned m_size;
+    [Validator='!(CheckedUint32 { *m_offset } + *m_size).hasOverflowed() && (*m_offset + *m_size <= m_handle->size())'] unsigned m_size;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2181,10 +2181,7 @@ void WebPage::firstRectForCharacterRangeAsync(const EditingRange& editingRange, 
 
     auto rangeForFirstLine = EditingRange::fromRange(*frame, makeSimpleRange(range->start, WTF::move(endBoundary)));
 
-    rangeForFirstLine.location = std::min(std::max(rangeForFirstLine.location, editingRange.location), editingRange.location + editingRange.length);
-    rangeForFirstLine.length = std::min(rangeForFirstLine.location + rangeForFirstLine.length, editingRange.location + editingRange.length) - rangeForFirstLine.location;
-
-    completionHandler(rect, rangeForFirstLine);
+    completionHandler(rect, EditingRange::clampedFirstLineRange(rangeForFirstLine, editingRange));
 }
 
 void WebPage::setCompositionAsync(const String& text, const Vector<CompositionUnderline>& underlines, const Vector<CompositionHighlight>& highlights, const HashMap<String, Vector<CharacterRange>>& annotations, const EditingRange& selection, const EditingRange& replacementEditingRange)

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -28,9 +28,13 @@
 
 #include "ArgumentCoders.h"
 #include "Decoder.h"
+#include "EditingRange.h"
 #include "Encoder.h"
+#include "GeneratedSerializers.h"
 #include "StreamConnectionEncoder.h"
 #include "Helpers/Test.h"
+#include <WebCore/ShareableResource.h>
+#include <limits>
 #include <wtf/StdLibExtras.h>
 
 namespace TestWebKitAPI {
@@ -719,5 +723,58 @@ TYPED_TEST_P(ArgumentCoderVectorTest, VectorTooBig)
 REGISTER_TYPED_TEST_SUITE_P(ArgumentCoderVectorTest,
     VectorTooBig);
 INSTANTIATE_TYPED_TEST_SUITE_P(ArgumentCoderTest, ArgumentCoderVectorTest, EncoderTypes, EncoderTypeNames);
+
+TEST(ArgumentCoderEditingRange, OverflowingRangeIsRejectedNotCrashed)
+{
+    IPC::Encoder encoder(IPC::MessageName::IPCTester_EmptyMessage, 0);
+    encoder << WebKit::EditingRange { std::numeric_limits<uint64_t>::max(), 1 };
+
+    auto decoder = IPC::Decoder::create(encoder.span(), { });
+    ASSERT_TRUE(decoder);
+
+    auto editingRange = decoder->decode<WebKit::EditingRange>();
+    EXPECT_FALSE(editingRange.has_value());
+    EXPECT_FALSE(decoder->isValid());
+}
+
+TEST(EditingRangeFirstLineClamp, NeverProducesOverflowingRange)
+{
+    constexpr auto max = std::numeric_limits<uint64_t>::max();
+
+    EXPECT_TRUE(WebKit::EditingRange::clampedFirstLineRange({ 0, 5 }, { max, 0 }).isValid());
+    EXPECT_TRUE(WebKit::EditingRange::clampedFirstLineRange({ 100, 10 }, { max - 2, 0 }).isValid());
+    EXPECT_TRUE(WebKit::EditingRange::clampedFirstLineRange({ max, max }, { max, max }).isValid());
+    EXPECT_TRUE(WebKit::EditingRange::clampedFirstLineRange({ max - 3, 10 }, { 5, max }).isValid());
+
+    auto unchanged = WebKit::EditingRange::clampedFirstLineRange({ 5, 3 }, { 2, 20 });
+    EXPECT_EQ(unchanged.location, 5u);
+    EXPECT_EQ(unchanged.length, 3u);
+
+    auto trimmed = WebKit::EditingRange::clampedFirstLineRange({ 5, 100 }, { 2, 10 });
+    EXPECT_TRUE(trimmed.isValid());
+    EXPECT_EQ(trimmed.location, 5u);
+    EXPECT_EQ(trimmed.location + trimmed.length, 12u);
+}
+
+#if ENABLE(SHAREABLE_RESOURCE)
+TEST(ArgumentCoderShareableResourceHandle, OverflowingOffsetAndSizeIsRejectedNotCrashed)
+{
+    auto sharedMemory = WebCore::SharedMemory::allocate(4096);
+    ASSERT_TRUE(sharedMemory);
+    auto memoryHandle = sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
+    ASSERT_TRUE(memoryHandle);
+
+    WebCore::ShareableResourceHandle handle { WTF::move(*memoryHandle), std::numeric_limits<unsigned>::max(), 1 };
+
+    IPC::Encoder encoder(IPC::MessageName::IPCTester_EmptyMessage, 0);
+    encoder << WTF::move(handle);
+
+    auto decoder = IPC::Decoder::create(encoder.span(), encoder.releaseAttachments());
+    ASSERT_TRUE(decoder);
+
+    auto result = decoder->decode<WebCore::ShareableResourceHandle>();
+    EXPECT_FALSE(result.has_value());
+}
+#endif // ENABLE(SHAREABLE_RESOURCE)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 5266b49c0b9d09b6770c72a35a513fb014013af7
<pre>
EditingRange with an overflowing location + length crashes the UIProcess on IPC decode
<a href="https://bugs.webkit.org/show_bug.cgi?id=317557">https://bugs.webkit.org/show_bug.cgi?id=317557</a>
<a href="https://rdar.apple.com/179393966">rdar://179393966</a>

Reviewed by Abrar Rahman Protyasha and Darin Adler.

WebPage::firstRectForCharacterRangeAsync() computed the &quot;actual range&quot; it sends
back to the UIProcess using unchecked 64-bit arithmetic. When the requested range
had a location near UINT64_MAX, location + length wrapped, and the resulting
EditingRange had a location + length that overflowed. On the UIProcess side, the
generated EditingRange decoder validated the range with Checked&lt;uint64_t&gt;, whose
default OverflowHandler is CrashOnOverflow, so decoding the reply deliberately
crashed the UIProcess instead of rejecting the message.

Fix both sides:
- The decode validator now uses CheckedUint64 (RecordOverflow), so an overflowing
  range fails to decode gracefully rather than crashing the receiving process.
- firstRectForCharacterRangeAsync() now clamps the first-line range with saturating
  arithmetic (EditingRange::clampedFirstLineRange), so the WebProcess never produces
  an overflowing range in the first place.

ShareableResourceHandle had the same latent bug (Checked&lt;unsigned&gt; in its m_size
validator); fix it the same way and mark the type [WebKitPlatform] so its generated
coder is reachable from the API tests.

Test: Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp

* Source/WebKit/Shared/EditingRange.cpp:
(WebKit::EditingRange::clampedFirstLineRange):
* Source/WebKit/Shared/EditingRange.h:
* Source/WebKit/Shared/EditingRange.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::firstRectForCharacterRangeAsync):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::TEST(ArgumentCoderEditingRange, OverflowingRangeIsRejectedNotCrashed)):
(TestWebKitAPI::TEST(EditingRangeFirstLineClamp, NeverProducesOverflowingRange)):
(TestWebKitAPI::TEST(ArgumentCoderShareableResourceHandle, OverflowingOffsetAndSizeIsRejectedNotCrashed)):

Canonical link: <a href="https://commits.webkit.org/315657@main">https://commits.webkit.org/315657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f113c33cd70b671869b43fd8f930ca747cd0dcff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127375 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9de8255f-fb24-4d0e-bee5-a5d43aa970af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171529 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132209 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f1a08fa-0fa3-403f-a440-4b6f44498b1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172622 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112712 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fe2a24f-876d-43ef-96a5-d299313f8699) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27719 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181621 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140656 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43241 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140492 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37817 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43930 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108167 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35759 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115695 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42440 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7057 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41833 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42088 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->