### PR TITLE
MediaList.appendMedium() should parse as a single media query and suppress duplicates

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-appendmedium-parse-single-and-dedup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-appendmedium-parse-single-and-dedup-expected.txt
@@ -1,0 +1,5 @@
+
+PASS appendMedium with a comma-separated list is a no-op
+PASS appendMedium with a comma-separated list leaves an existing list unchanged
+PASS appendMedium does not append a duplicate medium
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-appendmedium-parse-single-and-dedup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-appendmedium-parse-single-and-dedup.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Test: CSSOM MediaList.appendMedium parses as a single media query and suppresses duplicates</title>
+  <link rel="help" href="https://drafts.csswg.org/cssom/#dom-medialist-appendmedium">
+  <meta name="assert" content="appendMedium() parses its argument as a single media query (no-op if more than one query is produced) and does not append a query that is already present.">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <script>
+    function freshMediaList() {
+      var old = document.getElementById('test_style');
+      if (old)
+        old.remove();
+      var style = document.createElement('style');
+      style.id = 'test_style';
+      document.head.appendChild(style);
+      return style.sheet.media;
+    }
+
+    // Step 1 of appendMedium(): "parse a media query" returns null when the
+    // value parses to more than one media query, so the call must be a no-op.
+    test(function() {
+      var mediaList = freshMediaList();
+      mediaList.appendMedium("screen, print");
+      assert_equals(mediaList.length, 0, "comma-separated list must not append anything");
+      assert_equals(mediaList.mediaText, "");
+    }, "appendMedium with a comma-separated list is a no-op");
+
+    // Same rule, starting from a non-empty list: it must be left untouched.
+    test(function() {
+      var mediaList = freshMediaList();
+      mediaList.appendMedium("all");
+      mediaList.appendMedium("screen, print");
+      assert_equals(mediaList.length, 1);
+      assert_equals(mediaList.item(0), "all");
+      assert_equals(mediaList.mediaText, "all");
+    }, "appendMedium with a comma-separated list leaves an existing list unchanged");
+
+    // Step 3 of appendMedium(): if the parsed query already exists, return.
+    test(function() {
+      var mediaList = freshMediaList();
+      mediaList.appendMedium("screen");
+      mediaList.appendMedium("screen");
+      assert_equals(mediaList.length, 1, "duplicate medium must not be appended");
+      assert_equals(mediaList.mediaText, "screen");
+    }, "appendMedium does not append a duplicate medium");
+  </script>
+</body>
+</html>

--- a/Source/WebCore/css/MediaList.cpp
+++ b/Source/WebCore/css/MediaList.cpp
@@ -148,10 +148,25 @@ void MediaList::appendMedium(const String& value)
     if (value.isEmpty())
         return;
 
-    auto newQuery = MQ::MediaQueryParser::parse(value, strictCSSParserContext());
+    // https://drafts.csswg.org/cssom/#dom-medialist-appendmedium
+    auto parsedQueries = MQ::MediaQueryParser::parse(value, strictCSSParserContext());
+    if (parsedQueries.size() != 1)
+        return;
+
+    StringBuilder builder;
+    MQ::serialize(builder, parsedQueries[0]);
+    auto newQueryText = builder.toString();
 
     auto queries = mediaQueries();
-    queries.appendVector(newQuery);
+    bool alreadyPresent = queries.containsIf([&](auto& query) {
+        StringBuilder existingQueryBuilder;
+        MQ::serialize(existingQueryBuilder, query);
+        return existingQueryBuilder.toString() == newQueryText;
+    });
+    if (alreadyPresent)
+        return;
+
+    queries.append(WTF::move(parsedQueries[0]));
     setMediaQueries(WTF::move(queries));
 }
 


### PR DESCRIPTION
#### be9952291541540d2738c1b1d608a85810916163
<pre>
MediaList.appendMedium() should parse as a single media query and suppress duplicates
<a href="https://bugs.webkit.org/show_bug.cgi?id=317559">https://bugs.webkit.org/show_bug.cgi?id=317559</a>

Reviewed by Anne van Kesteren.

MediaList::appendMedium() did not follow the CSSOM algorithm
(<a href="https://drafts.csswg.org/cssom/#dom-medialist-appendmedium).">https://drafts.csswg.org/cssom/#dom-medialist-appendmedium).</a> It parsed
its argument with the comma-separated media query *list* parser and
unconditionally appended every resulting query, with no duplicate check.

Per the spec, the value must be parsed as a single media query: parsing is
a no-op if it yields anything other than exactly one query, and the query
must not be appended if it is already present in the list. As a result:

- appendMedium(&quot;screen, print&quot;) appended two queries instead of being a
  no-op.
- appendMedium(&quot;screen&quot;) called twice produced &quot;screen, screen&quot; instead of
  deduplicating to &quot;screen&quot;.

Fix appendMedium() to bail out unless parsing produces exactly one media
query, and to skip appending a query whose serialization already matches an
existing entry. This aligns our behavior with Blink, whose
MediaQuerySet::CopyAndAdd() rejects results whose size != 1 and skips
queries already in the list.

Test: imported/w3c/web-platform-tests/css/cssom/medialist-appendmedium-parse-single-and-dedup.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-appendmedium-parse-single-and-dedup-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-appendmedium-parse-single-and-dedup.html: Added.
* Source/WebCore/css/MediaList.cpp:
(WebCore::MediaList::appendMedium):

Canonical link: <a href="https://commits.webkit.org/315594@main">https://commits.webkit.org/315594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4733c280cbc9fa21c7fdd8555999df87688115b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43429 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36754 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127219 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c33162e-adee-4ab4-8ce2-b4accb486643) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132060 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92992 "1 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3120b981-26ad-44e2-a15e-e5e66ba794a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112563 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d1fd32a-2ff2-4176-9d89-9274fe1f4d05) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32198 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27563 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181465 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140508 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43085 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140344 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37763 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107938 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35615 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115539 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42284 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6869 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41677 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41820 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->