### PR TITLE
MediaList.deleteMedium() should parse its argument and remove all matching queries

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-deletemedium-parse-and-remove-all-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-deletemedium-parse-and-remove-all-expected.txt
@@ -1,0 +1,4 @@
+
+PASS deleteMedium matches a query that differs only in whitespace
+PASS deleteMedium removes every matching query, not only the first
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-deletemedium-parse-and-remove-all.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-deletemedium-parse-and-remove-all.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Test: CSSOM MediaList.deleteMedium parses its argument and removes all matches</title>
+  <link rel="help" href="https://drafts.csswg.org/cssom/#dom-medialist-deletemedium">
+  <meta name="assert" content="deleteMedium() parses its argument as a media query and removes every query that compares equal to it, rather than string-matching the raw argument against the serialized form and removing only the first match.">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <script>
+    function freshMediaList() {
+      var old = document.getElementById('test_style');
+      if (old)
+        old.remove();
+      var style = document.createElement('style');
+      style.id = 'test_style';
+      document.head.appendChild(style);
+      return style.sheet.media;
+    }
+
+    // deleteMedium() must parse its argument as a media query and compare the
+    // parsed result, not string-match the raw argument against the serialized
+    // query. An argument that differs only in insignificant whitespace must
+    // still match.
+    test(function() {
+      var mediaList = freshMediaList();
+      mediaList.mediaText = "screen and (min-width: 480px)";
+      assert_equals(mediaList.length, 1, "precondition: one query present");
+
+      // Same query, but no space after the colon -- parses to an equal query.
+      mediaList.deleteMedium("screen and (min-width:480px)");
+
+      assert_equals(mediaList.length, 0, "query should have been removed");
+      assert_equals(mediaList.mediaText, "");
+    }, "deleteMedium matches a query that differs only in whitespace");
+
+    // deleteMedium() must remove every matching query, not just the first.
+    test(function() {
+      var mediaList = freshMediaList();
+      mediaList.mediaText = "screen, print, screen";
+      assert_equals(mediaList.length, 3, "precondition: three queries present");
+
+      mediaList.deleteMedium("screen");
+
+      assert_equals(mediaList.length, 1, "all 'screen' queries should be removed");
+      assert_equals(mediaList.item(0), "print");
+      assert_equals(mediaList.mediaText, "print");
+    }, "deleteMedium removes every matching query, not only the first");
+  </script>
+</body>
+</html>

--- a/Source/WebCore/css/MediaList.cpp
+++ b/Source/WebCore/css/MediaList.cpp
@@ -119,15 +119,28 @@ String MediaList::item(unsigned index) const
 
 ExceptionOr<void> MediaList::deleteMedium(const String& value)
 {
+    // https://drafts.csswg.org/cssom/#dom-medialist-deletemedium
+    // The value is parsed as a single media query; bail unless parsing
+    // produces exactly one query.
+    auto parsedQueries = MQ::MediaQueryParser::parse(value, strictCSSParserContext());
+    if (parsedQueries.size() != 1)
+        return Exception { ExceptionCode::NotFoundError };
+
+    auto serializeQuery = [](const MQ::MediaQuery& query) {
+        StringBuilder builder;
+        MQ::serialize(builder, query);
+        return builder.toString();
+    };
+    auto queryToRemove = serializeQuery(parsedQueries[0]);
     auto queries = mediaQueries();
-    for (unsigned i = 0; i < queries.size(); ++i) {
-        if (equalIgnoringASCIICase(item(i), value)) {
-            queries.removeAt(i);
-            setMediaQueries(WTF::move(queries));
-            return { };
-        }
-    }
-    return Exception { ExceptionCode::NotFoundError };
+    auto removedCount = queries.removeAllMatching([&](auto& query) {
+        return serializeQuery(query) == queryToRemove;
+    });
+    if (!removedCount)
+        return Exception { ExceptionCode::NotFoundError };
+
+    setMediaQueries(WTF::move(queries));
+    return { };
 }
 
 void MediaList::appendMedium(const String& value)


### PR DESCRIPTION
#### fe205bdb796c4b09d211a2c8df1fca578c4674da
<pre>
MediaList.deleteMedium() should parse its argument and remove all matching queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=317560">https://bugs.webkit.org/show_bug.cgi?id=317560</a>

Reviewed by Anne van Kesteren.

MediaList::deleteMedium() did not follow the CSSOM algorithm
(<a href="https://drafts.csswg.org/cssom/#dom-medialist-deletemedium).">https://drafts.csswg.org/cssom/#dom-medialist-deletemedium).</a> It compared
the caller&apos;s raw, un-normalized argument string against each query&apos;s
*serialized* form using a case-insensitive string comparison, and removed
only the first match. As a result:

- deleteMedium(&quot;screen and (min-width:480px)&quot;) threw a NotFoundError against
  a stored &quot;screen and (min-width: 480px)&quot;, because serialization inserts a
  space after the colon and the raw input does not, so the strings differed.
- When the list contained more than one equal query, only the first was
  removed.

Per the spec, the argument must be parsed as a single media query, and every
query in the list that compares equal to it must be removed, throwing a
NotFoundError only when nothing matched. Fix deleteMedium() to parse the
argument and compare canonical serializations, removing all matching queries
via Vector::removeAllMatching(). An argument that does not parse to exactly
one media query results in a NotFoundError, as the spec requires.

This aligns our behavior with both Blink (MediaQuerySet::CopyAndRemove) and
Gecko (MediaList::delete_medium), which likewise parse the argument and
remove every structurally-equal query.

Test: imported/w3c/web-platform-tests/css/cssom/medialist-deletemedium-parse-and-remove-all.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-deletemedium-parse-and-remove-all-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/medialist-deletemedium-parse-and-remove-all.html: Added.
* Source/WebCore/css/MediaList.cpp:
(WebCore::MediaList::deleteMedium):

Canonical link: <a href="https://commits.webkit.org/315579@main">https://commits.webkit.org/315579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/741cb7d968b583b37e2de9f33542350b58ec4785

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127221 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8119a803-425c-4add-bbd9-0ea0773cffed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43060 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a42933f3-3004-412e-94c2-fd1222718538) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172468 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112565 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0de0dad-6903-424d-82d1-8ad85010e8fd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27565 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181467 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140346 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37754 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43776 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107947 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35616 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42286 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6866 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41679 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41934 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41822 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->