### PR TITLE
Web Inspector: unnecessary colon in front of non-class function properties

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js
@@ -152,8 +152,9 @@ WI.ObjectTreePropertyTreeElement = class ObjectTreePropertyTreeElement extends W
         // Property name.
         var nameElement = document.createElement("span");
         nameElement.className = "property-name";
-        nameElement.textContent = this.property.name + ": ";
         nameElement.title = this.propertyPathString(this.thisPropertyPath());
+
+        let shouldAddColon = true;
 
         // Property attributes.
         if (this._mode === WI.ObjectTreeView.Mode.Properties) {
@@ -195,8 +196,10 @@ WI.ObjectTreePropertyTreeElement = class ObjectTreePropertyTreeElement extends W
                 valueOrGetterElement = WI.FormattedValue.createElementForRemoteObject(resolvedValue, this.hadError());
 
                 // Special case a function property string.
-                if (resolvedValue.type === "function")
-                    valueOrGetterElement.textContent = this._functionPropertyString();
+                if (resolvedValue.type === "function") {
+                    shouldAddColon = false;
+                    valueOrGetterElement.textContent = this._functionParameterString();
+                }
             }
         } else {
             valueOrGetterElement = document.createElement("span");
@@ -205,6 +208,8 @@ WI.ObjectTreePropertyTreeElement = class ObjectTreePropertyTreeElement extends W
             if (this.property.hasSetter())
                 valueOrGetterElement.appendChild(this.createSetterElement());
         }
+
+        nameElement.textContent = this.property.name + (shouldAddColon ? ": " : "");
 
         valueOrGetterElement.classList.add("value");
         if (this.hadError())
@@ -283,11 +288,6 @@ WI.ObjectTreePropertyTreeElement = class ObjectTreePropertyTreeElement extends W
             return true;
 
         return false;
-    }
-
-    _functionPropertyString()
-    {
-        return "function" + this._functionParameterString();
     }
 
     _functionParameterString()


### PR DESCRIPTION
#### 856d17b8d8dbfc40ea8e3bc28033ef6aceb17a6b
<pre>
Web Inspector: unnecessary colon in front of non-class function properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=317562">https://bugs.webkit.org/show_bug.cgi?id=317562</a>

Reviewed by Alexey Proskuryakov.

Seeing a repeated `: function(` just adds a ton of noise.

For example, this
```js
{
    a: function() {},
    b: function() {},
    c: function() {},
}
```
is much more repetitive than
```js
{
    a() {},
    b() {},
    c() {},
}
```

* Source/WebInspectorUI/UserInterface/Views/ObjectTreePropertyTreeElement.js:
(WI.ObjectTreePropertyTreeElement.prototype._createTitlePropertyStyle):
(WI.ObjectTreePropertyTreeElement.prototype._functionPropertyString): Deleted.

Canonical link: <a href="https://commits.webkit.org/315731@main">https://commits.webkit.org/315731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93df4015431631459234011b695f4172812a9097

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179290 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43481 "Hash 93df4015 for PR 67573 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132442 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172888 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112944 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/43481 "Hash 93df4015 for PR 67573 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27986 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181887 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/43481 "Hash 93df4015 for PR 67573 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140893 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43507 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140724 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37884 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44196 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108501 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35992 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42707 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42099 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->