### PR TITLE
GCReachableRef's HashTraits peek()/take() use the wrong value type

### DIFF
--- a/Source/WebCore/dom/GCReachableRef.h
+++ b/Source/WebCore/dom/GCReachableRef.h
@@ -130,11 +130,11 @@ template<typename P> struct HashTraits<WebCore::GCReachableRef<P>> : SimpleClass
     }
 
     typedef P* PeekType;
-    static PeekType peek(const Ref<P>& value) { return const_cast<PeekType>(value.ptrAllowingHashTableEmptyValue()); }
+    static PeekType peek(const WebCore::GCReachableRef<P>& value) { return const_cast<PeekType>(value.ptrAllowingHashTableEmptyValue()); }
     static PeekType peek(P* value) { return value; }
 
-    typedef std::optional<Ref<P>> TakeType;
-    static TakeType take(Ref<P>&& value) { return isEmptyValue(value) ? std::nullopt : std::optional<Ref<P>>(WTF::move(value)); }
+    typedef std::optional<WebCore::GCReachableRef<P>> TakeType;
+    static TakeType take(WebCore::GCReachableRef<P>&& value) { return isEmptyValue(value) ? std::nullopt : std::optional<WebCore::GCReachableRef<P>>(WTF::move(value)); }
 };
 
 template <typename T>


### PR DESCRIPTION
#### 645f9091db79c271b9a6706da6be254ed89850a7
<pre>
GCReachableRef&apos;s HashTraits peek()/take() use the wrong value type
<a href="https://bugs.webkit.org/show_bug.cgi?id=317564">https://bugs.webkit.org/show_bug.cgi?id=317564</a>

Reviewed by Darin Adler.

HashTraits&lt;GCReachableRef&lt;P&gt;&gt;::peek() and take() were declared in terms of
Ref&lt;P&gt; instead of GCReachableRef&lt;P&gt;, a copy-paste leftover from RefHashTraits.
These members are not currently instantiated by any user of
HashSet&lt;GCReachableRef&lt;Node&gt;&gt; (MutationObserver / MutationObserverRegistration
only add, iterate, move and swap the set), so the file compiles today, but any
future call to take()/takeAny()/get() on such a container would fail to compile:
a GCReachableRef rvalue does not bind to a Ref&lt;P&gt; parameter, and the take()
body&apos;s isEmptyValue() check is declared for GCReachableRef&lt;P&gt;.

Fix the parameter and return types to use GCReachableRef&lt;P&gt;. TakeType is kept as
std::optional&lt;GCReachableRef&lt;P&gt;&gt; rather than RefPtr&lt;P&gt; so that taking a value out
of the set preserves its GCReachableRefMap registration through the move.

No change in behavior; no new tests as the affected code was previously
uninstantiated.

* Source/WebCore/dom/GCReachableRef.h:
(WTF::HashTraits&lt;WebCore::GCReachableRef&lt;P&gt;&gt;::peek):
(WTF::HashTraits&lt;WebCore::GCReachableRef&lt;P&gt;&gt;::take):

Canonical link: <a href="https://commits.webkit.org/315647@main">https://commits.webkit.org/315647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31114ad77b030440a7ae61df03bd5aadd277b56c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127216 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c17298ca-093b-4767-b2ce-af9fea2ccc4f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132057 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92990 "1 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/045c2053-dbf9-4474-af5c-79942dcacf4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112560 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f4a13d0-d434-4acd-9069-6c10386674a6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32195 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27560 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181462 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140505 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43082 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140341 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37806 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43771 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107929 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35613 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115536 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42281 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6868 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41674 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41817 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->