### PR TITLE
Clean up dead code in FragmentDirective parsing and range finding

### DIFF
--- a/Source/WebCore/dom/FragmentDirectiveParser.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveParser.cpp
@@ -38,9 +38,8 @@ namespace WebCore {
 FragmentDirectiveParser::FragmentDirectiveParser(StringView fragmentDirective)
 {
     parseFragmentDirective(fragmentDirective);
-    
+
     m_fragmentDirective = fragmentDirective;
-    m_isValid = true;
 }
 
 FragmentDirectiveParser::~FragmentDirectiveParser() = default;

--- a/Source/WebCore/dom/FragmentDirectiveParser.h
+++ b/Source/WebCore/dom/FragmentDirectiveParser.h
@@ -39,17 +39,13 @@ public:
     
     const Vector<ParsedTextDirective>& parsedTextDirectives() const LIFETIME_BOUND { return m_parsedTextDirectives; };
     StringView fragmentDirective() const { return m_fragmentDirective; };
-    StringView remainingURLFragment() const { return m_remainingURLFragment; };
-    bool isValid() const { return  m_isValid; };
-    
+
 private:
     FragmentDirectiveParser() = delete;
     void parseFragmentDirective(StringView);
-    
+
     Vector<ParsedTextDirective> m_parsedTextDirectives;
-    StringView m_remainingURLFragment;
     StringView m_fragmentDirective;
-    bool m_isValid { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -302,12 +302,6 @@ static std::optional<SimpleRange> advanceRangeStartToNextNonWhitespace(SimpleRan
 
         auto string = node->textContent();
 
-        if (string.substringSharingImpl(offset, 6) == "&nbsp;"_s)
-            offset += 6;
-
-        if (string.substringSharingImpl(offset, 5) == "&nbsp"_s)
-            offset += 5;
-        
         if (!isUnicodeWhitespace(string[offset]))
             return newRange;
         offset++;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3155,9 +3155,6 @@ bool LocalFrameView::scrollToTextFragment(IsRetry isRetry)
         return false;
 
     FragmentDirectiveParser fragmentDirectiveParser(fragmentDirective);
-    if (!fragmentDirectiveParser.isValid())
-        return false;
-
     auto parsedTextDirectives = fragmentDirectiveParser.parsedTextDirectives();
     auto highlightRanges = FragmentDirectiveRangeFinder::findRangesFromTextDirectives(parsedTextDirectives, document);
     if (m_frame->settings().scrollToTextFragmentMarkingEnabled()) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9238,11 +9238,6 @@ void WebPage::getTextFragmentMatch(CompletionHandler<void(const String&)>&& comp
         return;
     }
     FragmentDirectiveParser fragmentDirectiveParser(fragmentDirective);
-    if (!fragmentDirectiveParser.isValid()) {
-        completionHandler({ });
-        return;
-    }
-
     auto parsedTextDirectives = fragmentDirectiveParser.parsedTextDirectives();
     auto highlightRanges = FragmentDirectiveRangeFinder::findRangesFromTextDirectives(parsedTextDirectives, *document);
     if (highlightRanges.isEmpty()) {


### PR DESCRIPTION
#### 0d05b141742c9d80af6d6668505becd6a23f20fa
<pre>
Clean up dead code in FragmentDirective parsing and range finding
<a href="https://bugs.webkit.org/show_bug.cgi?id=317565">https://bugs.webkit.org/show_bug.cgi?id=317565</a>

Reviewed by Anne van Kesteren.

Address several dead/misleading code issues in the scroll-to-text-fragment
implementation found during code review:

- FragmentDirectiveParser::isValid() was meaningless: m_isValid was hardcoded
  to true on every construction, so the two caller guards (in LocalFrameView
  and WebPage) never fired. Rather than make it do something, remove isValid()
  and m_isValid entirely along with both caller guards. The empty-directives
  case those guards were nominally protecting against is already handled
  downstream: parsedTextDirectives() returns an empty vector, so
  findRangesFromTextDirectives() produces no ranges and the existing
  highlightRanges.isEmpty() checks take the early-return path.

- Removed FragmentDirectiveParser::remainingURLFragment() and its backing
  m_remainingURLFragment member. The member was never assigned and the getter
  had no callers, so it could only ever return an empty StringView.

- Removed the literal &quot;&amp;nbsp;&quot; / &quot;&amp;nbsp&quot; comparisons in
  advanceRangeStartToNextNonWhitespace(). A Text node&apos;s textContent holds
  decoded character data (an &amp;nbsp; entity is already U+00A0), so these
  branches never matched. The U+00A0 case is already handled by the following
  isUnicodeWhitespace() check. Dropping them also keeps the subsequent index
  in bounds (it could previously be advanced up to 11 past the intended spot).

No change in behavior.

* Source/WebCore/dom/FragmentDirectiveParser.cpp:
(WebCore::FragmentDirectiveParser::FragmentDirectiveParser):
* Source/WebCore/dom/FragmentDirectiveParser.h:
(WebCore::FragmentDirectiveParser::fragmentDirective const):
(WebCore::FragmentDirectiveParser::isValid const): Deleted.
(WebCore::FragmentDirectiveParser::remainingURLFragment const): Deleted.
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::advanceRangeStartToNextNonWhitespace):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToTextFragment):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getTextFragmentMatch):

Canonical link: <a href="https://commits.webkit.org/315593@main">https://commits.webkit.org/315593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0042da572c217f02163725008b164c98a2373a4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127237 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4752fe94-cab0-47ef-88af-fdc576752627) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132076 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b319d570-4b98-4ed3-9ba9-55f9a9667f1a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172484 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112579 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/503871ae-a32b-4a22-99f5-f800d53c0286) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32217 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27581 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181483 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140525 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43103 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140361 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37764 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43792 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107978 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35630 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115557 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42302 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6892 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41695 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41950 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41838 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->