### PR TITLE
[JSC] Optimize JSON related code for common cases

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
@@ -35,7 +35,7 @@ class VM;
 class JSONAtomStringCache {
 public:
     static constexpr auto maxStringLengthForCache = 27;
-    static constexpr auto capacity = 256;
+    static constexpr auto capacity = 512;
 
     struct Slot {
         char16_t m_buffer[maxStringLengthForCache] { };

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -90,7 +90,7 @@ ALWAYS_INLINE JSString* JSONAtomStringCache::makeJSString(std::span<const Charac
     if (characters.empty())
         return jsEmptyString(vm);
 
-    constexpr unsigned maxAtomizeStringLength = 10;
+    constexpr unsigned maxAtomizeStringLength = 16;
     auto firstCharacter = characters.front();
     if (characters.size() == 1) {
         if (firstCharacter <= maxSingleCharacterString)

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1385,11 +1385,12 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             }
             auto span = name.span8();
 
-            if (object.structure() != &structure) [[unlikely]] {
-                ASSERT_NOT_REACHED();
-                recordFailure("unexpected structure transition"_s);
-                return false;
-            }
+            // The structure cannot transition mid-iteration on FastStringifier's case.
+            // canPerformFastPropertyEnumeration ruled out getters/setters and
+            // the prototype is the original Object.prototype with no toJSON, so
+            // there is no JS observable to mutate the structure.
+            ASSERT(object.structure() == &structure);
+
             JSValue value = object.getDirect(entry.offset());
             if (value.isUndefined())
                 return true;
@@ -1418,6 +1419,37 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             buffer()[m_length + 1 + span.size()] = '"';
             buffer()[m_length + 1 + span.size() + 1] = ':';
             m_length += 1 + span.size() + 2;
+
+            if constexpr (std::same_as<CharType, Latin1Character>) {
+                // Inlining String case here since it is too common.
+                if (value.isCell() && value.asCell()->type() == StringType) [[likely]] {
+                    auto valueString = asString(value.asCell())->tryGetValue();
+                    if (!valueString.data.isNull() && valueString.data.is8Bit()) [[likely]] {
+                        unsigned valueLength = valueString.data.length();
+                        if (!hasRemainingCapacity(1 + valueLength + 1)) [[unlikely]] {
+                            recordBufferFull();
+                            return false;
+                        }
+                        buffer()[m_length] = '"';
+                        if (!stringCopySameType(valueString.data.span8(), buffer() + m_length + 1)) [[likely]] {
+                            buffer()[m_length + 1 + valueLength] = '"';
+                            m_length += 1 + valueLength + 1;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            // Also Int32 case is too common.
+            if (value.isInt32()) {
+                if (!hasRemainingCapacity(maxInt32StringLength)) [[unlikely]] {
+                    recordBufferFull();
+                    return false;
+                }
+                appendInt32(value.asInt32());
+                return true;
+            }
+
             append(value);
             return !haveFailure();
         });
@@ -1457,10 +1489,45 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             return;
         }
         buffer()[m_length++] = '[';
-        if (hasInt32(array.indexingType())) {
+
+        IndexingType indexingType = array.indexingType();
+        if (hasInt32(indexingType)) {
             appendInt32Array(array);
             if (haveFailure()) [[unlikely]]
                 return;
+            if (!hasRemainingCapacity()) [[unlikely]] {
+                recordBufferFull();
+                return;
+            }
+            buffer()[m_length++] = ']';
+            return;
+        }
+
+        if (hasContiguous(indexingType)) {
+            auto* butterfly = array.butterfly();
+            unsigned length = butterfly->publicLength();
+            if (length > butterfly->vectorLength()) [[unlikely]] {
+                recordFailure("!lengthBeyondVector"_s);
+                return;
+            }
+            auto data = butterfly->contiguous();
+            for (unsigned i = 0; i < length; ++i) {
+                if (i) {
+                    if (!hasRemainingCapacity()) [[unlikely]] {
+                        recordBufferFull();
+                        return;
+                    }
+                    buffer()[m_length++] = ',';
+                }
+                JSValue element = data.at(&array, i).get();
+                if (!element) [[unlikely]] {
+                    recordFailure("!canGetIndexQuickly"_s);
+                    return;
+                }
+                append(element);
+                if (haveFailure()) [[unlikely]]
+                    return;
+            }
             if (!hasRemainingCapacity()) [[unlikely]] {
                 recordBufferFull();
                 return;
@@ -1507,7 +1574,7 @@ NEVER_INLINE void FastStringifier<CharType, bufferMode>::appendInt32Array(JSArra
     auto* butterfly = array.butterfly();
     unsigned length = butterfly->publicLength();
     if (length > butterfly->vectorLength()) [[unlikely]] {
-        recordFailure("!canGetIndexQuickly"_s);
+        recordFailure("!lengthBeyondVector"_s);
         return;
     }
     auto data = butterfly->contiguousInt32();

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1477,8 +1477,15 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
             // After parseRecursively, user code may have run (e.g. due to a __proto__ setter in a
             // nested object), which may have changed the structure of the object. This invalidates
             // any cached transition, so reset it to Identifier to take the slow path.
-            if (object->structure() != originalStructure && std::holds_alternative<ExistingProperty>(property)) [[unlikely]]
-                property = Identifier::fromUid(vm, std::get<ExistingProperty>(property).structure->transitionPropertyName());
+            if constexpr (parserMode != StrictJSON) {
+                if (object->structure() != originalStructure && std::holds_alternative<ExistingProperty>(property)) [[unlikely]]
+                    property = Identifier::fromUid(vm, std::get<ExistingProperty>(property).structure->transitionPropertyName());
+            } else {
+                // StrictJSON can skip this entirely! There is no replacer/reviver and __proto__ setters in
+                // a strict JSON value cannot run user code, so the parent object's structure is guaranteed not to have
+                // transitioned during the recursive parse of `value`.
+                ASSERT(object->structure() == originalStructure);
+            }
 
             // When creating JSON object in this fast path, we know the following.
             //   1. The object is definitely JSFinalObject.


### PR DESCRIPTION
#### 299d0f154d7a21d6d68c8475065135a47490a647
<pre>
[JSC] Optimize JSON related code for common cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=317566">https://bugs.webkit.org/show_bug.cgi?id=317566</a>
<a href="https://rdar.apple.com/180265866">rdar://180265866</a>

Reviewed by Yijia Huang.

This adds careful micro-optimizations to JSON related code.

1. __proto__ receiver does not matter when parsing normal JSON
   (StrictJSON, not SloppyJSON etc.). Thus we do not need to check
   structure transition.
2. Increase JSONAtomStringCache capacity to 512 to hit atomization more.
3. Increase JSONAtomStringCache&apos;s candidate string length to 16 as we
   can see these strings too.
4. Similar to (1). But in FastStringifier, we have no way to cause
   structure transition during iteration. Thus making the check as ASSERT.
5. Inline super common leaf value serialization, 8-bit string and Int32.

* Source/JavaScriptCore/runtime/JSONAtomStringCache.h:
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::makeJSString):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::append):
(JSC::bufferMode&gt;::appendInt32Array):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::requires):

Canonical link: <a href="https://commits.webkit.org/315620@main">https://commits.webkit.org/315620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ffa15d8cee12ff6995c90718814f97d4012e8b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127301 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9b69581-7fa8-45ac-9d16-ef22a3d791fd) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132144 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47f76c9c-0a7c-4b27-8b02-db9523de6af1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172548 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112647 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a98c9a36-c068-47ff-a3f4-6e9758203c2f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27645 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/918 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181547 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30844 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140593 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43167 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140429 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43856 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108076 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35696 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115621 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42366 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6965 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54230 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41759 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42014 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41902 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->