### PR TITLE
[WebDriver] Improve driver logging coverage

### DIFF
--- a/Source/WebDriver/SessionHost.cpp
+++ b/Source/WebDriver/SessionHost.cpp
@@ -45,6 +45,13 @@ static WeakHashSet<SessionHost::BrowserTerminatedObserver>& browserTerminatedObs
 void SessionHost::inspectorDisconnected()
 {
     Ref<SessionHost> protectedThis(*this);
+
+    auto pendingRequestCount = m_commandRequests.size();
+    if (pendingRequestCount)
+        RELEASE_LOG_INFO(SessionHost, "Inspector disconnected; failing %u pending command(s)", pendingRequestCount);
+    else
+        RELEASE_LOG_INFO(SessionHost, "Inspector disconnected; no commands remaining.");
+
     // Browser closed or crashed, finish all pending commands with error.
     RefPtr<JSON::Object> errorResponse = JSON::Object::create();
     errorResponse->setString("message"_s, "Session terminated without a reply"_s);
@@ -74,6 +81,7 @@ long SessionHost::sendCommandToBackend(const String& command, RefPtr<JSON::Objec
     if (parameters)
         messageBuilder.append(",\"params\":"_s, parameters->toJSONString());
     messageBuilder.append('}');
+    RELEASE_LOG_INFO(SessionHost, "    SEND inspector #%04ld: Automation.%s (%u bytes)", sequenceID, command.utf8().data(), messageBuilder.length());
     sendMessageToBackend(messageBuilder.toString());
 
     return sequenceID;
@@ -116,6 +124,7 @@ void SessionHost::dispatchMessage(const String& message)
         if (resultObject->size())
             response.responseObject = WTF::move(resultObject);
     }
+    RELEASE_LOG_INFO(SessionHost, "    RECV inspector #%04d: %s", *sequenceID, response.isError ? "error" : "ok");
 
     responseHandler(WTF::move(response));
 }

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -33,7 +33,9 @@
 #include <cmath>
 #include <ranges>
 #include <wtf/Compiler.h>
+#include <wtf/FileSystem.h>
 #include <wtf/LoggerHelper.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/RunLoop.h>
 #include <wtf/SortedArrayMap.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -95,6 +97,9 @@ static void printUsageStatement(const char* programName)
     SAFE_PRINTF("               --bidi-port=<port>        Port number to use for BiDi's WebSocket connections\n");
 #endif
     SAFE_PRINTF("               --replace-on-new-session  Replace the existing session on new session request\n");
+    SAFE_PRINTF("\nEnvironment variables:\n");
+    SAFE_PRINTF("  WEBKIT_DEBUG=<channel>[,<channel>...]    Enable verbose logging for the given channels.\n");
+    SAFE_PRINTF("                                           Useful channels include: SessionHost, WebDriverClassic, and WebDriverBiDi (when enabled).\n");
 }
 
 int WebDriverService::run(int argc, char** argv)
@@ -179,6 +184,7 @@ int WebDriverService::run(int argc, char** argv)
 
     auto port = parseInteger<uint16_t>(portString);
     if (!port) {
+        RELEASE_LOG_ERROR(WebDriverClassic, "Invalid port %s provided", portString.utf8().data());
         fprintf(stderr, "Invalid port %s provided\n", portString.utf8().data());
         return EXIT_FAILURE;
     }
@@ -188,6 +194,7 @@ int WebDriverService::run(int argc, char** argv)
     if (!bidiPort) {
         const int16_t bidiPortIncrement = *port == std::numeric_limits<uint16_t>::max() ? -1 : 1;
         bidiPort = { *port + bidiPortIncrement };
+        RELEASE_LOG_INFO(WebDriverBiDi, "Invalid WebSocket BiDi port %s provided. Defaulting to %d.", bidiPortString.utf8().data(), *bidiPort);
         fprintf(stderr, "Invalid WebSocket BiDi port %s provided. Defaulting to %d.\n", bidiPortString.utf8().data(), *bidiPort);
     }
 #endif
@@ -195,18 +202,37 @@ int WebDriverService::run(int argc, char** argv)
     WTF::initializeMainThread();
 
     CString hostStr = host && !host->isNull() ? host->utf8() : "local";
+    auto programName = FileSystem::lastComponentOfPathIgnoringTrailingSlash(String::fromLatin1(argv[0]));
+    if (programName.isEmpty())
+        programName = "WebDriver"_s;
+    auto programNameStr = programName.utf8();
+
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_targetAddress.isEmpty())
+        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d bidi=%d", programNameStr.data(), hostStr.data(), *port, *bidiPort);
+    else
+        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d bidi=%d target=%s:%d", programNameStr.data(), hostStr.data(), *port, *bidiPort, m_targetAddress.utf8().data(), m_targetPort);
+#else
+    if (m_targetAddress.isEmpty())
+        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d", programNameStr.data(), hostStr.data(), *port);
+    else
+        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d target=%s:%d", programNameStr.data(), hostStr.data(), *port, m_targetAddress.utf8().data(), m_targetPort);
+#endif
+
 #if ENABLE(WEBDRIVER_BIDI)
     if (!m_bidiServer->listen(host ? *host : nullString(), *bidiPort)) {
+        RELEASE_LOG_ERROR(WebDriverBiDi, "Unable to listen for WebSocket BiDi server at host %s and port %d", hostStr.data(), *bidiPort);
         fprintf(stderr, "FATAL: Unable to listen for WebSocket BiDi server at host %s and port %d.\n", hostStr.data(), *bidiPort);
         return EXIT_FAILURE;
     }
-    RELEASE_LOG(WebDriverBiDi, "Started WebSocket BiDi server with host %s and port %d", hostStr.data(), *bidiPort);
+    RELEASE_LOG_INFO(WebDriverBiDi, "Started WebSocket BiDi server with host %s and port %d", hostStr.data(), *bidiPort);
 #endif // ENABLE(WEBDRIVER_BIDI)
     if (!m_server.listen(host, *port)) {
+        RELEASE_LOG_ERROR(WebDriverClassic, "Unable to listen for HTTP server at host %s and port %d", hostStr.data(), *port);
         fprintf(stderr, "FATAL: Unable to listen for HTTP server at host %s and port %d.\n", hostStr.data(), *port);
         return EXIT_FAILURE;
     }
-    RELEASE_LOG(WebDriverClassic, "Started HTTP server with host %s and port %d", hostStr.data(), *port);
+    RELEASE_LOG_INFO(WebDriverClassic, "Started HTTP server with host %s and port %d", hostStr.data(), *port);
 
     RunLoop::run();
 
@@ -347,15 +373,24 @@ bool WebDriverService::findCommand(HTTPMethod method, const String& path, Comman
 
 void WebDriverService::handleRequest(HTTPRequestHandler::Request&& request, Function<void (HTTPRequestHandler::Response&&)>&& replyHandler)
 {
+    Function<void (HTTPRequestHandler::Response&&)> actualReplyHandler = WTF::move(replyHandler);
+    if (LOG_CHANNEL(WebDriverClassic).state != WTFLogChannelState::Off) {
+        RELEASE_LOG_INFO(WebDriverClassic, "HTTP request %s %s (body=%zu bytes)", request.method.utf8().data(), request.path.utf8().data(), request.dataLength);
+        actualReplyHandler = [startTime = MonotonicTime::now(), replyHandler = WTF::move(actualReplyHandler)](HTTPRequestHandler::Response&& response) mutable {
+            RELEASE_LOG_INFO(WebDriverClassic, "HTTP response %u in %.0fms", response.statusCode, (MonotonicTime::now() - startTime).milliseconds());
+            replyHandler(WTF::move(response));
+        };
+    }
+
     auto method = toCommandHTTPMethod(request.method);
     if (!method) {
-        sendResponse(WTF::move(replyHandler), CommandResult::fail(CommandResult::ErrorCode::UnknownCommand, makeString("Unknown method: "_s, request.method)));
+        sendResponse(WTF::move(actualReplyHandler), CommandResult::fail(CommandResult::ErrorCode::UnknownCommand, makeString("Unknown method: "_s, request.method)));
         return;
     }
     CommandHandler handler;
     HashMap<String, String> parameters;
     if (!findCommand(method.value(), request.path, &handler, parameters)) {
-        sendResponse(WTF::move(replyHandler), CommandResult::fail(CommandResult::ErrorCode::UnknownCommand, makeString("Unknown command: "_s, request.path)));
+        sendResponse(WTF::move(actualReplyHandler), CommandResult::fail(CommandResult::ErrorCode::UnknownCommand, makeString("Unknown command: "_s, request.path)));
         return;
     }
 
@@ -363,13 +398,13 @@ void WebDriverService::handleRequest(HTTPRequestHandler::Request&& request, Func
     if (method.value() == HTTPMethod::Post) {
         auto messageValue = JSON::Value::parseJSON(String::fromUTF8({ request.data, request.dataLength }));
         if (!messageValue) {
-            sendResponse(WTF::move(replyHandler), CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "Invalid JSON in request body"_s));
+            sendResponse(WTF::move(actualReplyHandler), CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "Invalid JSON in request body"_s));
             return;
         }
 
         parametersObject = messageValue->asObject();
         if (!parametersObject) {
-            sendResponse(WTF::move(replyHandler), CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "Expected JSON object in request body"_s));
+            sendResponse(WTF::move(actualReplyHandler), CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "Expected JSON object in request body"_s));
             return;
         }
     } else
@@ -377,8 +412,8 @@ void WebDriverService::handleRequest(HTTPRequestHandler::Request&& request, Func
     for (const auto& parameter : parameters)
         parametersObject->setString(parameter.key, parameter.value);
 
-    ((*this).*handler)(WTF::move(parametersObject), [this, replyHandler = WTF::move(replyHandler)](CommandResult&& result) mutable {
-        sendResponse(WTF::move(replyHandler), WTF::move(result));
+    ((*this).*handler)(WTF::move(parametersObject), [this, actualReplyHandler = WTF::move(actualReplyHandler)](CommandResult&& result) mutable {
+        sendResponse(WTF::move(actualReplyHandler), WTF::move(result));
     });
 }
 

--- a/Source/WebDriver/glib/SessionHostGlib.cpp
+++ b/Source/WebDriver/glib/SessionHostGlib.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SessionHost.h"
 
+#include "Logging.h"
 #include "WebDriverService.h"
 #include <gio/gio.h>
 #include <wtf/NeverDestroyed.h>
@@ -118,6 +119,7 @@ struct ConnectToBrowserAsyncData {
     GUniquePtr<char> inspectorAddress;
     GRefPtr<GCancellable> cancellable;
     Function<void (std::optional<String> error)> completionHandler;
+    unsigned connectionAttemptCount { 0 };
 };
 
 static guint16 freePort()
@@ -151,6 +153,7 @@ void SessionHost::launchBrowser(Function<void (std::optional<String> error)>&& c
     );
     if (!targetIp.isEmpty()) {
         m_isRemoteBrowser = true;
+        RELEASE_LOG_INFO(SessionHost, "Attaching to already running RemoteInspector at %s", inspectorAddress.get());
         connectToBrowser(makeUnique<ConnectToBrowserAsyncData>(this, WTF::move(inspectorAddress), m_cancellable.get(), WTF::move(completionHandler)));
         return;
     }
@@ -167,9 +170,12 @@ void SessionHost::launchBrowser(Function<void (std::optional<String> error)>&& c
     for (unsigned i = 0; i < browserArgumentsSize; ++i)
         args.get()[i + 1] = g_strdup(m_capabilities.browserArguments.value()[i].utf8().data());
 
+    RELEASE_LOG_INFO(SessionHost, "Spawning local browser: %s with %zu argument(s)", args.get()[0], browserArgumentsSize);
+
     GUniqueOutPtr<GError> error;
     m_browser = adoptGRef(g_subprocess_launcher_spawnv(launcher.get(), args.get(), &error.outPtr()));
     if (error) {
+        RELEASE_LOG_ERROR(SessionHost, "Failed to spawn browser %s: %s", args.get()[0], error->message);
         completionHandler(String::fromUTF8(error->message));
         return;
     }
@@ -197,6 +203,9 @@ void SessionHost::connectToBrowser(std::unique_ptr<ConnectToBrowserAsyncData>&& 
     if (!m_browser && !m_isRemoteBrowser)
         return;
 
+    if (!data->connectionAttemptCount)
+        RELEASE_LOG_INFO(SessionHost, "Connecting to RemoteInspector at %s", data->inspectorAddress.get());
+
     RunLoop::mainSingleton().dispatchAfter(100_ms, [connectToBrowserData = WTF::move(data)]() mutable {
         auto* data = connectToBrowserData.release();
         if (g_cancellable_is_cancelled(data->cancellable.get()))
@@ -213,13 +222,18 @@ void SessionHost::connectToBrowser(std::unique_ptr<ConnectToBrowserAsyncData>&& 
                         return;
 
                     if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CONNECTION_REFUSED)) {
+                        data->connectionAttemptCount++;
+                        if (!(data->connectionAttemptCount % 10))
+                            RELEASE_LOG_INFO(SessionHost, "Still attempting connection to %s (attempt %u)", data->inspectorAddress.get(), data->connectionAttemptCount);
                         data->sessionHost->connectToBrowser(WTF::move(data));
                         return;
                     }
+                    RELEASE_LOG_ERROR(SessionHost, "Failed to connect to %s: %s", data->inspectorAddress.get(), error->message);
                     data->completionHandler(String::fromUTF8(error->message));
                     return;
                 }
 
+                RELEASE_LOG_INFO(SessionHost, "Connected to RemoteInspector at %s after %u attempt(s)", data->inspectorAddress.get(), data->connectionAttemptCount + 1);
                 data->sessionHost->setupConnection(SocketConnection::create(WTF::move(connection), messageHandlers(), data->sessionHost));
                 data->completionHandler(std::nullopt);
         }, data);
@@ -229,6 +243,12 @@ void SessionHost::connectToBrowser(std::unique_ptr<ConnectToBrowserAsyncData>&& 
 void SessionHost::connectionDidClose()
 {
     Ref<SessionHost> protectedThis(*this);
+
+    if (!m_targetIp.isEmpty())
+        RELEASE_LOG_INFO(SessionHost, "RemoteInspector at %s:%u closed connection", m_targetIp.utf8().data(), m_targetPort);
+    else
+        RELEASE_LOG_INFO(SessionHost, "Inspector connection closed (local browser)");
+
     m_browser = nullptr;
     m_isRemoteBrowser = false;
 
@@ -362,6 +382,7 @@ void SessionHost::setTargetList(uint64_t connectionID, Vector<Target>&& targetLi
         // such as WebPage (this can be ignored), or if the server has removed the Automation target
         // because the session has ended (in this case, we must reset our state).
         if (m_connectionID) {
+            RELEASE_LOG_INFO(SessionHost, "Remote browser removed all automation targets; disconnecting");
             if (m_socketConnection)
                 m_socketConnection->close();
             connectionDidClose();


### PR DESCRIPTION
#### a917f438fb1f8bca90b2d01a4440261d34bac180
<pre>
[WebDriver] Improve driver logging coverage
<a href="https://bugs.webkit.org/show_bug.cgi?id=316798">https://bugs.webkit.org/show_bug.cgi?id=316798</a>

Reviewed by BJ Burg.

To improve traceability, this commit adds RELEASE_LOG statements
covering the following areas of Source/WebDriver:

- Browser startup and lifetime (for glib ports)
- HTTP request and response
- Driver-&gt;Browser Automation.json commands and replies.

The added log statements cover mainly data like the request path, body
size, response status, and duration. The actual body with payload like
field values or JS code to be executed is omitted. For deeper
inspection, the existing LOG() statements that inspect the actual
payload are kept.

We opted for RELEASE_LOG instead of LOG due to the WebDriver-related
channels being low-volume in comparison to hotter ones internal to the
browser. On top of that, it should be easier for reporters to provide
release logs, helping get more useful bug reports.

Example output:

Started WebSocket BiDi server with host local and port 60782
Started HTTP server with host local and port 60781
HTTP request POST /session (body=303 bytes)
Spawning local browser: /sdk/webkit/WebKitBuild/WPE/Release/bin/MiniBrowser with 2 argument(s)
Connecting to RemoteInspector at 127.0.0.1:54821
Connected to RemoteInspector at 127.0.0.1:54821 after 1 attempt(s)
    SEND inspector #0001: Automation.createBrowsingContext (52 bytes)
    RECV inspector #0001: ok
HTTP response 200 in 196ms
HTTP request POST /session/fbc9c527-945d-4030-852e-50c5f1852557/url (body=43 bytes)
    SEND inspector #0002: Automation.resolveBrowsingContext (149 bytes)
    RECV inspector #0002: ok
    SEND inspector #0003: Automation.waitForNavigationToComplete (207 bytes)
    RECV inspector #0003: ok
    SEND inspector #0004: Automation.isShowingJavaScriptDialog (135 bytes)
    RECV inspector #0004: ok
    SEND inspector #0005: Automation.navigateBrowsingContext (212 bytes)
    RECV inspector #0005: ok
HTTP response 200 in 124ms

* Source/WebDriver/SessionHost.cpp:
(WebDriver::SessionHost::inspectorDisconnected):
(WebDriver::SessionHost::sendCommandToBackend):
(WebDriver::SessionHost::dispatchMessage):
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::printUsageStatement):
(WebDriver::WebDriverService::run):
(WebDriver::WebDriverService::handleRequest):
* Source/WebDriver/glib/SessionHostGlib.cpp:
(WebDriver::SessionHost::launchBrowser):
(WebDriver::SessionHost::connectToBrowser):
(WebDriver::SessionHost::connectionDidClose):
(WebDriver::SessionHost::setTargetList):

Canonical link: <a href="https://commits.webkit.org/316784@main">https://commits.webkit.org/316784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a316e8657a77482f0adc784073de9fe553938cb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130867 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134756 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155408 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115230 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35167 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31369 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185307 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143608 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46911 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143477 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38746 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47590 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112691 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38439 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119339 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46096 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9852 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45498 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->