### PR TITLE
Meta refresh to URL with different fragment identifier should not be treated as a page reload

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/refresh/same-document-refresh-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/refresh/same-document-refresh-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Same-Document Referrer from Refresh assert_equals: referrer header is unchanged expected "http://web-platform.test:8800/html/browsers/browsing-the-web/navigating-across-documents/refresh/same-document-refresh.html" but got "http://web-platform.test:8800/html/browsers/browsing-the-web/navigating-across-documents/refresh/resources/refresh-with-section.sub.html?url=%23section"
+PASS Same-Document Referrer from Refresh
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -217,7 +217,18 @@ public:
 
         UserGestureIndicator gestureIndicator { userGestureToForward() };
 
-        bool refresh = equalIgnoringFragmentIdentifier(protect(localFrame->document())->url(), url());
+        // A refresh whose target only adds or changes the fragment identifier is a same-document
+        // navigation, not a reload: forcing ReloadIgnoringCacheData would turn it into a full network
+        // load that resets the referrer. This only applies when the target URL itself carries a
+        // fragment that differs from the current one. A target without a fragment (e.g. a bare
+        // <meta http-equiv="refresh"> with no url=) is always a reload, even if the user has since
+        // navigated the document to a fragment.
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid-step
+        URL currentURL = protect(localFrame->document())->url();
+        bool isSameDocumentFragmentChange = equalIgnoringFragmentIdentifier(currentURL, url())
+            && url().hasFragmentIdentifier()
+            && currentURL.fragmentIdentifier() != url().fragmentIdentifier();
+        bool refresh = equalIgnoringFragmentIdentifier(currentURL, url()) && !isSameDocumentFragmentChange;
         ResourceRequest resourceRequest { URL { url() }, String { referrer() }, refresh ? ResourceRequestCachePolicy::ReloadIgnoringCacheData : ResourceRequestCachePolicy::UseProtocolCachePolicy };
         if (initiatedByMainFrame() == InitiatedByMainFrame::Yes)
             resourceRequest.setRequester(ResourceRequestRequester::Main);


### PR DESCRIPTION
#### d860ee92dac3d25b07d1315cc5ad860f54944135
<pre>
Meta refresh to URL with different fragment identifier should not be treated as a page reload
<a href="https://bugs.webkit.org/show_bug.cgi?id=314145">https://bugs.webkit.org/show_bug.cgi?id=314145</a>
<a href="https://rdar.apple.com/176933795">rdar://176933795</a>

Reviewed by Chris Dumez.

A refresh (via &lt;meta http-equiv=&quot;refresh&quot;&gt; or the HTTP Refresh header) whose
target URL equals the current document&apos;s URL ignoring fragments, but adds or
changes the fragment identifier, is a same-document fragment navigation per the
HTML &quot;navigate to a fragment&quot; step [1]. It must not issue a network request or emit
a new Referer header.

ScheduledRedirect::fire() decided whether the redirect was a &quot;refresh&quot; using
equalIgnoringFragmentIdentifier(), which is true both for an identical URL and
for the same URL with a different fragment. In the latter case it wrongly forced
ResourceRequestCachePolicy::ReloadIgnoringCacheData, which makes
FrameLoader::loadFrameRequest() pick FrameLoadType::Reload. Because
shouldPerformFragmentNavigation() bails out for reloads, WebKit performed a full
network load of the fragment URL instead of an in-document scroll, sending a
fresh Referer (the page&apos;s own URL) rather than preserving the original referrer.

Treat the redirect as a same-document fragment navigation only when the refresh&apos;s
own target URL carries a fragment that differs from the current document&apos;s
fragment. The decision is made against the target captured at parse time, not
against whatever fragment the user may have scrolled to afterward: a bare
&lt;meta http-equiv=&quot;refresh&quot;&gt; with no url= records a fragmentless target and must
always reload (preserving scroll restoration) even if the document&apos;s current URL
has since gained a fragment via location.assign(&apos;#1&apos;). Only when the target
itself adds or changes the fragment does the redirect flow as a Standard
navigation so shouldPerformFragmentNavigation() performs the same-document scroll
with the referrer unchanged.

[1] <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid-step">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid-step</a>

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/refresh/same-document-refresh-expected.txt: Progression.
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledRedirect::fire):

Canonical link: <a href="https://commits.webkit.org/316001@main">https://commits.webkit.org/316001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bf9b06ae12536330f7b29c5af240684c1696f2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128408 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2d85628-b4a5-44d8-99ae-45bb78249ebb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133120 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8a2b8ad-1c15-4816-b6dc-a6d1f5ae3396) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113617 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f2acfcb-4718-46f2-bc5f-e921497adc66) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34942 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33272 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28753 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182656 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141580 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44276 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141395 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38079 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44965 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109618 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36662 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116854 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43475 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8047 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42880 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43011 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->