### PR TITLE
Position::equals() compares against the wrong position's offset for after-children anchors

### DIFF
--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1543,7 +1543,7 @@ bool Position::equals(const Position& other) const
             ASSERT(!is<Text>(*other.m_anchorNode));
             return m_anchorNode == other.m_anchorNode;
         case PositionIsOffsetInAnchor:
-            return m_anchorNode == other.m_anchorNode && m_anchorNode->countChildNodes() == static_cast<unsigned>(m_offset);
+            return m_anchorNode == other.m_anchorNode && m_anchorNode->countChildNodes() == static_cast<unsigned>(other.m_offset);
         case PositionIsBeforeAnchor:
             return false;
         case PositionIsAfterAnchor:

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -201,7 +201,7 @@ public:
 
     // This is a tentative enhancement of operator== to account for different position types.
     // FIXME: Combine this function with operator==
-    bool NODELETE equals(const Position&) const;
+    WEBCORE_EXPORT bool NODELETE equals(const Position&) const;
 
 private:
     // For creating legacy editing positions: (Anchor type will be determined from editingIgnoresContent(node))

--- a/Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp
@@ -297,4 +297,32 @@ TEST(DocumentOrder, Positions)
     // FIXME: Add tests that cover shadow trees.
 }
 
+TEST(Position, EqualsAfterChildrenVersusOffsetInAnchor)
+{
+    auto document = createDocument();
+    auto& body = *document->body();
+
+    body.appendChild(HTMLDivElement::create(document));
+    body.appendChild(HTMLDivElement::create(document));
+    body.appendChild(HTMLDivElement::create(document));
+    ASSERT_EQ(body.countChildNodes(), 3u);
+
+    Position afterChildren { &body, Position::PositionIsAfterChildren };
+    Position offsetAtEnd = makeContainerOffsetPosition(&body, body.countChildNodes()); // (body, 3)
+
+    EXPECT_TRUE(offsetAtEnd.equals(afterChildren));
+    EXPECT_TRUE(afterChildren.equals(offsetAtEnd));
+
+    Position offsetAtStart = makeContainerOffsetPosition(&body, 0u);
+    EXPECT_FALSE(afterChildren.equals(offsetAtStart));
+    EXPECT_FALSE(offsetAtStart.equals(afterChildren));
+
+    Ref empty = HTMLDivElement::create(document);
+    body.appendChild(empty);
+    Position emptyAfterChildren { empty.ptr(), Position::PositionIsAfterChildren };
+    Position emptyOffsetZero = makeContainerOffsetPosition(empty.ptr(), 0u);
+    EXPECT_TRUE(emptyAfterChildren.equals(emptyOffsetZero));
+    EXPECT_TRUE(emptyOffsetZero.equals(emptyAfterChildren));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 481743afd51bd480c6a0a678cf7a835713726fc0
<pre>
Position::equals() compares against the wrong position&apos;s offset for after-children anchors
<a href="https://bugs.webkit.org/show_bug.cgi?id=317571">https://bugs.webkit.org/show_bug.cgi?id=317571</a>

Reviewed by Anne van Kesteren.

Position::equals() is the cross-anchor-type comparison used by VisiblePosition::operator==,
AXObjectCache text navigation, and editing commands. When comparing a position whose anchor
type is PositionIsAfterChildren against a PositionIsOffsetInAnchor position on the same node,
the comparison tested the child count against *this* position&apos;s m_offset. For an
after-children position m_offset is meaningless (it is 0, set by the AnchorType-only
constructor), so the predicate degenerated to &quot;countChildNodes() == 0&quot;. As a result two
positions that describe the same DOM location — e.g. (div, AfterChildren) and (div, 3) for a
div with three children — compared unequal, and the comparison was asymmetric with the
correct PositionIsOffsetInAnchor vs PositionIsAfterChildren branch.

Fix this by comparing against other.m_offset, mirroring the symmetric branch. Latent since
the function was introduced in 169247@main (213c76d42579) in 2015.

Test: Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp

* Source/WebCore/dom/Position.cpp:
(WebCore::Position::equals const):
* Source/WebCore/dom/Position.h:
* Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp:
(TestWebKitAPI::TEST(Position, EqualsAfterChildrenVersusOffsetInAnchor)):

Canonical link: <a href="https://commits.webkit.org/315595@main">https://commits.webkit.org/315595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db7393c0e8ddfc5834f9c8d9a13a2a8a11578a14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127225 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf1f29cf-03c4-46a1-8b6b-cfc0c5763c48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132066 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92998 "10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d067b8cf-0c57-485d-a315-eb0aad4a9c48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172472 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112569 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a260da68-d3d8-420b-9e53-344e6897702f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32205 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27569 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181471 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36371 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140516 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 14 flakes 6 failures; Uploaded test results; 2 failures; Compiled WebKit; 2 failures; Passed layout tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43091 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140350 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37765 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43780 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107957 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35622 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115545 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42290 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6877 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41683 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41938 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41826 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->