### PR TITLE
[GTK][WPE] REGRESSION(315523@main): Revert Swift toolchain support for Yocto builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,29 +40,6 @@ if (SWIFT_REQUIRED)
         endif ()
     endif ()
 
-    # Derive the Swift triple from the C compiler's target when cross-compiling
-    # (Yocto bakes --target=<sys> into CC, not CMAKE_C_COMPILER_TARGET).
-    if ((PORT STREQUAL "WPE" OR PORT STREQUAL "GTK") AND CMAKE_CROSSCOMPILING AND NOT CMAKE_Swift_COMPILER_TARGET)
-        set(_swift_target "")
-        if (CMAKE_C_COMPILER_TARGET)
-            set(_swift_target "${CMAKE_C_COMPILER_TARGET}")
-        elseif (CMAKE_C_COMPILER_ARG1 MATCHES "--target=([^ \t]+)")
-            set(_swift_target "${CMAKE_MATCH_1}")
-        endif ()
-        if (_swift_target)
-            set(CMAKE_Swift_COMPILER_TARGET "${_swift_target}" CACHE STRING "Swift target triple" FORCE)
-        elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-            set(CMAKE_Swift_COMPILER_TARGET "aarch64-unknown-linux-gnu" CACHE STRING "Swift target triple" FORCE)
-        elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv7" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
-            set(CMAKE_Swift_COMPILER_TARGET "armv7-unknown-linux-gnueabihf" CACHE STRING "Swift target triple" FORCE)
-        else ()
-            message(FATAL_ERROR
-                "Cannot derive a Swift target triple for "
-                "CMAKE_SYSTEM_PROCESSOR='${CMAKE_SYSTEM_PROCESSOR}'. "
-                "Pass -DCMAKE_Swift_COMPILER_TARGET=<triple> explicitly.")
-        endif ()
-    endif ()
-
     enable_language(Swift)
 
     # -F causes Swift to find C++23 framework headers in implicit module builds.
@@ -83,11 +60,6 @@ if (SWIFT_REQUIRED)
     string(REPLACE "<CMAKE_Swift_COMPILER>"
         "<CMAKE_Swift_COMPILER> --original-swift-compiler=${ORIGINAL_Swift_COMPILER}"
         CMAKE_Swift_CREATE_STATIC_LIBRARY "${CMAKE_Swift_CREATE_STATIC_LIBRARY}")
-else ()
-    # The Yocto cross-toolchain env injects -DCMAKE_Swift_FLAGS_INIT whenever the
-    # SDK ships swiftc, but only enable_language(Swift) above consumes it. Without
-    # Swift, touch it here so CMake doesn't warn that it went unused.
-    set(_unused_swift_flags_init "${CMAKE_Swift_FLAGS_INIT}")
 endif ()
 
 # -----------------------------------------------------------------------------

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -1380,12 +1380,6 @@ endif ()
 
 list(APPEND WebKit_SOURCES ${WebKit_DERIVED_SOURCES})
 
-if (SWIFT_REQUIRED)
-    # WebKit_SwiftCxxHeader is created by a DEFER CALL, so defer wiring its dep too.
-    add_custom_target(WebKit_DerivedHeadersForSwift DEPENDS ${WebKit_HEADERS} ${WebKit_DERIVED_SOURCES})
-    cmake_language(DEFER CALL add_dependencies WebKit_SwiftCxxHeader WebKit_DerivedHeadersForSwift)
-endif ()
-
 WEBKIT_COMPUTE_SOURCES(WebKit)
 if (DEFINED WebKit_SWIFT_INTEROP_SOURCES)
     list(REMOVE_ITEM WebKit_SOURCES ${WebKit_SWIFT_INTEROP_SOURCES})
@@ -1423,9 +1417,6 @@ if (DEFINED WebKit_SWIFT_INTEROP_SOURCES)
     WEBKIT_DEFINE_SUBTARGET(WebKit_SwiftInterop WebKit ${WebKit_SWIFT_INTEROP_SOURCES})
     WEBKIT_REUSE_PREFIX_HEADER(WebKit_SwiftInterop WebKit WebKitPrefix.h PREFIX_LANGUAGES CXX OBJCXX)
     target_compile_definitions(WebKit_SwiftInterop PRIVATE WK_COMPILING_SWIFT_INTEROP_SUBTARGET)
-    # Kept out of cmake_object_order_depends_target_WebKit (see below), so depend
-    # on the derived headers explicitly to avoid racing *Messages.h generation.
-    add_dependencies(WebKit_SwiftInterop WebKit_DerivedHeadersForSwift)
     # Feed objects into the WebKit link via a response file + LINK_DEPENDS so
     # cmake_object_order_depends_target_WebKit doesn't pick up this sub-target
     # (and through it, WebKit_SwiftCxxHeader).

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -865,16 +865,7 @@ function(_webkit_generate_platform_swift_args _target _resp_path _ordering_dep)
     if (CMAKE_OSX_SYSROOT)
         list(APPEND _clang_cmd "-isysroot" "${CMAKE_OSX_SYSROOT}")
     endif ()
-    # The bundle clang carries its target triple, --sysroot, --gcc-install-dir and
-    # libstdc++ -isystem dirs in CMAKE_CXX_COMPILER_ARG1. Mirror them here, since
-    # this hand-built preprocess doesn't get them automatically and without the
-    # sysroot, preprocessing wtf/Platform.h leaks host glibc. This also supplies
-    # --target, making the block below a fallback for builds where ARG1 is empty.
-    if (CMAKE_CXX_COMPILER_ARG1)
-        separate_arguments(_cxx_compiler_arg1 NATIVE_COMMAND "${CMAKE_CXX_COMPILER_ARG1}")
-        list(APPEND _clang_cmd ${_cxx_compiler_arg1})
-    endif ()
-    if (CMAKE_Swift_COMPILER_TARGET AND NOT CMAKE_CXX_COMPILER_ARG1)
+    if (CMAKE_Swift_COMPILER_TARGET)
         list(APPEND _clang_cmd "-target" "${CMAKE_Swift_COMPILER_TARGET}")
     endif ()
     if (WEBKIT_ADDITIONS_INCLUDE_PATH)
@@ -1097,12 +1088,6 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
                 if (_dir MATCHES "/clang/[0-9]+/include(/|$)")
                     continue ()
                 endif ()
-                # When cross-compiling, don't forward host implicit C include dirs
-                # to Swift's clang importer: as explicit -I they break the libstdc++
-                # `std` module build. The sysroot and baked-in flags cover the target.
-                if (CMAKE_CROSSCOMPILING)
-                    continue ()
-                endif ()
                 list(APPEND _swift_options "-Xcc" "-I${_dir}")
             endforeach ()
         endif ()
@@ -1154,12 +1139,7 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         endif ()
         list(APPEND _swift_options "-module-cache-path" "${CMAKE_BINARY_DIR}/SwiftModuleCache")
         set_property(DIRECTORY "${CMAKE_BINARY_DIR}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/SwiftModuleCache")
-        # -track-system-dependencies makes the clang importer resolve libstdc++'s
-        # modulemap via a /lib->/usr/lib path Yocto doesn't expose, breaking the
-        # cross build; there's no value in tracking a regenerated sysroot anyway.
-        if (NOT CMAKE_CROSSCOMPILING)
-            list(APPEND _swift_options "-track-system-dependencies")
-        endif ()
+        list(APPEND _swift_options "-track-system-dependencies")
         # We'll use these options both for mainstream cmake invocations of swiftc (here)
         # and for our own invocation to output an interoperability .h file (later).
         # target_compile_options deduplicates repeated tokens, so collapse each

--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -546,91 +546,52 @@ class YoctoCrossBuilder():
             original_setup_env_path = self._get_cross_toolchain_env_path(check_toolchain_built=False)
             _log.info('Patching toolchain environment-setup file to remove optimizations by default: {original_setup_env_path}'.format(original_setup_env_path=original_setup_env_path))
             # This does the following:
-            # 1. Drop the CFLAGS/CXXFLAGS/LDFLAGS/CPPFLAGS exports.
-            # 2. On the CC/CXX/CPP exports, keep only machine flags (-m*), '-E', and
-            #    the sysroot.
-            # 3. If the SDK ships clang (swift.org bundle), also emit a Clang form
-            #    swapping `<sys>-gcc/g++/cpp` for `clang/clang++/clang-cpp --target=<sys>`
-            #    (Swift/C++ interop is Clang-only), selected by the user via CC/CXX.
+            # 1. Remove any line that exports CFLAGS/CXXFLAGS/LDFLAGS/CPPFLAGS
+            # 2. On the line that exports the compiler variables (export CC, export CXX and export CPP)
+            #    remove any compiler flag that is not machine related (-m*) or is '-E' (for cpp) or is for the sysroot/target.
+            # 3. Do not override CC/CXX with the cross-compiled GCC compiler if the user wants to use Clang, instead
+            #    set CC/CXX pointing to the cross-compiled Clang (assuming the support was built in the toolchain).
             patched_setup_env_path = original_setup_env_path + "-no-opt-flags"
-            # Anchor on the trailing '=' so we don't also strip unrelated exports
-            # like CPPFLAGS_FOR_BUILD. No whitespace before '=' since shell variable
-            # assignments don't allow it.
             flags_regex = re.compile(r'export\s+(C|CXX|LD|CPP)FLAGS=')
-            compiler_regex = re.compile(r'export\s+C(C|XX|PP)=')
-            toolchain_binary_regex = re.compile(r'([\w-]+-)(gcc|g\+\+|cpp)$')
-            clang_for = {'gcc': 'clang', 'g++': 'clang++', 'cpp': 'clang-cpp'}
-            # Detect whether any SDK host sysroot has clang / swiftc binaries.
-            sysroots_dir = os.path.join(os.path.dirname(original_setup_env_path), 'sysroots')
-            sdk_has_clang = False
-            sdk_has_swiftc = False
-            if os.path.isdir(sysroots_dir):
-                for entry in os.listdir(sysroots_dir):
-                    host_bin = os.path.join(sysroots_dir, entry, 'usr', 'bin')
-                    if os.path.isfile(os.path.join(host_bin, 'clang')):
-                        sdk_has_clang = True
-                    if os.path.isfile(os.path.join(host_bin, 'swiftc')):
-                        sdk_has_swiftc = True
+            gcc_compiler_regex = re.compile(r'export\s+C(C|XX|PP)=')
+            clang_compiler_regex = re.compile(r'export\s+CLANGC(C|XX|PP)=')
             gcc_lines = []
             clang_lines = []
             with open(original_setup_env_path, 'r') as fr:
                 with open(patched_setup_env_path, 'w') as fw:
                     for line in fr.readlines():
                         if not flags_regex.match(line):
-                            if compiler_regex.match(line):
-                                # GCC form always; Clang form too when the SDK ships clang.
-                                gcc_line = ""
-                                clang_line = ""
+                            if gcc_compiler_regex.match(line) or clang_compiler_regex.match(line):
+                                newline = ""
                                 for word in line.strip().split():
                                     if word.startswith('-'):
-                                        if word.startswith('-m') or word == '-E' or word.startswith('--sysroot'):
-                                            gcc_line += " " + word
-                                            clang_line += " " + word
+                                        if word == '-E' or any(word.startswith(p) for p in ['-m', '--sysroot=', '--target=']):
+                                            newline += " " + word
                                     else:
-                                        gcc_line += " " + word
-                                        m = toolchain_binary_regex.search(word)
-                                        if m and sdk_has_clang:
-                                            target = m.group(1).rstrip('-')
-                                            # --gcc-install-dir/-isystem point at the
-                                            # sysroot so crt*.o/libgcc.a and the c++
-                                            # headers resolve. Globs expand at source time.
-                                            gcc_dir = ('$(ls -d "$SDKTARGETSYSROOT/usr/lib/gcc/' + target
-                                                       + '"/* 2>/dev/null | head -1)')
-                                            cxx_inc = ('$(ls -d "$SDKTARGETSYSROOT/usr/include/c++"'
-                                                       '/* 2>/dev/null | head -1)')
-                                            clang_line += " " + word.replace(m.group(0),
-                                                clang_for[m.group(2)] + " --target=" + target
-                                                + " --gcc-install-dir=" + gcc_dir
-                                                + " -isystem " + cxx_inc
-                                                + " -isystem " + cxx_inc + "/" + target)
-                                        else:
-                                            clang_line += " " + word
-                                if '="' in gcc_line and not gcc_line.endswith('"'):
-                                    gcc_line += '"'
-                                if '="' in clang_line and not clang_line.endswith('"'):
-                                    clang_line += '"'
-                                gcc_lines.append(gcc_line.strip() + '\n')
-                                clang_lines.append(clang_line.strip() + '\n')
+                                        newline += " " + word
+                                if '="' in newline and not newline.endswith('"'):
+                                    newline += '"'
+                                newline = newline.strip() + '\n'
+                                (clang_lines if clang_compiler_regex.match(line) else gcc_lines).append(newline)
                             else:
                                 fw.write(line)
-                    # Be strict: the setup-environment script is expected to export
-                    # exactly CC/CXX/CPP. If the count ever differs from 3 the file
-                    # changed shape and this has to be inspected to see what is going on.
+                    # The script should check the CC/CXX env var from the user, if is set to clang then export
+                    # the CLANGCC and CLANGCXX as CC/CXX, otherwise keep the default (GCC)
                     if len(gcc_lines) != 3:
                         raise RuntimeError('Unexpected CC/CXX/CPP parameters in setup-environment script')
-                    # Emit the compiler exports: Clang form when the SDK ships clang
-                    # and the user asked for it via CC/CXX, otherwise GCC.
-                    if sdk_has_clang and clang_lines:
+                    if clang_lines:
                         fw.write('\nif echo "${CC} ${CXX}" | grep -qi clang; then\n')
-                        for _cl in clang_lines:
-                            fw.write('    ' + _cl)
+                        for line in clang_lines:
+                            # Remove the CLANG prefix, so for example CLANGCXX becomes CXX
+                            line = re.sub(r'(export\s+)CLANG(CC|CXX|CPP)(=)', r'\1\2\3', line)
+                            fw.write(f'    {line}')
                         fw.write('else\n')
-                        for _gl in gcc_lines:
-                            fw.write('    ' + _gl)
+                        for line in gcc_lines:
+                            fw.write(f'    {line}')
                         fw.write('fi\n')
                     else:
-                        for _gl in gcc_lines:
-                            fw.write(_gl)
+                        for line in gcc_lines:
+                            fw.write(line)
                     # When building cog, meson tries to load the wpe headers that are on the repo from the sysroot path.
                     # That is not really a bug on meson as system libraries should be loaded from the sysroot when cross-building.
                     # Workaround the issue by creating a symlink that also resolves this WebKit repository path inside the sysroot.
@@ -638,54 +599,6 @@ class YoctoCrossBuilder():
                              '    mkdir -p "${{OECORE_TARGET_SYSROOT}}/{webkit_dir_up}"\n'
                              '    ln -s "{webkit_dir}" "${{OECORE_TARGET_SYSROOT}}/{webkit_dir_up}"\n'
                              'fi\n'.format(webkit_dir=self._webkit_dir, webkit_dir_up=os.path.dirname(self._webkit_dir)))
-                    # When the SDK ships swiftc, splice -DCMAKE_Swift_FLAGS_INIT into
-                    # BUILD_WEBKIT_ARGS to wire swiftc to the Yocto sysroot:
-                    #   -sdk / -I        target headers + Swift modules.
-                    #   -Xcc ...         swiftc's *compile* step spawns clang -cc1,
-                    #                    which -sdk doesn't reach, so the sysroot and
-                    #                    gcc-install-dir have to be handed to it here.
-                    #   -Xclang-linker   swiftc's *link* step spawns a separate clang
-                    #                    driver that does NOT inherit the -Xcc flags,
-                    #                    so --sysroot/--gcc-install-dir are repeated
-                    #                    for it. -fuse-ld=<abs <sys>-ld> additionally
-                    #                    forces the Yocto cross-linker; otherwise that
-                    #                    clang driver defaults to the host's ld and
-                    #                    links the target binary with the wrong linker.
-                    # The compile and link steps are distinct clang invocations, which
-                    # is why the sysroot/gcc-install-dir flags appear once per step.
-                    # Paths resolve at env-setup source time via shell.
-                    if sdk_has_swiftc:
-                        # Yocto splits gcc-install across usr/lib/<sys> and
-                        # usr/lib/gcc/<sys>; Swift's libstdc++ probe needs crtbegin.o
-                        # in the gcc/ tree, so copy what's missing (symlinks aren't
-                        # followed by the clang driver). Idempotent.
-                        fw.write(
-                            '\nif [ -n "${OECORE_TARGET_SYSROOT:-}" ] && [ -d "${OECORE_TARGET_SYSROOT}/usr/lib/swift" ]; then\n'
-                            '    _target_prefix="${TARGET_PREFIX%-}"\n'
-                            '    _gcc_src=$(ls -d "${OECORE_TARGET_SYSROOT}/usr/lib/${_target_prefix}"/* 2>/dev/null | head -1)\n'
-                            '    if [ -n "${_gcc_src}" ]; then\n'
-                            '        _gcc_ver=$(basename "${_gcc_src}")\n'
-                            '        _gcc_dst="${OECORE_TARGET_SYSROOT}/usr/lib/gcc/${_target_prefix}/${_gcc_ver}"\n'
-                            '        if [ -d "${_gcc_dst}" ] && [ ! -e "${_gcc_dst}/crtbegin.o" ]; then\n'
-                            '            for _f in "${_gcc_src}"/*; do\n'
-                            '                _bn=$(basename "${_f}")\n'
-                            '                [ -e "${_gcc_dst}/${_bn}" ] || cp -rp "${_f}" "${_gcc_dst}/${_bn}"\n'
-                            '            done\n'
-                            '            unset _f _bn\n'
-                            '        fi\n'
-                            '        unset _gcc_ver _gcc_dst\n'
-                            '    fi\n'
-                            '    unset _target_prefix _gcc_src\n'
-                            'fi\n'
-                            '\nif [ -n "${BUILD_WEBKIT_ARGS:-}" ] && [ -d "${OECORE_TARGET_SYSROOT}/usr/lib/swift" ]; then\n'
-                            '    _target_prefix="${TARGET_PREFIX%-}"\n'
-                            '    _gcc_install_dir=$(ls -d "${OECORE_TARGET_SYSROOT}/usr/lib/gcc/${_target_prefix}"/* 2>/dev/null | head -1)\n'
-                            '    _cross_ld=$(command -v "${_target_prefix}-ld" 2>/dev/null)\n'
-                            '    _swift_flags="-sdk ${OECORE_TARGET_SYSROOT} -I ${OECORE_TARGET_SYSROOT}/usr/lib/swift/linux -I ${OECORE_TARGET_SYSROOT}/usr/lib/swift -Xcc --sysroot=${OECORE_TARGET_SYSROOT} -Xcc --gcc-install-dir=${_gcc_install_dir} -Xclang-linker --sysroot=${OECORE_TARGET_SYSROOT} -Xclang-linker --gcc-install-dir=${_gcc_install_dir} -Xclang-linker -fuse-ld=${_cross_ld}"\n'
-                            '    BUILD_WEBKIT_ARGS="${BUILD_WEBKIT_ARGS} --cmakeargs=\\"-DCMAKE_Swift_FLAGS_INIT=\'${_swift_flags}\'\\""\n'
-                            '    export BUILD_WEBKIT_ARGS\n'
-                            '    unset _swift_flags _target_prefix _gcc_install_dir _cross_ld\n'
-                            'fi\n')
 
             # Put the patched setup-environ file in place of the other
             # and save a copy of the original just for debugging purposes

--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -51,23 +51,8 @@ for arg in "$@"; do
         pass_next_verbatim=
         continue
     fi
-    # Drop bare host `-I /usr/include` (or /usr/local/include): in a cross-build
-    # they leak host glibc into swiftc's clang importer and break the libstdc++
-    # `std` module. Safe everywhere (clang searches /usr/include by default).
-    if [[ -n "$pending_dash_I" ]]; then
-        pending_dash_I=
-        case "$arg" in
-            "/usr/include"|"/usr/local/include") ;;
-            *) args+=("-I" "$arg") ;;
-        esac
-        continue
-    fi
     case "$arg" in
-        "-I")
-            pending_dash_I=1
-            ;;
-        "-I/usr/include"|"-I/usr/local/include") ;;
-        "-Xcc"|"-Xlinker"|"-Xfrontend"|"-Xclang-linker")
+        "-Xcc"|"-Xlinker"|"-Xfrontend")
             args+=("$arg")
             pass_next_verbatim=1
             ;;
@@ -85,11 +70,7 @@ for arg in "$@"; do
             ;;
         "-include") skip_next=1 ;;
         "-fuse-ld="*)
-            # Link-only flag leaked into CFLAGS. -Xclang-linker passes it to the
-            # clang invocation swiftc uses *when it is used for linking* (not to
-            # the linker itself), instead of letting swiftc reject it at compile
-            # time. See swiftc's -Xclang-linker option documentation.
-            args+=("-Xclang-linker" "$arg")
+            args+=("-Xcc" "$arg")
             ;;
         # swiftc does not understand clang-specific include flags like
         # -isystem / -iquote / -idirafter; wrap them (and their following

--- a/Tools/yocto/README.md
+++ b/Tools/yocto/README.md
@@ -30,28 +30,6 @@ The script ```cross-toolchain-helper``` will parse this file and it will do the 
 
 For more info see the file ```${WebKitDirectory}/Tools/yocto/targets.conf```
 
-### Swift toolchain
-
-Swift support for WPE WebKit aarch64 and armv7 builds is provided by
-[jeremy-prater/meta-swift](https://github.com/jeremy-prater/meta-swift)
-(scarthgap branch), pinned in ```rpi/manifest.xml```. The swift.org prebuilt
-bundle (wrapped by the meta-webkit ```nativesdk-swift``` recipe) provides both
-swiftc and the clang/LLVM toolchain used to cross-build the GLib ports, so the
-whole toolchain is a single, consistent clang. WPE-specific glue lives as
-bbappends inside ```meta-openembedded_and_meta-webkit.patch```.
-
-| Target                    | Swift | Toolchain | Notes |
-| ------------------------- | ----- | --------- | ----- |
-| rpi3/4/5 64-bit (mesa)    | yes   | clang     | aarch64 |
-| rpi3/4 32-bit (mesa)      | no    | clang     | armv7; Swift does not compile on armv7 at present |
-| rpi3-32bits-userland      | no    | gcc       | wpebackend-rdk + constrained build; Swift opted out in its local.conf |
-| qemu-riscv64              | no    | gcc       | upstream Swift has no riscv64 target |
-
-meta-swift builds ```swift-stdlib```, ```swift-foundation``` and
-```libdispatch``` **from source** for each target architecture. Its
-```SWIFT_VERSION``` must match the swift.org bundle pinned by
-```nativesdk-swift```; bump them in lockstep.
-
 
 ### Integration with WebKit tooling script
 

--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -714,7 +714,7 @@ diff --git a/sources/meta-webkit/conf/distro/webkitdevci.conf b/sources/meta-web
 index 1f952c2..d299d1f 100644
 --- a/sources/meta-webkit/conf/distro/webkitdevci.conf
 +++ b/sources/meta-webkit/conf/distro/webkitdevci.conf
-@@ -47,6 +47,18 @@ PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
+@@ -47,6 +47,17 @@ PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
  PACKAGECONFIG:append:pn-php = " apache2"
  # Disable mysql support as we don't need to build mysql/mariadb
  PACKAGECONFIG:remove:pn-php = "mysql"
@@ -730,9 +730,8 @@ index 1f952c2..d299d1f 100644
  # Whitelist license from some deps.
  LICENSE_FLAGS_ACCEPTED:append = " commercial synaptics-killswitch"
 +
-+# The SDK host clang comes from the swift.org bundle (nativesdk-swift); keep
-+# meta-clang's nativesdk-clang out of the SDK host to avoid a conflict.
-+CLANGSDK = "0"
++# Optional support for clang if meta-clang is enabled
++CLANGSDK ?= "1"
 diff --git a/sources/meta-webkit/conf/layer.conf b/sources/meta-webkit/conf/layer.conf
 index 124c13d..1a38638 100644
 --- a/sources/meta-webkit/conf/layer.conf
@@ -746,6 +745,14 @@ index 124c13d..1a38638 100644
      "
  
  BBFILE_COLLECTIONS += "webkit"
+diff --git a/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend b/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend
+new file mode 100644
+index 0000000..b1950a5
+--- /dev/null
++++ b/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend
+@@ -0,0 +1,2 @@
++TOOLCHAIN_HOST_TASK:append = " nativesdk-clang nativesdk-compiler-rt nativesdk-compiler-rt-sanitizers"
++IMAGE_INSTALL:append = " clang compiler-rt compiler-rt-sanitizers libcxx"
 diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
 index 205c058..9cf85c8 100644
 --- a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -828,249 +835,3 @@ index 2355936..0820dd9 100644
          if ${@bb.utils.contains('PACKAGECONFIG', 'dhcp-ethernet', 'true', 'false', d)}; then
                 install -D -m0644 ${WORKDIR}/wired.network ${D}${systemd_unitdir}/network/80-wired.network
          fi
-diff --git a/sources/meta-webkit/recipes-browser/wpewebkit/wpewebkit_%.bbappend b/sources/meta-webkit/recipes-browser/wpewebkit/wpewebkit_%.bbappend
-new file mode 100644
-index 0000000..1a2b3c4
---- /dev/null
-+++ b/sources/meta-webkit/recipes-browser/wpewebkit/wpewebkit_%.bbappend
-@@ -0,0 +1,12 @@
-+# Optional Swift/C++ interop support for WPE WebKit (contributed upstream to
-+# meta-webkit). Off by default; enable per distro/image on a Swift-capable arch
-+# (aarch64/armv7; riscv64 has no upstream Swift target) with:
-+#     PACKAGECONFIG:append:pn-wpewebkit = " swift"
-+# CMAKE_Swift_COMPILER is the in-tree wrapper that ships in release tarballs;
-+# the Swift target triple is derived from CMAKE_SYSTEM_PROCESSOR in CMakeLists.txt.
-+PACKAGECONFIG[swift] = " \
-+    -DENABLE_SWIFT_DEMO_URI_SCHEME=ON -DENABLE_BACK_FORWARD_LIST_SWIFT=ON \
-+    -DCMAKE_Swift_COMPILER=${S}/Tools/Scripts/swift/swiftc-wrapper.sh \
-+    -DCMAKE_Swift_FLAGS_INIT='-sdk ${STAGING_DIR_TARGET} -resource-dir ${STAGING_DIR_TARGET}${libdir}/swift' \
-+    ,-DENABLE_SWIFT_DEMO_URI_SCHEME=OFF -DENABLE_BACK_FORWARD_LIST_SWIFT=OFF \
-+    ,swift-native swift-stdlib swift-foundation libdispatch"
-diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend
-new file mode 100644
-index 0000000..2b3c4d5
---- /dev/null
-+++ b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend
-@@ -0,0 +1,4 @@
-+# Pull the Swift runtime (from meta-swift) into the WPE WebKit packagegroup.
-+# Only aarch64: Swift does not compile on armv7 at present and riscv64 has no
-+# upstream Swift target.
-+RDEPENDS:packagegroup-wpewebkit-depends-core:append:aarch64 = " swift-stdlib swift-foundation libdispatch"
-diff --git a/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bbappend b/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bbappend
-new file mode 100644
-index 0000000..3c4d5e6
---- /dev/null
-+++ b/sources/meta-webkit/recipes-browser/images/webkit-dev-ci-tools.bbappend
-@@ -0,0 +1,5 @@
-+# Pull the swift.org host toolchain (swiftc, clang, lld, ...) into populate_sdk
-+# so out-of-bitbake cross builds via cross-toolchain-helper find it on PATH.
-+# nativesdk-swift packages the prebuilt bundle through standard SDK packaging.
-+
-+TOOLCHAIN_HOST_TASK += "nativesdk-swift"
-diff --git a/sources/meta-webkit/recipes-devtools/swift/nativesdk-swift.bb b/sources/meta-webkit/recipes-devtools/swift/nativesdk-swift.bb
-new file mode 100644
-index 0000000..4d5e6f7
---- /dev/null
-+++ b/sources/meta-webkit/recipes-devtools/swift/nativesdk-swift.bb
-@@ -0,0 +1,106 @@
-+SUMMARY = "Swift toolchain bundle for the populate_sdk host (swift.org prebuilt)"
-+HOMEPAGE = "https://swift.org/install/"
-+LICENSE = "Apache-2.0"
-+LIC_FILES_CHKSUM = "file://${S}/usr/share/swift/LICENSE.txt;md5=f6c482a0548ea60d6c2e015776534035"
-+
-+# Pin the bundle version to whatever swift-native (meta-swift) is using so
-+# the SDK's host swiftc/clang match the target stdlib's build provenance.
-+require recipes-devtools/swift/swift-version.inc
-+PV = "${SWIFT_VERSION}"
-+
-+# swift.org publishes per-host-arch tarballs (x86_64 unsuffixed, aarch64
-+# "-aarch64"). Use SDK_ARCH so we pick the binary for the SDK host machine.
-+def swift_sdk_arch_suffix(d):
-+    sdk_arch = d.getVar('SDK_ARCH')
-+    return '' if sdk_arch == 'x86_64' else '-{}'.format(sdk_arch)
-+
-+def swift_sdk_arch_checksum(d):
-+    sha256 = {
-+        "x86_64":  "648daccc9062045cb42431f6c7d620858b729abccb6bb9075a6b990e6259e897",
-+        "aarch64": "8b85ce9e2a13802654e2a097d8720f0726d0900adc3579af1649190cc6cd49be",
-+    }
-+    return sha256[d.getVar('SDK_ARCH')]
-+
-+# The bundle's ELF interpreter is the host loader (arch-specific); pick it by
-+# SDK_ARCH so the .interp padding below targets the right one.
-+def swift_sdk_arch_interpreter(d):
-+    sdk_arch = d.getVar('SDK_ARCH')
-+    if sdk_arch == 'x86_64':
-+        return 'ld-linux-x86-64.so.2'
-+    if sdk_arch == 'aarch64':
-+        return 'ld-linux-aarch64.so.1'
-+    bb.fatal('Unsupported SDK_ARCH for nativesdk-swift: {}'.format(sdk_arch))
-+
-+SWIFT_ARCH_SUFFIX = "${@swift_sdk_arch_suffix(d)}"
-+SWIFT_SDK_INTERPRETER = "${@swift_sdk_arch_interpreter(d)}"
-+SWIFT_LINUX_DISTRO = "amazonlinux2"
-+
-+SRC_DIR = "${SWIFT_TAG}-${SWIFT_LINUX_DISTRO}${SWIFT_ARCH_SUFFIX}"
-+SRC_URI = "https://download.swift.org/swift-${SWIFT_VERSION}-release/${SWIFT_LINUX_DISTRO}${SWIFT_ARCH_SUFFIX}/${SWIFT_TAG}/${SWIFT_TAG}-${SWIFT_LINUX_DISTRO}${SWIFT_ARCH_SUFFIX}.tar.gz"
-+SRC_URI[sha256sum] = "${@swift_sdk_arch_checksum(d)}"
-+
-+S = "${WORKDIR}/${SRC_DIR}"
-+
-+DEPENDS = "patchelf-native"
-+
-+# swift.org only publishes x86_64 and aarch64 host bundles; the checksum/
-+# interpreter maps above only know those two. Restrict the recipe accordingly.
-+COMPATIBLE_HOST = "(x86_64|aarch64).*-linux*"
-+
-+inherit nativesdk
-+
-+do_install() {
-+    install -d ${D}${bindir} ${D}${libdir} ${D}${includedir} ${D}${datadir}
-+    cp -rd ${S}/usr/bin/.     ${D}${bindir}/
-+    cp -rd ${S}/usr/lib/.     ${D}${libdir}/
-+    cp -rd ${S}/usr/include/. ${D}${includedir}/
-+    cp -rd ${S}/usr/share/.   ${D}${datadir}/
-+    if [ -d ${S}/usr/libexec ]; then
-+        install -d ${D}${libexecdir}
-+        cp -rd ${S}/usr/libexec/. ${D}${libexecdir}/
-+    fi
-+
-+    # Drop the bundle's host-side libdispatch/Foundation/Block/os headers and
-+    # modulemaps: meta-swift already provides target-arch versions in the sysroot,
-+    # so keeping both makes swiftc see duplicate module definitions.
-+    for d in dispatch os Block CoreFoundation _FoundationCShims _foundation_unicode shims; do
-+        rm -rf ${D}${libdir}/swift/${d}
-+    done
-+
-+    # swift.org binaries have a short .interp; Yocto's relocate_sdk.py aborts when
-+    # the SDK install path is >= p_filesz, so grow the slot with patchelf. Anchor
-+    # the placeholder with ${SDKPATH}/ (not /lib*, which relocate_sdk.py skips as
-+    # an external marker) so the relocator still processes it, then pad.
-+    pad=$(printf '%440s' '' | tr ' ' 'x')
-+    long_interp="${SDKPATH}/${pad}/lib/${SWIFT_SDK_INTERPRETER}"
-+    for f in ${D}${bindir}/* ${D}${libexecdir}/swift/*; do
-+        [ -f "$f" ] || continue
-+        case "$(file -b "$f" 2>/dev/null)" in
-+            *ELF*executable*)
-+                patchelf --set-interpreter "$long_interp" "$f" 2>/dev/null || true
-+                ;;
-+        esac
-+    done
-+}
-+
-+# The swift.org bundle is self-contained and pre-stripped. Don't let
-+# Yocto's QA / packaging machinery rewrite it beyond .interp padding.
-+INSANE_SKIP:${PN} = "already-stripped libdir staticdev arch dev-so dev-elf textrel file-rdeps libdir"
-+INHIBIT_PACKAGE_STRIP = "1"
-+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-+INHIBIT_SYSROOT_STRIP = "1"
-+
-+# The bundle is self-contained (its libs are found via $ORIGIN RPATH), but RPM's
-+# auto-provides scanner misses the bundled SONAMEs and emits bad Requires:; skip
-+# file-based dep generation entirely.
-+SKIP_FILEDEPS:${PN} = "1"
-+
-+# Single package; everything goes to the SDK host sysroot.
-+PACKAGES = "${PN}"
-+FILES:${PN} = " \
-+    ${bindir} \
-+    ${libdir} \
-+    ${includedir} \
-+    ${datadir} \
-+    ${libexecdir} \
-+"
-diff --git a/sources/meta-swift/classes/swift-common.bbclass b/sources/meta-swift/classes/swift-common.bbclass
---- a/sources/meta-swift/classes/swift-common.bbclass
-+++ b/sources/meta-swift/classes/swift-common.bbclass
-@@ -21,7 +21,9 @@
- 
- SWIFT_CLANG_VERSION = "21"
- 
--SWIFT_TARGET_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-unknown-linux-gnueabihf', '${TARGET_ARCH}-unknown-linux-gnu', d)}"
-+# Use Yocto's TARGET_SYS instead of the upstream Swift triple, so swiftc -target,
-+# .swiftinterface module names and clang's per-triple header lookup all agree.
-+SWIFT_TARGET_NAME = "${TARGET_SYS}"
- SWIFT_TARGET_ARCH = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7', '${TARGET_ARCH}', d)}"
- TARGET_CPU_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-a', '${TARGET_ARCH}', d)}"
- 
-diff --git a/sources/meta-swift/recipes-devtools/swift/swift-stdlib.bb b/sources/meta-swift/recipes-devtools/swift/swift-stdlib.bb
---- a/sources/meta-swift/recipes-devtools/swift/swift-stdlib.bb
-+++ b/sources/meta-swift/recipes-devtools/swift/swift-stdlib.bb
-@@ -39,10 +39,18 @@
- SWIFT_CXX_FLAGS = "${SWIFT_C_FLAGS}"
- SWIFT_CXX_LINK_FLAGS = "${SWIFT_C_LINK_FLAGS}"
- 
-+# clang's libstdc++ heuristic wants crt*.o and the gcc-internal include dirs in
-+# one place, but Yocto splits them across usr/lib/<sys> and usr/lib/gcc/<sys>.
-+# Copy the missing crt entries in additively (symlinks aren't followed here).
- do_fix_gcc_install_dir() {
--    # symbolic links do not work, will not be found by Swift clang driver
--    # this is necessary to make the libstdc++ location heuristic work, necessary for C++ interop
--    (cd ${STAGING_DIR_TARGET}/usr/lib && rm -rf gcc && mkdir -p gcc && cp -rp ${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS} gcc)
-+    src=${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION}
-+    dst=${STAGING_DIR_TARGET}/usr/lib/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}
-+    [ -d "${src}" ] || return 0
-+    mkdir -p "${dst}"
-+    for f in "${src}"/*; do
-+        bn=$(basename "${f}")
-+        [ -e "${dst}/${bn}" ] || cp -rp "${f}" "${dst}/${bn}"
-+    done
- }
- 
- addtask fix_gcc_install_dir before do_configure after do_prepare_recipe_sysroot
-diff --git a/sources/meta-swift/recipes-devtools/swift/swift-stdlib/0004-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch b/sources/meta-swift/recipes-devtools/swift/swift-stdlib/0004-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch
-new file mode 100644
---- /dev/null
-+++ b/sources/meta-swift/recipes-devtools/swift/swift-stdlib/0004-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch
-@@ -0,0 +1,30 @@
-+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-+From: Nikolas Zimmermann <nzimmermann@igalia.com>
-+Date: Thu, 28 May 2026 00:00:00 +0000
-+Subject: [PATCH] Allow overriding SWIFT_SDK_LINUX_ARCH_<arch>_TRIPLE
-+
-+Guard the per-arch defaults with if(NOT DEFINED) so meta-swift can supply
-+a Yocto-aligned triple (e.g. aarch64-poky-linux) from the toolchain file;
-+otherwise the stdlib emits modules named with the upstream triple and
-+consumers built with -target <vendor-triple> can't find them.
-+---
-+diff --git a/cmake/modules/SwiftConfigureSDK.cmake b/cmake/modules/SwiftConfigureSDK.cmake
-+--- a/cmake/modules/SwiftConfigureSDK.cmake
-++++ b/cmake/modules/SwiftConfigureSDK.cmake
-+@@ -422,7 +422,13 @@
-+         if(arch MATCHES "(armv5)")
-+-          set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnueabi")
-++          if(NOT DEFINED SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE)
-++            set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnueabi")
-++          endif()
-+         elseif(arch MATCHES "(armv6|armv7)")
-+-          set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnueabihf")
-++          if(NOT DEFINED SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE)
-++            set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnueabihf")
-++          endif()
-+         elseif(arch MATCHES "(aarch64|i686|powerpc|powerpc64|powerpc64le|s390x|x86_64|riscv64)")
-+-          set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnu")
-++          if(NOT DEFINED SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE)
-++            set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnu")
-++          endif()
-+         else()
-diff --git a/sources/meta-swift/recipes-devtools/swift/swift-stdlib.bb b/sources/meta-swift/recipes-devtools/swift/swift-stdlib.bb
---- a/sources/meta-swift/recipes-devtools/swift/swift-stdlib.bb
-+++ b/sources/meta-swift/recipes-devtools/swift/swift-stdlib.bb
-@@ -17,6 +17,7 @@
-     git://github.com/swiftlang/swift-experimental-string-processing.git;protocol=https;name=stringproc;tag=${SWIFT_TAG};nobranch=1;destsuffix=swift-experimental-string-processing; \
-     git://github.com/swiftlang/swift-syntax.git;protocol=https;name=syntax;tag=${SWIFT_TAG};nobranch=1;destsuffix=swift-syntax; \
-     file://0003-add-fix-for-metadataaccessor-abi-mismatch.patch;striplevel=1; \
-+    file://0004-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch;striplevel=1; \
-     "
- 
- S = "${UNPACKDIR}/swift"
-@@ -151,6 +152,9 @@
- set(SWIFT_HOST_VARIANT_ARCH ${SWIFT_TARGET_ARCH})
- set(SWIFT_SDKS LINUX)
- set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_PATH ${STAGING_DIR_TARGET})
-+# Override the per-arch module triple so .swiftinterface filenames use the
-+# Yocto SDK triple. Requires patch 0004 to honour this.
-+set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_TRIPLE ${SWIFT_TARGET_NAME})
- set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_LIBC_INCLUDE_DIRECTORY ${STAGING_DIR_TARGET}/usr/include)
- set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY ${STAGING_DIR_TARGET}/usr/include)
- set(SWIFT_LINUX_${SWIFT_TARGET_ARCH}_ICU_I18N ${STAGING_DIR_TARGET}/usr/lib/libicui18n.so)

--- a/Tools/yocto/rpi/bblayers.conf
+++ b/Tools/yocto/rpi/bblayers.conf
@@ -21,5 +21,4 @@ BBLAYERS ?= " \
   %(BSPDIR)s/sources/meta-browser/meta-chromium \
   %(BSPDIR)s/sources/meta-lts-mixins \
   %(BSPDIR)s/sources/meta-raspberrypi \
-  %(BSPDIR)s/sources/meta-swift \
   "

--- a/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
@@ -46,7 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
-TOOLCHAIN:pn-wpewebkit = "clang"
-RUNTIME:pn-wpewebkit = "llvm"

--- a/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
@@ -49,8 +49,3 @@ IMAGE_INSTALL:append = " gstreamer1.0-omx"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
 
-
-# This constrained armv7 target stays on GCC, so opt out of the Swift-gated
-# WebKit features that the meta-swift integration enables by default for :arm.
-DEPENDS:pn-wpewebkit:remove = "swift-native swift-stdlib swift-foundation libdispatch"
-EXTRA_OECMAKE:pn-wpewebkit:append = " -DENABLE_SWIFT_DEMO_URI_SCHEME=OFF -DENABLE_BACK_FORWARD_LIST_SWIFT=OFF"

--- a/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
@@ -46,7 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
-TOOLCHAIN:pn-wpewebkit = "clang"
-RUNTIME:pn-wpewebkit = "llvm"

--- a/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
@@ -46,7 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
-TOOLCHAIN:pn-wpewebkit = "clang"
-RUNTIME:pn-wpewebkit = "llvm"

--- a/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
@@ -46,7 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
-TOOLCHAIN:pn-wpewebkit = "clang"
-RUNTIME:pn-wpewebkit = "llvm"

--- a/Tools/yocto/rpi/local-rpi5-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi5-64bits-mesa.conf
@@ -46,7 +46,3 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
-
-# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
-TOOLCHAIN:pn-wpewebkit = "clang"
-RUNTIME:pn-wpewebkit = "llvm"

--- a/Tools/yocto/rpi/manifest.xml
+++ b/Tools/yocto/rpi/manifest.xml
@@ -15,6 +15,5 @@
   <project remote="github" revision="f26bab34e6c208149fe1ad04521864b663489f4d" name="kraj/meta-clang.git" path="sources/meta-clang"/>
   <project remote="github" revision="85eeb6b50883d22c977396f5e8fe211a7961cf2e" name="OSSystems/meta-browser.git" path="sources/meta-browser"/>
   <project remote="yocto" revision="c19b6da5a3afd3c892b3b1b44983e993ac6d5308" name="meta-lts-mixins" path="sources/meta-lts-mixins"/>
-  <project remote="github" revision="36f7997d0d2043e924c0a4c45dd3e3cfa76c14b5" name="jeremy-prater/meta-swift.git" path="sources/meta-swift"/>
 
 </manifest>


### PR DESCRIPTION
#### b13c216cbc1e3fd257de39a4504d30299805ed20
<pre>
[GTK][WPE] REGRESSION(315523@main): Revert Swift toolchain support for Yocto builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=317573">https://bugs.webkit.org/show_bug.cgi?id=317573</a>

Unreviewed fix.

We need to revert both 315550@main (&quot;[WPE][cross-toolchain-helper] Disable
Swift on armv7 (32-bit) targets, keep clang&quot;) and 315523@main (&quot;[GTK][WPE]
Enable Swift toolchain support in Yocto cross-builds&quot;) as it causes
issues on our rpi4 farm.

* CMakeLists.txt:
* Source/WebKit/CMakeLists.txt:
* Source/cmake/WebKitMacros.cmake:
* Tools/Scripts/cross-toolchain-helper:
(YoctoCrossBuilder.build_toolchain):
* Tools/Scripts/swift/swiftc-wrapper.sh:
* Tools/yocto/README.md:
* Tools/yocto/meta-openembedded_and_meta-webkit.patch:
* Tools/yocto/rpi/bblayers.conf:
* Tools/yocto/rpi/local-rpi3-32bits-mesa.conf:
* Tools/yocto/rpi/local-rpi3-32bits-userland.conf:
* Tools/yocto/rpi/local-rpi3-64bits-mesa.conf:
* Tools/yocto/rpi/local-rpi4-32bits-mesa.conf:
* Tools/yocto/rpi/local-rpi4-64bits-mesa.conf:
* Tools/yocto/rpi/local-rpi5-64bits-mesa.conf:
* Tools/yocto/rpi/manifest.xml:

Canonical link: <a href="https://commits.webkit.org/315583@main">https://commits.webkit.org/315583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/691a0ddc241ffd7d1c1b43ea8d20395b0fa0b664

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25815 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->