### PR TITLE
[LBSE] Preserve 2D transform flags when an SVG renderer loses its layer

### DIFF
--- a/LayoutTests/svg/transforms/transform-preserved-after-opacity-layer-removal-expected.html
+++ b/LayoutTests/svg/transforms/transform-preserved-after-opacity-layer-removal-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+</head>
+<body>
+<!-- The rect after its opacity layer is removed: still rotated, now fully opaque. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect x="60" y="90" width="80" height="20" fill="green" transform="rotate(45 100 100)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/transforms/transform-preserved-after-opacity-layer-removal.html
+++ b/LayoutTests/svg/transforms/transform-preserved-after-opacity-layer-removal.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html class="reftest-wait">
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+<script>
+    // A 2D-transformed leaf shape has a layer only for its opacity. Removing the opacity drops the
+    // layer -> the plain 2D transform must survive (it needs no layer), so the rect stays rotated.
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            document.getElementById('shape').removeAttribute('opacity');
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                document.documentElement.classList.remove('reftest-wait');
+            }));
+        }));
+    });
+</script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <rect id="shape" x="60" y="90" width="80" height="20" fill="green" opacity="0.5" transform="rotate(45 100 100)"/>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -170,8 +170,15 @@ void RenderLayerModelObject::styleDidChange(Style::Difference diff, const Style:
         gainedOrLostLayer = true;
         if (oldStyle && oldStyle->blendMode() != BlendMode::Normal)
             layer()->willRemoveChildWithBlendMode();
-        setHasTransformRelatedProperty(false); // All transform-related properties force layers, so we know we don't have one or the object doesn't support them.
-        setHasSVGTransform(false); // Same reason as for setHasTransformRelatedProperty().
+        // For CSS renderers every transform-related property forces a layer, so reaching the
+        // layer-removal branch means there is no transform and these flags can be cleared. Under
+        // LBSE a plain 2D SVG transform needs no layer, so an SVG renderer can lose its layer while
+        // still being transformed. updateFromStyle() above already set the correct flags for it, so
+        // leave them untouched here.
+        if (!isSVGLayerAwareRenderer()) {
+            setHasTransformRelatedProperty(false);
+            setHasSVGTransform(false);
+        }
         setHasReflection(false);
 
         // Repaint the about to be destroyed self-painting layer when style change also triggers repaint.


### PR DESCRIPTION
#### e34f69a66691276689fdaccbe67c44a0a91be982
<pre>
[LBSE] Preserve 2D transform flags when an SVG renderer loses its layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=317574">https://bugs.webkit.org/show_bug.cgi?id=317574</a>

Reviewed by Rob Buis.

RenderLayerModelObject::styleDidChange() unconditionally cleared
hasTransformRelatedProperty()/hasSVGTransform() in the layer-removal
branch, on the assumption that any transform-related property forces a
layer. That holds for CSS renderers but not under LBSE with conditional
layer creation activated, where a plain 2D SVG transform needs no layer.
So an SVG leaf that had a layer only for a grouping effect (for example
opacity) and then loses that effect would have its transform flags wiped
and never restored, leaving isTransformed() false and the element
painting untransformed...

updateFromStyle() (run at the top of styleDidChange) already sets the
correct flags for every SVG layer-aware renderer, so skip the clearing
for them and let those values stand as they are.

Test: svg/transforms/transform-preserved-after-opacity-layer-removal.html

* LayoutTests/svg/transforms/transform-preserved-after-opacity-layer-removal-expected.html: Added.
* LayoutTests/svg/transforms/transform-preserved-after-opacity-layer-removal.html: Added.
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/315597@main">https://commits.webkit.org/315597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/891b95949d73b8f43cc91dd164511848776dab0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171403 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132088 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172496 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112591 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27593 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143911 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181495 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140536 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140372 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43804 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108000 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25823 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35642 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42314 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6901 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->