### PR TITLE
KeyboardEvent/MouseEvent getModifierState("AltGraph") always returns false

### DIFF
--- a/LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt
+++ b/LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt
@@ -82,7 +82,7 @@ PASS new KeyboardEvent('eventType', { shiftKey: false }).shiftKey is false
 PASS new KeyboardEvent('eventType', { shiftKey: true }).shiftKey is true
 PASS new KeyboardEvent('eventType', { metaKey: false }).metaKey is false
 PASS new KeyboardEvent('eventType', { metaKey: true }).metaKey is true
-PASS new KeyboardEvent('eventType', { modifierAltGraph: true }).getModifierState('AltGraph') is false
+PASS new KeyboardEvent('eventType', { modifierAltGraph: true }).getModifierState('AltGraph') is true
 PASS new KeyboardEvent('eventType', { modifierCapsLock: true }).getModifierState('CapsLock') is true
 PASS new KeyboardEvent('eventType', { bubbles: true, cancelable: true, view: window, detail: 111, key: 'a', code: 'KeyA', keyIdentifier: 'chocolate', location: 222, ctrlKey: true, altKey: true, shiftKey: true, metaKey: true }).bubbles is true
 PASS new KeyboardEvent('eventType', { bubbles: true, cancelable: true, view: window, detail: 111, key: 'a', code: 'KeyA', keyIdentifier: 'chocolate', location: 222, ctrlKey: true, altKey: true, shiftKey: true, metaKey: true }).cancelable is true

--- a/LayoutTests/fast/events/constructors/keyboard-event-constructor.html
+++ b/LayoutTests/fast/events/constructors/keyboard-event-constructor.html
@@ -117,7 +117,7 @@ shouldBe("new KeyboardEvent('eventType', { location: {valueOf: function () { ret
     shouldBe("new KeyboardEvent('eventType', { " + attr + ": true })." + attr, "true");
 });
 
-shouldBeFalse("new KeyboardEvent('eventType', { modifierAltGraph: true }).getModifierState('AltGraph')");
+shouldBeTrue("new KeyboardEvent('eventType', { modifierAltGraph: true }).getModifierState('AltGraph')");
 shouldBeTrue("new KeyboardEvent('eventType', { modifierCapsLock: true }).getModifierState('CapsLock')");
 
 // All initializers are passed.

--- a/LayoutTests/fast/events/constructors/keyboard-event-getModifierState-expected.txt
+++ b/LayoutTests/fast/events/constructors/keyboard-event-getModifierState-expected.txt
@@ -37,7 +37,7 @@ PASS event.getModifierState('Control') is false
 PASS event.getModifierState('Alt') is false
 PASS event.getModifierState('Shift') is false
 PASS event.getModifierState('Meta') is false
-PASS event.getModifierState('AltGraph') is false
+PASS event.getModifierState('AltGraph') is true
 PASS event.getModifierState('CapsLock') is false
 PASS event.getModifierState('Control') is false
 PASS event.getModifierState('Alt') is false
@@ -49,7 +49,7 @@ PASS event.getModifierState('Control') is true
 PASS event.getModifierState('Alt') is true
 PASS event.getModifierState('Shift') is true
 PASS event.getModifierState('Meta') is true
-PASS event.getModifierState('AltGraph') is false
+PASS event.getModifierState('AltGraph') is true
 PASS event.getModifierState('CapsLock') is true
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/events/constructors/keyboard-event-getModifierState.html
+++ b/LayoutTests/fast/events/constructors/keyboard-event-getModifierState.html
@@ -53,7 +53,7 @@ shouldBeFalse("event.getModifierState('Control')");
 shouldBeFalse("event.getModifierState('Alt')");
 shouldBeFalse("event.getModifierState('Shift')");
 shouldBeFalse("event.getModifierState('Meta')");
-shouldBeFalse("event.getModifierState('AltGraph')");
+shouldBeTrue("event.getModifierState('AltGraph')");
 shouldBeFalse("event.getModifierState('CapsLock')");
 
 var event = new KeyboardEvent('keydown', { modifierCapsLock: true });
@@ -69,7 +69,7 @@ shouldBeTrue("event.getModifierState('Control')");
 shouldBeTrue("event.getModifierState('Alt')");
 shouldBeTrue("event.getModifierState('Shift')");
 shouldBeTrue("event.getModifierState('Meta')");
-shouldBeFalse("event.getModifierState('AltGraph')");
+shouldBeTrue("event.getModifierState('AltGraph')");
 shouldBeTrue("event.getModifierState('CapsLock')");
 </script>
 </body>

--- a/LayoutTests/fast/events/constructors/mouse-event-getModifierState-expected.txt
+++ b/LayoutTests/fast/events/constructors/mouse-event-getModifierState-expected.txt
@@ -37,7 +37,7 @@ PASS event.getModifierState('Control') is false
 PASS event.getModifierState('Alt') is false
 PASS event.getModifierState('Shift') is false
 PASS event.getModifierState('Meta') is false
-PASS event.getModifierState('AltGraph') is false
+PASS event.getModifierState('AltGraph') is true
 PASS event.getModifierState('CapsLock') is false
 PASS event.getModifierState('Control') is false
 PASS event.getModifierState('Alt') is false
@@ -49,7 +49,7 @@ PASS event.getModifierState('Control') is true
 PASS event.getModifierState('Alt') is true
 PASS event.getModifierState('Shift') is true
 PASS event.getModifierState('Meta') is true
-PASS event.getModifierState('AltGraph') is false
+PASS event.getModifierState('AltGraph') is true
 PASS event.getModifierState('CapsLock') is true
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/events/constructors/mouse-event-getModifierState.html
+++ b/LayoutTests/fast/events/constructors/mouse-event-getModifierState.html
@@ -53,7 +53,7 @@ shouldBeFalse("event.getModifierState('Control')");
 shouldBeFalse("event.getModifierState('Alt')");
 shouldBeFalse("event.getModifierState('Shift')");
 shouldBeFalse("event.getModifierState('Meta')");
-shouldBeFalse("event.getModifierState('AltGraph')");
+shouldBeTrue("event.getModifierState('AltGraph')");
 shouldBeFalse("event.getModifierState('CapsLock')");
 
 var event = new MouseEvent('mousedown', { modifierCapsLock: true });
@@ -69,7 +69,7 @@ shouldBeTrue("event.getModifierState('Control')");
 shouldBeTrue("event.getModifierState('Alt')");
 shouldBeTrue("event.getModifierState('Shift')");
 shouldBeTrue("event.getModifierState('Meta')");
-shouldBeFalse("event.getModifierState('AltGraph')");
+shouldBeTrue("event.getModifierState('AltGraph')");
 shouldBeTrue("event.getModifierState('CapsLock')");
 </script>
 </body>

--- a/LayoutTests/fast/events/init-event-clears-capslock-expected.txt
+++ b/LayoutTests/fast/events/init-event-clears-capslock-expected.txt
@@ -13,7 +13,7 @@ PASS keyEvent.getModifierState("Control") is true
 PASS keyEvent.getModifierState("Shift") is true
 PASS keyEvent.getModifierState("Alt") is true
 PASS keyEvent.getModifierState("Meta") is true
-PASS keyEvent.getModifierState("AltGraph") is false
+PASS keyEvent.getModifierState("AltGraph") is true
 PASS keyEvent.getModifierState("CapsLock") is true
 keyEvent.initKeyboardEvent('keydown', false, false, window, 'U+0041', 0, /* ctrl */ false, /* alt */ false, /* shift */ false, /* meta */ false, /* altGraph */ false)
 PASS keyEvent.ctrlKey is false
@@ -47,7 +47,7 @@ PASS mouseEvent.getModifierState("Control") is true
 PASS mouseEvent.getModifierState("Shift") is true
 PASS mouseEvent.getModifierState("Alt") is true
 PASS mouseEvent.getModifierState("Meta") is true
-PASS mouseEvent.getModifierState("AltGraph") is false
+PASS mouseEvent.getModifierState("AltGraph") is true
 PASS mouseEvent.getModifierState("CapsLock") is true
 mouseEvent.initMouseEvent('mousedown', false, false, window, 0, 0, 0, 0, 0, /* ctrl */ false, /* alt */ false, /* shift */ false, /* meta */ false)
 PASS mouseEvent.ctrlKey is false

--- a/LayoutTests/fast/events/init-event-clears-capslock.html
+++ b/LayoutTests/fast/events/init-event-clears-capslock.html
@@ -16,7 +16,7 @@ shouldBeTrue('keyEvent.getModifierState("Control")');
 shouldBeTrue('keyEvent.getModifierState("Shift")');
 shouldBeTrue('keyEvent.getModifierState("Alt")');
 shouldBeTrue('keyEvent.getModifierState("Meta")');
-shouldBeFalse('keyEvent.getModifierState("AltGraph")');
+shouldBeTrue('keyEvent.getModifierState("AltGraph")');
 shouldBeTrue('keyEvent.getModifierState("CapsLock")');
 
 evalAndLog(`keyEvent.initKeyboardEvent('keydown', false, false, window, 'U+0041', 0, /* ctrl */ false, /* alt */ false, /* shift */ false, /* meta */ false, /* altGraph */ false)`);
@@ -53,7 +53,7 @@ shouldBeTrue('mouseEvent.getModifierState("Control")');
 shouldBeTrue('mouseEvent.getModifierState("Shift")');
 shouldBeTrue('mouseEvent.getModifierState("Alt")');
 shouldBeTrue('mouseEvent.getModifierState("Meta")');
-shouldBeFalse('mouseEvent.getModifierState("AltGraph")');
+shouldBeTrue('mouseEvent.getModifierState("AltGraph")');
 shouldBeTrue('mouseEvent.getModifierState("CapsLock")');
 
 evalAndLog(`mouseEvent.initMouseEvent('mousedown', false, false, window, 0, 0, 0, 0, 0, /* ctrl */ false, /* alt */ false, /* shift */ false, /* meta */ false)`);

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/event-getmodifierstate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/event-getmodifierstate-expected.txt
@@ -1,0 +1,18 @@
+
+PASS KeyboardEvent.getModifierState() returns false for every modifier when none are set
+PASS KeyboardEvent.getModifierState('Control') reflects ctrlKey in isolation
+PASS KeyboardEvent.getModifierState('Shift') reflects shiftKey in isolation
+PASS KeyboardEvent.getModifierState('Alt') reflects altKey in isolation
+PASS KeyboardEvent.getModifierState('Meta') reflects metaKey in isolation
+PASS KeyboardEvent.getModifierState('AltGraph') reflects modifierAltGraph in isolation
+PASS KeyboardEvent.getModifierState('CapsLock') reflects modifierCapsLock in isolation
+PASS KeyboardEvent.getModifierState() reports every modifier when all are set
+PASS MouseEvent.getModifierState() returns false for every modifier when none are set
+PASS MouseEvent.getModifierState('Control') reflects ctrlKey in isolation
+PASS MouseEvent.getModifierState('Shift') reflects shiftKey in isolation
+PASS MouseEvent.getModifierState('Alt') reflects altKey in isolation
+PASS MouseEvent.getModifierState('Meta') reflects metaKey in isolation
+PASS MouseEvent.getModifierState('AltGraph') reflects modifierAltGraph in isolation
+PASS MouseEvent.getModifierState('CapsLock') reflects modifierCapsLock in isolation
+PASS MouseEvent.getModifierState() reports every modifier when all are set
+

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/event-getmodifierstate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/event-getmodifierstate.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>getModifierState() reflects the EventModifierInit modifiers</title>
+<link rel="help" href="https://w3c.github.io/uievents/#dom-keyboardevent-getmodifierstate">
+<link rel="help" href="https://w3c.github.io/uievents/#interface-EventModifierInit">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+// https://w3c.github.io/uievents/#dom-keyboardevent-getmodifierstate
+// Each modifier exposed through EventModifierInit must be reported by
+// getModifierState() using its corresponding modifier key value, and the
+// modifiers must be independent of one another.
+
+// EventModifierInit member -> getModifierState() key value.
+const modifiers = [
+    { init: "ctrlKey", key: "Control" },
+    { init: "shiftKey", key: "Shift" },
+    { init: "altKey", key: "Alt" },
+    { init: "metaKey", key: "Meta" },
+    { init: "modifierAltGraph", key: "AltGraph" },
+    { init: "modifierCapsLock", key: "CapsLock" },
+];
+
+// Modifier key values defined by the specification that have no
+// EventModifierInit member; a constructed event can never set them, so
+// getModifierState() must always report them as false.
+const unsettableKeys = ["Fn", "FnLock", "Hyper", "NumLock", "ScrollLock", "Super", "Symbol", "SymbolLock"];
+
+const allKeys = modifiers.map(modifier => modifier.key).concat(unsettableKeys);
+
+for (const ctor of [
+    { name: "KeyboardEvent", construct: init => new KeyboardEvent("keydown", init) },
+    { name: "MouseEvent", construct: init => new MouseEvent("mousedown", init) },
+]) {
+    test(() => {
+        const event = ctor.construct({});
+        for (const key of allKeys)
+            assert_false(event.getModifierState(key), key);
+    }, `${ctor.name}.getModifierState() returns false for every modifier when none are set`);
+
+    for (const modifier of modifiers) {
+        test(() => {
+            const event = ctor.construct({ [modifier.init]: true });
+            assert_true(event.getModifierState(modifier.key), `${modifier.key} should be active`);
+            for (const key of allKeys) {
+                if (key !== modifier.key)
+                    assert_false(event.getModifierState(key), `${key} should be inactive`);
+            }
+        }, `${ctor.name}.getModifierState('${modifier.key}') reflects ${modifier.init} in isolation`);
+    }
+
+    test(() => {
+        const init = {};
+        for (const modifier of modifiers)
+            init[modifier.init] = true;
+        const event = ctor.construct(init);
+        for (const modifier of modifiers)
+            assert_true(event.getModifierState(modifier.key), `${modifier.key} should be active`);
+        for (const key of unsettableKeys)
+            assert_false(event.getModifierState(key), `${key} should be inactive`);
+    }, `${ctor.name}.getModifierState() reports every modifier when all are set`);
+}
+</script>

--- a/Source/WebCore/dom/UIEventWithKeyState.cpp
+++ b/Source/WebCore/dom/UIEventWithKeyState.cpp
@@ -59,6 +59,8 @@ bool UIEventWithKeyState::getModifierState(const String& keyIdentifier) const
         return metaKey();
     if (keyIdentifier == "CapsLock"_s)
         return capsLockKey();
+    if (keyIdentifier == "AltGraph"_s)
+        return altGraphKey();
     // FIXME: The specification also has Fn, FnLock, Hyper, NumLock, Super, ScrollLock, Symbol, SymbolLock.
     return false;
 }

--- a/Source/WebCore/dom/UIEventWithKeyState.h
+++ b/Source/WebCore/dom/UIEventWithKeyState.h
@@ -39,6 +39,7 @@ public:
     bool altKey() const { return m_modifiers.contains(Modifier::AltKey); }
     bool metaKey() const { return m_modifiers.contains(Modifier::MetaKey); }
     bool capsLockKey() const { return m_modifiers.contains(Modifier::CapsLockKey); }
+    bool altGraphKey() const { return m_modifiers.contains(Modifier::AltGraphKey); }
 
     OptionSet<Modifier> modifierKeys() const { return m_modifiers; }
 

--- a/Source/WebCore/platform/PlatformEvent.h
+++ b/Source/WebCore/platform/PlatformEvent.h
@@ -82,7 +82,8 @@ enum class PlatformEventModifier : uint8_t {
     ShiftKey    = 1 << 3,
     CapsLockKey = 1 << 4,
 
-    // Never used in native platforms but added for initEvent
+    // Populated from native events on platforms with an AltGraph (AltGr) key
+    // (Windows, GTK/X11); also set for JS-constructed events via initEvent.
     AltGraphKey = 1 << 5,
 };
 

--- a/Source/WebCore/platform/win/WindowsKeyNames.cpp
+++ b/Source/WebCore/platform/win/WindowsKeyNames.cpp
@@ -242,29 +242,22 @@ WindowsKeyNames::WindowsKeyNames()
     updateLayout();
 }
 
-String WindowsKeyNames::domKeyFromParams(WPARAM virtualKey, LPARAM lParam)
+auto WindowsKeyNames::currentKeyModifiers() -> KeyModifierSet
 {
-    bool extended = lParam & 0x01000000;
     KeyModifierSet modifiers;
     if (GetKeyState(VK_SHIFT) < 0)
         modifiers.add(KeyModifier::Shift);
     if (GetKeyState(VK_CONTROL) < 0)
         modifiers.add(KeyModifier::Control);
-    if (GetKeyState(VK_MENU ) < 0)
+    if (GetKeyState(VK_MENU) < 0)
         modifiers.add(KeyModifier::Alt);
     if (GetKeyState(VK_CAPITAL) & 1)
         modifiers.add(KeyModifier::CapsLock);
+    return modifiers;
+}
 
-    updateLayout();
-    // Windows expresses right-Alt as VK_MENU with the extended flag set.
-    // This key should generate AltGraph under layouts which use that modifier.
-    if (virtualKey == VK_MENU && extended && m_hasAltGraph)
-        return "AltGraph"_s;
-
-    String key = nonPrintableVirtualKeyToDomKey(virtualKey, m_keyboardLayout);
-    if (!key.isNull())
-        return key;
-
+auto WindowsKeyNames::printableKeyFromVirtualKey(unsigned virtualKey, KeyModifierSet modifiers) -> PrintableKey
+{
     const KeyModifierSet modifiersToTry[] = {
         // Trying to match Firefox's behavior and UIEvents DomKey guidelines.
         // If the combination doesn't produce a printable character, the key value
@@ -276,14 +269,75 @@ String WindowsKeyNames::domKeyFromParams(WPARAM virtualKey, LPARAM lParam)
 
     for (auto tryModifiers : modifiersToTry) {
         const auto& it = m_printableKeyCodeToKey.find(std::make_pair(virtualKey, tryModifiers));
-        if (it != m_printableKeyCodeToKey.end()) {
-            key = it->value;
-            if (!key.isNull())
-                return key;
+        if (it != m_printableKeyCodeToKey.end() && !it->value.isNull()) {
+            // A printable character produced with both Control and Alt held means
+            // the key is AltGraph-shifted on this layout.
+            return { it->value, hasControlAndAlt(tryModifiers) };
         }
     }
 
+    return { };
+}
+
+String WindowsKeyNames::domKeyFromParams(WPARAM virtualKey, LPARAM lParam)
+{
+    bool extended = lParam & 0x01000000;
+    auto modifiers = currentKeyModifiers();
+
+    updateLayout();
+    // Windows expresses right-Alt as VK_MENU with the extended flag set.
+    // This key should generate AltGraph under layouts which use that modifier.
+    if (virtualKey == VK_MENU && extended && m_hasAltGraph)
+        return "AltGraph"_s;
+
+    String key = nonPrintableVirtualKeyToDomKey(virtualKey, m_keyboardLayout);
+    if (!key.isNull())
+        return key;
+
+    key = printableKeyFromVirtualKey(virtualKey, modifiers).key;
+    if (!key.isNull())
+        return key;
+
     return "Unidentified"_s;
+}
+
+bool WindowsKeyNames::shouldExposeLeftControlPlusRightAltAsAltGraph()
+{
+    updateLayout();
+    // m_hasAltGraph is true only for layouts that actually define AltGraph; on
+    // other layouts the right-Alt key behaves as a plain Alt and must not be
+    // folded into AltGraph.
+    return m_hasAltGraph && GetKeyState(VK_RMENU) < 0;
+}
+
+bool WindowsKeyNames::shouldExposeAltGraphForKeyEvent(UINT message, WPARAM virtualKey, LPARAM)
+{
+    // 1. The physical AltGr key is delivered as left-Control + right-Alt, so a
+    //    held right-Alt on a layout that defines AltGraph is AltGr regardless of
+    //    which key it modifies. This call also refreshes the cached layout
+    //    (m_hasAltGraph) relied upon below.
+    if (shouldExposeLeftControlPlusRightAltAsAltGraph())
+        return true;
+
+    // The remaining cases cover AltGr simulated purely via the Control+Alt
+    // combination, which both Blink and Gecko expose as AltGraph.
+    if (GetKeyState(VK_CONTROL) >= 0 || GetKeyState(VK_MENU) >= 0)
+        return false;
+
+    // 2. A character message delivered while Control and Alt are held is, by
+    //    definition, the product of the AltGr combination: a character was
+    //    generated, so report AltGraph. This is independent of the layout, since
+    //    the character itself is the evidence.
+    if (message == WM_CHAR || message == WM_SYSCHAR || message == WM_IME_CHAR)
+        return true;
+
+    // 3. Otherwise this is AltGr only on a layout that defines AltGraph and only
+    //    if the key produces a printable character requiring the Control+Alt
+    //    combination (an AltGraph-shifted key); plain Control+Alt shortcuts keep
+    //    reporting Control and Alt.
+    if (!m_hasAltGraph)
+        return false;
+    return printableKeyFromVirtualKey(virtualKey, currentKeyModifiers()).isAltGraphShifted;
 }
 
 String WindowsKeyNames::domKeyFromChar(char16_t c)

--- a/Source/WebCore/platform/win/WindowsKeyNames.h
+++ b/Source/WebCore/platform/win/WindowsKeyNames.h
@@ -44,11 +44,40 @@ public:
     WEBCORE_EXPORT String domKeyFromChar(char16_t);
     WEBCORE_EXPORT String domCodeFromLParam(LPARAM);
 
+    // Windows has no dedicated AltGr key; it synthesizes AltGr as a left-Control
+    // + right-Alt combination. Returns whether that combination should currently
+    // be reported as the AltGraph modifier: true only while right-Alt is held on
+    // a keyboard layout that actually defines AltGraph (otherwise right-Alt is a
+    // plain Alt). Used for events that carry no key code (mouse, wheel).
+    WEBCORE_EXPORT bool shouldExposeLeftControlPlusRightAltAsAltGraph();
+
+    // Whether the given keyboard event should be reported with the AltGraph
+    // modifier in place of Control+Alt. Beyond the right-Alt case above, this
+    // also recognises AltGr simulated via Control+Alt: a character message
+    // delivered under Control+Alt, or a key whose printable character requires
+    // the Control+Alt combination on the active layout. Matches Blink and Gecko.
+    WEBCORE_EXPORT bool shouldExposeAltGraphForKeyEvent(UINT message, WPARAM virtualKey, LPARAM);
+
     enum class KeyModifier : uint8_t;
     using KeyModifierSet = OptionSet<KeyModifier>;
 
 private:
     void updateLayout();
+
+    KeyModifierSet currentKeyModifiers();
+
+    struct PrintableKey {
+        // The DOM key string, or a null String if the key produces no printable
+        // character under the requested modifiers.
+        String key;
+        // Whether the matched modifier combination needed both Control and Alt,
+        // i.e. the key is AltGraph-shifted on the active layout.
+        bool isAltGraphShifted { false };
+    };
+    // Looks up the printable DOM key produced by |virtualKey| under the active
+    // layout for |modifiers|, following the UIEvents key guidelines.
+    PrintableKey printableKeyFromVirtualKey(unsigned virtualKey, KeyModifierSet);
+
 
     HKL m_keyboardLayout = 0;
     bool m_hasAltGraph = false;

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -25,7 +25,8 @@
     ControlKey,
     AltKey,
     MetaKey,
-    CapsLockKey
+    CapsLockKey,
+    AltGraphKey
 };
 
 class WebKit::WebEvent {

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -231,6 +231,8 @@ OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier>
         result.add(WebCore::PlatformEvent::Modifier::MetaKey);
     if (modifiers.contains(WebEventModifier::CapsLockKey))
         result.add(WebCore::PlatformEvent::Modifier::CapsLockKey);
+    if (modifiers.contains(WebEventModifier::AltGraphKey))
+        result.add(WebCore::PlatformEvent::Modifier::AltGraphKey);
     return result;
 }
 
@@ -247,6 +249,8 @@ OptionSet<WebEventModifier> kit(OptionSet<WebCore::PlatformEvent::Modifier> modi
         result.add(WebEventModifier::MetaKey);
     if (modifiers.contains(WebCore::PlatformEvent::Modifier::CapsLockKey))
         result.add(WebEventModifier::CapsLockKey);
+    if (modifiers.contains(WebCore::PlatformEvent::Modifier::AltGraphKey))
+        result.add(WebEventModifier::AltGraphKey);
     return result;
 }
 

--- a/Source/WebKit/Shared/WebEventModifier.cpp
+++ b/Source/WebKit/Shared/WebEventModifier.cpp
@@ -47,6 +47,8 @@ OptionSet<WebEventModifier> NODELETE modifiersFromPlatformEventModifiers(OptionS
         result.add(WebEventModifier::MetaKey);
     if (modifiers.contains(WebCore::PlatformEventModifier::CapsLockKey))
         result.add(WebEventModifier::CapsLockKey);
+    if (modifiers.contains(WebCore::PlatformEventModifier::AltGraphKey))
+        result.add(WebEventModifier::AltGraphKey);
     return result;
 }
 

--- a/Source/WebKit/Shared/WebEventModifier.h
+++ b/Source/WebKit/Shared/WebEventModifier.h
@@ -40,6 +40,7 @@ enum class WebEventModifier : uint8_t {
     AltKey      = 1 << 2,
     MetaKey     = 1 << 3,
     CapsLockKey = 1 << 4,
+    AltGraphKey = 1 << 5,
 };
 
 OptionSet<WebEventModifier> NODELETE modifiersFromPlatformEventModifiers(OptionSet<WebCore::PlatformEventModifier>);

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -84,6 +84,12 @@ static inline OptionSet<WebEventModifier> modifiersForEvent(const GdkEvent* even
         modifiers.add(WebEventModifier::MetaKey);
     if (state & GDK_LOCK_MASK && eventModifiersContainCapsLock(const_cast<GdkEvent*>(event)))
         modifiers.add(WebEventModifier::CapsLockKey);
+#if !GTK_CHECK_VERSION(4, 0, 0)
+    // On X11 the AltGraph (ISO_Level3_Shift) modifier is reported as Mod5. This
+    // GdkModifierType bit only exists in GTK3; GTK4 (and later) no longer expose it.
+    if (state & GDK_MOD5_MASK)
+        modifiers.add(WebEventModifier::AltGraphKey);
+#endif
 
     GdkEventType type = gdk_event_get_event_type(const_cast<GdkEvent*>(event));
     if (type != GDK_KEY_PRESS)
@@ -110,6 +116,14 @@ static inline OptionSet<WebEventModifier> modifiersForEvent(const GdkEvent* even
     case GDK_KEY_Meta_L:
     case GDK_KEY_Meta_R:
         modifiers.add(WebEventModifier::MetaKey);
+        break;
+    case GDK_KEY_ISO_Level3_Shift:
+    case GDK_KEY_ISO_Level3_Latch:
+    case GDK_KEY_ISO_Level3_Lock:
+    case GDK_KEY_ISO_Level5_Shift:
+    case GDK_KEY_ISO_Level5_Latch:
+    case GDK_KEY_ISO_Level5_Lock:
+        modifiers.add(WebEventModifier::AltGraphKey);
         break;
     case GDK_KEY_Caps_Lock:
         modifiers.add(WebEventModifier::CapsLockKey);

--- a/Source/WebKit/Shared/win/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
@@ -110,26 +110,37 @@ static inline bool IsKeyInDownState(int vk)
     return ::GetKeyState(vk) & 0x8000;
 }
 
+static WindowsKeyNames& windowsKeyNames()
+{
+    static NeverDestroyed<WindowsKeyNames> keyNames;
+    return keyNames;
+}
+
 static inline OptionSet<WebEventModifier> modifiersForEvent(WPARAM wparam)
 {
     OptionSet<WebEventModifier> modifiers;
-    if (wparam & MK_CONTROL)
+    bool shouldExposeAltGraph = windowsKeyNames().shouldExposeLeftControlPlusRightAltAsAltGraph();
+    if (shouldExposeAltGraph)
+        modifiers.add(WebEventModifier::AltGraphKey);
+    if ((wparam & MK_CONTROL) && !shouldExposeAltGraph)
         modifiers.add(WebEventModifier::ControlKey);
     if (wparam & MK_SHIFT)
         modifiers.add(WebEventModifier::ShiftKey);
-    if (IsKeyInDownState(VK_MENU))
+    if (IsKeyInDownState(VK_MENU) && !shouldExposeAltGraph)
         modifiers.add(WebEventModifier::AltKey);
     return modifiers;
 }
 
-static inline OptionSet<WebEventModifier> modifiersForCurrentKeyState()
+static inline OptionSet<WebEventModifier> modifiersForCurrentKeyState(bool shouldExposeAltGraph)
 {
     OptionSet<WebEventModifier> modifiers;
-    if (IsKeyInDownState(VK_CONTROL))
+    if (shouldExposeAltGraph)
+        modifiers.add(WebEventModifier::AltGraphKey);
+    if (IsKeyInDownState(VK_CONTROL) && !shouldExposeAltGraph)
         modifiers.add(WebEventModifier::ControlKey);
     if (IsKeyInDownState(VK_SHIFT))
         modifiers.add(WebEventModifier::ShiftKey);
-    if (IsKeyInDownState(VK_MENU))
+    if (IsKeyInDownState(VK_MENU) && !shouldExposeAltGraph)
         modifiers.add(WebEventModifier::AltKey);
     return modifiers;
 }
@@ -456,12 +467,6 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(HWND hWnd, UINT message, WPAR
     return WebWheelEvent( { WebEventType::Wheel, modifiers, MonotonicTime::now() }, flooredIntPoint(position), flooredIntPoint(globalPosition), FloatSize(deltaX, deltaY), FloatSize(wheelTicksX, wheelTicksY), granularity);
 }
 
-static WindowsKeyNames& windowsKeyNames()
-{
-    static NeverDestroyed<WindowsKeyNames> keyNames;
-    return keyNames;
-}
-
 WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam)
 {
     auto type = keyboardEventTypeForEvent(message);
@@ -476,7 +481,7 @@ WebKeyboardEvent WebEventFactory::createWebKeyboardEvent(HWND hwnd, UINT message
     bool autoRepeat = HIWORD(lparam) & KF_REPEAT;
     bool isKeypad = isKeypadEvent(wparam, lparam, type);
     bool isSystemKey = isSystemKeyEvent(message);
-    auto modifiers = modifiersForCurrentKeyState();
+    auto modifiers = modifiersForCurrentKeyState(windowsKeyNames().shouldExposeAltGraphForKeyEvent(message, wparam, lparam));
 
     return WebKeyboardEvent( { type, modifiers, MonotonicTime::now() }, text, unmodifiedText, key, code, keyIdentifier, windowsVirtualKeyCode, nativeVirtualKeyCode, macCharCode, autoRepeat, isKeypad, isSystemKey);
 }

--- a/Tools/TestWebKitAPI/PlatformWin.cmake
+++ b/Tools/TestWebKitAPI/PlatformWin.cmake
@@ -23,6 +23,7 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/win/DIBPixelData.cpp
     Tests/WebCore/win/LinkedFonts.cpp
     Tests/WebCore/win/WebCoreBundle.cpp
+    Tests/WebCore/win/WindowsKeyNames.cpp
 
     win/TestWebCoreStubs.cpp
 )

--- a/Tools/TestWebKitAPI/Tests/WebCore/win/WindowsKeyNames.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/win/WindowsKeyNames.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/WindowsKeyNames.h>
+#include <windows.h>
+
+namespace TestWebKitAPI {
+
+using WebCore::WindowsKeyNames;
+
+namespace {
+
+// Keyboard layout identifiers, matching the ones Chromium uses for its
+// equivalent AltGraph tests (ui/events/test/keyboard_layout_win.cc). French
+// (France) defines the AltGraph modifier; US English does not.
+constexpr auto englishUSLayoutName = L"00000409";
+constexpr auto frenchLayoutName = L"0000040c";
+
+// The Euro sign produced by AltGr+E on the French layout.
+constexpr char16_t euroSign = 0x20AC;
+
+// Activates the requested keyboard layout for the duration of a test, and
+// restores both the previously active layout and the thread's keyboard input
+// state on destruction so that tests don't perturb one another.
+class ScopedKeyboardLayout {
+public:
+    explicit ScopedKeyboardLayout(const wchar_t* layoutName)
+        : m_originalLayout(GetKeyboardLayout(0))
+    {
+        GetKeyboardState(m_originalState);
+        m_layout = LoadKeyboardLayoutW(layoutName, KLF_ACTIVATE);
+        if (m_layout)
+            ActivateKeyboardLayout(m_layout, 0);
+    }
+
+    ~ScopedKeyboardLayout()
+    {
+        SetKeyboardState(m_originalState);
+        ActivateKeyboardLayout(m_originalLayout, 0);
+    }
+
+    // The requested layout may not be installed on the test machine; callers
+    // should skip when it could not be activated.
+    bool isActive() const { return m_layout && GetKeyboardLayout(0) == m_layout; }
+
+private:
+    HKL m_originalLayout;
+    HKL m_layout { nullptr };
+    BYTE m_originalState[256] { };
+};
+
+// Marks the given virtual keys as held in the thread's keyboard input state, so
+// that GetKeyState() (used by WindowsKeyNames) observes them as down.
+void setKeysDown(std::initializer_list<int> virtualKeys)
+{
+    BYTE state[256] = { };
+    for (int virtualKey : virtualKeys)
+        state[virtualKey] = 0x80;
+    SetKeyboardState(state);
+}
+
+// Builds the lParam Windows delivers for a key, with the extended-key bit set
+// when |extended| is true (which is how right-Alt is expressed).
+LPARAM lParamForKey(bool extended)
+{
+    return extended ? (1 << 24) : 0;
+}
+
+} // namespace
+
+// US English defines no AltGraph modifier, so right-Alt is always a plain Alt
+// and is never folded into AltGraph, regardless of the key.
+TEST(WindowsKeyNames, AltGraphNotReportedOnLayoutWithoutAltGraph)
+{
+    ScopedKeyboardLayout layout(englishUSLayoutName);
+    if (!layout.isActive())
+        GTEST_SKIP() << "US English keyboard layout is not available.";
+
+    WindowsKeyNames keyNames;
+    setKeysDown({ VK_RMENU, VK_LCONTROL, VK_MENU, VK_CONTROL });
+
+    EXPECT_FALSE(keyNames.shouldExposeLeftControlPlusRightAltAsAltGraph());
+    EXPECT_FALSE(keyNames.shouldExposeAltGraphForKeyEvent(WM_KEYDOWN, 'C', lParamForKey(false)));
+    EXPECT_FALSE(keyNames.shouldExposeAltGraphForKeyEvent(WM_KEYDOWN, 'E', lParamForKey(false)));
+}
+
+// On a layout that defines AltGraph (French), a held right-Alt is AltGraph for
+// any key it modifies, matching Blink.
+TEST(WindowsKeyNames, RightAltIsAltGraphForAnyKey)
+{
+    ScopedKeyboardLayout layout(frenchLayoutName);
+    if (!layout.isActive())
+        GTEST_SKIP() << "French keyboard layout is not available.";
+
+    WindowsKeyNames keyNames;
+    setKeysDown({ VK_RMENU, VK_LCONTROL, VK_MENU, VK_CONTROL });
+
+    EXPECT_TRUE(keyNames.shouldExposeLeftControlPlusRightAltAsAltGraph());
+    EXPECT_TRUE(keyNames.shouldExposeAltGraphForKeyEvent(WM_KEYDOWN, 'C', lParamForKey(false)));
+    EXPECT_TRUE(keyNames.shouldExposeAltGraphForKeyEvent(WM_KEYDOWN, 'E', lParamForKey(false)));
+}
+
+// With left-Control + left-Alt held (no right-Alt), AltGraph is reported only
+// for keys whose character requires the Control+Alt (AltGr) combination; plain
+// Control+Alt shortcuts keep reporting Control and Alt.
+TEST(WindowsKeyNames, ControlPlusAltIsAltGraphOnlyForAltGraphShiftedKeys)
+{
+    ScopedKeyboardLayout layout(frenchLayoutName);
+    if (!layout.isActive())
+        GTEST_SKIP() << "French keyboard layout is not available.";
+
+    WindowsKeyNames keyNames;
+    setKeysDown({ VK_LMENU, VK_LCONTROL, VK_MENU, VK_CONTROL });
+
+    // AltGr+C produces no character on French, so this stays a plain Control+Alt.
+    EXPECT_FALSE(keyNames.shouldExposeAltGraphForKeyEvent(WM_KEYDOWN, 'C', lParamForKey(false)));
+    // AltGr+E produces the Euro sign on French, so it is AltGraph-shifted.
+    EXPECT_TRUE(keyNames.shouldExposeAltGraphForKeyEvent(WM_KEYDOWN, 'E', lParamForKey(false)));
+}
+
+// A character message delivered while Control and Alt are held is, by
+// definition, the product of the AltGr combination.
+TEST(WindowsKeyNames, CharacterMessageUnderControlAndAltIsAltGraph)
+{
+    ScopedKeyboardLayout layout(frenchLayoutName);
+    if (!layout.isActive())
+        GTEST_SKIP() << "French keyboard layout is not available.";
+
+    WindowsKeyNames keyNames;
+    setKeysDown({ VK_LCONTROL, VK_CONTROL, VK_LMENU, VK_MENU });
+
+    EXPECT_TRUE(keyNames.shouldExposeAltGraphForKeyEvent(WM_CHAR, euroSign, 0));
+}
+
+// AltGraph is not reported unless both Control and Alt are held.
+TEST(WindowsKeyNames, NoAltGraphWithoutControlAndAlt)
+{
+    ScopedKeyboardLayout layout(frenchLayoutName);
+    if (!layout.isActive())
+        GTEST_SKIP() << "French keyboard layout is not available.";
+
+    WindowsKeyNames keyNames;
+    setKeysDown({ });
+
+    EXPECT_FALSE(keyNames.shouldExposeAltGraphForKeyEvent(WM_KEYDOWN, 'E', lParamForKey(false)));
+    EXPECT_FALSE(keyNames.shouldExposeAltGraphForKeyEvent(WM_CHAR, euroSign, 0));
+}
+
+// The DOM key string side mirrors the modifier side: the right-Alt key itself
+// resolves to "AltGraph", and an AltGraph-shifted key resolves to its AltGr
+// character.
+TEST(WindowsKeyNames, DomKeyReflectsAltGraph)
+{
+    ScopedKeyboardLayout layout(frenchLayoutName);
+    if (!layout.isActive())
+        GTEST_SKIP() << "French keyboard layout is not available.";
+
+    WindowsKeyNames keyNames;
+
+    setKeysDown({ VK_RMENU, VK_LCONTROL, VK_MENU, VK_CONTROL });
+    EXPECT_STREQ(keyNames.domKeyFromParams(VK_MENU, lParamForKey(true)).utf8().data(), "AltGraph");
+
+    setKeysDown({ VK_LMENU, VK_LCONTROL, VK_MENU, VK_CONTROL });
+    EXPECT_STREQ(keyNames.domKeyFromParams('E', lParamForKey(false)).utf8().data(), "\xE2\x82\xAC" /* euro, UTF-8 */);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 57433782cf018a78f66796bc6412e159a21ac082
<pre>
KeyboardEvent/MouseEvent getModifierState(&quot;AltGraph&quot;) always returns false
<a href="https://bugs.webkit.org/show_bug.cgi?id=317576">https://bugs.webkit.org/show_bug.cgi?id=317576</a>

Reviewed by Darin Adler and Anne van Kesteren.

UIEventWithKeyState tracks the AltGraph modifier: modifiersFromInitializer()
reads EventModifierInit.modifierAltGraph and records Modifier::AltGraphKey in
m_modifiers. However, getModifierState() had no branch for the &quot;AltGraph&quot; key
identifier, so it fell through to the default and returned false even when the
event was constructed with modifierAltGraph: true. This diverges from the UI
Events specification, which lists &quot;AltGraph&quot; as a valid modifier key value, and
from Blink and Gecko, both of which report it.

Add an altGraphKey() accessor alongside capsLockKey() and handle &quot;AltGraph&quot; in
getModifierState(). This fixes the JS-constructed (initEvent) path.

Beyond that, the AltGraph state was never propagated for trusted (native) events
on any platform. The PlatformEventModifier::AltGraphKey bit was set only from
initializers, and the WebKit-process WebEventModifier enum did not even have an
AltGraphKey value, so the bit was dropped crossing the UI/Web process boundary.
As a result getModifierState(&quot;AltGraph&quot;) would still return false for real
keystrokes even on keyboards that have an AltGr key.

The UI Events specification states that &quot;Some operating systems simulate the
AltGraph modifier key with the combination of the Alt and Control modifier keys&quot;
and that &quot;Implementations are encouraged to use the AltGraph modifier key&quot;
(<a href="https://www.w3.org/TR/uievents/#keys-modifiers).">https://www.w3.org/TR/uievents/#keys-modifiers).</a> It lists AltGraph as a
first-class modifier key value and places no normative equivalence between
AltGraph and Control+Alt. Blink and Gecko both follow this guidance, exposing
AltGraph rather than Control + Alt for AltGr input. This change matches them; it
does not implement the broader (and incorrect) notion that any Control+Alt is
AltGraph (<a href="https://webkit.org/b/76988)">https://webkit.org/b/76988)</a>, which would break genuine Control+Alt
shortcuts.

Plumb AltGraph through the trusted-event path:
- Add WebEventModifier::AltGraphKey and serialize it, and carry it through both
  directions of WebEventConversion as well as modifiersFromPlatformEventModifiers.
- Windows has no dedicated AltGr key and, on layouts that define AltGraph,
  simulates it via the Control+Alt combination. WindowsKeyNames::
  shouldExposeAltGraphForKeyEvent() reports AltGraph in place of Control + Alt in
  the same three cases Blink does: a held right-Alt (VK_RMENU) on such a layout
  (regardless of which key it modifies); a character message (WM_CHAR /
  WM_SYSCHAR / WM_IME_CHAR) delivered while Control and Alt are down (the produced
  character is itself the evidence of AltGr); and a key whose printable character
  requires the Control+Alt combination on the active layout (an AltGraph-shifted
  key). Mouse and wheel events carry no key code, so they use the right-Alt case
  alone via shouldExposeLeftControlPlusRightAltAsAltGraph(). Both paths reuse the
  existing m_hasAltGraph layout detection and m_printableKeyCodeToKey lookup.
- GTK: map the X11 Mod5 state (GTK3) and the ISO_Level3/Level5 key values to
  AltGraphKey. GTK4 no longer exposes the Mod5 mask through GdkModifierType, so
  only the AltGraph key event itself is covered there.

macOS/iOS keyboards have no AltGr key, so the modifier is intentionally not
populated from native events on those platforms.

The accompanying web-platform-test exhaustively covers getModifierState() for
every modifier exposed through EventModifierInit (Control, Shift, Alt, Meta,
AltGraph, CapsLock) on both KeyboardEvent and MouseEvent: each modifier set in
isolation, all of them set together, and none set, asserting independence and
that the spec modifiers without an init member always read back as false.

The Windows AltGr handling cannot be exercised from a layout test (it depends on
the active OS keyboard layout), so it is covered by a TestWebKitAPI unit test
that mirrors Chromium&apos;s AltGraphEventTest: it activates the US English and
French (France) layouts, synthesizes the relevant key state, and asserts that
WindowsKeyNames reports AltGraph for the right-Alt, AltGraph-shifted, and
character-message cases while leaving plain Control+Alt and AltGraph-less layouts
untouched. It skips gracefully when a layout is not installed.

Test: imported/w3c/web-platform-tests/uievents/constructors/event-getmodifierstate.html

* LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt:
* LayoutTests/fast/events/constructors/keyboard-event-constructor.html:
* LayoutTests/fast/events/constructors/keyboard-event-getModifierState-expected.txt:
* LayoutTests/fast/events/constructors/keyboard-event-getModifierState.html:
* LayoutTests/fast/events/constructors/mouse-event-getModifierState-expected.txt:
* LayoutTests/fast/events/constructors/mouse-event-getModifierState.html:
* LayoutTests/fast/events/init-event-clears-capslock-expected.txt:
* LayoutTests/fast/events/init-event-clears-capslock.html:
* LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/event-getmodifierstate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/uievents/constructors/event-getmodifierstate.html: Added.
* Source/WebCore/dom/UIEventWithKeyState.cpp:
(WebCore::UIEventWithKeyState::getModifierState const):
* Source/WebCore/dom/UIEventWithKeyState.h:
(WebCore::UIEventWithKeyState::altGraphKey const):
* Source/WebCore/platform/PlatformEvent.h:
* Source/WebCore/platform/win/WindowsKeyNames.cpp:
(WebCore::WindowsKeyNames::currentKeyModifiers):
(WebCore::WindowsKeyNames::printableKeyFromVirtualKey):
(WebCore::WindowsKeyNames::domKeyFromParams):
(WebCore::WindowsKeyNames::shouldExposeLeftControlPlusRightAltAsAltGraph):
(WebCore::WindowsKeyNames::shouldExposeAltGraphForKeyEvent):
* Source/WebCore/platform/win/WindowsKeyNames.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::platform):
(WebKit::kit):
* Source/WebKit/Shared/WebEventModifier.cpp:
(WebKit::modifiersFromPlatformEventModifiers):
* Source/WebKit/Shared/WebEventModifier.h:
* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::modifiersForEvent):
* Source/WebKit/Shared/win/WebEventFactory.cpp:
(WebKit::modifiersForEvent):
(WebKit::modifiersForCurrentKeyState):
(WebKit::WebEventFactory::createWebKeyboardEvent):
* Tools/TestWebKitAPI/PlatformWin.cmake:
* Tools/TestWebKitAPI/Tests/WebCore/win/WindowsKeyNames.cpp: Added.

Canonical link: <a href="https://commits.webkit.org/315804@main">https://commits.webkit.org/315804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a61280d9c9f3212eb53925dcf99d20e7536d1111

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127663 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58fa031e-c9c4-4d42-9434-935ab25a975e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132464 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93325 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/263c7afc-52aa-4b10-99c9-a95e5a748646) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172910 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112966 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7cc2f33b-6e5b-4c50-88a7-deeea4b59427) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32604 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28008 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181909 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140914 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140745 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37940 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44218 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29270 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108545 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36012 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115983 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42729 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7369 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42121 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42376 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42264 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->