### PR TITLE
[LBSE] Broaden svgTransformAttributeChangeInducesLayerComposition() to isRenderSVGContainer()

### DIFF
--- a/LayoutTests/platform/glib/svg/transforms/nested-svg-transform-attribute-creates-layer-expected.txt
+++ b/LayoutTests/platform/glib/svg/transforms/nested-svg-transform-attribute-creates-layer-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x204
+  RenderBlock {HTML} at (0,0) size 800x203.50
+    RenderBody {BODY} at (0,0) size 800x203.50
+      RenderText {#text} at (0,0) size 0x0
+layer at (0,0) size 200x200
+  RenderSVGRoot {svg} at (0,0) size 200x200
+layer at (0,0) size 200x200
+  RenderSVGViewportContainer at (0,0) size 200x200
+layer at (0,0) size 200x200
+  RenderSVGViewportContainer {svg} at (0,0) size 200x200
+layer at (60,90) size 80x20
+  RenderSVGRect {rect} at (60,90) size 80x20 [fill={[type=SOLID] [color=#008000]}] [x=60.00] [y=90.00] [width=80.00] [height=20.00]

--- a/LayoutTests/svg/transforms/nested-svg-transform-attribute-creates-layer-expected.txt
+++ b/LayoutTests/svg/transforms/nested-svg-transform-attribute-creates-layer-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x204
+  RenderBlock {HTML} at (0,0) size 800x204
+    RenderBody {BODY} at (0,0) size 800x204
+      RenderText {#text} at (0,0) size 0x0
+layer at (0,0) size 200x200
+  RenderSVGRoot {svg} at (0,0) size 200x200
+layer at (0,0) size 200x200
+  RenderSVGViewportContainer at (0,0) size 200x200
+layer at (0,0) size 200x200
+  RenderSVGViewportContainer {svg} at (0,0) size 200x200
+layer at (60,90) size 80x20
+  RenderSVGRect {rect} at (60,90) size 80x20 [fill={[type=SOLID] [color=#008000]}] [x=60.00] [y=90.00] [width=80.00] [height=20.00]

--- a/LayoutTests/svg/transforms/nested-svg-transform-attribute-creates-layer.html
+++ b/LayoutTests/svg/transforms/nested-svg-transform-attribute-creates-layer.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, body { margin: 0; padding: 0; }
+    svg { width: 200px; height: 200px; }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+    // A nested <svg> (RenderSVGViewportContainer) needs a RenderLayer once its transform attribute
+    // is non-identity. Adding it dynamically must create that layer, otherwise requiresLayer() and
+    // hasLayer() disagree and the nested viewport is left in a stale layer state. The render-tree
+    // dump shows a "layer at" line for the nested <svg> only when the layer exists.
+    window.addEventListener('load', () => {
+        requestAnimationFrame(() => {
+            document.body.offsetTop;
+            document.getElementById('inner').setAttribute('transform', 'rotate(45 100 100)');
+            requestAnimationFrame(() => {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    });
+</script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <svg id="inner" x="0" y="0" width="200" height="200">
+        <rect x="60" y="90" width="80" height="20" fill="green"/>
+    </svg>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -703,9 +703,11 @@ bool RenderLayerModelObject::pointInSVGClippingArea(const FloatPoint& point) con
 
 bool RenderLayerModelObject::svgTransformAttributeChangeInducesLayerComposition()
 {
-    // True when a just-parsed SVG transform attribute flips whether this transformable
-    // container needs, so the change must create or destroy one.
-    if (!isRenderSVGTransformableContainer())
+    // True when a just-parsed SVG transform attribute flips whether this container needs a layer,
+    // so the change must create or destroy one. A 2D transform gates layer creation for any SVG
+    // container (requiresLayer() returns true for isTransformed() && isRenderSVGContainer()), which
+    // covers both <g> (RenderSVGTransformableContainer) and nested <svg> (RenderSVGViewportContainer).
+    if (!isRenderSVGContainer())
         return false;
     // requiresLayer() reads the cached hasSVGTransform() flag - so make sure it's not stale.
     updateHasSVGTransformFlags();
@@ -720,7 +722,7 @@ void RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange
 
     // A layer is neither created nor destroyed below, so probe it once up front.
     const bool isLayered = hasLayer();
-    ASSERT(!isRenderSVGTransformableContainer() || requiresLayer() == isLayered);
+    ASSERT(!isRenderSVGContainer() || requiresLayer() == isLayered);
 
     // Refresh the transform, returning the (previous, current) pair. For layered renderers this
     // forces a stacking context on an identity-to-non-identity transition (the batched flush skips


### PR DESCRIPTION
#### 165d95b9677cdd673b09dd7e5dcf18087189656a
<pre>
[LBSE] Broaden svgTransformAttributeChangeInducesLayerComposition() to isRenderSVGContainer()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317575">https://bugs.webkit.org/show_bug.cgi?id=317575</a>

Reviewed by Rob Buis.

svgTransformAttributeChangeInducesLayerComposition() only routed the
transform-attribute fast path through a style/layer recompute for
RenderSVGTransformableContainer, but missed RenderSVGViewportContainer.
(requiresLayer() returns true for isTransformed() and
Without the recompute the fast path took the non-layer transform
update instead, leaving requiresLayer() and hasLayer()
in disagreement and no layer created or destroyed.

Broaden the type check to isRenderSVGContainer(), which covers both &lt;g&gt;
and nested &lt;svg&gt; and adapt the assertion in
updateTransformAndRepaintForSVGAfterAttributeChange() in the same way.

Test: svg/transforms/nested-svg-transform-attribute-creates-layer.html

* LayoutTests/platform/glib/svg/transforms/nested-svg-transform-attribute-creates-layer-expected.txt: Added.
* LayoutTests/svg/transforms/nested-svg-transform-attribute-creates-layer-expected.txt: Added.
* LayoutTests/svg/transforms/nested-svg-transform-attribute-creates-layer.html: Added.
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::svgTransformAttributeChangeInducesLayerComposition):
(WebCore::RenderLayerModelObject::updateTransformAndRepaintForSVGAfterAttributeChange):

Canonical link: <a href="https://commits.webkit.org/315596@main">https://commits.webkit.org/315596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54459ef0743f7044608cd11228e2e1ab9ab2e655

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178895 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127248 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171402 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132087 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172495 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112590 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32227 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27592 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181494 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140535 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140371 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43803 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107999 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35640 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115568 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42313 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6900 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41706 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41961 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->