### PR TITLE
filter on an inline element does not apply to a block-level descendant

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+.box {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    background: green;
+    filter: blur(2px);
+}
+</style>
+<p>There should be a blurred green square.</p>
+<div>
+  <span class="box"></span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+.box {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    background: green;
+    filter: blur(2px);
+}
+</style>
+<p>There should be a blurred green square.</p>
+<div>
+  <span class="box"></span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/filter-effects-1/#FilterProperty">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=277228">
+<link rel="match" href="filtered-inline-applies-to-block-ref.html">
+<meta name="assert" content="A filter on an inline element applies to a block-level descendant whose own children are inline, even when the inline parent has no inline children of its own.">
+<style>
+a { filter: blur(2px); }
+.box {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+</style>
+<p>There should be a blurred green square.</p>
+<a href="https://www.w3.org/">
+  <div>
+    <span class="box"></span>
+  </div>
+</a>


### PR DESCRIPTION
#### 23bb224c5de47acfb0ec4de735615ff1520606de
<pre>
filter on an inline element does not apply to a block-level descendant
<a href="https://bugs.webkit.org/show_bug.cgi?id=277228">https://bugs.webkit.org/show_bug.cgi?id=277228</a>
<a href="https://rdar.apple.com/132671670">rdar://132671670</a>

Reviewed by Simon Fraser.

This adds a WPT test for the case where a filter set on an inline
element should apply to a block-level descendant, even when the inline
ancestor has no inline children of its own. The CSS `filter` property
is non-inherited per css-filter-effects-1 — the descendants are not
&quot;inheriting&quot; the filter; the filter applies to the element together
with its painting subtree, which includes the block descendant and its
own inline grandchild.

The shape exercised is:
    &lt;a filter&gt; → &lt;div&gt; → &lt;span class=&quot;box&quot;&gt;

With the bug, the inline `&lt;a&gt;` had a zero bounding box (RenderInline
with no inline children), so the source image was never built and the
descendant never rendered through the filter. It is now fixed in
WebKit, but no WPT test guarded the regression.

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block.html: Added.

Canonical link: <a href="https://commits.webkit.org/315788@main">https://commits.webkit.org/315788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81c832b43fc4527451186d8754d3e0d331a0554a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127374 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/490ad20c-f01b-4496-b13b-889351f89465) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132207 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93125 "1 flakes 9 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ec480b6-bb32-4cfd-a55d-d789c44bfe9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112710 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec5450fa-8ec2-4fb1-83de-4797713359e6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32346 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27718 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181620 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36512 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140654 "Found 1 new test failure: imported/w3c/web-platform-tests/css/filter-effects/filtered-inline-applies-to-block.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140490 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37916 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43929 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108166 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35758 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42439 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7081 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41832 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41975 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->