### PR TITLE
WebGL: Deleting draw framebuffer modifies read framebuffer binding

### DIFF
--- a/LayoutTests/webgl/delete-draw-framebuffer-preserves-read-binding-expected.txt
+++ b/LayoutTests/webgl/delete-draw-framebuffer-preserves-read-binding-expected.txt
@@ -1,0 +1,15 @@
+Test that deleteFramebuffer() on the draw framebuffer alone does not unbind the read framebuffer.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 6 PASS, 0 FAIL
+
+PASS getError was expected value: NO_ERROR : deleteFramebuffer(drawFB) succeeds
+PASS gl.getParameter(gl.READ_FRAMEBUFFER_BINDING) is readFB
+PASS gl.getParameter(gl.DRAW_FRAMEBUFFER_BINDING) is null
+PASS gl.checkFramebufferStatus(gl.READ_FRAMEBUFFER) is gl.FRAMEBUFFER_COMPLETE
+PASS read green after delete
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/delete-draw-framebuffer-preserves-read-binding.html
+++ b/LayoutTests/webgl/delete-draw-framebuffer-preserves-read-binding.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="1" height="1"></canvas>
+<script>
+"use strict";
+description("Test that deleteFramebuffer() on the draw framebuffer alone does not unbind the read framebuffer.");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext(canvas, undefined, 2);
+gl.clearColor(1, 0, 0, 1);
+gl.clear(gl.COLOR_BUFFER_BIT);
+
+var green = [0, 255, 0, 255];
+var texture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(green));
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+var readFB = gl.createFramebuffer();
+gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFB);
+gl.framebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+var drawFB = gl.createFramebuffer();
+gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, drawFB);
+gl.deleteFramebuffer(drawFB);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "deleteFramebuffer(drawFB) succeeds");
+
+shouldBe("gl.getParameter(gl.READ_FRAMEBUFFER_BINDING)", "readFB");
+shouldBeNull("gl.getParameter(gl.DRAW_FRAMEBUFFER_BINDING)");
+shouldBe("gl.checkFramebufferStatus(gl.READ_FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+wtu.checkCanvasRect(gl, 0, 0, 1, 1, green, "read green after delete");
+
+finishTest();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -684,24 +684,14 @@ void WebGL2RenderingContext::deleteFramebuffer(WebGLFramebuffer* framebuffer)
     if (!deleteObject(locker, framebuffer))
         return;
 
-    GCGLenum target = 0;
-    RefPtr context = m_context;
-    if (framebuffer == m_framebufferBinding) {
-        if (framebuffer == m_readFramebufferBinding) {
-            target = GraphicsContextGL::FRAMEBUFFER;
-            m_framebufferBinding = nullptr;
-            m_readFramebufferBinding = nullptr;
-        } else {
-            target = GraphicsContextGL::DRAW_FRAMEBUFFER;
-            m_framebufferBinding = nullptr;
-        }
-        context->bindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER, 0);
-    } else if (framebuffer == m_readFramebufferBinding) {
-        target = GraphicsContextGL::READ_FRAMEBUFFER;
+    if (framebuffer == m_readFramebufferBinding) {
         m_readFramebufferBinding = nullptr;
-    }
-    if (target)
-        context->bindFramebuffer(target, 0);
+        if (framebuffer == m_framebufferBinding)
+            setFramebuffer(locker, GraphicsContextGL::FRAMEBUFFER, nullptr);
+        else
+            setFramebuffer(locker, GraphicsContextGL::READ_FRAMEBUFFER, nullptr);
+    } else if (framebuffer == m_framebufferBinding)
+        setFramebuffer(locker, GraphicsContextGL::DRAW_FRAMEBUFFER, nullptr);
 }
 
 void WebGL2RenderingContext::framebufferTextureLayer(GCGLenum target, GCGLenum attachment, WebGLTexture* texture, GCGLint level, GCGLint layer)


### PR DESCRIPTION
#### bfb5f5089189759d16ee77fd878d85dad0db7070
<pre>
WebGL: Deleting draw framebuffer modifies read framebuffer binding
<a href="https://bugs.webkit.org/show_bug.cgi?id=317581">https://bugs.webkit.org/show_bug.cgi?id=317581</a>
<a href="https://rdar.apple.com/problem/180286828">rdar://problem/180286828</a>

Reviewed by Dan Glastonbury.

Reset the READ_FRAMEBUFFER binding point only if the framebuffer object
was bound to it.

Test: webgl/delete-draw-framebuffer-preserves-read-binding.html

* LayoutTests/webgl/delete-draw-framebuffer-preserves-read-binding-expected.txt: Added.
* LayoutTests/webgl/delete-draw-framebuffer-preserves-read-binding.html: Added.
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::deleteFramebuffer):

Canonical link: <a href="https://commits.webkit.org/315676@main">https://commits.webkit.org/315676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18a58bfd81afcc19183c3c3015fcaadb4a87be26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127442 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31bdf57d-220d-4c71-b7ef-18fa9e3fd301) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171596 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132276 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14093ffa-9355-4385-a01c-4ce8f83a3ad5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172689 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112779 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd124066-99a5-46fe-875d-525bd411ff11) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32413 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27786 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181688 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34396 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140722 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140558 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37846 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43997 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108266 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35822 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115762 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42508 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7137 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41900 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42155 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->