### PR TITLE
REGRESSION(314242@main): Crash in Style::extractFillLayerPropertyShorthand

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-coordinated-shorthand-layer-count-crash-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-coordinated-shorthand-layer-count-crash-expected.txt
@@ -1,0 +1,14 @@
+getComputedStyle of the background/mask shorthand must not crash when a non-image longhand has fewer specified values than background-image/mask-image (the longhand list is shorter than the layer count). The shorter list should repeat across layers.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS backgroundOf("background-image: url(a.png), url(b.png); background-repeat: repeat-x;").match(/repeat-x/g).length is 2
+PASS backgroundOf("background-image: url(a.png), url(b.png); background-size: cover;").match(/cover/g).length is 2
+PASS backgroundOf("background-image: url(a.png), url(b.png), url(c.png); background-repeat: repeat-x, repeat-y;").match(/repeat-x/g).length is 2
+PASS backgroundOf("background-image: url(a.png), url(b.png), url(c.png); background-repeat: repeat-x, repeat-y;").match(/repeat-y/g).length is 1
+PASS maskOf("mask-image: url(a.png), url(b.png); mask-repeat: repeat-x;").match(/repeat-x/g).length is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-coordinated-shorthand-layer-count-crash.html
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-coordinated-shorthand-layer-count-crash.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("getComputedStyle of the background/mask shorthand must not crash when a non-image longhand has fewer specified values than background-image/mask-image (the longhand list is shorter than the layer count). The shorter list should repeat across layers.");
+
+function backgroundOf(declaration)
+{
+    var element = document.createElement("div");
+    element.setAttribute("style", declaration);
+    document.body.appendChild(element);
+    var value = getComputedStyle(element).getPropertyValue("background");
+    element.remove();
+    return value;
+}
+
+function maskOf(declaration)
+{
+    var element = document.createElement("div");
+    element.setAttribute("style", declaration);
+    document.body.appendChild(element);
+    var value = getComputedStyle(element).getPropertyValue("mask");
+    element.remove();
+    return value;
+}
+
+// Reaching these assertions at all proves getComputedStyle did not crash. The
+// counts verify the single specified value is repeated into each image layer.
+
+// Before-slash longhand (background-repeat) shorter than the image layer count.
+shouldBe('backgroundOf("background-image: url(a.png), url(b.png); background-repeat: repeat-x;").match(/repeat-x/g).length', '2');
+
+// After-slash longhand (background-size) shorter than the image layer count.
+shouldBe('backgroundOf("background-image: url(a.png), url(b.png); background-size: cover;").match(/cover/g).length', '2');
+
+// Three image layers, two repeat values: modulo repetition gives layers x, y, x.
+shouldBe('backgroundOf("background-image: url(a.png), url(b.png), url(c.png); background-repeat: repeat-x, repeat-y;").match(/repeat-x/g).length', '2');
+shouldBe('backgroundOf("background-image: url(a.png), url(b.png), url(c.png); background-repeat: repeat-x, repeat-y;").match(/repeat-y/g).length', '1');
+
+// Mask shorthand, same shape.
+shouldBe('maskOf("mask-image: url(a.png), url(b.png); mask-repeat: repeat-x;").match(/repeat-x/g).length', '2');
+</script>
+</body>
+</html>

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -116,7 +116,6 @@ style/StyleBuilder.cpp
 style/StyleBuilderCustom.h
 style/StyleDifference.cpp
 style/StyleDocumentScope.cpp
-style/StyleExtractorCustom.h
 style/StyleInvalidationFunctions.h
 style/StyleRelations.cpp
 style/StyleScope.cpp

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -1912,20 +1912,26 @@ template<CSSPropertyID property> inline Ref<CSSValue> extractFillLayerPropertySh
     // The computed properties are returned as lists of properties, with a list of layers in each.
     // We want to swap that around to have a list of layers, with a list of properties in each.
 
+    // A coordinated list longhand only serializes its specified values, which may be fewer
+    // than layerCount. The used value for a given layer repeats those values (modulo their
+    // count), so index into the longhand list by the layer index modulo its size.
+    auto valueForLayer = [&](const CSSValue& shorthandValue, size_t layerIndex) -> CSSValue& {
+        if (layerCount == 1)
+            return const_cast<CSSValue&>(shorthandValue);
+        auto& list = downcast<CSSValueList>(shorthandValue);
+        return const_cast<CSSValue&>(*list.item(layerIndex % list.size()));
+    };
+
     CSSValueListBuilder layers;
     for (size_t i = 0; i < layerCount; i++) {
         CSSValueListBuilder beforeList;
         if (i == layerCount - 1 && lastValue)
             beforeList.append(*lastValue);
-        for (size_t j = 0; j < propertiesBeforeSlashSeparator.length(); j++) {
-            auto& value = *before->item(j);
-            beforeList.append(const_cast<CSSValue&>(layerCount == 1 ? value : *downcast<CSSValueList>(value).item(i)));
-        }
+        for (size_t j = 0; j < propertiesBeforeSlashSeparator.length(); j++)
+            beforeList.append(valueForLayer(*before->item(j), i));
         CSSValueListBuilder afterList;
-        for (size_t j = 0; j < propertiesAfterSlashSeparator.length(); j++) {
-            auto& value = *after->item(j);
-            afterList.append(const_cast<CSSValue&>(layerCount == 1 ? value : *downcast<CSSValueList>(value).item(i)));
-        }
+        for (size_t j = 0; j < propertiesAfterSlashSeparator.length(); j++)
+            afterList.append(valueForLayer(*after->item(j), i));
         auto list = CSSValueList::createSlashSeparated(CSSValueList::createSpaceSeparated(WTF::move(beforeList)), CSSValueList::createSpaceSeparated(WTF::move(afterList)));
         if (layerCount == 1)
             return list;


### PR DESCRIPTION
#### a21ae4a906e1d4c20696c86b22a8082f643c0397
<pre>
REGRESSION(314242@main): Crash in Style::extractFillLayerPropertyShorthand
<a href="https://bugs.webkit.org/show_bug.cgi?id=317585">https://bugs.webkit.org/show_bug.cgi?id=317585</a>
<a href="https://rdar.apple.com/179879711">rdar://179879711</a>

Reviewed by Alan Baradlay.

extractFillLayerPropertyShorthand (StyleExtractorCustom.h) assumes every per-longhand computed-value
list has exactly layerCount items which is not necessarily true.

Test: fast/css/getComputedStyle/computed-style-coordinated-shorthand-layer-count-crash.html
* LayoutTests/fast/css/getComputedStyle/computed-style-coordinated-shorthand-layer-count-crash-expected.txt: Added.
* LayoutTests/fast/css/getComputedStyle/computed-style-coordinated-shorthand-layer-count-crash.html: Added.
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::extractFillLayerPropertyShorthand):

Index each longhand list with item(layerIndex % list.size()), restoring the pre-regression used-value repeat semantics.

Canonical link: <a href="https://commits.webkit.org/315603@main">https://commits.webkit.org/315603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c694ee14d13eabea62db7f5b58ba545c6e68cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43473 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36806 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127263 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/663594eb-c008-49e9-a6e4-53def12954ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171417 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132101 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/526861bc-8005-429a-9936-8eaebdeabb13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172510 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112604 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6ab5a4b-e7a8-4504-b14d-c665475cb964) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27607 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181509 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34217 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37770 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43818 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108018 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35653 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115583 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42328 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6916 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41721 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41864 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->