### PR TITLE
[

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 *.pbxuser
 *.perspective*
 *.pyc

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -306,7 +306,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitializeContext()
     eglContextAttributes.append(0);
 #endif
 
-    if (contains(unsafeSpan(displayExtensions), "EGL_ANGLE_power_preference"_span)) {
+    if (WTF::contains(unsafeSpan(displayExtensions), "EGL_ANGLE_power_preference"_span)) {
         eglContextAttributes.append(EGL_POWER_PREFERENCE_ANGLE);
         // EGL_LOW_POWER_ANGLE is the default. Change to
         // EGL_HIGH_POWER_ANGLE if desired.

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -142,6 +142,7 @@ struct WebPageCreationParameters {
 
     bool alwaysShowsHorizontalScroller { false };
     bool alwaysShowsVerticalScroller { false };
+    bool mainFrameIsScrollable { true };
 
     bool suppressScrollbarAnimations { false };
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -56,6 +56,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     bool alwaysShowsHorizontalScroller;
     bool alwaysShowsVerticalScroller;
+    bool mainFrameIsScrollable;
 
     bool suppressScrollbarAnimations;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -235,6 +235,7 @@ enum {
     PROP_ZOOM_LEVEL,
 #if PLATFORM(GTK)
     PROP_MAIN_FRAME_SCROLLING_ENABLED,
+    PROP_FIT_CONTENT_HEIGHT,
 #endif
     PROP_IS_LOADING,
     PROP_IS_PLAYING_AUDIO,
@@ -1106,6 +1107,9 @@ static void webkitWebViewSetProperty(GObject* object, guint propId, const GValue
     case PROP_MAIN_FRAME_SCROLLING_ENABLED:
         webkit_web_view_set_main_frame_scrolling_enabled(webView, g_value_get_boolean(value));
         break;
+    case PROP_FIT_CONTENT_HEIGHT:
+        webkit_web_view_set_fit_content_height(webView, g_value_get_boolean(value));
+        break;
 #endif
 #if !ENABLE(2022_GLIB_API)
     case PROP_IS_EPHEMERAL:
@@ -1202,6 +1206,9 @@ static void webkitWebViewGetProperty(GObject* object, guint propId, GValue* valu
 #if PLATFORM(GTK)
     case PROP_MAIN_FRAME_SCROLLING_ENABLED:
         g_value_set_boolean(value, webkit_web_view_get_main_frame_scrolling_enabled(webView));
+        break;
+    case PROP_FIT_CONTENT_HEIGHT:
+        g_value_set_boolean(value, webkit_web_view_get_fit_content_height(webView));
         break;
 #endif
     case PROP_IS_LOADING:
@@ -1551,6 +1558,25 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
             "main-frame-scrolling-enabled",
             nullptr, nullptr,
             TRUE,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WebKitWebView:fit-content-height:
+     *
+     * Whether the #WebKitWebView requests its main-frame content height.
+     *
+     * When this property is %TRUE, the widget requests a natural height based on
+     * the latest intrinsic content height for its measured width. The value is
+     * updated asynchronously as layout changes, so the widget may initially
+     * request its fallback height. The default value is %FALSE.
+     *
+     * Since: 2.54
+     */
+    sObjProperties[PROP_FIT_CONTENT_HEIGHT] =
+        g_param_spec_boolean(
+            "fit-content-height",
+            nullptr, nullptr,
+            FALSE,
             WEBKIT_PARAM_READWRITE);
 #endif
 
@@ -4275,7 +4301,8 @@ gdouble webkit_web_view_get_zoom_level(WebKitWebView* webView)
  * larger scrollable GTK interface, where the outer container owns scrolling.
  *
  * This does not change page contents and is not equivalent to injecting CSS
- * such as `overflow: hidden`.
+ * such as `overflow: hidden`. It also does not make the widget request its full
+ * content height; use webkit_web_view_set_fit_content_height() for that.
  *
  * Since: 2.54
  */
@@ -4306,6 +4333,55 @@ gboolean webkit_web_view_get_main_frame_scrolling_enabled(WebKitWebView* webView
     g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), TRUE);
 
     return getPage(webView).mainFrameIsScrollable();
+}
+
+/**
+ * webkit_web_view_set_fit_content_height:
+ * @web_view: a #WebKitWebView
+ * @fit_content_height: whether the widget should request its content height
+ *
+ * Sets whether @web_view should request enough height to fit its main-frame
+ * contents for the current width.
+ *
+ * When enabled, WebKit uses the main frame's intrinsic content size to update
+ * the widget's natural height. The value is updated asynchronously as layout
+ * changes, so the widget may initially request its fallback height until the
+ * WebProcess reports the first content size.
+ *
+ * This property only affects GTK size negotiation. To prevent the web view from
+ * scrolling internally, also call
+ * webkit_web_view_set_main_frame_scrolling_enabled() with %FALSE.
+ *
+ * Since: 2.54
+ */
+void webkit_web_view_set_fit_content_height(WebKitWebView* webView, gboolean fitContentHeight)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+
+    fitContentHeight = !!fitContentHeight;
+    if (webkit_web_view_get_fit_content_height(webView) == fitContentHeight)
+        return;
+
+    webkitWebViewBaseSetFitContentHeight(WEBKIT_WEB_VIEW_BASE(webView), fitContentHeight);
+    g_object_notify_by_pspec(G_OBJECT(webView), sObjProperties[PROP_FIT_CONTENT_HEIGHT]);
+}
+
+/**
+ * webkit_web_view_get_fit_content_height:
+ * @web_view: a #WebKitWebView
+ *
+ * Gets whether @web_view requests its main-frame content height.
+ *
+ * Returns: %TRUE if @web_view requests its main-frame content height, or
+ *   %FALSE otherwise
+ *
+ * Since: 2.54
+ */
+gboolean webkit_web_view_get_fit_content_height(WebKitWebView* webView)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), FALSE);
+
+    return webkitWebViewBaseGetFitContentHeight(WEBKIT_WEB_VIEW_BASE(webView));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -233,6 +233,9 @@ enum {
 
     PROP_URI,
     PROP_ZOOM_LEVEL,
+#if PLATFORM(GTK)
+    PROP_MAIN_FRAME_SCROLLING_ENABLED,
+#endif
     PROP_IS_LOADING,
     PROP_IS_PLAYING_AUDIO,
 #if !ENABLE(2022_GLIB_API)
@@ -1099,6 +1102,11 @@ static void webkitWebViewSetProperty(GObject* object, guint propId, const GValue
     case PROP_ZOOM_LEVEL:
         webkit_web_view_set_zoom_level(webView, g_value_get_double(value));
         break;
+#if PLATFORM(GTK)
+    case PROP_MAIN_FRAME_SCROLLING_ENABLED:
+        webkit_web_view_set_main_frame_scrolling_enabled(webView, g_value_get_boolean(value));
+        break;
+#endif
 #if !ENABLE(2022_GLIB_API)
     case PROP_IS_EPHEMERAL:
         webView->priv->isEphemeral = g_value_get_boolean(value);
@@ -1191,6 +1199,11 @@ static void webkitWebViewGetProperty(GObject* object, guint propId, GValue* valu
     case PROP_ZOOM_LEVEL:
         g_value_set_double(value, webkit_web_view_get_zoom_level(webView));
         break;
+#if PLATFORM(GTK)
+    case PROP_MAIN_FRAME_SCROLLING_ENABLED:
+        g_value_set_boolean(value, webkit_web_view_get_main_frame_scrolling_enabled(webView));
+        break;
+#endif
     case PROP_IS_LOADING:
         g_value_set_boolean(value, webkit_web_view_is_loading(webView));
         break;
@@ -1519,6 +1532,27 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
             nullptr, nullptr,
             0, G_MAXDOUBLE, 1,
             WEBKIT_PARAM_READWRITE);
+
+#if PLATFORM(GTK)
+    /**
+     * WebKitWebView:main-frame-scrolling-enabled:
+     *
+     * Whether the main frame of the #WebKitWebView is scrollable.
+     *
+     * When this property is %FALSE, main-frame scrolling is disabled and
+     * main-frame scrollbars are hidden. This is useful when embedding a web
+     * view inside a larger scrollable GTK interface, where the outer container
+     * owns scrolling. The default value is %TRUE.
+     *
+     * Since: 2.54
+     */
+    sObjProperties[PROP_MAIN_FRAME_SCROLLING_ENABLED] =
+        g_param_spec_boolean(
+            "main-frame-scrolling-enabled",
+            nullptr, nullptr,
+            TRUE,
+            WEBKIT_PARAM_READWRITE);
+#endif
 
     /**
      * WebKitWebView:is-loading:
@@ -4227,6 +4261,53 @@ gdouble webkit_web_view_get_zoom_level(WebKitWebView* webView)
     gboolean zoomTextOnly = webkit_settings_get_zoom_text_only(webView->priv->settings.get());
     return zoomTextOnly ? page->textZoomFactor() : page->pageZoomFactor() / pageScale;
 }
+
+#if PLATFORM(GTK)
+/**
+ * webkit_web_view_set_main_frame_scrolling_enabled:
+ * @web_view: a #WebKitWebView
+ * @enabled: whether main-frame scrolling is enabled
+ *
+ * Sets whether the main frame of @web_view can scroll.
+ *
+ * When @enabled is %FALSE, main-frame scrolling is disabled and main-frame
+ * scrollbars are hidden. This is useful when embedding a web view inside a
+ * larger scrollable GTK interface, where the outer container owns scrolling.
+ *
+ * This does not change page contents and is not equivalent to injecting CSS
+ * such as `overflow: hidden`.
+ *
+ * Since: 2.54
+ */
+void webkit_web_view_set_main_frame_scrolling_enabled(WebKitWebView* webView, gboolean enabled)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+
+    enabled = !!enabled;
+    if (webkit_web_view_get_main_frame_scrolling_enabled(webView) == enabled)
+        return;
+
+    getPage(webView).setMainFrameIsScrollable(enabled);
+    g_object_notify_by_pspec(G_OBJECT(webView), sObjProperties[PROP_MAIN_FRAME_SCROLLING_ENABLED]);
+}
+
+/**
+ * webkit_web_view_get_main_frame_scrolling_enabled:
+ * @web_view: a #WebKitWebView
+ *
+ * Gets whether the main frame of @web_view can scroll.
+ *
+ * Returns: %TRUE if main-frame scrolling is enabled, or %FALSE otherwise
+ *
+ * Since: 2.54
+ */
+gboolean webkit_web_view_get_main_frame_scrolling_enabled(WebKitWebView* webView)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), TRUE);
+
+    return getPage(webView).mainFrameIsScrollable();
+}
+#endif
 
 /**
  * webkit_web_view_can_execute_editing_command:

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -641,6 +641,12 @@ webkit_web_view_set_main_frame_scrolling_enabled     (WebKitWebView             
                                                       gboolean                   enabled);
 WEBKIT_API gboolean
 webkit_web_view_get_main_frame_scrolling_enabled     (WebKitWebView             *web_view);
+
+WEBKIT_API void
+webkit_web_view_set_fit_content_height               (WebKitWebView             *web_view,
+                                                      gboolean                   fit_content_height);
+WEBKIT_API gboolean
+webkit_web_view_get_fit_content_height               (WebKitWebView             *web_view);
 #endif
 
 WEBKIT_API void

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -635,6 +635,14 @@ webkit_web_view_set_zoom_level                       (WebKitWebView             
 WEBKIT_API gdouble
 webkit_web_view_get_zoom_level                       (WebKitWebView             *web_view);
 
+#if PLATFORM(GTK)
+WEBKIT_API void
+webkit_web_view_set_main_frame_scrolling_enabled     (WebKitWebView             *web_view,
+                                                      gboolean                   enabled);
+WEBKIT_API gboolean
+webkit_web_view_get_main_frame_scrolling_enabled     (WebKitWebView             *web_view);
+#endif
+
 WEBKIT_API void
 webkit_web_view_can_execute_editing_command          (WebKitWebView             *web_view,
                                                       const gchar               *command,

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -355,6 +355,11 @@ void PageClientImpl::didChangeContentSize(const IntSize& size)
     webkitWebViewBaseSetContentsSize(WEBKIT_WEB_VIEW_BASE(m_viewWidget), size);
 }
 
+void PageClientImpl::intrinsicContentSizeDidChange(const IntSize& size)
+{
+    webkitWebViewBaseSetIntrinsicContentSize(WEBKIT_WEB_VIEW_BASE(m_viewWidget), size);
+}
+
 #if ENABLE(DRAG_SUPPORT)
 void PageClientImpl::startDrag(SelectionData&& selection, OptionSet<DragOperation> dragOperationMask, RefPtr<ShareableBitmap>&& dragImage, IntPoint&& dragImageHotspot)
 {

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -115,6 +115,7 @@ private:
     void updateAcceleratedCompositingMode(const LayerTreeContext&) override;
 
     void didChangeContentSize(const WebCore::IntSize&) override;
+    void intrinsicContentSizeDidChange(const WebCore::IntSize&) override;
     void didCommitLoadForMainFrame(const String& mimeType, bool useCustomContentProvider) override;
     void didStartProvisionalLoadForMainFrame() override;
     void didFirstVisuallyNonEmptyLayoutForMainFrame() override;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -342,8 +342,11 @@ struct _WebKitWebViewBasePrivate {
     KeyBindingTranslator keyBindingTranslator;
     TouchEventsMap touchEvents;
     IntSize contentsSize;
+    IntSize intrinsicContentSize;
+    int fitContentHeightWidth { 0 };
     std::optional<MotionEvent> lastMotionEvent;
     bool isBlank;
+    bool fitContentHeight { false };
     bool shouldNotifyFocusEvents { true };
 
     ToplevelWindow* toplevelOnScreenWindow { nullptr };
@@ -977,6 +980,38 @@ static void webkitWebViewBaseSetSize(WebKitWebViewBase* webViewBase, const IntSi
         drawingArea->setSize(priv->viewSize);
 }
 
+static bool webkitWebViewBaseUpdateFitContentHeightWidth(WebKitWebViewBase* webViewBase, int width)
+{
+    auto* priv = webViewBase->priv;
+    if (!priv->fitContentHeight)
+        return false;
+
+    width = std::max(width, 0);
+    if (width == priv->fitContentHeightWidth)
+        return false;
+
+    priv->fitContentHeightWidth = width;
+    priv->intrinsicContentSize = { };
+    priv->pageProxy->setMinimumSizeForAutoLayout(width > 0 ? IntSize(width, 1) : IntSize());
+    return true;
+}
+
+static int webkitWebViewBaseNaturalHeight(WebKitWebViewBase* webViewBase)
+{
+    auto* priv = webViewBase->priv;
+    if (priv->fitContentHeight && priv->intrinsicContentSize.height() > 0)
+        return priv->intrinsicContentSize.height();
+    return priv->contentsSize.height();
+}
+
+static GtkSizeRequestMode webkitWebViewBaseGetRequestMode(GtkWidget* widget)
+{
+    if (WEBKIT_WEB_VIEW_BASE(widget)->priv->fitContentHeight)
+        return GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH;
+
+    return GTK_WIDGET_CLASS(webkit_web_view_base_parent_class)->get_request_mode(widget);
+}
+
 #if USE(GTK4)
 static void webkitWebViewBaseSizeAllocate(GtkWidget* widget, int width, int height, int baseline)
 #else
@@ -1037,18 +1072,23 @@ static void webkitWebViewBaseSizeAllocate(GtkWidget* widget, GtkAllocation* allo
 #endif
 
     webkitWebViewBaseSetSize(webViewBase, viewRect.size());
+    if (webkitWebViewBaseUpdateFitContentHeightWidth(webViewBase, viewRect.width()))
+        gtk_widget_queue_resize(widget);
 }
 
 #if USE(GTK4)
-static void webkitWebViewBaseMeasure(GtkWidget* widget, GtkOrientation orientation, int, int* minimumSize, int* naturalSize, int*, int*)
+static void webkitWebViewBaseMeasure(GtkWidget* widget, GtkOrientation orientation, int forSize, int* minimumSize, int* naturalSize, int*, int*)
 {
-    WebKitWebViewBasePrivate* priv = WEBKIT_WEB_VIEW_BASE(widget)->priv;
+    auto* webViewBase = WEBKIT_WEB_VIEW_BASE(widget);
+    WebKitWebViewBasePrivate* priv = webViewBase->priv;
     switch (orientation) {
     case GTK_ORIENTATION_HORIZONTAL:
         *naturalSize = priv->contentsSize.width();
         break;
     case GTK_ORIENTATION_VERTICAL:
-        *naturalSize = priv->contentsSize.height();
+        if (forSize > 0)
+            webkitWebViewBaseUpdateFitContentHeightWidth(webViewBase, forSize);
+        *naturalSize = webkitWebViewBaseNaturalHeight(webViewBase);
         break;
     }
 
@@ -1064,9 +1104,17 @@ static void webkitWebViewBaseGetPreferredWidth(GtkWidget* widget, gint* minimumS
 
 static void webkitWebViewBaseGetPreferredHeight(GtkWidget* widget, gint* minimumSize, gint* naturalSize)
 {
-    WebKitWebViewBasePrivate* priv = WEBKIT_WEB_VIEW_BASE(widget)->priv;
+    auto* webViewBase = WEBKIT_WEB_VIEW_BASE(widget);
     *minimumSize = 0;
-    *naturalSize = priv->contentsSize.height();
+    *naturalSize = webkitWebViewBaseNaturalHeight(webViewBase);
+}
+
+static void webkitWebViewBaseGetPreferredHeightForWidth(GtkWidget* widget, gint width, gint* minimumSize, gint* naturalSize)
+{
+    auto* webViewBase = WEBKIT_WEB_VIEW_BASE(widget);
+    webkitWebViewBaseUpdateFitContentHeightWidth(webViewBase, width);
+    *minimumSize = 0;
+    *naturalSize = webkitWebViewBaseNaturalHeight(webViewBase);
 }
 #endif
 
@@ -2431,11 +2479,13 @@ static void webkit_web_view_base_class_init(WebKitWebViewBaseClass* webkitWebVie
     widgetClass->draw = webkitWebViewBaseDraw;
 #endif
     widgetClass->size_allocate = webkitWebViewBaseSizeAllocate;
+    widgetClass->get_request_mode = webkitWebViewBaseGetRequestMode;
 #if USE(GTK4)
     widgetClass->measure = webkitWebViewBaseMeasure;
 #else
     widgetClass->get_preferred_width = webkitWebViewBaseGetPreferredWidth;
     widgetClass->get_preferred_height = webkitWebViewBaseGetPreferredHeight;
+    widgetClass->get_preferred_height_for_width = webkitWebViewBaseGetPreferredHeightForWidth;
 #endif
     widgetClass->map = webkitWebViewBaseMap;
     widgetClass->unmap = webkitWebViewBaseUnmap;
@@ -2870,6 +2920,41 @@ void webkitWebViewBaseSetContentsSize(WebKitWebViewBase* webkitWebViewBase, cons
     if (priv->contentsSize == contentsSize)
         return;
     priv->contentsSize = contentsSize;
+    gtk_widget_queue_resize(GTK_WIDGET(webkitWebViewBase));
+}
+
+void webkitWebViewBaseSetIntrinsicContentSize(WebKitWebViewBase* webkitWebViewBase, const IntSize& intrinsicContentSize)
+{
+    WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
+    if (priv->intrinsicContentSize == intrinsicContentSize)
+        return;
+
+    priv->intrinsicContentSize = intrinsicContentSize;
+    if (priv->fitContentHeight)
+        gtk_widget_queue_resize(GTK_WIDGET(webkitWebViewBase));
+}
+
+void webkitWebViewBaseSetFitContentHeight(WebKitWebViewBase* webkitWebViewBase, bool fitContentHeight)
+{
+    WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
+    if (priv->fitContentHeight == fitContentHeight)
+        return;
+
+    priv->fitContentHeight = fitContentHeight;
+    priv->fitContentHeightWidth = 0;
+
+    if (fitContentHeight) {
+        webkitWebViewBaseUpdateFitContentHeightWidth(webkitWebViewBase,
+            webkitWebViewBaseGetViewSize(webkitWebViewBase).width());
+    } else
+        priv->pageProxy->setMinimumSizeForAutoLayout({ });
+
+    gtk_widget_queue_resize(GTK_WIDGET(webkitWebViewBase));
+}
+
+bool webkitWebViewBaseGetFitContentHeight(WebKitWebViewBase* webkitWebViewBase)
+{
+    return webkitWebViewBase->priv->fitContentHeight;
 }
 
 void webkitWebViewBaseResetClickCounter(WebKitWebViewBase* webkitWebViewBase)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -79,6 +79,9 @@ GUniquePtr<GdkEvent> webkitWebViewBaseTakeContextMenuEvent(WebKitWebViewBase*);
 void webkitWebViewBaseSetInputMethodState(WebKitWebViewBase*, std::optional<WebKit::InputMethodState>&&);
 void webkitWebViewBaseUpdateTextInputState(WebKitWebViewBase*);
 void webkitWebViewBaseSetContentsSize(WebKitWebViewBase*, const WebCore::IntSize&);
+void webkitWebViewBaseSetIntrinsicContentSize(WebKitWebViewBase*, const WebCore::IntSize&);
+void webkitWebViewBaseSetFitContentHeight(WebKitWebViewBase*, bool);
+bool webkitWebViewBaseGetFitContentHeight(WebKitWebViewBase*);
 
 void webkitWebViewBaseSetFocus(WebKitWebViewBase*, bool focused);
 void webkitWebViewBaseSetEditable(WebKitWebViewBase*, bool editable);

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -557,12 +557,12 @@ public:
     virtual RetainPtr<NSView> inspectorAttachmentView() = 0;
     virtual _WKRemoteObjectRegistry *remoteObjectRegistry() = 0;
 
-    virtual void intrinsicContentSizeDidChange(const WebCore::IntSize& intrinsicContentSize) = 0;
-
     virtual void registerInsertionUndoGrouping() = 0;
 
     virtual void setFocusedElementInputType(InputType) = 0;
 #endif // PLATFORM(MAC)
+
+    virtual void intrinsicContentSizeDidChange(const WebCore::IntSize&) { }
 
 #if ENABLE(HORIZONTAL_BANNER_VIEW_OVERLAYS)
     virtual void didUpdateTransientZoomStateForScrollPocket(std::optional<TransientZoomState>) { }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6771,6 +6771,19 @@ void WebPageProxy::setAlwaysShowsVerticalScroller(bool alwaysShowsVerticalScroll
     send(Messages::WebPage::SetAlwaysShowsVerticalScroller(alwaysShowsVerticalScroller));
 }
 
+void WebPageProxy::setMainFrameIsScrollable(bool isScrollable)
+{
+    if (isScrollable == m_mainFrameIsScrollable)
+        return;
+
+    m_mainFrameIsScrollable = isScrollable;
+
+    if (!hasRunningProcess())
+        return;
+
+    send(Messages::WebPage::SetMainFrameIsScrollable(isScrollable));
+}
+
 void WebPageProxy::listenForLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
 {
     if (milestones == internals().observedLayoutMilestones)
@@ -11374,10 +11387,8 @@ void WebPageProxy::didChangeContentSize(const IntSize& size)
 
 void WebPageProxy::didChangeIntrinsicContentSize(const IntSize& intrinsicContentSize)
 {
-#if USE(APPKIT)
     if (RefPtr pageClient = this->pageClient())
         pageClient->intrinsicContentSizeDidChange(intrinsicContentSize);
-#endif
 }
 
 #if ENABLE(WEBXR)
@@ -13719,6 +13730,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     }
     parameters.alwaysShowsHorizontalScroller = m_alwaysShowsHorizontalScroller;
     parameters.alwaysShowsVerticalScroller = m_alwaysShowsVerticalScroller;
+    parameters.mainFrameIsScrollable = m_mainFrameIsScrollable;
     parameters.suppressScrollbarAnimations = m_suppressScrollbarAnimations;
     parameters.paginationMode = m_paginationMode;
     parameters.paginationBehavesLikeColumns = m_paginationBehavesLikeColumns;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1338,7 +1338,6 @@ public:
 
 #if PLATFORM(COCOA)
     void windowAndViewFramesChanged(const WebCore::FloatRect& viewFrameInWindowCoordinates, const WebCore::FloatPoint& accessibilityViewCoordinates);
-    void setMainFrameIsScrollable(bool);
     bool shouldDelayWindowOrderingForEvent(const WebMouseEvent&);
     void setRemoteLayerTreeRootNode(RemoteLayerTreeNode*);
 
@@ -1586,6 +1585,8 @@ public:
 
     void setAlwaysShowsHorizontalScroller(bool);
     void setAlwaysShowsVerticalScroller(bool);
+    void setMainFrameIsScrollable(bool);
+    bool mainFrameIsScrollable() const { return m_mainFrameIsScrollable; }
     bool alwaysShowsHorizontalScroller() const { return m_alwaysShowsHorizontalScroller; }
     bool alwaysShowsVerticalScroller() const { return m_alwaysShowsVerticalScroller; }
 
@@ -3925,6 +3926,7 @@ private:
 
     bool m_alwaysShowsHorizontalScroller { false };
     bool m_alwaysShowsVerticalScroller { false };
+    bool m_mainFrameIsScrollable { true };
 
     bool m_suppressScrollbarAnimations { false };
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -247,14 +247,6 @@ void WebPageProxy::updateMouseEventTargetAfterWindowAndViewFramesChanged(const F
     protect(legacyMainFrameProcess())->send(Messages::WebPage::UpdateMouseEventTargetAfterWindowAndViewFramesChanged(webMouseLocationInWindow, webMouseLocationInScreen), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::setMainFrameIsScrollable(bool isScrollable)
-{
-    if (!hasRunningProcess())
-        return;
-
-    protect(legacyMainFrameProcess())->send(Messages::WebPage::SetMainFrameIsScrollable(isScrollable), webPageIDInMainFrameProcess());
-}
-
 void WebPageProxy::attributedSubstringForCharacterRangeAsync(const EditingRange& range, CompletionHandler<void(const WebCore::AttributedString&, const EditingRange&)>&& callbackFunction)
 {
     if (!hasRunningProcess()) {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -673,6 +673,7 @@ void DrawingAreaCoordinatedGraphics::display(UpdateInfo& updateInfo)
         updateInfo.updateRects.append(rect);
     }
 
+    webPage->flushPendingIntrinsicContentSizeUpdate();
     webPage->didUpdateRendering();
 
     // Layout can trigger more calls to setNeedsDisplay and we don't want to process them

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -199,6 +199,7 @@ void LayerTreeHost::updateRendering()
     m_pendingResize = false;
     m_forceFrameSync = false;
 
+    page->flushPendingIntrinsicContentSizeUpdate();
     page->didUpdateRendering();
 
     // Eject any backing stores whose only reference is held in the HashMap cache.

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -202,6 +202,7 @@ void LayerTreeHost::flushLayers()
     m_pendingResize = false;
     m_forceFrameSync = false;
 
+    page->flushPendingIntrinsicContentSizeUpdate();
     page->didUpdateRendering();
 
     // Eject any backing stores whose only reference is held in the HashMap cache.

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
@@ -262,6 +262,7 @@ void NonCompositedFrameRenderer::updateRendering()
     }
 
     m_surface->didRenderFrame();
+    webPage->flushPendingIntrinsicContentSizeUpdate();
     webPage->didUpdateRendering();
 
     if (drawingArea) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -638,6 +638,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #endif
     , m_alwaysShowsHorizontalScroller { parameters.alwaysShowsHorizontalScroller }
     , m_alwaysShowsVerticalScroller { parameters.alwaysShowsVerticalScroller }
+    , m_mainFrameIsScrollable { parameters.mainFrameIsScrollable }
     , m_shouldRenderCanvasInGPUProcess { parameters.shouldRenderCanvasInGPUProcess }
     , m_shouldRenderDOMInGPUProcess { parameters.shouldRenderDOMInGPUProcess }
     , m_shouldPlayMediaInGPUProcess { parameters.shouldPlayMediaInGPUProcess }
@@ -1151,6 +1152,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     setMinimumSizeForAutoLayout(parameters.minimumSizeForAutoLayout);
     setSizeToContentAutoSizeMaximumSize(parameters.sizeToContentAutoSizeMaximumSize);
     setAutoSizingShouldExpandToViewHeight(parameters.autoSizingShouldExpandToViewHeight);
+    setMainFrameIsScrollable(parameters.mainFrameIsScrollable);
     setViewportSizeForCSSViewportUnits(parameters.viewportSizeForCSSViewportUnits);
 
     setScrollPinningBehavior(parameters.scrollPinningBehavior);
@@ -1581,6 +1583,8 @@ void WebPage::reinitializeWebPage(WebPageCreationParameters&& parameters)
 
     setMinimumSizeForAutoLayout(parameters.minimumSizeForAutoLayout);
     setSizeToContentAutoSizeMaximumSize(parameters.sizeToContentAutoSizeMaximumSize);
+    setAutoSizingShouldExpandToViewHeight(parameters.autoSizingShouldExpandToViewHeight);
+    setMainFrameIsScrollable(parameters.mainFrameIsScrollable);
 
     if (m_activityState != parameters.activityState)
         setActivityState(parameters.activityState, ActivityStateChangeAsynchronous, [] { });

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -580,7 +580,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #if PLATFORM(COCOA)
     WindowAndViewFramesChanged(struct WebKit::ViewWindowCoordinates coordinates) -> () Async
     UpdateMouseEventTargetAfterWindowAndViewFramesChanged(WebCore::DoublePoint mousePositionInView, WebCore::DoublePoint currentMouseGlobalPosition)
-    SetMainFrameIsScrollable(bool isScrollable)
     RegisterUIProcessAccessibilityTokens(struct WebCore::AccessibilityRemoteToken elementToken, struct WebCore::AccessibilityRemoteToken windowToken)
     GetStringSelectionForPasteboard() -> (String stringValue) Synchronous
     GetDataSelectionForPasteboard(String pasteboardType) -> (RefPtr<WebCore::SharedBuffer> buffer) Synchronous
@@ -625,6 +624,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ShouldAllowRemoveBackground(struct WebCore::ElementContext context) -> (bool result)
 #endif
 
+    SetMainFrameIsScrollable(bool isScrollable)
     SetAlwaysShowsHorizontalScroller(bool alwaysShowsHorizontalScroller)
     SetAlwaysShowsVerticalScroller(bool alwaysShowsVerticalScroller)
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -244,6 +244,7 @@ void DrawingAreaWC::updateRendering()
 
     OptionSet<FinalizeRenderingUpdateFlags> flags;
     webPage->finalizeRenderingUpdate(flags);
+    webPage->flushPendingIntrinsicContentSizeUpdate();
     webPage->didUpdateRendering();
 
     willStartRenderingUpdateDisplay();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp
@@ -358,6 +358,47 @@ static void testWebViewZoomLevel(WebViewTest* test, gconstpointer)
     g_assert_cmpfloat(webkit_web_view_get_zoom_level(test->webView()), ==, 2.5);
 }
 
+#if PLATFORM(GTK)
+static void testWebViewMainFrameScrollingEnabled(WebViewTest* test, gconstpointer)
+{
+    gboolean mainFrameScrollingEnabled = FALSE;
+    unsigned mainFrameScrollingNotifications = 0;
+
+    g_object_get(test->webView(), "main-frame-scrolling-enabled", &mainFrameScrollingEnabled, nullptr);
+    g_assert_true(mainFrameScrollingEnabled);
+
+    g_signal_connect(test->webView(), "notify::main-frame-scrolling-enabled",
+        G_CALLBACK(+[](WebKitWebView*, GParamSpec*, unsigned* notifications) {
+            ++*notifications;
+        }), &mainFrameScrollingNotifications);
+
+    webkit_web_view_set_main_frame_scrolling_enabled(test->webView(), FALSE);
+    g_assert_false(webkit_web_view_get_main_frame_scrolling_enabled(test->webView()));
+    g_assert_cmpuint(mainFrameScrollingNotifications, ==, 1);
+
+    webkit_web_view_set_main_frame_scrolling_enabled(test->webView(), FALSE);
+    g_assert_cmpuint(mainFrameScrollingNotifications, ==, 1);
+
+    g_object_set(test->webView(), "main-frame-scrolling-enabled", TRUE, nullptr);
+    g_assert_true(webkit_web_view_get_main_frame_scrolling_enabled(test->webView()));
+    g_assert_cmpuint(mainFrameScrollingNotifications, ==, 2);
+
+    webkit_web_view_set_main_frame_scrolling_enabled(test->webView(), FALSE);
+    test->loadHtml("<html><body style='height: 10000px'></body></html>", nullptr);
+    test->waitUntilLoadFinished();
+
+    GUniqueOutPtr<GError> error;
+    JSCValue* value = test->runJavaScriptAndWaitUntilFinished("window.scrollTo(0, 1000); window.scrollY", &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), ==, 0);
+
+    webkit_web_view_set_main_frame_scrolling_enabled(test->webView(), TRUE);
+    value = test->runJavaScriptAndWaitUntilFinished("window.scrollTo(0, 1000); window.scrollY", &error.outPtr());
+    g_assert_no_error(error.get());
+    g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(value), >, 0);
+}
+#endif
+
 static void testWebViewRunAsyncFunctions(WebViewTest* test, gconstpointer)
 {
     GUniqueOutPtr<GError> error;
@@ -2289,6 +2330,9 @@ void beforeAll()
     WebViewTest::add("WebKitWebView", "custom-charset", testWebViewCustomCharset);
     WebViewTest::add("WebKitWebView", "settings", testWebViewSettings);
     WebViewTest::add("WebKitWebView", "zoom-level", testWebViewZoomLevel);
+#if PLATFORM(GTK)
+    WebViewTest::add("WebKitWebView", "main-frame-scrolling-enabled", testWebViewMainFrameScrollingEnabled);
+#endif
     WebViewTest::add("WebKitWebView", "run-javascript", testWebViewRunJavaScript);
     WebViewTest::add("WebKitWebView", "run-async-js-functions", testWebViewRunAsyncFunctions);
 #if ENABLE(FULLSCREEN_API)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp
@@ -359,18 +359,28 @@ static void testWebViewZoomLevel(WebViewTest* test, gconstpointer)
 }
 
 #if PLATFORM(GTK)
-static void testWebViewMainFrameScrollingEnabled(WebViewTest* test, gconstpointer)
+static void testWebViewMainFrameScrollingAndFitContentHeight(WebViewTest* test, gconstpointer)
 {
     gboolean mainFrameScrollingEnabled = FALSE;
+    gboolean fitContentHeight = TRUE;
     unsigned mainFrameScrollingNotifications = 0;
+    unsigned fitContentHeightNotifications = 0;
 
-    g_object_get(test->webView(), "main-frame-scrolling-enabled", &mainFrameScrollingEnabled, nullptr);
+    g_object_get(test->webView(),
+        "main-frame-scrolling-enabled", &mainFrameScrollingEnabled,
+        "fit-content-height", &fitContentHeight,
+        nullptr);
     g_assert_true(mainFrameScrollingEnabled);
+    g_assert_false(fitContentHeight);
 
     g_signal_connect(test->webView(), "notify::main-frame-scrolling-enabled",
         G_CALLBACK(+[](WebKitWebView*, GParamSpec*, unsigned* notifications) {
             ++*notifications;
         }), &mainFrameScrollingNotifications);
+    g_signal_connect(test->webView(), "notify::fit-content-height",
+        G_CALLBACK(+[](WebKitWebView*, GParamSpec*, unsigned* notifications) {
+            ++*notifications;
+        }), &fitContentHeightNotifications);
 
     webkit_web_view_set_main_frame_scrolling_enabled(test->webView(), FALSE);
     g_assert_false(webkit_web_view_get_main_frame_scrolling_enabled(test->webView()));
@@ -382,6 +392,19 @@ static void testWebViewMainFrameScrollingEnabled(WebViewTest* test, gconstpointe
     g_object_set(test->webView(), "main-frame-scrolling-enabled", TRUE, nullptr);
     g_assert_true(webkit_web_view_get_main_frame_scrolling_enabled(test->webView()));
     g_assert_cmpuint(mainFrameScrollingNotifications, ==, 2);
+
+    webkit_web_view_set_fit_content_height(test->webView(), TRUE);
+    g_assert_true(webkit_web_view_get_fit_content_height(test->webView()));
+    g_assert_cmpuint(fitContentHeightNotifications, ==, 1);
+    g_assert_cmpint(gtk_widget_get_request_mode(GTK_WIDGET(test->webView())),
+        ==, GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH);
+
+    webkit_web_view_set_fit_content_height(test->webView(), TRUE);
+    g_assert_cmpuint(fitContentHeightNotifications, ==, 1);
+
+    g_object_set(test->webView(), "fit-content-height", FALSE, nullptr);
+    g_assert_false(webkit_web_view_get_fit_content_height(test->webView()));
+    g_assert_cmpuint(fitContentHeightNotifications, ==, 2);
 
     webkit_web_view_set_main_frame_scrolling_enabled(test->webView(), FALSE);
     test->loadHtml("<html><body style='height: 10000px'></body></html>", nullptr);
@@ -2331,7 +2354,8 @@ void beforeAll()
     WebViewTest::add("WebKitWebView", "settings", testWebViewSettings);
     WebViewTest::add("WebKitWebView", "zoom-level", testWebViewZoomLevel);
 #if PLATFORM(GTK)
-    WebViewTest::add("WebKitWebView", "main-frame-scrolling-enabled", testWebViewMainFrameScrollingEnabled);
+    WebViewTest::add("WebKitWebView", "main-frame-scrolling-and-fit-content-height",
+        testWebViewMainFrameScrollingAndFitContentHeight);
 #endif
     WebViewTest::add("WebKitWebView", "run-javascript", testWebViewRunJavaScript);
     WebViewTest::add("WebKitWebView", "run-async-js-functions", testWebViewRunAsyncFunctions);


### PR DESCRIPTION
#### 6fa4234dcab59521466508f1768b65850b9ff1c0
<pre>
[GTK] Add fit-content-height sizing mode for WebKitWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=317584">https://bugs.webkit.org/show_bug.cgi?id=317584</a>

Add WebKitWebView:fit-content-height and corresponding getter and setter
API for GTK. When enabled, WebKitWebView uses height-for-width measurement
and reports a natural height based on the latest intrinsic content size for
the measured or allocated width.

Store fit-content-height state in WebKitWebViewBase, update fixed-width
autosizing when GTK provides a new width, and queue resizes when the cached
intrinsic content size changes. The implementation keeps measurement
asynchronous and never blocks GTK size negotiation on the WebProcess.

Add API test coverage for property defaults, notify behavior, and request
mode switching to GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH.

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Test: Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp

* .gitignore:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitializeContext):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewSetProperty):
(webkitWebViewGetProperty):
(webkit_web_view_class_init):
(webkit_web_view_set_fit_content_height):
(webkit_web_view_get_fit_content_height):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseUpdateFitContentHeightWidth):
(webkitWebViewBaseNaturalHeight):
(webkitWebViewBaseGetRequestMode):
(webkitWebViewBaseSizeAllocate):
(webkitWebViewBaseMeasure):
(webkitWebViewBaseGetPreferredHeight):
(webkitWebViewBaseGetPreferredHeightForWidth):
(webkit_web_view_base_class_init):
(webkitWebViewBaseSetContentsSize):
(webkitWebViewBaseSetIntrinsicContentSize):
(webkitWebViewBaseSetFitContentHeight):
(webkitWebViewBaseGetFitContentHeight):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp:
(testWebViewMainFrameScrollingAndFitContentHeight):
(beforeAll):
(testWebViewMainFrameScrollingEnabled): Deleted.
</pre>
----------------------------------------------------------------------
#### 7a794d25d651ff9bf20d014030250c4fd9666c69
<pre>
[GTK] Deliver intrinsic content size updates to PageClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=317584">https://bugs.webkit.org/show_bug.cgi?id=317584</a>

Make PageClient::intrinsicContentSizeDidChange() available outside the
Mac-specific PageClient section and implement it for the GTK PageClient.

Flush pending intrinsic content size updates from the coordinated and WC
rendering update paths before didUpdateRendering(), matching the existing
CoreAnimation drawing-area behavior. This lets GTK receive asynchronous
intrinsic size changes after layout updates.

This is infrastructure for GTK height-for-width WebKitWebView sizing.

No new tests as this should be covered by existing tests.

* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::intrinsicContentSizeDidChange):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::intrinsicContentSizeDidChange):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::display):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::updateRendering):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp:
(WebKit::LayerTreeHost::flushLayers):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp:
(WebKit::NonCompositedFrameRenderer::updateRendering):
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::DrawingAreaWC::updateRendering):
</pre>
----------------------------------------------------------------------
#### 3dc7d4cdfd971179ac85850a92090786287516d7
<pre>
[GTK] Add API to disable main-frame scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=317584">https://bugs.webkit.org/show_bug.cgi?id=317584</a>

Add WebKitWebView:main-frame-scrolling-enabled and corresponding getter
and setter API for GTK. The property uses the shared WebPageProxy main-frame
scrollability plumbing to disable main-frame scrolling and hide main-frame
scrollbars without changing page contents.

Add API coverage for the default value, property notifications, redundant
setter calls, and programmatic scroll suppression with window.scrollTo().

This is intended for applications that embed web views inside a larger GTK
scrolling interface, where the outer container owns scrolling.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewSetProperty):
(webkitWebViewGetProperty):
(webkit_web_view_class_init):
(webkit_web_view_get_zoom_level):
(webkit_web_view_set_main_frame_scrolling_enabled):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp:
(testWebViewMainFrameScrollingAndFitContentHeight):
(serverCallback):
(beforeAll):
</pre>
----------------------------------------------------------------------
#### 99060f7c109df106ae1807094d0523a084bcbe0e
<pre>
[WebKit] Make main-frame scrollability state platform-neutral
<a href="https://bugs.webkit.org/show_bug.cgi?id=317584">https://bugs.webkit.org/show_bug.cgi?id=317584</a>

Move SetMainFrameIsScrollable out of the Cocoa-only IPC block and make
WebPageProxy::setMainFrameIsScrollable() shared code. Store the current
main-frame scrollability value on WebPageProxy and include it in
WebPageCreationParameters so newly-created and reinitialized WebPage instances
apply the setting before main-frame view creation.

This preserves the existing Cocoa behavior while allowing non-Cocoa ports to
reuse the same WebCore/WebKit2 scrollability path.

No new tests. This only moves existing plumbing to shared code; port-specific
API coverage should be added separately.

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setMainFrameIsScrollable):
(WebKit::WebPageProxy::didChangeIntrinsicContentSize):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::setMainFrameIsScrollable): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_allowsImmersiveEnvironments):
(WebKit::WebPage::reinitializeWebPage):
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fa4234dcab59521466508f1768b65850b9ff1c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169540 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43462 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36794 "Hash 6fa4234d for PR 67597 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171406 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43891 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43091 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132091 "Found 3 new test failures: fast/history/site-isolation/go-back-then-navigate-subframe.html fast/history/site-isolation/history-back-initial-vs-final-url.html fast/loader/site-isolation/form-state-restore-with-frames.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93025 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172499 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/43891 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/36794 "Hash 6fa4234d for PR 67597 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112594 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/43891 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/43091 "Hash 6fa4234d for PR 67597 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27596 "Built successfully") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/36794 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/43891 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/36794 "Hash 6fa4234d for PR 67597 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181498 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34206 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/43091 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140539 "Found 3 new test failures: fast/history/site-isolation/go-back-then-navigate-subframe.html fast/history/site-isolation/history-back-initial-vs-final-url.html fast/loader/site-isolation/form-state-restore-with-frames.html (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43118 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/36794 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140375 "Found 1 new API test failure: WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/main-frame-scrolling-and-fit-content-height (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43807 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/36794 "Hash 6fa4234d for PR 67597 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108004 "The change is no longer eligible for processing.") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/43807 "Hash 6fa4234d for PR 67597 does not build (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115572 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42317 "Hash 6fa4234d for PR 67597 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/36794 "Hash 6fa4234d for PR 67597 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41710 "Hash 6fa4234d for PR 67597 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41965 "Hash 6fa4234d for PR 67597 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41853 "Hash 6fa4234d for PR 67597 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->