### PR TITLE
[WPE][GTK] Remove incorrect use of G_GNUC_CONST for get_type() functions

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.h
@@ -45,7 +45,7 @@ struct _WebKitVideoSinkClass {
     GstVideoSinkClass parentClass;
 };
 
-GType webkit_video_sink_get_type() G_GNUC_CONST;
+GType webkit_video_sink_get_type();
 
 GstElement* webkitVideoSinkNew();
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
@@ -76,7 +76,7 @@ typedef enum {
 typedef struct _WebKitFeature WebKitFeature;
 
 WEBKIT_API GType
-webkit_feature_get_type          (void) G_GNUC_CONST;
+webkit_feature_get_type          (void);
 
 WEBKIT_API WebKitFeature *
 webkit_feature_ref               (WebKitFeature *feature);

--- a/Source/WebKit/UIProcess/API/glib/WebKitImage.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitImage.h.in
@@ -51,7 +51,7 @@ webkit_image_as_bytes          (WebKitImage *image);
 typedef struct _WebKitImageList WebKitImageList;
 
 WEBKIT_API GType
-webkit_image_list_get_type     (void) G_GNUC_CONST;
+webkit_image_list_get_type     (void);
 
 WEBKIT_API WebKitImageList *
 webkit_image_list_ref          (WebKitImageList *image_list);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMEventTarget.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMEventTarget.h
@@ -54,7 +54,7 @@ struct _WebKitDOMEventTargetIface {
 };
 
 
-WEBKIT_DEPRECATED GType     webkit_dom_event_target_get_type(void) G_GNUC_CONST;
+WEBKIT_DEPRECATED GType     webkit_dom_event_target_get_type(void);
 
 /**
  * webkit_dom_event_target_dispatch_event:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNodeFilter.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNodeFilter.h
@@ -229,7 +229,7 @@ struct _WebKitDOMNodeFilterIface {
 };
 
 
-WEBKIT_DEPRECATED GType webkit_dom_node_filter_get_type(void) G_GNUC_CONST;
+WEBKIT_DEPRECATED GType webkit_dom_node_filter_get_type(void);
 
 /**
  * webkit_dom_node_filter_accept_node:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMXPathNSResolver.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMXPathNSResolver.h
@@ -44,7 +44,7 @@ struct _WebKitDOMXPathNSResolverIface {
 };
 
 
-WEBKIT_DEPRECATED GType webkit_dom_xpath_ns_resolver_get_type(void) G_GNUC_CONST;
+WEBKIT_DEPRECATED GType webkit_dom_xpath_ns_resolver_get_type(void);
 
 /**
  * webkit_dom_xpath_ns_resolver_lookup_namespace_uri:


### PR DESCRIPTION
#### dd7e7858bd9ccd79e5a9770ffbe371fa8afa5bf0
<pre>
[WPE][GTK] Remove incorrect use of G_GNUC_CONST for get_type() functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=317588">https://bugs.webkit.org/show_bug.cgi?id=317588</a>

Reviewed by Carlos Garcia Campos.

GCC has become more aggressive about optimizing away the type
initialization. Let&apos;s get ahead of this.

Canonical link: <a href="https://commits.webkit.org/315601@main">https://commits.webkit.org/315601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bc1d50dc39113f81dd6df5d3dd7d0412931b851

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169543 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178902 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127255 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171409 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132094 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172502 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112597 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181501 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34209 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43121 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37767 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43810 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28824 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108014 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35647 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115575 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42320 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6909 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->