### PR TITLE
[GStreamer] Flickering on looping background videos on the Framework website

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4134,9 +4134,8 @@ void MediaPlayerPrivateGStreamer::flushCurrentBuffer()
     }
 
 #if USE(COORDINATED_GRAPHICS)
-    auto shouldWait = m_videoDecoderPlatform == GstVideoDecoderPlatform::Video4Linux ? CoordinatedPlatformLayerBufferProxy::ShouldWait::Yes : CoordinatedPlatformLayerBufferProxy::ShouldWait::No;
-    GST_DEBUG_OBJECT(pipeline(), "Flushing video sample %s", shouldWait == CoordinatedPlatformLayerBufferProxy::ShouldWait::Yes ? "synchronously" : "");
-    m_contentsBufferProxy->dropCurrentBufferWhilePreservingTexture(shouldWait);
+    GST_DEBUG_OBJECT(pipeline(), "Flushing video sample");
+    m_contentsBufferProxy->dropCurrentBufferWhilePreservingTexture();
 #endif
 }
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -537,8 +537,11 @@ void CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy()
 #if USE(SKIA)
     if (m_skiaTarget) {
         if (auto* buffer = m_skiaTarget->contentsBuffer()) {
-            if (is<CoordinatedPlatformLayerBufferVideo>(*buffer))
-                m_contentsBuffer.pending = downcast<CoordinatedPlatformLayerBufferVideo>(*buffer).copyBuffer();
+            if (is<CoordinatedPlatformLayerBufferVideo>(*buffer)) {
+                auto& videoBuffer = downcast<CoordinatedPlatformLayerBufferVideo>(*buffer);
+                m_contentsBuffer.pending = videoBuffer.copyBuffer();
+                videoBuffer.clearVideoFrame();
+            }
             m_skiaTarget->setContentsBuffer(WTF::move(m_contentsBuffer.pending));
         }
         return;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -293,6 +293,12 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferDMABuf::skiaImage()
 }
 #endif
 
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDMABuf::copyBuffer(OptionSet<TextureMapperFlags> flags) const
+{
+    auto buffer = m_dmabuf.copyRef();
+    return CoordinatedPlatformLayerBufferDMABuf::create(WTF::move(buffer), flags, m_fenceFD.duplicate());
+}
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS) && USE(GBM)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
@@ -42,6 +42,8 @@ public:
     CoordinatedPlatformLayerBufferDMABuf(Ref<DMABufBuffer>&&, OptionSet<TextureMapperFlags>, WTF::UnixFileDescriptor&&);
     virtual ~CoordinatedPlatformLayerBufferDMABuf();
 
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> copyBuffer(OptionSet<TextureMapperFlags>) const;
+
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp
@@ -103,7 +103,7 @@ void CoordinatedPlatformLayerBufferProxy::setDisplayBuffer(std::unique_ptr<Coord
 }
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
-void CoordinatedPlatformLayerBufferProxy::dropCurrentBufferWhilePreservingTexture(ShouldWait shouldWait)
+void CoordinatedPlatformLayerBufferProxy::dropCurrentBufferWhilePreservingTexture()
 {
     RefPtr<RunLoop> compositingRunLoop;
     {
@@ -121,11 +121,6 @@ void CoordinatedPlatformLayerBufferProxy::dropCurrentBufferWhilePreservingTextur
 
         m_layer->replaceCurrentContentsBufferWithCopy();
     };
-
-    if (shouldWait == ShouldWait::No) {
-        compositingRunLoop->dispatch(WTF::move(dropCurrentBuffer));
-        return;
-    }
 
     BinarySemaphore semaphore;
     compositingRunLoop->dispatch([&semaphore, function = WTF::move(dropCurrentBuffer)]() mutable {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.h
@@ -47,8 +47,7 @@ public:
     void setDisplayBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&);
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
-    enum class ShouldWait : bool { No, Yes };
-    void dropCurrentBufferWhilePreservingTexture(ShouldWait);
+    void dropCurrentBufferWhilePreservingTexture();
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -99,6 +99,18 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferRGB::skiaImage()
 }
 #endif
 
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferRGB::copyBuffer(OptionSet<TextureMapperFlags> flags) const
+{
+    auto textureID = this->textureID();
+    if (!textureID)
+        return nullptr;
+
+    auto size = this->size();
+    auto texture = BitmapTexture::create(size);
+    texture->copyFromExternalTexture(textureID, { IntPoint::zero(), size }, { });
+    return CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), flags, nullptr);
+}
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
@@ -42,6 +42,8 @@ public:
 
     unsigned textureID() const { return m_textureID; }
 
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> copyBuffer(OptionSet<TextureMapperFlags>) const;
+
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -51,15 +51,15 @@
 
 namespace WebCore {
 
-std::unique_ptr<CoordinatedPlatformLayerBufferVideo> CoordinatedPlatformLayerBufferVideo::create(Ref<VideoFrameGStreamer>&& frame, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags)
+std::unique_ptr<CoordinatedPlatformLayerBufferVideo> CoordinatedPlatformLayerBufferVideo::create(const Ref<VideoFrameGStreamer>& frame, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags)
 {
     auto size = frame->presentationSize();
-    return makeUnique<CoordinatedPlatformLayerBufferVideo>(WTF::move(frame), WTF::move(size), videoDecoderPlatform, gstGLEnabled, flags);
+    return makeUnique<CoordinatedPlatformLayerBufferVideo>(frame, WTF::move(size), videoDecoderPlatform, gstGLEnabled, flags);
 }
 
-CoordinatedPlatformLayerBufferVideo::CoordinatedPlatformLayerBufferVideo(Ref<VideoFrameGStreamer>&& frame, IntSize&& size, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags)
+CoordinatedPlatformLayerBufferVideo::CoordinatedPlatformLayerBufferVideo(const Ref<VideoFrameGStreamer>& frame, IntSize&& size, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform, bool gstGLEnabled, OptionSet<TextureMapperFlags> flags)
     : CoordinatedPlatformLayerBuffer(Type::Video, WTF::move(size), flags, nullptr)
-    , m_videoFrame(WTF::move(frame))
+    , m_videoFrame(frame.copyRef())
     , m_videoDecoderPlatform(videoDecoderPlatform)
     , m_buffer(createBufferIfNeeded(gstGLEnabled))
 {
@@ -69,22 +69,40 @@ CoordinatedPlatformLayerBufferVideo::~CoordinatedPlatformLayerBufferVideo() = de
 
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::copyBuffer() const
 {
-    if (!m_buffer || !is<CoordinatedPlatformLayerBufferRGB>(*m_buffer))
+    if (!m_buffer)
         return nullptr;
 
-    auto& buffer = downcast<CoordinatedPlatformLayerBufferRGB>(*m_buffer);
-    auto textureID = buffer.textureID();
-    if (!textureID)
-        return nullptr;
+    if (is<CoordinatedPlatformLayerBufferRGB>(*m_buffer)) {
+        auto& buffer = downcast<CoordinatedPlatformLayerBufferRGB>(*m_buffer);
+        return buffer.copyBuffer(m_flags);
+    }
 
-    auto size = buffer.size();
-    auto texture = BitmapTexture::create(size);
-    texture->copyFromExternalTexture(textureID, { IntPoint::zero(), size }, { });
-    return CoordinatedPlatformLayerBufferRGB::create(WTF::move(texture), m_flags, nullptr);
+    if (is<CoordinatedPlatformLayerBufferYUV>(*m_buffer)) {
+        auto& buffer = downcast<CoordinatedPlatformLayerBufferYUV>(*m_buffer);
+        return buffer.copyBuffer(m_flags);
+    }
+
+    if (is<CoordinatedPlatformLayerBufferDMABuf>(*m_buffer)) {
+        auto& buffer = downcast<CoordinatedPlatformLayerBufferDMABuf>(*m_buffer);
+        return buffer.copyBuffer(m_flags);
+    }
+
+    return nullptr;
+}
+
+void CoordinatedPlatformLayerBufferVideo::clearVideoFrame()
+{
+    Locker lock { m_videoFrameLock };
+    m_mappedVideoFrame.reset();
+    m_videoFrame = nullptr;
 }
 
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded(bool gstGLEnabled)
 {
+    Locker lock { m_videoFrameLock };
+    if (!m_videoFrame)
+        return nullptr;
+
     const auto& sample = m_videoFrame->sample();
     auto buffer = gst_sample_get_buffer(sample.get());
     auto memory = gst_buffer_peek_memory(buffer, 0);
@@ -133,6 +151,10 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 #if USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferFromDMABufMemory()
 {
+    assertIsHeld(m_videoFrameLock);
+    if (!m_videoFrame)
+        return nullptr;
+
     auto videoInfo = m_videoFrame->info();
     if (GST_VIDEO_INFO_HAS_ALPHA(&videoInfo))
         m_flags.add({ TextureMapperFlags::ShouldBlend, TextureMapperFlags::ShouldPremultiply });
@@ -179,6 +201,10 @@ static std::optional<CoordinatedPlatformLayerBufferYUV::Format> yuvFormatFromGst
 
 std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferFromGLMemory()
 {
+    assertIsHeld(m_videoFrameLock);
+    if (!m_videoFrame)
+        return nullptr;
+
     const auto& sample = m_videoFrame->sample();
     m_mappedVideoFrame.emplace(GstMappedFrame(sample, static_cast<GstMapFlags>(GST_MAP_READ | GST_MAP_GL)));
     if (!*m_mappedVideoFrame) {
@@ -247,6 +273,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 
 void CoordinatedPlatformLayerBufferVideo::createBufferFromMappedFrameIfNeeded()
 {
+    Locker lock { m_videoFrameLock };
     if (!m_mappedVideoFrame)
         return;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
@@ -36,11 +36,13 @@ using DMABufFormat = std::pair<uint32_t, uint64_t>;
 
 class CoordinatedPlatformLayerBufferVideo final : public CoordinatedPlatformLayerBuffer {
 public:
-    static std::unique_ptr<CoordinatedPlatformLayerBufferVideo> create(Ref<VideoFrameGStreamer>&&, std::optional<GstVideoDecoderPlatform>, bool gstGLEnabled, OptionSet<TextureMapperFlags>);
-    CoordinatedPlatformLayerBufferVideo(Ref<VideoFrameGStreamer>&&, IntSize&&, std::optional<GstVideoDecoderPlatform>, bool gstGLEnabled, OptionSet<TextureMapperFlags>);
+    static std::unique_ptr<CoordinatedPlatformLayerBufferVideo> create(const Ref<VideoFrameGStreamer>&, std::optional<GstVideoDecoderPlatform>, bool gstGLEnabled, OptionSet<TextureMapperFlags>);
+    CoordinatedPlatformLayerBufferVideo(const Ref<VideoFrameGStreamer>&, IntSize&&, std::optional<GstVideoDecoderPlatform>, bool gstGLEnabled, OptionSet<TextureMapperFlags>);
     virtual ~CoordinatedPlatformLayerBufferVideo();
 
     std::unique_ptr<CoordinatedPlatformLayerBuffer> copyBuffer() const;
+
+    void clearVideoFrame();
 
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
@@ -58,8 +60,9 @@ private:
 #endif
     void createBufferFromMappedFrameIfNeeded();
 
-    Ref<VideoFrameGStreamer> m_videoFrame;
-    std::optional<GstMappedFrame> m_mappedVideoFrame;
+    Lock m_videoFrameLock;
+    RefPtr<VideoFrameGStreamer> m_videoFrame WTF_GUARDED_BY_LOCK(m_videoFrameLock);
+    std::optional<GstMappedFrame> m_mappedVideoFrame WTF_GUARDED_BY_LOCK(m_videoFrameLock);
     std::optional<GstVideoDecoderPlatform> m_videoDecoderPlatform;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;
 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
@@ -293,6 +293,15 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferYUV::skiaImage()
 }
 #endif
 
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferYUV::copyBuffer(OptionSet<TextureMapperFlags> flags) const
+{
+    const auto& size = this->size();
+    std::array<unsigned, 4> planes = m_planes;
+    std::array<unsigned, 4> yuvPlane = m_yuvPlane;
+    std::array<unsigned, 4> yuvPlaneOffset = m_yuvPlaneOffset;
+    return CoordinatedPlatformLayerBufferYUV::create(m_format, m_planeCount, WTF::move(planes), WTF::move(yuvPlane), WTF::move(yuvPlaneOffset), m_yuvToRgbColorSpace, m_transferFunction, size, flags, nullptr);
+}
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
@@ -43,6 +43,8 @@ public:
     CoordinatedPlatformLayerBufferYUV(Format, unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     virtual ~CoordinatedPlatformLayerBufferYUV();
 
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> copyBuffer(OptionSet<TextureMapperFlags>) const;
+
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 


### PR DESCRIPTION
#### 440c33af25a257d25bccf412d8865f4520d90b49
<pre>
[GStreamer] Flickering on looping background videos on the Framework website
<a href="https://bugs.webkit.org/show_bug.cgi?id=316619">https://bugs.webkit.org/show_bug.cgi?id=316619</a>

Reviewed by NOBODY (OOPS!).

Seamless video looping isn&apos;t enabled on that website because seeks are attempted on paused
pipelines, hence flushes are done at EOS. White frames were rendered at EOS before seeking back to
zero because the corresponding compositor video buffers were not copied. The proposed solution is to
implement copying for YUV and DMABuf buffer implementations.

As the dropCurrentBufferWhilePreservingTexture logic is now synchronous, there is no need to do
texture copies, because the underlying GstSample and its GstBuffer remain valid until the appsink
video sink has received the FLUSH_STOP event, see also:

<a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/11931">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/11931</a>

Manually verified on frame.work with all DMABuf sink and hw decoders combinations, including those
involving CoordinatedPlatformLayerBufferYUV.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::flushCurrentBuffer):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::replaceCurrentContentsBufferWithCopy):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::CoordinatedPlatformLayerBufferDMABuf::copyBuffer const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.cpp:
(WebCore::CoordinatedPlatformLayerBufferProxy::dropCurrentBufferWhilePreservingTexture):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp:
(WebCore::CoordinatedPlatformLayerBufferRGB::copyBuffer const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::create):
(WebCore::CoordinatedPlatformLayerBufferVideo::CoordinatedPlatformLayerBufferVideo):
(WebCore::CoordinatedPlatformLayerBufferVideo::copyBuffer const):
(WebCore::CoordinatedPlatformLayerBufferVideo::clearVideoFrame):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromDMABufMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromGLMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromMappedFrameIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp:
(WebCore::CoordinatedPlatformLayerBufferYUV::copyBuffer const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/440c33af25a257d25bccf412d8865f4520d90b49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179088 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132274 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93188 "1 flakes 10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172688 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35392 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 12 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34105 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32411 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27785 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144466 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests; 3 api tests failed or timed out; Running compile-webkit-without-change; 2 api tests failed or timed out; Passed API tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181687 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140720 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43307 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43996 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108265 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35819 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115761 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42507 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7145 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41899 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->