### PR TITLE
[css-backgrounds] Two animation tests started failing with STP 246 after 314242@main

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-position-composition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-position-composition-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (-0.25) should be [75px 275px, 75px 275px] assert_equals: expected "75px 275px , 75px 275px " but got "75px 275px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (0) should be [100px 300px, 100px 300px] assert_equals: expected "100px 300px , 100px 300px " but got "100px 300px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (0.25) should be [125px 325px, 125px 325px] assert_equals: expected "125px 325px , 125px 325px " but got "125px 325px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (0.5) should be [150px 350px, 150px 350px] assert_equals: expected "150px 350px , 150px 350px " but got "150px 350px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (0.75) should be [175px 375px, 175px 375px] assert_equals: expected "175px 375px , 175px 375px " but got "175px 375px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (1) should be [200px 400px, 200px 400px] assert_equals: expected "200px 400px , 200px 400px " but got "200px 400px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (1.25) should be [225px 425px, 225px 425px] assert_equals: expected "225px 425px , 225px 425px " but got "225px 425px "
-FAIL Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (-0.25) should be [110% 105%, 110% 105%] assert_equals: expected "110 % 105 % , 110 % 105 % " but got "110 % 105 % "
-FAIL Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (0) should be [100% 100%, 100% 100%] assert_equals: expected "100 % 100 % , 100 % 100 % " but got "100 % 100 % "
-FAIL Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (0.25) should be [90% 95%, 90% 95%] assert_equals: expected "90 % 95 % , 90 % 95 % " but got "90 % 95 % "
-FAIL Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (0.5) should be [80% 90%, 80% 90%] assert_equals: expected "80 % 90 % , 80 % 90 % " but got "80 % 90 % "
-FAIL Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (0.75) should be [70% 85%, 70% 85%] assert_equals: expected "70 % 85 % , 70 % 85 % " but got "70 % 85 % "
-FAIL Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (1) should be [60% 80%, 60% 80%] assert_equals: expected "60 % 80 % , 60 % 80 % " but got "60 % 80 % "
-FAIL Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (1.25) should be [50% 75%, 50% 75%] assert_equals: expected "50 % 75 % , 50 % 75 % " but got "50 % 75 % "
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (-0.25) should be [75px 275px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (0) should be [100px 300px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (0.25) should be [125px 325px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (0.5) should be [150px 350px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (0.75) should be [175px 375px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (1) should be [200px 400px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to add [160px 260px] at (1.25) should be [225px 425px]
+PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (-0.25) should be [110% 105%]
+PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (0) should be [100% 100%]
+PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (0.25) should be [90% 95%]
+PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (0.5) should be [80% 90%]
+PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (0.75) should be [70% 85%]
+PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (1) should be [60% 80%]
+PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%] to add [right 80% bottom 40%] at (1.25) should be [50% 75%]
 PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%, top 180% left 160%] to add [right 80% bottom 40%] at (-0.25) should be [110% 105%, 235% 230%]
 PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%, top 180% left 160%] to add [right 80% bottom 40%] at (0) should be [100% 100%, 200% 200%]
 PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%, top 180% left 160%] to add [right 80% bottom 40%] at (0.25) should be [90% 95%, 165% 170%]
@@ -20,18 +20,18 @@ PASS Compositing: property <background-position> underlying [top 20% left 40%] f
 PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%, top 180% left 160%] to add [right 80% bottom 40%] at (0.75) should be [70% 85%, 95% 110%]
 PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%, top 180% left 160%] to add [right 80% bottom 40%] at (1) should be [60% 80%, 60% 80%]
 PASS Compositing: property <background-position> underlying [top 20% left 40%] from add [left 60% top 80%, top 180% left 160%] to add [right 80% bottom 40%] at (1.25) should be [50% 75%, 25% 50%]
-FAIL Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (-0.25) should be [75px 150px, 75px 150px] assert_equals: expected "75px 150px , 75px 150px " but got "75px 150px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (0) should be [100px 200px, 100px 200px] assert_equals: expected "100px 200px , 100px 200px " but got "100px 200px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (0.25) should be [125px 250px, 125px 250px] assert_equals: expected "125px 250px , 125px 250px " but got "125px 250px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (0.5) should be [150px 300px, 150px 300px] assert_equals: expected "150px 300px , 150px 300px " but got "150px 300px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (0.75) should be [175px 350px, 175px 350px] assert_equals: expected "175px 350px , 175px 350px " but got "175px 350px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (1) should be [200px 400px, 200px 400px] assert_equals: expected "200px 400px , 200px 400px " but got "200px 400px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (1.25) should be [225px 450px, 225px 450px] assert_equals: expected "225px 450px , 225px 450px " but got "225px 450px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (-0.25) should be [75px 275px, 75px 275px] assert_equals: expected "75px 275px , 75px 275px " but got "75px 275px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (0) should be [100px 300px, 100px 300px] assert_equals: expected "100px 300px , 100px 300px " but got "100px 300px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (0.25) should be [125px 325px, 125px 325px] assert_equals: expected "125px 325px , 125px 325px " but got "125px 325px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (0.5) should be [150px 350px, 150px 350px] assert_equals: expected "150px 350px , 150px 350px " but got "150px 350px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (0.75) should be [175px 375px, 175px 375px] assert_equals: expected "175px 375px , 175px 375px " but got "175px 375px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (1) should be [200px 400px, 200px 400px] assert_equals: expected "200px 400px , 200px 400px " but got "200px 400px "
-FAIL Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (1.25) should be [225px 425px, 225px 425px] assert_equals: expected "225px 425px , 225px 425px " but got "225px 425px "
+PASS Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (-0.25) should be [75px 150px]
+PASS Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (0) should be [100px 200px]
+PASS Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (0.25) should be [125px 250px]
+PASS Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (0.5) should be [150px 300px]
+PASS Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (0.75) should be [175px 350px]
+PASS Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (1) should be [200px 400px]
+PASS Compositing: property <background-position> underlying [40px 140px] from replace [100px 200px] to add [160px 260px] at (1.25) should be [225px 450px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (-0.25) should be [75px 275px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (0) should be [100px 300px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (0.25) should be [125px 325px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (0.5) should be [150px 350px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (0.75) should be [175px 375px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (1) should be [200px 400px]
+PASS Compositing: property <background-position> underlying [40px 140px] from add [60px 160px] to replace [200px 400px] at (1.25) should be [225px 425px]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-position-composition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-position-composition.html
@@ -21,13 +21,13 @@ test_composition({
   addFrom: '60px 160px',
   addTo: '160px 260px',
 }, [
-  {at: -0.25, expect: '75px 275px, 75px 275px'},
-  {at: 0, expect: '100px 300px, 100px 300px'},
-  {at: 0.25, expect: '125px 325px, 125px 325px'},
-  {at: 0.5, expect: '150px 350px, 150px 350px'},
-  {at: 0.75, expect: '175px 375px, 175px 375px'},
-  {at: 1, expect: '200px 400px, 200px 400px'},
-  {at: 1.25, expect: '225px 425px, 225px 425px'},
+  {at: -0.25, expect: '75px 275px'},
+  {at: 0, expect: '100px 300px'},
+  {at: 0.25, expect: '125px 325px'},
+  {at: 0.5, expect: '150px 350px'},
+  {at: 0.75, expect: '175px 375px'},
+  {at: 1, expect: '200px 400px'},
+  {at: 1.25, expect: '225px 425px'},
 ]);
 
 test_composition({
@@ -36,13 +36,13 @@ test_composition({
   addFrom: 'left 60% top 80%',
   addTo: 'right 80% bottom 40%',
 }, [
-  {at: -0.25, expect: '110% 105%, 110% 105%'},
-  {at: 0, expect: '100% 100%, 100% 100%'},
-  {at: 0.25, expect: '90% 95%, 90% 95%'},
-  {at: 0.5, expect: '80% 90%, 80% 90%'},
-  {at: 0.75, expect: '70% 85%, 70% 85%'},
-  {at: 1, expect: '60% 80%, 60% 80%'},
-  {at: 1.25, expect: '50% 75%, 50% 75%'},
+  {at: -0.25, expect: '110% 105%'},
+  {at: 0, expect: '100% 100%'},
+  {at: 0.25, expect: '90% 95%'},
+  {at: 0.5, expect: '80% 90%'},
+  {at: 0.75, expect: '70% 85%'},
+  {at: 1, expect: '60% 80%'},
+  {at: 1.25, expect: '50% 75%'},
 ]);
 
 test_composition({
@@ -66,13 +66,13 @@ test_composition({
   replaceFrom: '100px 200px',
   addTo: '160px 260px',
 }, [
-  {at: -0.25, expect: '75px 150px, 75px 150px'},
-  {at: 0, expect: '100px 200px, 100px 200px'},
-  {at: 0.25, expect: '125px 250px, 125px 250px'},
-  {at: 0.5, expect: '150px 300px, 150px 300px'},
-  {at: 0.75, expect: '175px 350px, 175px 350px'},
-  {at: 1, expect: '200px 400px, 200px 400px'},
-  {at: 1.25, expect: '225px 450px, 225px 450px'},
+  {at: -0.25, expect: '75px 150px'},
+  {at: 0, expect: '100px 200px'},
+  {at: 0.25, expect: '125px 250px'},
+  {at: 0.5, expect: '150px 300px'},
+  {at: 0.75, expect: '175px 350px'},
+  {at: 1, expect: '200px 400px'},
+  {at: 1.25, expect: '225px 450px'},
 ]);
 
 test_composition({
@@ -81,13 +81,13 @@ test_composition({
   addFrom: '60px 160px',
   replaceTo: '200px 400px',
 }, [
-  {at: -0.25, expect: '75px 275px, 75px 275px'},
-  {at: 0, expect: '100px 300px, 100px 300px'},
-  {at: 0.25, expect: '125px 325px, 125px 325px'},
-  {at: 0.5, expect: '150px 350px, 150px 350px'},
-  {at: 0.75, expect: '175px 375px, 175px 375px'},
-  {at: 1, expect: '200px 400px, 200px 400px'},
-  {at: 1.25, expect: '225px 425px, 225px 425px'},
+  {at: -0.25, expect: '75px 275px'},
+  {at: 0, expect: '100px 300px'},
+  {at: 0.25, expect: '125px 325px'},
+  {at: 0.5, expect: '150px 350px'},
+  {at: 0.75, expect: '175px 375px'},
+  {at: 1, expect: '200px 400px'},
+  {at: 1.25, expect: '225px 425px'},
 ]);
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-size-composition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-size-composition-expected.txt
@@ -1,39 +1,39 @@
 
-PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px, 260px 260px] to add [160px 160px] at (-0.25) should be [75px 75px, 325px 325px]
+PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px, 260px 260px] to add [160px 160px] at (-0.25) should be [ 75px  75px, 325px 325px]
 PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px, 260px 260px] to add [160px 160px] at (0) should be [100px 100px, 300px 300px]
 PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px, 260px 260px] to add [160px 160px] at (0.25) should be [125px 125px, 275px 275px]
 PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px, 260px 260px] to add [160px 160px] at (0.5) should be [150px 150px, 250px 250px]
 PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px, 260px 260px] to add [160px 160px] at (0.75) should be [175px 175px, 225px 225px]
 PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px, 260px 260px] to add [160px 160px] at (1) should be [200px 200px, 200px 200px]
 PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px, 260px 260px] to add [160px 160px] at (1.25) should be [225px 225px, 175px 175px]
-PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (-0.25) should be [calc(50px + 0%) calc(100px + 30%), 225% 230%]
-PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (0) should be [calc(40px + 20%) calc(80px + 40%), 200% 200%]
-PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (0.25) should be [calc(30px + 40%) calc(60px + 50%), 175% 170%]
-PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (0.5) should be [calc(20px + 60%) calc(40px + 60%), 150% 140%]
-PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (0.75) should be [calc(10px + 80%) calc(20px + 70%), 125% 110%]
-PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (1) should be [100% 80%, 100% 80%]
-PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (1.25) should be [calc(-10px + 120%) calc(-20px + 90%), 75% 50%]
-FAIL Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (-0.25) should be [75px 75px, 75px 75px] assert_equals: expected "75px 75px , 75px 75px " but got "75px 75px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (0) should be [100px 100px, 100px 100px] assert_equals: expected "100px 100px , 100px 100px " but got "100px 100px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (0.25) should be [125px 125px, 125px 125px] assert_equals: expected "125px 125px , 125px 125px " but got "125px 125px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (0.5) should be [150px 150px, 150px 150px] assert_equals: expected "150px 150px , 150px 150px " but got "150px 150px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (0.75) should be [175px 175px, 175px 175px] assert_equals: expected "175px 175px , 175px 175px " but got "175px 175px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (1) should be [200px 200px, 200px 200px] assert_equals: expected "200px 200px , 200px 200px " but got "200px 200px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (1.25) should be [225px 225px, 225px 225px] assert_equals: expected "225px 225px , 225px 225px " but got "225px 225px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (-0.25) should be [75px 75px, 75px 75px] assert_equals: expected "75px 75px , 75px 75px " but got "75px 75px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (0) should be [100px 100px, 100px 100px] assert_equals: expected "100px 100px , 100px 100px " but got "100px 100px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (0.25) should be [125px 125px, 125px 125px] assert_equals: expected "125px 125px , 125px 125px " but got "125px 125px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (0.5) should be [150px 150px, 150px 150px] assert_equals: expected "150px 150px , 150px 150px " but got "150px 150px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (0.75) should be [175px 175px, 175px 175px] assert_equals: expected "175px 175px , 175px 175px " but got "175px 175px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (1) should be [200px 200px, 200px 200px] assert_equals: expected "200px 200px , 200px 200px " but got "200px 200px "
-FAIL Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (1.25) should be [225px 225px, 225px 225px] assert_equals: expected "225px 225px , 225px 225px " but got "225px 225px "
-FAIL Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (-0.25) should be [75px 125px, 75px 125px] assert_equals: expected "75px 125px , 75px 125px " but got "75px 125px "
-FAIL Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (0) should be [100px 150px, 100px 150px] assert_equals: expected "100px 150px , 100px 150px " but got "100px 150px "
-FAIL Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (0.25) should be [125px 175px, 125px 175px] assert_equals: expected "125px 175px , 125px 175px " but got "125px 175px "
-FAIL Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (0.5) should be [150px 200px, 150px 200px] assert_equals: expected "150px 200px , 150px 200px " but got "150px 200px "
-FAIL Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (0.75) should be [175px 225px, 175px 225px] assert_equals: expected "175px 225px , 175px 225px " but got "175px 225px "
-FAIL Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (1) should be [200px 250px, 200px 250px] assert_equals: expected "200px 250px , 200px 250px " but got "200px 250px "
-FAIL Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (1.25) should be [225px 275px, 225px 275px] assert_equals: expected "225px 275px , 225px 275px " but got "225px 275px "
+PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (-0.25) should be [calc( 50px +   0%) calc(100px + 30%), 225% 230%]
+PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (0) should be [calc( 40px +  20%) calc( 80px + 40%), 200% 200%]
+PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (0.25) should be [calc( 30px +  40%) calc( 60px + 50%), 175% 170%]
+PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (0.5) should be [calc( 20px +  60%) calc( 40px + 60%), 150% 140%]
+PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (0.75) should be [calc( 10px +  80%) calc( 20px + 70%), 125% 110%]
+PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (1) should be [             100%               80%,  100%  80%]
+PASS Compositing: property <background-size> underlying [20% 40%] from add [40px 80px, 180% 160%] to add [80% 40%] at (1.25) should be [calc(-10px + 120%) calc(-20px + 90%),  75%  50%]
+PASS Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (-0.25) should be [75px 75px]
+PASS Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (0) should be [100px 100px]
+PASS Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (0.25) should be [125px 125px]
+PASS Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (0.5) should be [150px 150px]
+PASS Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (0.75) should be [175px 175px]
+PASS Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (1) should be [200px 200px]
+PASS Compositing: property <background-size> underlying [40px 40px] from replace [100px 100px] to add [160px 160px] at (1.25) should be [225px 225px]
+PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (-0.25) should be [75px 75px]
+PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (0) should be [100px 100px]
+PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (0.25) should be [125px 125px]
+PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (0.5) should be [150px 150px]
+PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (0.75) should be [175px 175px]
+PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (1) should be [200px 200px]
+PASS Compositing: property <background-size> underlying [40px 40px] from add [60px 60px] to replace [200px 200px] at (1.25) should be [225px 225px]
+PASS Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (-0.25) should be [75px 125px]
+PASS Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (0) should be [100px 150px]
+PASS Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (0.25) should be [125px 175px]
+PASS Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (0.5) should be [150px 200px]
+PASS Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (0.75) should be [175px 225px]
+PASS Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (1) should be [200px 250px]
+PASS Compositing: property <background-size> underlying [auto, contain] from add [100px 150px] to replace [200px 250px] at (1.25) should be [225px 275px]
 PASS Compositing: property <background-size> underlying [auto 100px, contain] from add [[object Object]] to replace [auto 200px, contain] at (-0.25) should be [auto 75px, contain]
 PASS Compositing: property <background-size> underlying [auto 100px, contain] from add [[object Object]] to replace [auto 200px, contain] at (0) should be [auto 100px, contain]
 PASS Compositing: property <background-size> underlying [auto 100px, contain] from add [[object Object]] to replace [auto 200px, contain] at (0.25) should be [auto 125px, contain]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-size-composition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-size-composition.html
@@ -14,32 +14,32 @@
 <script>
 test_composition({
   property: 'background-size',
-  underlying: '40px 40px',
+  underlying: '40px 40px',              // intepreted as [  40px  40px,  40px  40px] via repetition
   addFrom: '60px 60px, 260px 260px',
-  addTo: '160px 160px',
+  addTo: '160px 160px',                 // intepreted as [ 160px 160px, 160px 160px] via repetition
 }, [
-  {at: -0.25, expect: '75px 75px, 325px 325px'},
-  {at: 0, expect: '100px 100px, 300px 300px'},
-  {at: 0.25, expect: '125px 125px, 275px 275px'},
-  {at: 0.5, expect: '150px 150px, 250px 250px'},
-  {at: 0.75, expect: '175px 175px, 225px 225px'},
-  {at: 1, expect: '200px 200px, 200px 200px'},
-  {at: 1.25, expect: '225px 225px, 175px 175px'},
+  {at: -0.25, expect: ' 75px  75px, 325px 325px'},
+  {at: 0, expect:     '100px 100px, 300px 300px'},
+  {at: 0.25, expect:  '125px 125px, 275px 275px'},
+  {at: 0.5, expect:   '150px 150px, 250px 250px'},
+  {at: 0.75, expect:  '175px 175px, 225px 225px'},
+  {at: 1, expect:     '200px 200px, 200px 200px'},
+  {at: 1.25, expect:  '225px 225px, 175px 175px'},
 ]);
 
 test_composition({
   property: 'background-size',
-  underlying: '20% 40%',
+  underlying: '20% 40%',            // intepreted as [ 20% 40%, 20% 40%] via repetition
   addFrom: '40px 80px, 180% 160%',
-  addTo: '80% 40%',
+  addTo: '80% 40%',                 // intepreted as [ 80% 40%, 80% 40%] via repetition
 }, [
-  {at: -0.25, expect: 'calc(50px + 0%) calc(100px + 30%), 225% 230%'},
-  {at: 0, expect: 'calc(40px + 20%) calc(80px + 40%), 200% 200%'},
-  {at: 0.25, expect: 'calc(30px + 40%) calc(60px + 50%), 175% 170%'},
-  {at: 0.5, expect: 'calc(20px + 60%) calc(40px + 60%), 150% 140%'},
-  {at: 0.75, expect: 'calc(10px + 80%) calc(20px + 70%), 125% 110%'},
-  {at: 1, expect: '100% 80%, 100% 80%'},
-  {at: 1.25, expect: 'calc(-10px + 120%) calc(-20px + 90%), 75% 50%'},
+  {at: -0.25, expect: 'calc( 50px +   0%) calc(100px + 30%), 225% 230%'},
+  {at: 0, expect:     'calc( 40px +  20%) calc( 80px + 40%), 200% 200%'},
+  {at: 0.25, expect:  'calc( 30px +  40%) calc( 60px + 50%), 175% 170%'},
+  {at: 0.5, expect:   'calc( 20px +  60%) calc( 40px + 60%), 150% 140%'},
+  {at: 0.75, expect:  'calc( 10px +  80%) calc( 20px + 70%), 125% 110%'},
+  {at: 1, expect:     '             100%               80%,  100%  80%'},
+  {at: 1.25, expect:  'calc(-10px + 120%) calc(-20px + 90%),  75%  50%'},
 ]);
 
 test_composition({
@@ -48,13 +48,13 @@ test_composition({
   replaceFrom: '100px 100px',
   addTo: '160px 160px',
 }, [
-  {at: -0.25, expect: '75px 75px, 75px 75px'},
-  {at: 0, expect: '100px 100px, 100px 100px'},
-  {at: 0.25, expect: '125px 125px, 125px 125px'},
-  {at: 0.5, expect: '150px 150px, 150px 150px'},
-  {at: 0.75, expect: '175px 175px, 175px 175px'},
-  {at: 1, expect: '200px 200px, 200px 200px'},
-  {at: 1.25, expect: '225px 225px, 225px 225px'},
+  {at: -0.25, expect: '75px 75px'},
+  {at: 0, expect: '100px 100px'},
+  {at: 0.25, expect: '125px 125px'},
+  {at: 0.5, expect: '150px 150px'},
+  {at: 0.75, expect: '175px 175px'},
+  {at: 1, expect: '200px 200px'},
+  {at: 1.25, expect: '225px 225px'},
 ]);
 
 test_composition({
@@ -63,13 +63,13 @@ test_composition({
   addFrom: '60px 60px',
   replaceTo: '200px 200px',
 }, [
-  {at: -0.25, expect: '75px 75px, 75px 75px'},
-  {at: 0, expect: '100px 100px, 100px 100px'},
-  {at: 0.25, expect: '125px 125px, 125px 125px'},
-  {at: 0.5, expect: '150px 150px, 150px 150px'},
-  {at: 0.75, expect: '175px 175px, 175px 175px'},
-  {at: 1, expect: '200px 200px, 200px 200px'},
-  {at: 1.25, expect: '225px 225px, 225px 225px'},
+  {at: -0.25, expect: '75px 75px'},
+  {at: 0, expect: '100px 100px'},
+  {at: 0.25, expect: '125px 125px'},
+  {at: 0.5, expect: '150px 150px'},
+  {at: 0.75, expect: '175px 175px'},
+  {at: 1, expect: '200px 200px'},
+  {at: 1.25, expect: '225px 225px'},
 ]);
 
 test_composition({
@@ -78,13 +78,13 @@ test_composition({
   addFrom: '100px 150px',
   replaceTo: '200px 250px',
 }, [
-  {at: -0.25, expect: '75px 125px, 75px 125px'},
-  {at: 0, expect: '100px 150px, 100px 150px'},
-  {at: 0.25, expect: '125px 175px, 125px 175px'},
-  {at: 0.5, expect: '150px 200px, 150px 200px'},
-  {at: 0.75, expect: '175px 225px, 175px 225px'},
-  {at: 1, expect: '200px 250px, 200px 250px'},
-  {at: 1.25, expect: '225px 275px, 225px 275px'},
+  {at: -0.25, expect: '75px 125px'},
+  {at: 0, expect: '100px 150px'},
+  {at: 0.25, expect: '125px 175px'},
+  {at: 0.5, expect: '150px 200px'},
+  {at: 0.75, expect: '175px 225px'},
+  {at: 1, expect: '200px 250px'},
+  {at: 1.25, expect: '225px 275px'},
 ]);
 
 test_composition({


### PR DESCRIPTION
#### 6d161b817f6ea269ee9be8b1145b3d7f8558dee7
<pre>
[css-backgrounds] Two animation tests started failing with STP 246 after 314242@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=317415">https://bugs.webkit.org/show_bug.cgi?id=317415</a>

Reviewed by Tim Nguyen.

Updates WPT tests to expect the standard serialization for coordinated value lists
as implemented in 314242@main.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-position-composition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-position-composition.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-size-composition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-size-composition.html:

Canonical link: <a href="https://commits.webkit.org/315675@main">https://commits.webkit.org/315675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ac05fd4ccb73500c4f1a4b3ade19a0d798d750a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127269 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132106 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93041 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172516 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35079 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112609 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32244 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144183 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181515 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140555 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43135 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151932 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140391 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37844 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43824 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28841 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108032 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35662 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42334 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6926 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->