### PR TITLE
[Site Isolation] Expand Page.getResourceTree cross-origin test coverage

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/frame-id-consistency-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/frame-id-consistency-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Test that a cross-origin (process-swapped) frame's protocol id is consistent across the Page and Network domains under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.FrameIdConsistency
+-- Running test case: SiteIsolation.Page.FrameIdConsistency.PageAndNetworkAgree
+PASS: Cross-origin child frame should appear in the resource tree.
+PASS: Child frame id should be hosting-process-qualified (frame-<processID>.<frameID>).
+PASS: Page-domain child frame id should resolve to a frame in WI.networkManager.
+PASS: Resolved frame's url should match the cross-origin child's url.
+PASS: There should be exactly one frame for the child's url (Page and Network must not disagree on its id).
+PASS: Cross-origin child's stylesheet subresource should be tracked by the Network domain on that frame.
+PASS: Network-tracked subresource's parent frame should be the same frame the Page domain identified (consistent frame id across domains).
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/frame-id-consistency-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/frame-id-consistency-cross-origin-iframe.html
@@ -1,0 +1,89 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame-with-subresource.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.FrameIdConsistency");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.FrameIdConsistency.PageAndNetworkAgree",
+        description: "A cross-origin frame loads provisionally in a new process and commits (a process swap). Its protocol frame id is hosting-process-qualified (frame-<processID>.<frameID>), and both the Page domain (getResourceTree / frameNavigated) and the Network domain (requestWillBeSent) must compute the same id for it, so a network-tracked subresource attaches to the same frame the resource tree reports. This is the bug-310164 invariant. See webkit.org/b/310164.",
+        async test() {
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+            let frameTarget = (await targetAddedPromise).data.target;
+
+            // Drive/await the cross-origin child's commit, then poll getResourceTree (Page domain)
+            // until the child reports its committed url. Record the Page-domain frame id.
+            let frameTree;
+            let child;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                if (!frameTarget.executionContext) {
+                    await Promise.race([
+                        frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                        new Promise((resolve) => setTimeout(resolve, 100)),
+                    ]);
+                }
+                ({ frameTree } = await WI.backendTarget.PageAgent.getResourceTree());
+                child = frameTree.childFrames?.[0];
+                if (child && child.frame.url.endsWith("/resource-tree-frame-with-subresource.html"))
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+
+            InspectorTest.expectThat(!!child, "Cross-origin child frame should appear in the resource tree.");
+            if (!child)
+                return;
+
+            let pageChildId = child.frame.id;
+            InspectorTest.expectThat(/^frame-\d+\.\d+$/.test(pageChildId), "Child frame id should be hosting-process-qualified (frame-<processID>.<frameID>).");
+
+            // The Page-domain id must resolve to a frame in the frontend model (which is fed by the
+            // live Page.frameNavigated and Network.requestWillBeSent events), and that frame must be
+            // the unique entry for the child's url -- a Page/Network id mismatch would split it into
+            // two entries or orphan the resource.
+            let childFrame = WI.networkManager.frameForIdentifier(pageChildId);
+            InspectorTest.expectThat(!!childFrame, "Page-domain child frame id should resolve to a frame in WI.networkManager.");
+            if (!childFrame)
+                return;
+
+            InspectorTest.expectThat(childFrame.url.endsWith("/resource-tree-frame-with-subresource.html"), "Resolved frame's url should match the cross-origin child's url.");
+            let framesWithChildURL = WI.networkManager.frames.filter((frame) => frame.url && frame.url.endsWith("/resource-tree-frame-with-subresource.html"));
+            InspectorTest.expectEqual(framesWithChildURL.length, 1, "There should be exactly one frame for the child's url (Page and Network must not disagree on its id).");
+
+            // The stylesheet subresource is tracked by the Network domain (requestWillBeSent carries
+            // a hosting-process-qualified frameId). Poll until it is attached, then confirm it landed
+            // on the same frame the Page domain identified -- i.e. both domains agree on the id.
+            let cssResource = null;
+            for (let attempt = 0; attempt < 50; ++attempt) {
+                for (let resource of childFrame.resourceCollection) {
+                    if (resource.url.endsWith("/resource-tree-subframe-style.css")) {
+                        cssResource = resource;
+                        break;
+                    }
+                }
+                if (cssResource)
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+
+            InspectorTest.expectThat(!!cssResource, "Cross-origin child's stylesheet subresource should be tracked by the Network domain on that frame.");
+            if (cssResource)
+                InspectorTest.expectThat(cssResource.parentFrame === childFrame, "Network-tracked subresource's parent frame should be the same frame the Page domain identified (consistent frame id across domains).");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that a cross-origin (process-swapped) frame's protocol id is consistent across the Page and Network domains under site isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-nested-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-nested-cross-origin-iframe-expected.txt
@@ -1,0 +1,24 @@
+Test that Page.getResourceTree recurses through a nested cross-origin grandchild under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.GetResourceTreeNestedGrandchild
+-- Running test case: SiteIsolation.Page.GetResourceTreeNestedGrandchild.MainChildGrandchild
+PASS: Main frame should have a non-empty id.
+PASS: Main frame should have no parentId.
+PASS: Main frame should have exactly one child frame.
+PASS: Child frame should have a non-empty id.
+PASS: Child frame's parentId should match the main frame's id.
+PASS: Child frame's name attribute should be reported.
+PASS: Child frame URL should point at the grandchild-hosting document.
+PASS: Child frame should be cross-origin to the main frame.
+PASS: Child frame should have exactly one grandchild frame.
+PASS: Grandchild frame should have a non-empty id.
+PASS: Grandchild frame's parentId should match the child frame's id.
+PASS: Grandchild frame's name attribute should be reported.
+PASS: Grandchild frame URL should point at the leaf document.
+PASS: Grandchild frame should share the main frame's (flipped-back) security origin.
+PASS: Grandchild frame id should differ from the main frame id despite the shared origin.
+PASS: Grandchild frame id should differ from the child frame id.
+PASS: Child frame's cached stylesheet subresource should be reported.
+PASS: Grandchild frame's cached stylesheet subresource should be reported.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-nested-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-nested-cross-origin-iframe.html
@@ -1,0 +1,89 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIFrame() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "child-frame";
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame-with-grandchild.html`;
+    document.body.appendChild(iframe);
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.GetResourceTreeNestedGrandchild");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.GetResourceTreeNestedGrandchild.MainChildGrandchild",
+        description: "getResourceTree should recurse main(A) -> child(B) -> grandchild(A), reporting distinct ids (the grandchild lands back on the main frame's host, the exact frame-id collision topology) and aggregating each frame's resources three processes deep.",
+        async test() {
+            // Track every frame target as it is added so we can drive each one's execution
+            // context (created right after commit). Nested cross-origin frames commit with
+            // CommitTiming::WaitForLoad in their own processes; their committed url/origin and
+            // resources only reach the proxy after commit, so poll getResourceTree until the
+            // grandchild's committed url appears.
+            let frameTargets = [];
+            WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, (event) => {
+                frameTargets.push(event.data.target);
+            });
+
+            InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+
+            let frameTree;
+            let child;
+            let grandchild;
+            for (let attempt = 0; attempt < 100; ++attempt) {
+                for (let frameTarget of frameTargets) {
+                    if (!frameTarget.executionContext) {
+                        await Promise.race([
+                            frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                            new Promise((resolve) => setTimeout(resolve, 50)),
+                        ]);
+                    }
+                }
+                ({ frameTree } = await WI.backendTarget.PageAgent.getResourceTree());
+                child = frameTree.childFrames?.[0];
+                grandchild = child?.childFrames?.[0];
+                if (grandchild && grandchild.frame.url.endsWith("/resource-tree-frame-with-subresource.html"))
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+
+            InspectorTest.expectThat(!!frameTree.frame.id, "Main frame should have a non-empty id.");
+            InspectorTest.expectEqual(frameTree.frame.parentId, undefined, "Main frame should have no parentId.");
+
+            InspectorTest.expectEqual(frameTree.childFrames?.length, 1, "Main frame should have exactly one child frame.");
+            InspectorTest.expectThat(!!child.frame.id, "Child frame should have a non-empty id.");
+            InspectorTest.expectEqual(child.frame.parentId, frameTree.frame.id, "Child frame's parentId should match the main frame's id.");
+            InspectorTest.expectEqual(child.frame.name, "child-frame", "Child frame's name attribute should be reported.");
+            InspectorTest.expectThat(child.frame.url.endsWith("/resource-tree-frame-with-grandchild.html"), "Child frame URL should point at the grandchild-hosting document.");
+            InspectorTest.expectThat(child.frame.securityOrigin !== frameTree.frame.securityOrigin, "Child frame should be cross-origin to the main frame.");
+
+            InspectorTest.expectEqual(child.childFrames?.length, 1, "Child frame should have exactly one grandchild frame.");
+            InspectorTest.expectThat(!!grandchild.frame.id, "Grandchild frame should have a non-empty id.");
+            InspectorTest.expectEqual(grandchild.frame.parentId, child.frame.id, "Grandchild frame's parentId should match the child frame's id.");
+            InspectorTest.expectEqual(grandchild.frame.name, "grandchild-frame", "Grandchild frame's name attribute should be reported.");
+            InspectorTest.expectThat(grandchild.frame.url.endsWith("/resource-tree-frame-with-subresource.html"), "Grandchild frame URL should point at the leaf document.");
+
+            // The grandchild flips back to the main frame's host, so it shares the main frame's
+            // security origin while living in a different (re-used) process. The frame ids must
+            // still be distinct -- this is the main(A)/grandchild(A) collision the id scheme fixes.
+            InspectorTest.expectEqual(grandchild.frame.securityOrigin, frameTree.frame.securityOrigin, "Grandchild frame should share the main frame's (flipped-back) security origin.");
+            InspectorTest.expectThat(grandchild.frame.id !== frameTree.frame.id, "Grandchild frame id should differ from the main frame id despite the shared origin.");
+            InspectorTest.expectThat(grandchild.frame.id !== child.frame.id, "Grandchild frame id should differ from the child frame id.");
+
+            // Resources should aggregate three processes deep: the child (host B) and the
+            // grandchild (host A) each load the stylesheet subresource.
+            let childStyle = (child.resources || []).find((resource) => resource.url.endsWith("/resource-tree-subframe-style.css"));
+            InspectorTest.expectThat(!!childStyle, "Child frame's cached stylesheet subresource should be reported.");
+            let grandchildStyle = (grandchild.resources || []).find((resource) => resource.url.endsWith("/resource-tree-subframe-style.css"));
+            InspectorTest.expectThat(!!grandchildStyle, "Grandchild frame's cached stylesheet subresource should be reported.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that Page.getResourceTree recurses through a nested cross-origin grandchild under site isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-sibling-cross-origin-iframes-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-sibling-cross-origin-iframes-expected.txt
@@ -1,0 +1,19 @@
+Test that Page.getResourceTree reports mixed cross-origin and same-origin siblings under site isolation.
+
+
+== Running test suite: SiteIsolation.Page.GetResourceTreeSiblings
+-- Running test case: SiteIsolation.Page.GetResourceTreeSiblings.MixedOriginSiblings
+PASS: Main frame should have exactly three child frames.
+PASS: First cross-origin sibling should appear in the tree.
+PASS: Second cross-origin sibling should appear in the tree.
+PASS: Same-origin sibling should appear in the tree.
+PASS: Main frame and all three siblings should have distinct ids.
+PASS: First cross-origin sibling's parentId should match the main frame's id.
+PASS: Second cross-origin sibling's parentId should match the main frame's id.
+PASS: Same-origin sibling's parentId should match the main frame's id.
+PASS: First cross-origin sibling should be cross-origin to the main frame.
+PASS: Second cross-origin sibling should be cross-origin to the main frame.
+PASS: Same-origin sibling should share the main frame's security origin.
+PASS: Second cross-origin sibling's stylesheet subresource should be reported on that frame.
+PASS: First cross-origin sibling should not report the other sibling's stylesheet.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-sibling-cross-origin-iframes.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resource-tree-sibling-cross-origin-iframes.html
@@ -1,0 +1,107 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addFrames() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let sameOriginHost = location.hostname;
+
+    function add(name, host, doc) {
+        let iframe = document.createElement("iframe");
+        iframe.name = name;
+        iframe.src = `http://${host}:8000/site-isolation/inspector/page/resources/${doc}`;
+        document.body.appendChild(iframe);
+    }
+
+    // Two cross-origin siblings (one with a subresource) plus one same-origin sibling, all
+    // under the main frame, to exercise sibling linkage, distinct ids, and per-frame resource
+    // attribution in a mixed tree.
+    add("cross-sibling-1", crossOriginHost, "resource-tree-frame.html");
+    add("cross-sibling-2", crossOriginHost, "resource-tree-frame-with-subresource.html");
+    add("same-origin-sibling", sameOriginHost, "resource-tree-frame.html");
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.GetResourceTreeSiblings");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.GetResourceTreeSiblings.MixedOriginSiblings",
+        description: "getResourceTree should report multiple cross-origin siblings plus a same-origin sibling under one main frame, each with correct parent linkage, distinct ids, and resources attributed to the right frame.",
+        async test() {
+            let frameTargets = [];
+            WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, (event) => {
+                frameTargets.push(event.data.target);
+            });
+
+            InspectorTest.evaluateInPage("addFrames()");
+
+            // childFrames order is not guaranteed; index siblings by name. Poll until all three
+            // siblings are present and both cross-origin children have committed (their url and,
+            // for cross-sibling-2, its cached stylesheet have arrived via Page.frameNavigated).
+            let frameTree;
+            let subframesByName;
+            for (let attempt = 0; attempt < 100; ++attempt) {
+                for (let frameTarget of frameTargets) {
+                    if (!frameTarget.executionContext) {
+                        await Promise.race([
+                            frameTarget.awaitEvent(WI.FrameTarget.Event.ExecutionContextAdded),
+                            new Promise((resolve) => setTimeout(resolve, 50)),
+                        ]);
+                    }
+                }
+                ({ frameTree } = await WI.backendTarget.PageAgent.getResourceTree());
+                subframesByName = new Map((frameTree.childFrames || []).map((entry) => [entry.frame.name, entry]));
+                let crossSibling2 = subframesByName.get("cross-sibling-2");
+                let ready = subframesByName.size === 3
+                    && subframesByName.get("cross-sibling-1")?.frame.url.endsWith("/resource-tree-frame.html")
+                    && crossSibling2?.frame.url.endsWith("/resource-tree-frame-with-subresource.html")
+                    && (crossSibling2?.resources || []).some((resource) => resource.url.endsWith("/resource-tree-subframe-style.css"));
+                if (ready)
+                    break;
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+
+            InspectorTest.expectEqual(frameTree.childFrames?.length, 3, "Main frame should have exactly three child frames.");
+
+            let crossSibling1 = subframesByName.get("cross-sibling-1");
+            let crossSibling2 = subframesByName.get("cross-sibling-2");
+            let sameOriginSibling = subframesByName.get("same-origin-sibling");
+
+            InspectorTest.expectThat(!!crossSibling1, "First cross-origin sibling should appear in the tree.");
+            InspectorTest.expectThat(!!crossSibling2, "Second cross-origin sibling should appear in the tree.");
+            InspectorTest.expectThat(!!sameOriginSibling, "Same-origin sibling should appear in the tree.");
+            if (!crossSibling1 || !crossSibling2 || !sameOriginSibling)
+                return;
+
+            // Each sibling links to the main frame and has an id distinct from the main frame and
+            // from every other sibling.
+            let ids = [frameTree.frame.id, crossSibling1.frame.id, crossSibling2.frame.id, sameOriginSibling.frame.id];
+            InspectorTest.expectEqual(new Set(ids).size, 4, "Main frame and all three siblings should have distinct ids.");
+
+            let siblings = [
+                { label: "First cross-origin", entry: crossSibling1 },
+                { label: "Second cross-origin", entry: crossSibling2 },
+                { label: "Same-origin", entry: sameOriginSibling },
+            ];
+            for (let { label, entry } of siblings)
+                InspectorTest.expectEqual(entry.frame.parentId, frameTree.frame.id, `${label} sibling's parentId should match the main frame's id.`);
+
+            InspectorTest.expectThat(crossSibling1.frame.securityOrigin !== frameTree.frame.securityOrigin, "First cross-origin sibling should be cross-origin to the main frame.");
+            InspectorTest.expectThat(crossSibling2.frame.securityOrigin !== frameTree.frame.securityOrigin, "Second cross-origin sibling should be cross-origin to the main frame.");
+            InspectorTest.expectEqual(sameOriginSibling.frame.securityOrigin, frameTree.frame.securityOrigin, "Same-origin sibling should share the main frame's security origin.");
+
+            // Resources must be attributed to the correct frame: only cross-sibling-2 loads the
+            // stylesheet.
+            let sibling2HasStyle = (crossSibling2.resources || []).some((resource) => resource.url.endsWith("/resource-tree-subframe-style.css"));
+            InspectorTest.expectThat(sibling2HasStyle, "Second cross-origin sibling's stylesheet subresource should be reported on that frame.");
+            let sibling1HasStyle = (crossSibling1.resources || []).some((resource) => resource.url.endsWith("/resource-tree-subframe-style.css"));
+            InspectorTest.expectThat(!sibling1HasStyle, "First cross-origin sibling should not report the other sibling's stylesheet.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that Page.getResourceTree reports mixed cross-origin and same-origin siblings under site isolation.</p>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-tree-frame-with-grandchild.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/resources/resource-tree-frame-with-grandchild.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <title>Cross-origin frame with grandchild</title>
-<p>Cross-origin child that embeds a grandchild back on the original host.</p>
+<link rel="stylesheet" href="resource-tree-subframe-style.css">
+<p>Cross-origin frame that nests a grandchild iframe back on the original host.</p>
 <script>
-// This page is loaded on the cross-origin host (B). Embed a grandchild iframe
-// back on the original host (A) so the grandchild shares the main frame's
-// process -- the main(A) -> child(B) -> grandchild(A) collision topology.
-let grandchildHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+// Flip the host again so the grandchild lands back on the main frame's origin
+// (only localhost/127.0.0.1 are available). This reproduces the main(A) -> child(B)
+// -> grandchild(A) topology that exercises the frame-id collision fix.
+let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
 let iframe = document.createElement("iframe");
 iframe.name = "grandchild-frame";
-iframe.src = `http://${grandchildHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame.html`;
+iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/page/resources/resource-tree-frame-with-subresource.html`;
 document.body.appendChild(iframe);
 </script>


### PR DESCRIPTION
<pre>
[Site Isolation] Expand Page.getResourceTree cross-origin test coverage
https://bugs.webkit.org/show_bug.cgi?id=316669
rdar://179117653

Reviewed by NOBODY (OOPS!).

Three new LayoutTests, each guarding a specific landed mechanism:

- resource-tree-nested-cross-origin-iframe.html: main(A) -> child(B) ->
  grandchild(A). The grandchild flips back to the main frame's host, sharing its
  security origin while living in a different process -- the exact id-collision
  topology the hosting-process-qualified frame ids fix (bug 310164). Asserts
  distinct ids, parent linkage, names, urls, and that resources aggregate three
  processes deep.

- resource-tree-sibling-cross-origin-iframes.html: two cross-origin siblings plus a same-origin sibling under one main frame. Asserts correct parent linkage, distinct ids, and per-frame resource attribution in a mixed tree.

- frame-id-consistency-cross-origin-iframe.html: a cross-origin (process-swapped) frame's protocol id is hosting-process-qualified and identical across the Page domain (getResourceTree) and the Network domain (a network-tracked subresource attaches to the same frame). The bug-310164 cross-domain invariant.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7fb7998b8ccbebe2e93c7b13fd1b9d0fa806efa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127310 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd2d0363-f23d-46dc-9b1f-baf7a11ac54b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132147 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93075 "1 flakes 9 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/377e8b44-326c-4843-8584-b9417d231d23) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112650 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9df6612-c74f-4b84-a5b9-8efe3d0cf5b1) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34311 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/sandbox/meta-element.sub.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32284 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27654 "Built successfully") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144448 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; 3 api tests failed or timed out; 2 api tests failed or timed out; Compiled WebKit (warnings); 3 api tests failed or timed out; Running analyze-api-tests-results") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181556 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140596 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43176 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151973 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140432 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43865 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108086 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35699 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42375 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6967 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41768 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42023 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41911 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->