### PR TITLE
[CMake] Build Fix Undefined symbol bssl::CloseFD when linking WebCore

### DIFF
--- a/Source/ThirdParty/libwebrtc/WebRTCPrefix.h
+++ b/Source/ThirdParty/libwebrtc/WebRTCPrefix.h
@@ -118,7 +118,6 @@
 #include "third_party/boringssl/src/pki/cert_errors.h"
 #include "third_party/boringssl/src/pki/parser.h"
 #include "third_party/boringssl/src/ssl/internal.h"
-#include "third_party/boringssl/src/tool/internal.h"
 #include "vpx/vpx_codec.h"
 
 #endif


### PR DESCRIPTION
#### 5bccdc64b07a02222366484ee0b702e44caa75f3
<pre>
[CMake] Build Fix Undefined symbol bssl::CloseFD when linking WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=317590">https://bugs.webkit.org/show_bug.cgi?id=317590</a>
<a href="https://rdar.apple.com/180310399">rdar://180310399</a>

Reviewed by Geoffrey Garen and Pascoe.

315200@main added third_party/boringssl/src/tool/internal.h to the
libwebrtc prefix header as part of an auto-generated list of headers used
by &gt;= 15 files. That header belongs to the BoringSSL command-line tool,
not the library: it declares ScopedFD, whose inline reset() calls
bssl::CloseFD(), which is only defined in tool/fd.cc -- a file never
compiled into libwebrtc. Pulling it into the PCH caused ScopedFD::reset()
to be emitted as a weak symbol referencing the missing CloseFD, producing
an undefined-symbol error when linking WebCore.

No library source actually includes tool/internal.h or uses ScopedFD, so
remove it from the prefix header.

* Source/ThirdParty/libwebrtc/WebRTCPrefix.h:

Canonical link: <a href="https://commits.webkit.org/315608@main">https://commits.webkit.org/315608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8df9e79539d16f95e096a6388b5797e6290c1a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127278 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37035c84-5314-4055-822f-4c92c254febd) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132114 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48a157bc-45ee-4e0c-aae3-2d14393aae7f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172525 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112617 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27cb2194-0775-4875-a6af-bd3f48a17d3e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32252 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27622 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181524 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140563 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43144 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43833 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108041 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25829 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35667 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42343 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6930 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41879 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->