### PR TITLE
git commit --amend keeps reordering my carefully-crafted commit messages

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -330,7 +330,7 @@ def amended_message(full_message, combined_changes, amend_changes, update_change
         else:
             commit_message_parser = CommitMessageParser()
         commit_message_parser.parse_message(full_message)
-        updated_changelog_lines = commit_message_parser.apply_comments_to_modified_files_lines(combined_changes)
+        updated_changelog_lines = commit_message_parser.reconcile_with_changed_files(combined_changes)
         reviewed_by_lines = (commit_message_parser.reviewed_by_lines or ['Reviewed by NOBODY (OOPS!).'])
         description_lines = (commit_message_parser.description_lines or ['Explanation of why this fixes the bug (OOPS!).'])
         tests_lines = commit_message_parser.tests_lines + [''] if commit_message_parser.tests_lines else []

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py
@@ -360,6 +360,104 @@ class CommitMessageParser:
             return deleted_result
         return result
 
+    def _file_identity(self, line):
+        # The "* path:" prefix is identical whether the file is modified, Added. or
+        # Removed., so a file keeps one identity as its status changes.
+        match = MODIFIED_FILE_PATTERN.match(line)
+        return match.group(1) if match else None
+
+    def _group_into_blocks(self, lines):
+        # A file header opens a block; the function, comment and blank lines after it
+        # belong to it. Lines before the first header are returned as the preamble.
+        preamble = []
+        blocks = []
+        for line in lines:
+            identity = self._file_identity(line)
+            if identity is not None:
+                blocks.append((identity, [line]))
+            elif blocks:
+                blocks[-1][1].append(line)
+            else:
+                preamble.append(line)
+        return preamble, blocks
+
+    def reconcile_with_changed_files(self, modified_files_lines):
+        """Update the original modified-files section to match the current diff.
+
+        The original section is kept as written -- order, comments, spacing -- except:
+        a file no longer changed keeps only its trailing notes, a file that gained
+        functions has the new markers added before its trailing notes, and files new
+        since the original message are appended at the end.
+
+        modified_files_lines is the regenerated list (prepare-ChangeLog format).
+        """
+        _, current_blocks = self._group_into_blocks(modified_files_lines)
+        current_order = []
+        generated_block = {}
+        for identity, lines in current_blocks:
+            if identity not in generated_block:
+                current_order.append(identity)
+            generated_block[identity] = lines
+        current_identities = set(current_order)
+
+        preamble, original_blocks = self._group_into_blocks(self.modified_files_lines)
+        original_identities = {identity for identity, _ in original_blocks}
+
+        result = list(preamble)
+        for identity, lines in original_blocks:
+            if identity in current_identities:
+                result.extend(self._add_new_functions(lines, generated_block[identity]))
+            else:
+                result.extend(self._trailing_notes(lines))
+        for identity in current_order:
+            if identity not in original_identities:
+                result.extend(generated_block[identity])
+        return result
+
+    def _function_identity(self, line):
+        # The "(function):" prefix is identical across plain, commented and Deleted.
+        # lines, so a function keeps one identity as its status changes.
+        match = MODIFIED_FUNCTION_PATTERN.match(line)
+        return match.group(1) if match else None
+
+    def _trailing_notes(self, block_lines):
+        # A file that's no longer changed loses its file and function markers (and the
+        # notes on them); only free-form notes survive. Surrounding blanks are trimmed
+        # so the removed markers don't leave stray blank lines behind.
+        notes = [
+            line for line in block_lines
+            if self._file_identity(line) is None and self._function_identity(line) is None
+        ]
+        start = 0
+        while start < len(notes) and not notes[start].strip():
+            start += 1
+        end = len(notes)
+        while end > start and not notes[end - 1].strip():
+            end -= 1
+        return notes[start:end]
+
+    def _add_new_functions(self, original_lines, generated_lines):
+        original_functions = {
+            identity for identity in map(self._function_identity, original_lines)
+            if identity is not None
+        }
+        new_function_lines = [
+            line for line in generated_lines
+            if self._function_identity(line) is not None
+            and self._function_identity(line) not in original_functions
+        ]
+        if not new_function_lines:
+            return list(original_lines)
+
+        # After the last marker, i.e. before any trailing notes.
+        insert_at = len(original_lines)
+        while insert_at > 0:
+            previous = original_lines[insert_at - 1]
+            if self._file_identity(previous) is not None or self._function_identity(previous) is not None:
+                break
+            insert_at -= 1
+        return original_lines[:insert_at] + new_function_lines + original_lines[insert_at:]
+
     def delete_trailing_blank_lines(self, lines):
         chomp_at = 0
         for line in reversed(lines):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py
@@ -35,6 +35,20 @@ Commit description.
 
 
 class TestCommitParser(unittest.TestCase):
+    maxDiff = None
+
+    @staticmethod
+    def lines(text):
+        return text.strip('\n').split('\n')
+
+    def assert_reconcile(self, before, changed, after):
+        # `changed` is prepare-ChangeLog output: files sorted, comments stripped.
+        commit_message_parser = CommitMessageParser()
+        commit_message_parser.parse_message(COMMIT_MSG_BASE + before)
+        self.assertEqual(
+            self.lines(after),
+            commit_message_parser.reconcile_with_changed_files(self.lines(changed)),
+        )
 
     def test_basic_commit(self):
         commit_message_parser = CommitMessageParser()
@@ -166,4 +180,304 @@ class TestCommitParser(unittest.TestCase):
                     '(Class.function): Deleted.',
                 ],
                 return_deleted=True),
+        )
+
+    def test_reconcile_preserves_original_verbatim(self):
+        self.assert_reconcile(
+            before='''
+* B.cpp: Comment b.
+(B::foo):
+(B::bar):
+* A.cpp: Comment a.
+(A::baz):
+''',
+            changed='''
+* A.cpp:
+(A::baz):
+* B.cpp:
+(B::bar):
+(B::foo):
+''',
+            after='''
+* B.cpp: Comment b.
+(B::foo):
+(B::bar):
+* A.cpp: Comment a.
+(A::baz):
+''',
+        )
+
+    def test_reconcile_preserves_spacing(self):
+        self.assert_reconcile(
+            before='''
+* Source/A.cpp: Comment.
+(A::foo):
+
+* LayoutTests/t.html: Comment.
+''',
+            changed='''
+* LayoutTests/t.html:
+* Source/A.cpp:
+(A::foo):
+''',
+            after='''
+* Source/A.cpp: Comment.
+(A::foo):
+
+* LayoutTests/t.html: Comment.
+''',
+        )
+
+    def test_reconcile_drops_files_no_longer_changed(self):
+        self.assert_reconcile(
+            before='''
+* B.cpp: Comment b.
+(B::foo):
+* A.cpp: Comment a.
+''',
+            changed='''
+* A.cpp:
+''',
+            after='''
+* A.cpp: Comment a.
+''',
+        )
+
+    def test_reconcile_removed_file_keeps_trailing_notes(self):
+        self.assert_reconcile(
+            before='''
+* Gone.cpp: File-level note.
+(Gone::init): Function comment.
+- A trailing note.
+- Another trailing note.
+* Kept.cpp: Still here.
+''',
+            changed='''
+* Kept.cpp:
+''',
+            after='''
+- A trailing note.
+- Another trailing note.
+* Kept.cpp: Still here.
+''',
+        )
+
+    def test_reconcile_inserts_new_function_before_trailing_note(self):
+        self.assert_reconcile(
+            before='''
+* Bar.cpp: Explanation.
+(Bar::old): Did a thing.
+- Trailing note.
+''',
+            changed='''
+* Bar.cpp:
+(Bar::old):
+(Bar::new):
+''',
+            after='''
+* Bar.cpp: Explanation.
+(Bar::old): Did a thing.
+(Bar::new):
+- Trailing note.
+''',
+        )
+
+    def test_reconcile_inserts_new_function_at_end_without_note(self):
+        self.assert_reconcile(
+            before='''
+* Bar.cpp: Explanation.
+(Bar::old): Did a thing.
+''',
+            changed='''
+* Bar.cpp:
+(Bar::old):
+(Bar::new):
+''',
+            after='''
+* Bar.cpp: Explanation.
+(Bar::old): Did a thing.
+(Bar::new):
+''',
+        )
+
+    def test_reconcile_appends_new_files_at_end(self):
+        self.assert_reconcile(
+            before='''
+* A.cpp: Comment a.
+(A::foo):
+''',
+            changed='''
+* A.cpp:
+* C.cpp: Added.
+(C::C):
+''',
+            after='''
+* A.cpp: Comment a.
+(A::foo):
+* C.cpp: Added.
+(C::C):
+''',
+        )
+
+    def test_reconcile_keeps_original_status_and_comments(self):
+        self.assert_reconcile(
+            before='''
+* Foo.cpp: Added. My note.
+''',
+            changed='''
+* Foo.cpp:
+''',
+            after='''
+* Foo.cpp: Added. My note.
+''',
+        )
+
+    def test_reconcile_without_original_uses_generated(self):
+        self.assert_reconcile(
+            before='',
+            changed='''
+* A.cpp:
+(A::foo):
+* B.cpp:
+''',
+            after='''
+* A.cpp:
+(A::foo):
+* B.cpp:
+''',
+        )
+
+    def test_reconcile_keep_drop_and_add_together(self):
+        self.assert_reconcile(
+            before='''
+* Kept.cpp: Keep me.
+(Kept::a): Did a.
+* Gone.cpp: Drop me.
+(Gone::b): Old work.
+- A note worth keeping.
+''',
+            changed='''
+* Kept.cpp:
+(Kept::a):
+(Kept::new):
+* New.cpp: Added.
+(New::ctor):
+''',
+            after='''
+* Kept.cpp: Keep me.
+(Kept::a): Did a.
+(Kept::new):
+- A note worth keeping.
+* New.cpp: Added.
+(New::ctor):
+''',
+        )
+
+    def test_reconcile_new_function_when_file_had_none(self):
+        self.assert_reconcile(
+            before='''
+* Bar.cpp: Explanation.
+''',
+            changed='''
+* Bar.cpp:
+(Bar::new):
+''',
+            after='''
+* Bar.cpp: Explanation.
+(Bar::new):
+''',
+        )
+
+    def test_reconcile_new_function_before_multiline_notes(self):
+        self.assert_reconcile(
+            before='''
+* Bar.cpp:
+(Bar::old):
+- Note one.
+- Note two.
+''',
+            changed='''
+* Bar.cpp:
+(Bar::old):
+(Bar::new):
+''',
+            after='''
+* Bar.cpp:
+(Bar::old):
+(Bar::new):
+- Note one.
+- Note two.
+''',
+        )
+
+    def test_reconcile_multiple_new_functions_keep_order(self):
+        self.assert_reconcile(
+            before='''
+* Bar.cpp:
+(Bar::old):
+''',
+            changed='''
+* Bar.cpp:
+(Bar::old):
+(Bar::new1):
+(Bar::new2):
+''',
+            after='''
+* Bar.cpp:
+(Bar::old):
+(Bar::new1):
+(Bar::new2):
+''',
+        )
+
+    def test_reconcile_keeps_function_no_longer_regenerated(self):
+        self.assert_reconcile(
+            before='''
+* A.cpp: Comment.
+(A::keep): Keep.
+(A::gone): No longer touched.
+''',
+            changed='''
+* A.cpp:
+(A::keep):
+''',
+            after='''
+* A.cpp: Comment.
+(A::keep): Keep.
+(A::gone): No longer touched.
+''',
+        )
+
+    def test_reconcile_keeps_function_status(self):
+        self.assert_reconcile(
+            before='''
+* Foo.cpp:
+(Foo::bar): Deleted.
+''',
+            changed='''
+* Foo.cpp:
+(Foo::bar):
+''',
+            after='''
+* Foo.cpp:
+(Foo::bar): Deleted.
+''',
+        )
+
+    def test_reconcile_removed_file_trims_separator_blank(self):
+        self.assert_reconcile(
+            before='''
+* Gone.cpp:
+(Gone::a):
+- Keep this note.
+
+* Kept.cpp:
+''',
+            changed='''
+* Kept.cpp:
+''',
+            after='''
+- Keep this note.
+* Kept.cpp:
+''',
         )


### PR DESCRIPTION
#### c7abfe63cd86b0c7b3daf6555eaaa0849085cfaa
<pre>
git commit --amend keeps reordering my carefully-crafted commit messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=317591">https://bugs.webkit.org/show_bug.cgi?id=317591</a>
<a href="https://rdar.apple.com/180311337">rdar://180311337</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

I often reorder and group blocks of changes in the commit message.
Since 295625@main, upon amending, these changes are lost.

Make the reconciliation a bit smarter, keeping the user-generated ordering and grouping.
New files are added at the end, old files are still deleted, and lose their
per-file comments, but do not remove block comments (since there&apos;s a good chance
the block comment is still relevant to earlier listed files, and if that&apos;s not
true, it&apos;s better for the user to fix it up themselves).

* Tools/Scripts/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py:
(CommitMessageParser._file_identity):
(CommitMessageParser):
(CommitMessageParser._group_into_blocks):
(CommitMessageParser.reconcile_with_changed_files):
(CommitMessageParser._function_identity):
(CommitMessageParser._trailing_notes):
(CommitMessageParser._add_new_functions):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py:
(TestCommitParser):
(TestCommitParser.lines):
(TestCommitParser.assert_reconcile):

Canonical link: <a href="https://commits.webkit.org/315682@main">https://commits.webkit.org/315682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8a548f3d2f764bab36ae22735389dc4539122aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127279 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/734f59e1-926f-41a3-9c56-1ce89c83dd86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171433 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132115 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93048 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6edadd81-37d9-48b0-9824-f9764363a031) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172526 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35096 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112618 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/665f99b9-bb88-447f-92a6-c30dd6875e9d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/168888 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32255 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27623 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181525 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36421 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140565 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/168967 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43145 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140401 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37855 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43834 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108042 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35669 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42344 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6932 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41737 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41880 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->