### PR TITLE
[git-webkit] Auto-update Radar when uploading a pull-request

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import argparse
 import os
 import re
 import sys
@@ -134,6 +135,14 @@ class PullRequest(Command):
             '--no-issue', '--no-bug',
             dest='update_issue', default=True,
             help='Disable automatic bug creation and updates',
+            action=arguments.NoAction,
+        )
+        parser.add_argument(
+            '--update-radar', '--no-update-radar',
+            dest='update_radar', default=True,
+            help=('Update the state of the associated Radar when creating a pull request'
+                  if radar.Tracker.radarclient() is not None
+                  else argparse.SUPPRESS),
             action=arguments.NoAction,
         )
         parser.add_argument(
@@ -772,6 +781,15 @@ class PullRequest(Command):
             cls.add_comment_to_issue(not_radar, pr, commit_class=commit_class)
         elif issue and update_issue:
             cls.add_comment_to_issue(issue, pr, commit_class=commit_class)
+
+        if radar_issue and update_issue and radar_issue.tracker.radarclient():
+            if args.update_radar and radar_issue.state == 'Analyze' and radar_issue.substate in ['Investigate', 'Fix']:
+                try:
+                    radar_issue.set_state(state='Analyze', substate='Review')
+                    print('Updated {} to Analyze/Review'.format(radar_issue.link))
+                except radar_issue.tracker.radarclient().exceptions.UnsuccessfulResponseException as e:
+                    sys.stderr.write('Failed to update {}:\n'.format(radar_issue.link))
+                    sys.stderr.write('{}\n'.format(e))
 
         if issue and pr._metadata and pr._metadata.get('issue'):
             log.info('Syncing PR labels with issue component...')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -1662,6 +1662,7 @@ No pre-PR checks to run""")
             captured.stdout.getvalue(),
             "Created 'PR 1 | [Testing] Existing commit'!\n"
             'Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n'
+            'Updated rdar://1 to Analyze/Review\n'
             'https://github.example.com/WebKit/WebKit/pull/1\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -1738,6 +1739,7 @@ No pre-PR checks to run""")
             captured.stdout.getvalue(),
             "Created 'PR 1 | [Testing] Existing commit'!\n"
             'Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n'
+            'Updated rdar://1 to Analyze/Review\n'
             'https://github.example.com/WebKit/WebKit/pull/1\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -1817,6 +1819,7 @@ No pre-PR checks to run""")
             captured.stdout.getvalue(),
             "Created 'PR 1 | [Testing] Existing commit'!\n"
             'Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n'
+            'Updated rdar://1 to Analyze/Review\n'
             'https://github.example.com/WebKit/WebKit/pull/1\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -1887,6 +1890,7 @@ No pre-PR checks to run""")
             captured.stdout.getvalue(),
             "Created 'PR 1 | [Testing] Existing commit'!\n"
             'Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n'
+            'Updated rdar://1 to Analyze/Review\n'
             'https://github.example.com/WebKit/WebKit/pull/1\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -1909,6 +1913,76 @@ No pre-PR checks to run""")
                 'Synced PR labels with issue component!',
             ],
         )
+
+    def test_update_radar(self):
+        def run(args, substate='Investigate', message=None):
+            issues = list(bmocks.ISSUES)
+            issues[0] = dict(bmocks.ISSUES[0], substate=substate)
+            if message is None:
+                message = '[Testing] Existing commit\nbugs.example.com/show_bug.cgi?id=1\n<rdar://problem/1>\n'
+
+            with mocks.remote.GitHub(projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
+                self.BUGZILLA.split('://')[-1],
+                projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+                environment=Environment(
+                    BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                    BUGS_EXAMPLE_COM_PASSWORD='password',
+                ),
+            ), bmocks.Radar(issues=issues), patch(
+                'webkitbugspy.Tracker._trackers', [
+                    bugzilla.Tracker(self.BUGZILLA, radar_importer=bmocks.USERS['Radar WebKit Bug Importer']),
+                    radar.Tracker(),
+                ],
+            ), mocks.local.Git(
+                self.path, remote='https://{}'.format(remote.remote),
+                remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+            ) as repo, mocks.local.Svn():
+
+                repo.commits['eng/pr-branch'] = [
+                    repo.commits[repo.default_branch][-1],
+                    Commit(
+                        hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                        branch='eng/pr-branch',
+                        author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                        identifier="5.1@eng/pr-branch",
+                        timestamp=int(time.time()),
+                        message=message
+                    )
+                ]
+
+                repo.head = repo.commits['eng/pr-branch'][-1]
+                result = program.main(args=args, path=self.path)
+                rdar_tracker = next(t for t in Tracker._trackers if isinstance(t, radar.Tracker))
+                return result, rdar_tracker.issue(1).substate
+
+        # on by default: Investigate → Review
+        result, substate = run(('pull-request', '--no-history'))
+        self.assertEqual(0, result)
+        self.assertEqual('Review', substate)
+
+        # on by default: Fix → Review
+        result, substate = run(('pull-request', '--no-history'), substate='Fix')
+        self.assertEqual(0, result)
+        self.assertEqual('Review', substate)
+
+        # --no-update-radar: no change
+        result, substate = run(('pull-request', '--no-history', '--no-update-radar'))
+        self.assertEqual(0, result)
+        self.assertEqual('Investigate', substate)
+
+        # substate not Investigate or Fix: no change
+        result, substate = run(('pull-request', '--no-history'), substate='Screen')
+        self.assertEqual(0, result)
+        self.assertEqual('Screen', substate)
+
+        # new radar: no change
+        result, substate = run(
+            ('pull-request', '--no-history'),
+            substate='Screen',
+            message='[Testing] Existing commit\nbugs.example.com/show_bug.cgi?id=1\n'
+        )
+        self.assertEqual(0, result)
+        self.assertEqual('Screen', substate)
 
     def test_no_update_issue(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
@@ -2209,6 +2283,7 @@ No pre-PR checks to run""")
             captured.stdout.getvalue(),
             "Created 'PR 1 | <rdar://problem/1> [Testing] Existing commit'!\n"
             'Posted pull request link to rdar://1\n'
+            'Updated rdar://1 to Analyze/Review\n'
             'https://bitbucket.example.com/projects/WEBKIT/repos/webkit/pull-requests/1/overview\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -2261,6 +2336,7 @@ No pre-PR checks to run""")
             captured.stdout.getvalue(),
             "Created 'PR 1 | <rdar://problem/1> [Testing] Existing commit'!\n"
             'Posted pull request link to rdar://1\n'
+            'Updated rdar://1 to Analyze/Review\n'
             'https://bitbucket.example.com/projects/WEBKIT/repos/webkit/pull-requests/1/overview\n',
         )
         self.assertEqual(captured.stderr.getvalue(), '')


### PR DESCRIPTION
#### 02059fcf6f679bcabd3f4942458d9f2e107d6ecc
<pre>
[git-webkit] Auto-update Radar when uploading a pull-request
<a href="https://rdar.apple.com/130129302">rdar://130129302</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317460">https://bugs.webkit.org/show_bug.cgi?id=317460</a>

Reviewed by Elliott Williams.

When a pull-request is created or updated, automatically update the
associated Radar. Controlled by the `webkitscmpy.update-radar` config
key (default: true) and a `--update-radar` / `--no-update-radar` flag.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.parser): Add --update-radar / --no-update-radar argument.
(PullRequest.create_pull_request): Update radar after PR is created or updated.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/315767@main">https://commits.webkit.org/315767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b2e5526b7278b7e3c6611d5b6d5d878d077092b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45008 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43574 "Hash 4b2e5526 for PR 67607 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132521 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172978 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113023 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169340 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/43574 "Hash 4b2e5526 for PR 67607 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28077 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181978 "Built successfully") | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/43574 "Hash 4b2e5526 for PR 67607 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140979 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/169419 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43597 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140804 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37908 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44286 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108632 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36072 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42797 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7437 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->