### PR TITLE
Clean up Adjuster::adjust

### DIFF
--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -475,36 +475,35 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
         if (style.display() == DisplayType::InlineFlow && !style.pseudoElementType() && style.writingMode().computedWritingMode() != m_parentStyle.writingMode().computedWritingMode())
             style.setDisplayMaintainingOriginalDisplay(DisplayType::InlineFlowRoot);
 
+        auto display = style.display();
+
         // We do not honor position:relative or position:sticky on table row groups. Table rows are
         // allowed to be position:relative (they extend RenderBlock and can be proper containing blocks).
-        if ((style.display() == DisplayType::TableHeaderGroup || style.display() == DisplayType::TableRowGroup
-            || style.display() == DisplayType::TableFooterGroup)
+        if ((display == DisplayType::TableHeaderGroup || display == DisplayType::TableRowGroup || display == DisplayType::TableFooterGroup)
             && style.position() == PositionType::Relative)
             style.setPosition(PositionType::Static);
 
         // writing-mode does not apply to table row groups, table column groups, table rows, and table columns.
-        if (style.display() == DisplayType::TableColumn || style.display() == DisplayType::TableColumnGroup || style.display() == DisplayType::TableFooterGroup
-            || style.display() == DisplayType::TableHeaderGroup || style.display() == DisplayType::TableRow || style.display() == DisplayType::TableRowGroup)
+        if (display.isInternalTableBox() && display != DisplayType::TableCell)
             style.setWritingMode(m_parentStyle.writingMode().computedWritingMode());
 
         // FIXME: Adjust this once CSSWG clarifies exactly how the initial value should compute on other display types.
         // For now, this gives mostly backwards-compatible behavior.
-        if (style.display() == DisplayType::BlockGrid || style.display() == DisplayType::InlineGrid) {
+        auto adjustGridAutoFlow = [&](GridAutoFlow::Direction direction) {
             if (auto gridAutoFlow = style.gridAutoFlow(); gridAutoFlow.direction() == GridAutoFlow::Direction::Normal) {
-                gridAutoFlow.setDirection(GridAutoFlow::Direction::Row);
+                gridAutoFlow.setDirection(direction);
                 style.setGridAutoFlow(gridAutoFlow);
             }
-        } else if (style.display() == DisplayType::BlockGridLanes || style.display() == DisplayType::InlineGridLanes) {
-            if (auto gridAutoFlow = style.gridAutoFlow(); gridAutoFlow.direction() == GridAutoFlow::Direction::Normal) {
-                if (!style.gridTemplateRows().isNone() && style.gridTemplateColumns().isNone())
-                    gridAutoFlow.setDirection(GridAutoFlow::Direction::Column);
-                else
-                    gridAutoFlow.setDirection(GridAutoFlow::Direction::Row);
-                style.setGridAutoFlow(gridAutoFlow);
-            }
+        };
+        if (display.isGridBox())
+            adjustGridAutoFlow(GridAutoFlow::Direction::Row);
+        else if (display.isGridLanesBox()) {
+            auto direction = (!style.gridTemplateRows().isNone() && style.gridTemplateColumns().isNone())
+                ? GridAutoFlow::Direction::Column : GridAutoFlow::Direction::Row;
+            adjustGridAutoFlow(direction);
         }
 
-        if (style.display().isDeprecatedFlexibleBox()) {
+        if (display.isDeprecatedFlexibleBox()) {
             // FIXME: Since we don't support block-flow on flexible boxes yet, disallow setting
             // of block-flow to anything other than StyleWritingMode::HorizontalTb.
             // https://bugs.webkit.org/show_bug.cgi?id=46418 - Flexible box support.
@@ -738,10 +737,8 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
         style.setJustifyItems(m_parentBoxStyle.justifyItems());
 
 #if HAVE(CORE_MATERIAL)
-    if (appleVisualEffectNeedsBackdrop(style.appleVisualEffect()))
-        style.setUsedAppleVisualEffectForSubtree(style.appleVisualEffect());
-    else
-        style.setUsedAppleVisualEffectForSubtree(m_parentStyle.usedAppleVisualEffectForSubtree());
+    auto appleVisualEffect = style.appleVisualEffect();
+    style.setUsedAppleVisualEffectForSubtree(appleVisualEffectNeedsBackdrop(appleVisualEffect) ? appleVisualEffect : m_parentStyle.usedAppleVisualEffectForSubtree());
 #endif
 
     style.setUsedTouchAction(computeUsedTouchAction(style, m_parentStyle.usedTouchAction()));
@@ -788,10 +785,9 @@ void Adjuster::adjust(Style::ComputedStyle& style) const
 #endif
     }
 
-    if (m_parentStyle.contentVisibility() != ContentVisibility::Hidden) {
-        if (m_element && ContainmentChecker { style, *m_element }.isSkippedContentRoot())
-            style.setUsedContentVisibility(style.contentVisibility());
-    }
+    if (m_parentStyle.contentVisibility() != ContentVisibility::Hidden && m_element && ContainmentChecker { style, *m_element }.isSkippedContentRoot())
+        style.setUsedContentVisibility(style.contentVisibility());
+
     if (style.contentVisibility() == ContentVisibility::Auto) {
         style.setContainIntrinsicWidth(style.containIntrinsicWidth().addingAuto());
         style.setContainIntrinsicHeight(style.containIntrinsicHeight().addingAuto());


### PR DESCRIPTION
#### 06f07393db1b7398c957c5279979c550c72d08d7
<pre>
Clean up Adjuster::adjust
<a href="https://bugs.webkit.org/show_bug.cgi?id=317593">https://bugs.webkit.org/show_bug.cgi?id=317593</a>
<a href="https://rdar.apple.com/180313431">rdar://180313431</a>

Reviewed by Simon Fraser.

A few micro-optimizations to the flow.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Canonical link: <a href="https://commits.webkit.org/315688@main">https://commits.webkit.org/315688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28c017e736943d28f3d3ea73057d96501fdaad06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127285 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a57c8142-4755-461c-aa82-4c2c6641e30f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171439 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132120 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93053 "3 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30b28473-3ea5-420a-9bf6-1dcf0f048c2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172532 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35095 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112623 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bba90e72-1d43-4408-8a7c-3a57882a1224) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32263 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181531 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140570 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43151 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140406 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37857 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43840 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108051 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35676 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115605 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42350 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6971 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41743 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41886 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->