### PR TITLE
[HTML Tracks] Add more tests for untested areas of the HTML TextTrack specification

### DIFF
--- a/LayoutTests/media/track/text-track-cue-edge-times-expected.txt
+++ b/LayoutTests/media/track/text-track-cue-edge-times-expected.txt
@@ -1,0 +1,6 @@
+
+PASS unbounded cue (endTime = Infinity) stays active across monotonic advance
+PASS VTTCue accepts negative startTime and endTime
+PASS cue entirely before time 0 cannot be active
+PASS cue spanning time 0 is active when currentTime is within range
+

--- a/LayoutTests/media/track/text-track-cue-edge-times.html
+++ b/LayoutTests/media/track/text-track-cue-edge-times.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html>
+<head>
+    <title>TextTrack cue edge times: unbounded and pre-zero</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.7 "Text tracks" -- text track cue start/end times
+//     https://html.spec.whatwg.org/multipage/media.html#text-track-cue-end-time
+//
+// - An unbounded text track cue (endTime = +Infinity) cannot become
+//   inactive through monotonic playback advance alone.
+// - Text track cue start/end times can be negative; cues entirely
+//   before time 0 cannot be active (since currentTime >= 0 always).
+
+const MEDIA_SRC = "../content/test-25fps.mp4";
+
+function makeReadyVideo(t) {
+    const video = document.createElement("video");
+    video.muted = true;
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    video.src = MEDIA_SRC;
+    return video;
+}
+
+function whenSeekedTo(video, time) {
+    return new Promise(resolve => {
+        const handler = () => {
+            video.removeEventListener("seeked", handler);
+            resolve();
+        };
+        video.addEventListener("seeked", handler);
+        if (video.readyState >= video.HAVE_METADATA)
+            video.currentTime = time;
+        else
+            video.addEventListener("loadedmetadata",
+                () => { video.currentTime = time; }, { once: true });
+    });
+}
+
+promise_test(async t => {
+    // VTTCue with endTime = +Infinity stays active across monotonic
+    // playback advance once it's entered.
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+
+    const cue = new VTTCue(0, Infinity, "unbounded");
+    tt.addCue(cue);
+    assert_equals(cue.endTime, Infinity, "endTime stored as Infinity");
+
+    await whenSeekedTo(video, 0.1);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_array_equals([...tt.activeCues], [cue],
+        "unbounded cue active at t=0.1");
+
+    // Advance playback by seeking forward; the cue should remain active.
+    await whenSeekedTo(video, 0.5);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_array_equals([...tt.activeCues], [cue],
+        "unbounded cue still active at t=0.5");
+
+    await whenSeekedTo(video, 1.0);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_array_equals([...tt.activeCues], [cue],
+        "unbounded cue still active at t=1.0");
+}, "unbounded cue (endTime = Infinity) stays active across monotonic advance");
+
+test(() => {
+    // Negative start/end times are storable on a VTTCue.
+    const cue = new VTTCue(-5, -1, "pre-zero");
+    assert_equals(cue.startTime, -5);
+    assert_equals(cue.endTime, -1);
+}, "VTTCue accepts negative startTime and endTime");
+
+promise_test(async t => {
+    // A cue entirely before time 0 must never be active, since
+    // currentPlaybackPosition >= 0.
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+
+    const preZeroCue = new VTTCue(-5, -1, "before zero");
+    const validCue = new VTTCue(0, 100, "after zero");
+    tt.addCue(preZeroCue);
+    tt.addCue(validCue);
+
+    await whenSeekedTo(video, 0);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_false([...tt.activeCues].includes(preZeroCue),
+        "pre-zero cue is not active at t=0");
+    assert_true([...tt.activeCues].includes(validCue),
+        "valid cue is active at t=0");
+
+    await whenSeekedTo(video, 0.5);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_false([...tt.activeCues].includes(preZeroCue),
+        "pre-zero cue is not active at t=0.5");
+}, "cue entirely before time 0 cannot be active");
+
+promise_test(async t => {
+    // A cue spanning across time 0 (negative start, positive end) IS
+    // active when currentTime falls within its range.
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+
+    const spanningCue = new VTTCue(-1, 0.5, "spanning zero");
+    tt.addCue(spanningCue);
+
+    await whenSeekedTo(video, 0.1);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_array_equals([...tt.activeCues], [spanningCue],
+        "spanning cue is active at t=0.1 (within [-1, 0.5))");
+
+    await whenSeekedTo(video, 1.0);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_array_equals([...tt.activeCues], [],
+        "spanning cue is not active at t=1.0 (past endTime=0.5)");
+}, "cue spanning time 0 is active when currentTime is within range");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/text-track-cue-events-and-handlers-expected.txt
+++ b/LayoutTests/media/track/text-track-cue-events-and-handlers-expected.txt
@@ -1,0 +1,7 @@
+
+PASS TextTrackCue: onenter and onexit IDL attributes exist (default null)
+PASS endTime setter: throws TypeError for NaN
+PASS endTime setter: throws TypeError for -Infinity
+PASS endTime setter: accepts +Infinity
+FAIL endTime setter: shrinking past currentTime fires 'exit' via time marches on assert_true: 'exit' fires when endTime is shrunk past currentTime expected true got false
+

--- a/LayoutTests/media/track/text-track-cue-events-and-handlers.html
+++ b/LayoutTests/media/track/text-track-cue-events-and-handlers.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html>
+<head>
+    <title>TextTrackCue event handler IDL attributes and endTime mutation</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.10 "Text track API" -- TextTrackCue event handler IDL attributes:
+//     https://html.spec.whatwg.org/multipage/media.html#texttrackcue
+//   §4.8.13.7 "Text tracks" -- text-track-cue-end-time:
+//     https://html.spec.whatwg.org/multipage/media.html#text-track-cue-end-time
+//
+// - TextTrackCue exposes onenter and onexit event handler IDL attributes.
+// - Setting cue.endTime to a value <= currentTime while the cue is in a
+//   showing/hidden track in a media element triggers time marches on,
+//   which fires 'exit' on the cue.
+// - The endTime setter throws TypeError for -Infinity or NaN.
+
+const MEDIA_SRC = "../content/test-25fps.mp4";
+
+function makeReadyVideo(t) {
+    const video = document.createElement("video");
+    video.muted = true;
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    video.src = MEDIA_SRC;
+    return video;
+}
+
+function whenSeekedTo(video, time) {
+    return new Promise(resolve => {
+        video.addEventListener("seeked", resolve, { once: true });
+        if (video.readyState >= video.HAVE_METADATA)
+            video.currentTime = time;
+        else
+            video.addEventListener("loadedmetadata",
+                () => { video.currentTime = time; }, { once: true });
+    });
+}
+
+test(() => {
+    // onenter and onexit IDL attributes exist and default to null.
+    const cue = new VTTCue(0, 1, "test");
+    assert_true("onenter" in cue, "TextTrackCue exposes onenter");
+    assert_true("onexit" in cue, "TextTrackCue exposes onexit");
+    assert_equals(cue.onenter, null, "onenter default is null");
+    assert_equals(cue.onexit, null, "onexit default is null");
+}, "TextTrackCue: onenter and onexit IDL attributes exist (default null)");
+
+test(() => {
+    // endTime setter throws TypeError for NaN.
+    const cue = new VTTCue(0, 1, "test");
+    assert_throws_js(TypeError, () => { cue.endTime = NaN; },
+        "endTime = NaN throws TypeError");
+}, "endTime setter: throws TypeError for NaN");
+
+test(() => {
+    // endTime setter throws TypeError for -Infinity.
+    const cue = new VTTCue(0, 1, "test");
+    assert_throws_js(TypeError, () => { cue.endTime = -Infinity; },
+        "endTime = -Infinity throws TypeError");
+}, "endTime setter: throws TypeError for -Infinity");
+
+test(() => {
+    // +Infinity is allowed.
+    const cue = new VTTCue(0, 1, "test");
+    cue.endTime = Infinity;
+    assert_equals(cue.endTime, Infinity);
+}, "endTime setter: accepts +Infinity");
+
+promise_test(async t => {
+    // Mutating endTime such that the cue is no longer active triggers
+    // time marches on. Per the time-marches-on algorithm step 11, a cue
+    // that transitioned from "current cues" to "other cues" with its
+    // active flag still set queues an 'exit' event task. WebKit must:
+    //   (a) fire 'exit' on the cue
+    //   (b) clear the active flag (so the cue is no longer in activeCues)
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+    const cue = new VTTCue(0, 100, "covers t=0.5");
+    tt.addCue(cue);
+
+    await whenSeekedTo(video, 0.5);
+    await new Promise(r => t.step_timeout(r, 50));
+    assert_array_equals([...tt.activeCues], [cue], "cue active at t=0.5");
+
+    let exitFired = false;
+    cue.onexit = () => { exitFired = true; };
+
+    // Shrink the cue to end before currentTime. Per spec, "If cue is in
+    // a text track that is in a media element, run time marches on."
+    cue.endTime = 0.1;
+    await new Promise(r => t.step_timeout(r, 100));
+
+    assert_true(exitFired,
+        "'exit' fires when endTime is shrunk past currentTime");
+    assert_array_equals([...tt.activeCues], [],
+        "cue no longer active after endTime moved before currentTime");
+}, "endTime setter: shrinking past currentTime fires 'exit' via time marches on");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/text-track-in-band-exposure-expected.txt
+++ b/LayoutTests/media/track/text-track-in-band-exposure-expected.txt
@@ -1,0 +1,6 @@
+
+PASS TextTrack.inBandMetadataTrackDispatchType: IDL attribute exists, empty for non-in-band tracks
+PASS in-band track is exposed via addtrack on the media element
+PASS in-band non-metadata track: inBandMetadataTrackDispatchType is empty
+PASS in-band track does not block readyState progression (loaded immediately)
+

--- a/LayoutTests/media/track/text-track-in-band-exposure.html
+++ b/LayoutTests/media/track/text-track-in-band-exposure.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html>
+<head>
+    <title>In-band text tracks: exposure, readiness, dispatch type</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../media-source/mp4-generator.js"></script>
+    <script src="caption-generator.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.7 "Text tracks":
+//     - "in-band metadata track dispatch type" definition
+//       https://html.spec.whatwg.org/multipage/media.html#text-track-in-band-metadata-track-dispatch-type
+//   §4.8.13.7.1 "Sourcing in-band text tracks":
+//     https://html.spec.whatwg.org/multipage/media.html#sourcing-in-band-text-tracks
+//   §4.8.13.10 "Text track API":
+//     - TextTrack.inBandMetadataTrackDispatchType
+//       https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-inbandmetadatatrackdispatchtype
+//
+// In-band text tracks (those exposed by the media resource itself, not via
+// a <track> element) must:
+//   - have readiness state "loaded" by the time they are exposed
+//   - have an empty inBandMetadataTrackDispatchType for non-metadata kinds
+//   - be removed from the media element's list of pending text tracks
+//     during load (i.e. they must not block readyState progression)
+//
+// We exercise this with synthetic CEA-608 captions injected via
+// mp4-generator.js + caption-generator.js — these produce a real fragmented
+// MP4 with an in-band CEA-608 captions track, exercising the platform's
+// in-band parser path.
+//
+// TODO: the metadata-track case (where inBandMetadataTrackDispatchType
+// must be non-empty per §4.8.13.7.1 step 6) requires extending
+// mp4-generator.js to emit a 'mett'/'metx' sample-entry track. That's
+// deferred to a future round.
+
+function buildCaptionedMp4() {
+    const FRAME_COUNT = 60;
+    const FRAME_DURATION = 1001;     // 30000/1001 ≈ 29.97fps
+    const TIMESCALE = 30000;
+    const TOTAL_TICKS = FRAME_COUNT * FRAME_DURATION;
+    const CUE_TICKS = 20 * FRAME_DURATION;
+    const CAPTION_START_OFFSET = TIMESCALE; // 1 second
+
+    const captionSamples = Captions.buildPopOnCueSamples({
+        cues: [
+            { text: 'Cue 1', durationTicks: CUE_TICKS },
+            { text: 'Cue 2', durationTicks: CUE_TICKS },
+        ],
+        totalDurationTicks: TOTAL_TICKS,
+    });
+
+    const videoSamples = Array.from({ length: FRAME_COUNT }, (_, i) => ({
+        duration: FRAME_DURATION,
+        isSync: i % 30 === 0,
+        dts: i * FRAME_DURATION,
+        pts: i * FRAME_DURATION,
+    }));
+
+    const { init, media } = MP4.samples({
+        timescale: TIMESCALE,
+        tracks: [
+            { id: 1, type: 'video' },
+            { id: 2, type: 'captions' },
+        ],
+        trackSamples: {
+            1: videoSamples,
+            2: captionSamples.map(s => ({
+                duration: s.duration,
+                data: s.data,
+                isSync: true,
+                dts: CAPTION_START_OFFSET,
+                pts: CAPTION_START_OFFSET,
+            })),
+        },
+    });
+
+    const combined = new Uint8Array(init.byteLength + media.byteLength);
+    combined.set(new Uint8Array(init), 0);
+    combined.set(new Uint8Array(media), init.byteLength);
+    return URL.createObjectURL(new Blob([combined], { type: 'video/mp4' }));
+}
+
+function makeVideo(t) {
+    const video = document.createElement("video");
+    video.muted = true;
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    return video;
+}
+
+test(() => {
+    // The IDL attribute exists on TextTrack and is a string-typed accessor.
+    const dummy = document.createElement("video").addTextTrack("captions");
+    assert_true("inBandMetadataTrackDispatchType" in dummy,
+        "TextTrack exposes inBandMetadataTrackDispatchType");
+    assert_equals(typeof dummy.inBandMetadataTrackDispatchType, "string");
+    // For an addTextTrack-created (non-in-band) track it must be empty.
+    assert_equals(dummy.inBandMetadataTrackDispatchType, "",
+        "addTextTrack-created track has empty inBandMetadataTrackDispatchType");
+}, "TextTrack.inBandMetadataTrackDispatchType: IDL attribute exists, empty for non-in-band tracks");
+
+promise_test(async t => {
+    // Synthetic captioned MP4 -> in-band track exposed via addtrack event.
+    const video = makeVideo(t);
+    video.src = buildCaptionedMp4();
+
+    const ev = await new Promise((resolve, reject) => {
+        video.textTracks.addEventListener("addtrack", resolve, { once: true });
+        video.addEventListener("error", reject, { once: true });
+        t.step_timeout(() => reject(new Error("addtrack timeout")), 5000);
+    });
+
+    assert_equals(ev.track, video.textTracks[0],
+        "addtrack event fires with the in-band TextTrack");
+    assert_equals(ev.track.kind, "captions",
+        "in-band CEA-608 track kind is 'captions'");
+}, "in-band track is exposed via addtrack on the media element");
+
+promise_test(async t => {
+    // Behavior under §4.8.13.7.1 sourcing-in-band-text-tracks step 6:
+    // For a non-metadata in-band track, the dispatch type is the empty
+    // string. (Metadata-kind tracks are deferred to a future round; see
+    // file header.)
+    const video = makeVideo(t);
+    video.src = buildCaptionedMp4();
+
+    await new Promise((resolve, reject) => {
+        video.textTracks.addEventListener("addtrack", resolve, { once: true });
+        video.addEventListener("error", reject, { once: true });
+        t.step_timeout(() => reject(new Error("addtrack timeout")), 5000);
+    });
+
+    const tt = video.textTracks[0];
+    assert_not_equals(tt.kind, "metadata",
+        "synthetic CEA-608 track is NOT metadata-kind");
+    assert_equals(tt.inBandMetadataTrackDispatchType, "",
+        "non-metadata in-band track has empty inBandMetadataTrackDispatchType");
+}, "in-band non-metadata track: inBandMetadataTrackDispatchType is empty");
+
+promise_test(async t => {
+    // §4.8.13.7.1 step 5: "Set the new text track's readiness state to
+    // loaded." In-band tracks must NEVER be in pending-text-tracks state;
+    // their readiness is loaded by the time they're exposed. We verify
+    // indirectly: the video reaches HAVE_FUTURE_DATA (canplay) without
+    // ever being blocked on the in-band track.
+    const video = makeVideo(t);
+    video.src = buildCaptionedMp4();
+
+    let addtrackFired = false;
+    video.textTracks.addEventListener("addtrack",
+        () => { addtrackFired = true; }, { once: true });
+
+    await new Promise((resolve, reject) => {
+        video.addEventListener("canplay", resolve, { once: true });
+        video.addEventListener("error", reject, { once: true });
+        t.step_timeout(() => reject(new Error("canplay timeout")), 5000);
+    });
+
+    assert_true(addtrackFired,
+        "addtrack must fire by the time canplay reaches the page");
+    assert_greater_than_equal(video.readyState, video.HAVE_FUTURE_DATA,
+        "video reaches HAVE_FUTURE_DATA -- in-band track did not block readyState");
+}, "in-band track does not block readyState progression (loaded immediately)");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/text-track-time-marches-on-expected.txt
+++ b/LayoutTests/media/track/text-track-time-marches-on-expected.txt
@@ -1,0 +1,7 @@
+
+PASS adding a track with cues mid-stream fires enter + cuechange
+PASS removing an active cue clears its active flag synchronously
+PASS cue not in track.cues is not part of the track
+PASS time marches on: tasks sorted by cue order when sharing an event time
+PASS removing a track with active cues clears their active flags
+

--- a/LayoutTests/media/track/text-track-time-marches-on.html
+++ b/LayoutTests/media/track/text-track-time-marches-on.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html>
+<head>
+    <title>Time marches on: cue lifecycle during playback and mutations</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard §4.8.13.9 "Playing the media resource",
+// "time marches on" steps:
+//   https://html.spec.whatwg.org/multipage/media.html#time-marches-on
+//
+// When the current playback position changes (playback or seeking), the
+// "time marches on" steps run. We exercise:
+//
+// - Adding a track with cues mid-playback fires enter/cuechange.
+// - Removing a cue or removing a track fires exit if the cue was active.
+// - Prepared-task ordering: when multiple cues share an event time,
+//   tasks are sorted by time ascending, then text-track-cue-order, then
+//   enter-before-exit.
+// - A cue is part of a track only when listed in track.cues, not merely
+//   associated.
+
+const MEDIA_SRC = "../content/test-25fps.mp4";
+
+function makeReadyVideo(t) {
+    const video = document.createElement("video");
+    video.muted = true;
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    video.src = MEDIA_SRC;
+    return video;
+}
+
+function whenSeekedTo(video, time) {
+    return new Promise(resolve => {
+        const handler = () => {
+            video.removeEventListener("seeked", handler);
+            resolve();
+        };
+        video.addEventListener("seeked", handler);
+        if (video.readyState >= video.HAVE_METADATA)
+            video.currentTime = time;
+        else
+            video.addEventListener("loadedmetadata",
+                () => { video.currentTime = time; }, { once: true });
+    });
+}
+
+function nextTick(t) {
+    return new Promise(r => t.step_timeout(r, 50));
+}
+
+promise_test(async t => {
+    // Adding a track-with-cues mid-stream should fire 'enter' on cues
+    // that are active at the current playback position, and 'cuechange'
+    // on the track.
+    const video = makeReadyVideo(t);
+    await whenSeekedTo(video, 0.5);
+
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+
+    const cue = new VTTCue(0, 100, "covers t=0.5");
+
+    let enterFired = false;
+    let cuechangeFired = false;
+    cue.onenter = () => { enterFired = true; };
+    tt.oncuechange = () => { cuechangeFired = true; };
+
+    tt.addCue(cue);
+    await nextTick(t);
+
+    assert_true(enterFired, "'enter' fires when a cue is added covering currentTime");
+    assert_true(cuechangeFired, "'cuechange' fires on track when cue becomes active");
+    assert_array_equals([...tt.activeCues], [cue], "cue is in activeCues");
+}, "adding a track with cues mid-stream fires enter + cuechange");
+
+promise_test(async t => {
+    // Removing a currently-active cue must clear its active flag
+    // synchronously per HTML §4.8.13.7 "text track cue active flag".
+    //
+    // `tt.activeCues` cannot observe the cleared flag directly (the cue
+    // is no longer in tt.cues, so it can never be in activeCues). Instead,
+    // re-add the cue at a time outside its range and confirm no 'exit'
+    // event fires — if the flag had survived removeCue, time-marches-on
+    // would queue exit (the cue would be in "other cues" with active flag
+    // set, per step 11 of the time-marches-on algorithm).
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+    const cue = new VTTCue(0, 0.5, "in-range");
+    tt.addCue(cue);
+
+    await whenSeekedTo(video, 0.1);
+    await nextTick(t);
+    assert_array_equals([...tt.activeCues], [cue], "cue active before removal");
+
+    let exitAfterRemove = false;
+    cue.onexit = () => { exitAfterRemove = true; };
+
+    tt.removeCue(cue);
+    await whenSeekedTo(video, 0.8);
+    await nextTick(t);
+    tt.addCue(cue);
+    await nextTick(t);
+
+    assert_false(exitAfterRemove,
+        "no 'exit' fires after removeCue + re-add at out-of-range time " +
+        "(active flag was correctly cleared on removeCue)");
+}, "removing an active cue clears its active flag synchronously");
+
+promise_test(async t => {
+    // A cue is part of a track only when listed in track.cues.
+    // A VTTCue created but not added has cue.track === null and is not
+    // active even if its time range covers currentTime.
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+
+    const cue = new VTTCue(0, 100, "covers t=0.5 but not added");
+    assert_equals(cue.track, null, "unattached cue has track=null");
+
+    await whenSeekedTo(video, 0.5);
+    await nextTick(t);
+    assert_array_equals([...tt.activeCues], [],
+        "unattached cue is not in activeCues");
+}, "cue not in track.cues is not part of the track");
+
+promise_test(async t => {
+    // Time marches on (step 13): tasks in `events` are sorted by:
+    //   1. ascending time
+    //   2. then by relative text track cue order
+    //   3. then by enter-before-exit (only when same time AND same cue order)
+    //
+    // Within a track, cue order is by start time first (HTML §4.8.13.7).
+    // Our two cues share an event time of 0.5 but have different start
+    // times (0 and 0.5), so the enter-before-exit tiebreaker does NOT
+    // apply. Sort by cue order: cueA (start=0) precedes cueB (start=0.5),
+    // so A's exit task is queued before B's enter task.
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+
+    const cueA = new VTTCue(0, 0.5, "exits at 0.5");
+    const cueB = new VTTCue(0.5, 1.0, "enters at 0.5");
+    tt.addCue(cueA);
+    tt.addCue(cueB);
+
+    // Park the video at t=0 so cueA is initially active.
+    await whenSeekedTo(video, 0);
+    await nextTick(t);
+    assert_array_equals([...tt.activeCues], [cueA], "cueA active at t=0");
+
+    const events = [];
+    cueA.onexit = () => events.push("A.exit");
+    cueB.onenter = () => events.push("B.enter");
+
+    // Seek to a position where cueA has exited and cueB has entered.
+    await whenSeekedTo(video, 0.6);
+    await nextTick(t);
+
+    assert_array_equals(events, ["A.exit", "B.enter"],
+        "tasks fire in cue-order: A.exit (cue order earlier) before B.enter");
+    assert_array_equals([...tt.activeCues], [cueB], "cueB is active at t=0.6");
+}, "time marches on: tasks sorted by cue order when sharing an event time");
+
+promise_test(async t => {
+    // Removing a track from the media element clears its cues' active
+    // flags. Per the time-marches-on spec, removing a track from the
+    // media element's list of text tracks runs the rules for updating
+    // text track rendering, but does not queue 'exit' events.
+    const video = makeReadyVideo(t);
+    const trackEl = document.createElement("track");
+    trackEl.kind = "subtitles";
+    trackEl.src = "data:text/vtt;charset=utf-8,"
+        + encodeURIComponent("WEBVTT\n\n00:00:00.000 --> 00:01:00.000\nactive\n");
+    video.appendChild(trackEl);
+    const tt = trackEl.track;
+    tt.mode = "showing";
+    await new Promise(resolve => {
+        if (trackEl.readyState === trackEl.LOADED)
+            resolve();
+        else
+            trackEl.addEventListener("load", resolve, { once: true });
+    });
+    await whenSeekedTo(video, 0.5);
+    await nextTick(t);
+    assert_equals(tt.activeCues.length, 1, "one cue active before removal");
+
+    video.removeChild(trackEl);
+    // Per spec §4.8.13.7 "text track cue active flag", removing the track
+    // from the media element's list of text tracks must synchronously
+    // clear active flags. Track mode is still "showing", so activeCues
+    // must be a non-null (live, empty) list.
+    assert_not_equals(tt.activeCues, null,
+        "activeCues is non-null (mode still 'showing' on detached track)");
+    assert_equals(tt.activeCues.length, 0,
+        "cue active flags were synchronously cleared on track removal");
+}, "removing a track with active cues clears their active flags");
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### b8b58f1e185332af0c185a5b5c37480971cd7741
<pre>
[HTML Tracks] Add more tests for untested areas of the HTML TextTrack specification
<a href="https://rdar.apple.com/180313782">rdar://180313782</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317594">https://bugs.webkit.org/show_bug.cgi?id=317594</a>

Reviewed by Eric Carlson.

Add a second batch of tests covering previously untested TextTrack
behaviors: cue lifecycle during playback (time marches on with
seeking and mid-stream cue mutations), TextTrackCue event handlers
and endTime setter semantics, cue edge cases (unbounded endTime and
negative-time cues), and in-band TextTrack exposure rules
(IDL accessor presence, empty dispatch type for non-metadata kinds,
in-band tracks not blocking readyState). The in-band test uses
synthetic CEA-608 captions via mp4-generator.js / caption-generator.js
to avoid an external asset dependency.

text-track-cue-events-and-handlers.html&apos;s &quot;endTime setter: shrinking
past currentTime fires &apos;exit&apos;&quot; subtest fails because WebKit clears
activeCues but does not fire &apos;exit&apos;; the failure is tracked by
<a href="https://rdar.apple.com/180298688">rdar://180298688</a> and recorded inline in the test&apos;s expected.txt.

* LayoutTests/media/track/text-track-cue-edge-times-expected.txt: Added.
* LayoutTests/media/track/text-track-cue-edge-times.html: Added.
* LayoutTests/media/track/text-track-cue-events-and-handlers-expected.txt: Added.
* LayoutTests/media/track/text-track-cue-events-and-handlers.html: Added.
* LayoutTests/media/track/text-track-in-band-exposure-expected.txt: Added.
* LayoutTests/media/track/text-track-in-band-exposure.html: Added.
* LayoutTests/media/track/text-track-time-marches-on-expected.txt: Added.
* LayoutTests/media/track/text-track-time-marches-on.html: Added.

Canonical link: <a href="https://commits.webkit.org/315618@main">https://commits.webkit.org/315618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bceeecb4c2bc08d936ce46a0fa8f91a4421fa03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127284 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcffecef-553d-456f-a825-ce91a026cb74) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132119 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/739c469e-3171-4047-b1b6-34713c3914f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172531 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/34990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152477 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112622 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96b7f454-feaf-44da-943b-eaad827362cd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27628 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181530 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140571 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37780 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43839 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28856 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108050 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35674 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42349 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6941 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->