### PR TITLE
Typing in complicated Mail replies lags.

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -252,6 +252,9 @@ struct WEBCORE_EXPORT AttributedString {
     RetainPtr<NSDictionary> documentAttributesAsNSDictionary() const;
     RetainPtr<NSAttributedString> nsAttributedString() const;
     bool NODELETE isNull() const;
+
+    WEBCORE_EXPORT static unsigned encodeFontCacheMissesForTesting();
+    WEBCORE_EXPORT static unsigned decodeFontCacheMissesForTesting();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -38,6 +38,7 @@
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/text/StringBuilder.h>
 #if PLATFORM(MAC)
 #import <AppKit/AppKit.h>
 #import <pal/spi/mac/NSTextTableSPI.h>
@@ -61,6 +62,21 @@ using IdentifierToTableMap = HashMap<AttributedStringTextTableID, RetainPtr<NSTe
 using IdentifierToTableBlockMap = HashMap<AttributedStringTextTableBlockID, RetainPtr<NSTextTableBlock>>;
 using IdentifierToListMap = HashMap<AttributedStringTextListID, RetainPtr<NSTextList>>;
 
+using NSFontToInstalledFontCache = HashMap<CTFontRef, std::unique_ptr<InstalledFont>>;
+using InstalledFontToCTFontCache = HashMap<String, RetainPtr<CTFontRef>>;
+
+static unsigned s_encodeFontCacheMisses;
+static unsigned s_decodeFontCacheMisses;
+
+unsigned AttributedString::encodeFontCacheMissesForTesting()
+{
+    return s_encodeFontCacheMisses;
+}
+
+unsigned AttributedString::decodeFontCacheMissesForTesting()
+{
+    return s_decodeFontCacheMisses;
+}
 
 using TableToIdentifierMap = HashMap<NSTextTable *, AttributedString::TextTableID>;
 using TableBlockToIdentifierMap = HashMap<NSTextTableBlock *, AttributedString::TextTableBlockID>;
@@ -346,7 +362,77 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #endif
 
-static RetainPtr<id> toNSObject(const AttributedString::AttributeValue& value, IdentifierToTableMap& tables, IdentifierToTableBlockMap& tableBlocks, IdentifierToListMap& lists)
+static String stringifyCFNumber(CFNumberRef number)
+{
+    if (!number)
+        return { };
+    double value = 0;
+    CFNumberGetValue(number, kCFNumberDoubleType, &value);
+    return String::number(value);
+}
+
+static String stringifyCFBoolean(CFBooleanRef boolean)
+{
+    if (!boolean)
+        return { };
+    return CFBooleanGetValue(boolean) ? "1"_s : "0"_s;
+}
+
+// Keep in sync with FontPlatformSerializedAttributes; any new field needs to be folded in
+// or bailed on, or two distinct fonts will alias in the cache.
+static String cacheKeyForInstalledFont(const InstalledFont& font)
+{
+    return WTF::switchOn(font.font,
+        [&] (const InstalledFont::SystemUIFont& systemFont) -> String {
+            return makeString("S|"_s, static_cast<unsigned>(systemFont.systemUIFontType), '|', systemFont.language, '|', font.metadata.pointSize);
+        },
+        [&] (const InstalledFont::PostScriptFont& postScriptFont) -> String {
+            if (postScriptFont.fontSerializedAttributes) {
+                auto& attributes = *postScriptFont.fontSerializedAttributes;
+                if (attributes.matrix || attributes.paletteColors || attributes.featureSettings)
+                    return { };
+                StringBuilder builder;
+                builder.append("P|"_s, postScriptFont.postScriptName, '|', postScriptFont.fontDescriptorOptions, '|', font.metadata.pointSize, '|', attributes.fontName, '|', attributes.descriptorLanguage, '|', attributes.descriptorTextStyle);
+                builder.append("|b|"_s, stringifyCFBoolean(attributes.ignoreLegibilityWeight.get()));
+                builder.append("|n|"_s,
+                    stringifyCFNumber(attributes.baselineAdjust.get()), '|',
+                    stringifyCFNumber(attributes.fallbackOption.get()), '|',
+                    stringifyCFNumber(attributes.fixedAdvance.get()), '|',
+                    stringifyCFNumber(attributes.orientation.get()), '|',
+                    stringifyCFNumber(attributes.palette.get()), '|',
+                    stringifyCFNumber(attributes.size.get()), '|',
+                    stringifyCFNumber(attributes.sizeCategory.get()), '|',
+                    stringifyCFNumber(attributes.track.get()), '|',
+                    stringifyCFNumber(attributes.unscaledTracking.get()));
+#if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
+                builder.append("|a|"_s, stringifyCFNumber(attributes.additionalNumber.get()));
+#endif
+                if (attributes.traits) {
+                    auto& traits = *attributes.traits;
+                    builder.append("|t|"_s, traits.uiFontDesign, '|', stringifyCFNumber(traits.weight.get()), '|', stringifyCFNumber(traits.width.get()), '|', stringifyCFNumber(traits.symbolic.get()), '|', stringifyCFNumber(traits.grade.get()));
+                }
+                if (attributes.opticalSize) {
+                    builder.append("|o|"_s);
+                    WTF::switchOn(attributes.opticalSize->opticalSize,
+                        [&] (const RetainPtr<CFNumberRef>& number) {
+                            builder.append(stringifyCFNumber(number.get()));
+                        },
+                        [&] (const String& string) {
+                            builder.append(string);
+                        });
+                }
+                if (attributes.variations) {
+                    builder.append("|v|"_s);
+                    for (auto& pair : *attributes.variations)
+                        builder.append(stringifyCFNumber(pair.first.get()), '=', stringifyCFNumber(pair.second.get()), ',');
+                }
+                return builder.toString();
+            }
+            return makeString("P|"_s, postScriptFont.postScriptName, '|', postScriptFont.fontDescriptorOptions, '|', font.metadata.pointSize);
+        });
+}
+
+static RetainPtr<id> toNSObject(const AttributedString::AttributeValue& value, IdentifierToTableMap& tables, IdentifierToTableBlockMap& tableBlocks, IdentifierToListMap& lists, InstalledFontToCTFontCache& fontCache)
 {
     return WTF::switchOn(value.value, [] (double value) -> RetainPtr<id> {
         return adoptNS([[NSNumber alloc] initWithDouble:value]);
@@ -391,8 +477,17 @@ static RetainPtr<id> toNSObject(const AttributedString::AttributeValue& value, I
         return value;
     }, [] (const RetainPtr<NSDate>& value) -> RetainPtr<id> {
         return value;
-    }, [] (const InstalledFont& font) -> RetainPtr<id> {
-        return (__bridge PlatformFont *)font.toCTFont().get();
+    }, [&] (const InstalledFont& font) -> RetainPtr<id> {
+        auto key = cacheKeyForInstalledFont(font);
+        if (!key.isNull()) {
+            if (RetainPtr cached = fontCache.get(key))
+                return (__bridge PlatformFont *)cached.get();
+        }
+        ++s_decodeFontCacheMisses;
+        RetainPtr ctFont = font.toCTFont();
+        if (ctFont && !key.isNull())
+            fontCache.set(key, ctFont);
+        return (__bridge PlatformFont *)ctFont.get();
     }, [] (const AttributedString::ColorFromPlatformColor& value) -> RetainPtr<id> {
         return cocoaColor(value.color);
     }, [] (const AttributedString::ColorFromCGColor& value) -> RetainPtr<id> {
@@ -400,11 +495,11 @@ static RetainPtr<id> toNSObject(const AttributedString::AttributeValue& value, I
     });
 }
 
-static RetainPtr<NSDictionary> toNSDictionary(const HashMap<String, AttributedString::AttributeValue>& map, IdentifierToTableMap& tables, IdentifierToTableBlockMap& tableBlocks, IdentifierToListMap& lists)
+static RetainPtr<NSDictionary> toNSDictionary(const HashMap<String, AttributedString::AttributeValue>& map, IdentifierToTableMap& tables, IdentifierToTableBlockMap& tableBlocks, IdentifierToListMap& lists, InstalledFontToCTFontCache& fontCache)
 {
     auto result = adoptNS([[NSMutableDictionary alloc] initWithCapacity:map.size()]);
     for (auto& pair : map) {
-        if (auto nsObject = toNSObject(pair.value, tables, tableBlocks, lists))
+        if (auto nsObject = toNSObject(pair.value, tables, tableBlocks, lists, fontCache))
             [result setObject:nsObject.get() forKey:pair.key.createNSString().get()];
     }
     return result;
@@ -423,7 +518,8 @@ RetainPtr<NSDictionary> AttributedString::documentAttributesAsNSDictionary() con
     IdentifierToTableMap tables;
     IdentifierToTableBlockMap tableBlocks;
     IdentifierToListMap lists;
-    return toNSDictionary(*documentAttributes, tables, tableBlocks, lists);
+    InstalledFontToCTFontCache fontCache;
+    return toNSDictionary(*documentAttributes, tables, tableBlocks, lists, fontCache);
 }
 
 RetainPtr<NSAttributedString> AttributedString::nsAttributedString() const
@@ -434,11 +530,12 @@ RetainPtr<NSAttributedString> AttributedString::nsAttributedString() const
     IdentifierToTableMap tables;
     IdentifierToTableBlockMap tableBlocks;
     IdentifierToListMap lists;
+    InstalledFontToCTFontCache fontCache;
     RetainPtr result = adoptNS([[NSMutableAttributedString alloc] initWithString:string.createNSString().get()]);
     for (auto& pair : attributes) {
         auto& map = pair.second;
         auto& range = pair.first;
-        [result addAttributes:toNSDictionary(map, tables, tableBlocks, lists).get() range:NSMakeRange(range.location, range.length)];
+        [result addAttributes:toNSDictionary(map, tables, tableBlocks, lists, fontCache).get() range:NSMakeRange(range.location, range.length)];
     }
     return result;
 }
@@ -692,7 +789,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     };
 }
 
-static std::optional<AttributedString::AttributeValue> extractValue(id value, TableToIdentifierMap& tableIDs, TableBlockToIdentifierMap& tableBlockIDs, ListToIdentifierMap& listIDs)
+static std::optional<AttributedString::AttributeValue> extractValue(id value, TableToIdentifierMap& tableIDs, TableBlockToIdentifierMap& tableBlockIDs, ListToIdentifierMap& listIDs, NSFontToInstalledFontCache& fontCache)
 {
     if (CFGetTypeID((CFTypeRef)value) == CGColorGetTypeID())
         return { { AttributedString::ColorFromCGColor  { Color::createAndPreserveColorSpace((CGColorRef) value) } } };
@@ -739,8 +836,18 @@ static std::optional<AttributedString::AttributeValue> extractValue(id value, Ta
         }
         return { { textAttachment } };
     }
-    if ([value isKindOfClass:PlatformFontClass])
-        return { { *Font::create(FontPlatformData((__bridge CTFontRef)value, [(PlatformFont *)value pointSize]))->toSerializableInstalledFont() } };
+    if ([value isKindOfClass:PlatformFontClass]) {
+        RetainPtr ctFont = bridge_cast((PlatformFont *)value);
+        if (auto it = fontCache.find(ctFont.get()); it != fontCache.end())
+            return AttributedString::AttributeValue { *it->value };
+        ++s_encodeFontCacheMisses;
+        auto installedFont = Font::create(FontPlatformData(ctFont.get(), [(PlatformFont *)value pointSize]))->toSerializableInstalledFont();
+        if (!installedFont)
+            return std::nullopt;
+        AttributedString::AttributeValue result { *installedFont };
+        fontCache.set(ctFont.get(), makeUniqueWithoutFastMallocCheck<InstalledFont>(WTF::move(*installedFont)));
+        return result;
+    }
     if ([value isKindOfClass:PlatformColorClass])
         return { { AttributedString::ColorFromPlatformColor { colorFromCocoaColor((PlatformColor *)value) } } };
     if (value) {
@@ -751,7 +858,7 @@ static std::optional<AttributedString::AttributeValue> extractValue(id value, Ta
     return std::nullopt;
 }
 
-static HashMap<String, AttributedString::AttributeValue> extractDictionary(NSDictionary *dictionary, TableToIdentifierMap& tableIDs, TableBlockToIdentifierMap& tableBlockIDs, ListToIdentifierMap& listIDs)
+static HashMap<String, AttributedString::AttributeValue> extractDictionary(NSDictionary *dictionary, TableToIdentifierMap& tableIDs, TableBlockToIdentifierMap& tableBlockIDs, ListToIdentifierMap& listIDs, NSFontToInstalledFontCache& fontCache)
 {
     HashMap<String, AttributedString::AttributeValue> result;
     [dictionary enumerateKeysAndObjectsUsingBlock:[&](id key, id value, BOOL *) {
@@ -760,7 +867,7 @@ static HashMap<String, AttributedString::AttributeValue> extractDictionary(NSDic
             ASSERT_NOT_REACHED();
             return;
         }
-        auto extractedValue = extractValue(value, tableIDs, tableBlockIDs, listIDs);
+        auto extractedValue = extractValue(value, tableIDs, tableBlockIDs, listIDs, fontCache);
         if (!extractedValue) {
             ASSERT_NOT_REACHED();
             return;
@@ -780,13 +887,14 @@ AttributedString AttributedString::fromNSAttributedStringAndDocumentAttributes(R
     __block TableToIdentifierMap tableIDs;
     __block TableBlockToIdentifierMap tableBlockIDs;
     __block ListToIdentifierMap listIDs;
+    __block NSFontToInstalledFontCache fontCache;
     __block AttributedString result;
     result.string = [string string];
     [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired usingBlock: ^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
-        result.attributes.append({ Range { range.location, range.length }, extractDictionary(attributes, tableIDs, tableBlockIDs, listIDs) });
+        result.attributes.append({ Range { range.location, range.length }, extractDictionary(attributes, tableIDs, tableBlockIDs, listIDs, fontCache) });
     }];
     if (dictionary)
-        result.documentAttributes = extractDictionary(dictionary.get(), tableIDs, tableBlockIDs, listIDs);
+        result.documentAttributes = extractDictionary(dictionary.get(), tableIDs, tableBlockIDs, listIDs, fontCache);
     return { WTF::move(result) };
 }
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -671,6 +671,7 @@
 				WebCore/cocoa/AudioStreamDescriptionCocoa.mm,
 				WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm,
 				WebCore/cocoa/AVFoundationSoftLinkTest.mm,
+				WebCore/cocoa/AttributedStringFontCache.mm,
 				WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp,
 				WebCore/cocoa/CaptionPreferencesTests.mm,
 				WebCore/cocoa/CoreMediaUtilities.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AttributedStringFontCache.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AttributedStringFontCache.mm
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Helpers/Test.h"
+#import <CoreText/CoreText.h>
+#import <WebCore/AttributedString.h>
+#import <wtf/RetainPtr.h>
+
+#if PLATFORM(MAC)
+#import <AppKit/AppKit.h>
+#else
+#import <UIKit/UIKit.h>
+#endif
+
+namespace TestWebKitAPI {
+
+TEST(AttributedStringFontCache, RoundTripDeduplicatesSharedFont)
+{
+    constexpr unsigned runCount = 200;
+
+    RetainPtr font = [PlatformFont systemFontOfSize:14];
+    RetainPtr string = adoptNS([[NSMutableString alloc] initWithCapacity:runCount]);
+    for (unsigned i = 0; i < runCount; ++i)
+        [string appendString:@"X"];
+
+    RetainPtr nsString = adoptNS([[NSMutableAttributedString alloc] initWithString:string]);
+    for (unsigned i = 0; i < runCount; ++i) {
+        // Alternate foreground color so adjacent attribute dictionaries differ and NSMutableAttributedString
+        // does not coalesce runs. The font itself is shared across every run.
+        RetainPtr color = (i % 2) ? [PlatformColor redColor] : [PlatformColor blueColor];
+        [nsString addAttributes:@{
+            NSFontAttributeName: font,
+            NSForegroundColorAttributeName: color,
+        } range:NSMakeRange(i, 1)];
+    }
+
+    auto encodeMissesBefore = WebCore::AttributedString::encodeFontCacheMissesForTesting();
+    auto decodeMissesBefore = WebCore::AttributedString::decodeFontCacheMissesForTesting();
+
+    auto webCoreString = WebCore::AttributedString::fromNSAttributedString(WTF::move(nsString));
+
+    auto encodeMissesAfterEncode = WebCore::AttributedString::encodeFontCacheMissesForTesting();
+    EXPECT_EQ(1u, encodeMissesAfterEncode - encodeMissesBefore);
+
+    RetainPtr roundTripped = webCoreString.nsAttributedString();
+    EXPECT_TRUE(roundTripped);
+    EXPECT_EQ(runCount, [roundTripped length]);
+
+    auto decodeMissesAfterDecode = WebCore::AttributedString::decodeFontCacheMissesForTesting();
+    EXPECT_EQ(1u, decodeMissesAfterDecode - decodeMissesBefore);
+}
+
+static RetainPtr<PlatformFont> fontWithBaselineAdjust(double baselineAdjust)
+{
+    RetainPtr adjustNumber = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &baselineAdjust));
+    CFTypeRef keys[] = { kCTFontBaselineAdjustAttribute };
+    CFTypeRef values[] = { adjustNumber.get() };
+    RetainPtr adjustDict = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    RetainPtr base = adoptCF(CTFontDescriptorCreateWithNameAndSize(CFSTR("Helvetica"), 14));
+    RetainPtr descriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(base.get(), adjustDict.get()));
+    RetainPtr ctFont = adoptCF(CTFontCreateWithFontDescriptor(descriptor.get(), 14, nullptr));
+    return (__bridge PlatformFont *)ctFont.get();
+}
+
+static std::optional<double> baselineAdjustForFont(PlatformFont *font)
+{
+    RetainPtr descriptor = adoptCF(CTFontCopyFontDescriptor((__bridge CTFontRef)font));
+    RetainPtr value = adoptCF(static_cast<CFNumberRef>(CTFontDescriptorCopyAttribute(descriptor.get(), kCTFontBaselineAdjustAttribute)));
+    if (!value)
+        return std::nullopt;
+    double result = 0;
+    if (!CFNumberGetValue(value.get(), kCFNumberDoubleType, &result))
+        return std::nullopt;
+    return result;
+}
+
+TEST(AttributedStringFontCache, PostScriptFontsDifferingInBaselineAdjustDoNotCollide)
+{
+    // Two fonts with the same PostScript name but different kCTFontBaselineAdjustAttribute values.
+    // The decode cache key is derived from a stringified summary of InstalledFont content; if a
+    // distinguishing attribute is omitted from that summary, these two InstalledFonts alias to the
+    // same key and the second run renders with the first font's CTFont. Verifies each run
+    // round-trips back to a CTFont with the right baseline adjustment.
+
+    RetainPtr fontA = fontWithBaselineAdjust(3);
+    RetainPtr fontB = fontWithBaselineAdjust(7);
+    ASSERT_TRUE(fontA);
+    ASSERT_TRUE(fontB);
+
+    RetainPtr nsString = adoptNS([[NSMutableAttributedString alloc] initWithString:@"AB"]);
+    [nsString addAttribute:NSFontAttributeName value:fontA.get() range:NSMakeRange(0, 1)];
+    [nsString addAttribute:NSFontAttributeName value:fontB.get() range:NSMakeRange(1, 1)];
+
+    auto webCoreString = WebCore::AttributedString::fromNSAttributedString(WTF::move(nsString));
+    RetainPtr roundTripped = webCoreString.nsAttributedString();
+    EXPECT_TRUE(roundTripped);
+
+    PlatformFont *gotA = [roundTripped attribute:NSFontAttributeName atIndex:0 effectiveRange:nullptr];
+    PlatformFont *gotB = [roundTripped attribute:NSFontAttributeName atIndex:1 effectiveRange:nullptr];
+    EXPECT_TRUE(gotA);
+    EXPECT_TRUE(gotB);
+
+    auto baselineAdjustA = baselineAdjustForFont(gotA);
+    auto baselineAdjustB = baselineAdjustForFont(gotB);
+    EXPECT_TRUE(baselineAdjustA.has_value());
+    EXPECT_TRUE(baselineAdjustB.has_value());
+    EXPECT_DOUBLE_EQ(3, *baselineAdjustA);
+    EXPECT_DOUBLE_EQ(7, *baselineAdjustB);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### b17b549e3fbe4a929404b037e1888f4db2dbb91f
<pre>
Typing in complicated Mail replies lags.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317589">https://bugs.webkit.org/show_bug.cgi?id=317589</a>
<a href="https://rdar.apple.com/175785816">rdar://175785816</a>

Reviewed by Abrar Rahman Protyasha.

When the same font appears in many attribute runs of an NSAttributedString — the typical shape of styled mail content
— AttributedString::fromNSAttributedString and AttributedString::nsAttributedString redo expensive font work for every
run. On the encode side that means Font::create + platformGlyphInit + determinePitch, which queries
kCTFontIsUserInstalledAttribute via uncached XT property lookups; on the decode side it means
CTFontDescriptorCreateWithAttributesAndOptions + CTFontCreateWithFontDescriptor. In a sample taken while typing into a
complex Mail message, that work dominated the IPC dispatch CPU.

Add a per-call cache in each direction. The encode-side cache is keyed on CTFontRef identity because
NSAttributedString interns shared font attributes, so the same pointer recurs across runs. The decode-side cache is
keyed on a stringified summary of InstalledFont content (postScriptName, descriptor options, point size, plus traits,
opticalSize, and variations content) because each AttributeValue carries its own copy. Both caches live for one
fromNSAttributedString / nsAttributedString call and are threaded through the existing parameter pattern that already
passes the table/list/block ID maps.

The decode-side key omits matrix, paletteColors, and featureSettings; when any of those is set on the source font the
call falls through to the slow path uncached. Those are uncommon in mail and including them in a stringified key would
be either lossy (matrix is opaque CFData; palette colors are CGColors) or expensive enough to defeat the cache.

Adds two miss counters with WEBCORE_EXPORT accessors for testing, and a TestWebKitAPI test that round-trips a
200-run NSMutableAttributedString whose runs all share one NSFont (alternated by foreground color so the runs don&apos;t
coalesce) and asserts each direction&apos;s miss counter advanced by exactly 1.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/AttributedStringFontCache.mm

* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::AttributedString::encodeFontCacheMissesForTesting):
(WebCore::AttributedString::decodeFontCacheMissesForTesting):
(WebCore::stringifyCFNumber):
(WebCore::stringifyCFBoolean):
(WebCore::cacheKeyForInstalledFont):
(WebCore::toNSObject):
(WebCore::toNSDictionary):
(WebCore::AttributedString::documentAttributesAsNSDictionary const):
(WebCore::AttributedString::nsAttributedString const):
(WebCore::extractValue):
(WebCore::extractDictionary):
(WebCore::AttributedString::fromNSAttributedStringAndDocumentAttributes):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/AttributedStringFontCache.mm: Added.
(TestWebKitAPI::TEST(AttributedStringFontCache, RoundTripDeduplicatesSharedFont)):
(TestWebKitAPI::fontWithBaselineAdjust):
(TestWebKitAPI::baselineAdjustForFont):
(TestWebKitAPI::TEST(AttributedStringFontCache, PostScriptFontsDifferingInBaselineAdjustDoNotCollide)):

Canonical link: <a href="https://commits.webkit.org/316044@main">https://commits.webkit.org/316044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/635ac9c45b9ab21594938da81826904930548a3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128484 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29d96c20-05a4-45d9-8738-d1a5a87a81e6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133192 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1511da75-de49-4902-a2ca-6b8bfc242bf5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173728 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113686 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39a22bd5-d41a-4ec1-9c02-0c0b63459e92) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35030 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33348 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28827 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182732 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141654 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44350 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141466 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45039 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109732 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36733 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116930 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43550 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8121 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43197 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->