### PR TITLE
[WebGPU] Render pipeline silently produces no draw output when given pipeline-overridable constants that its vertex/fragment entry points don't use

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_317110-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_317110-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: pipeline created
+CONSOLE MESSAGE: no validation error
+CONSOLE MESSAGE: invalid override rejected
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_317110.html
+++ b/LayoutTests/fast/webgpu/regression/repro_317110.html
@@ -1,0 +1,74 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    // Override `WG` is declared in the module and used only by a compute
+    // entry point, not by the vertex/fragment entry points. Supplying a
+    // value for it via `constants` on a render pipeline must be valid per
+    // the WebGPU spec and must not cause draws to be silently dropped.
+    let module = device.createShaderModule({code: `
+      override WG: u32;
+      @compute @workgroup_size(WG) fn cs() {}
+
+      @vertex fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+        var p = array<vec2f,3>(vec2f(-1,-1), vec2f(3,-1), vec2f(-1,3));
+        return vec4f(p[i], 0, 1);
+      }
+      @fragment fn fs() -> @location(0) vec4f {
+        return vec4f(0.0, 1.0, 0.0, 1.0);
+      }`});
+
+    let pipeline = device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {module, entryPoint: 'vs', constants: {WG: 8}},
+      fragment: {module, entryPoint: 'fs', targets: [{format: 'rgba8unorm'}], constants: {WG: 8}},
+    });
+    log(pipeline ? 'pipeline created' : 'pipeline null');
+
+    let texture = device.createTexture({
+      format: 'rgba8unorm',
+      size: [4, 4, 1],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    });
+    let enc = device.createCommandEncoder();
+    let pass = enc.beginRenderPass({
+      colorAttachments: [{
+        view: texture.createView(),
+        loadOp: 'clear', storeOp: 'store',
+        clearValue: {r: 0, g: 0, b: 0, a: 1},
+      }],
+    });
+    pass.setPipeline(pipeline);
+    pass.draw(3);
+    pass.end();
+    device.queue.submit([enc.finish()]);
+    await device.queue.onSubmittedWorkDone();
+
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+
+    // Also confirm passing an identifier that does NOT refer to any override
+    // in the module still produces a validation error.
+    device.pushErrorScope('validation');
+    try {
+      device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {module, entryPoint: 'vs', constants: {DOES_NOT_EXIST: 1}},
+        fragment: {module, entryPoint: 'fs', targets: [{format: 'rgba8unorm'}]},
+      });
+    } catch (e) { }
+    let secondError = await device.popErrorScope();
+    log(secondError ? 'invalid override rejected' : 'invalid override accepted');
+
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WGSL/WGSLShaderModule.cpp
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.cpp
@@ -88,6 +88,16 @@ std::optional<Error> ShaderModule::validateOverrides(const PrepareResult& prepar
     return std::nullopt;
 }
 
+bool ShaderModule::containsOverride(const String& key) const
+{
+    for (auto* variable : m_overrides) {
+        String name = variable->id().has_value() ? String::number(*variable->id()) : variable->originalName();
+        if (name == key)
+            return true;
+    }
+    return false;
+}
+
 void ShaderModule::initializeOverloads()
 {
     // This file contains the overloads generated from `TypeDeclarations.rb`

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -300,6 +300,7 @@ public:
     const OverloadedDeclaration* lookupOverload(const String&) const;
 
     void addOverride(AST::Variable& variable) { m_overrides.append(&variable); }
+    bool containsOverride(const String& key) const;
 
     Result<ConstantValue> ensureOverrideValue(const AST::Expression&, const HashMap<String, ConstantValue>&) const;
 

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -27,6 +27,7 @@
 
 #import "APIConversions.h"
 #import "ShaderModule.h"
+#import "WGSLShaderModule.h"
 
 #if !defined(NDEBUG) || (defined(ENABLE_LIBFUZZER) && ENABLE_LIBFUZZER && defined(ASAN_ENABLED) && ASAN_ENABLED)
 #include <csignal>
@@ -79,8 +80,15 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
     for (const auto entry : constants) {
         auto keyEntry = fromAPI(entry.key);
         auto indexIterator = entryPointInformation.specializationConstants.find(keyEntry);
-        if (indexIterator == entryPointInformation.specializationConstants.end())
+        if (indexIterator == entryPointInformation.specializationConstants.end()) {
+            // Per WebGPU spec: providing a value for an override declared in the
+            // shader module but not statically used by this entry point is valid
+            // and the value is ignored. Returning an invalid pipeline only when
+            // the identifier does not refer to any override in the module.
+            if (ast->containsOverride(keyEntry))
+                continue;
             return { };
+        }
 
         const auto& specializationConstant = indexIterator->value;
         switch (specializationConstant.type) {


### PR DESCRIPTION
#### 8acb03441a23a4a938d81df76ebc630d7e66013f
<pre>
[WebGPU] Render pipeline silently produces no draw output when given pipeline-overridable constants that its vertex/fragment entry points don&apos;t use
<a href="https://bugs.webkit.org/show_bug.cgi?id=317110">https://bugs.webkit.org/show_bug.cgi?id=317110</a>
<a href="https://rdar.apple.com/180267884">rdar://180267884</a>

Reviewed by Dan Glastonbury.

The spec says to allow unused overrides.

Test: fast/webgpu/regression/repro_317110.html

* LayoutTests/fast/webgpu/regression/repro_317110-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_317110.html: Added.
* Source/WebGPU/WGSL/WGSLShaderModule.cpp:
(WGSL::ShaderModule::containsOverride const):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):

Canonical link: <a href="https://commits.webkit.org/315653@main">https://commits.webkit.org/315653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fcc9afc0a4b6841bac42808e1a3f9d68420b73b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178939 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127292 "Built successfully") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132129 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93059 "1 flakes 10 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172539 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112632 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32267 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181538 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34246 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36433 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 344 new passes 23 flakes 6 failures; Uploaded test results; 344 new passes 14 flakes 4 failures; Compiled WebKit (warnings); layout-tests; Passed layout tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140578 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140414 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37812 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43847 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28863 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108059 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35683 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115612 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42357 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6948 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41750 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41893 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->