### PR TITLE
REGRESSION (315475@main): Linking AVKit in WebCoreTestSupport causes a dependency cycle

### DIFF
--- a/Source/WebCore/Configurations/WebCoreTestSupport.xcconfig
+++ b/Source/WebCore/Configurations/WebCoreTestSupport.xcconfig
@@ -61,7 +61,7 @@ CLANG_INSTRUMENT_FOR_OPTIMIZATION_PROFILING = NO; // Disable PGO profile generat
 WK_PGO_GEN_FLAGS = ; // Disable IR PGO profile generation
 WK_PGO_USE_CFLAGS = ; // Disable IR PGO profile use
 WK_PGO_USE_LDFLAGS = ; // Disable IR PGO profile use
-OTHER_LDFLAGS[sdk=iphone*] = $(WK_COMMON_OTHER_LDFLAGS) -lAccessibility -framework AVKit -framework CoreText -framework Metal $(ANGLE_LDFLAGS) $(LIBWEBRTC_LDFLAGS) $(SOURCE_VERSION_LDFLAGS);
+OTHER_LDFLAGS[sdk=iphone*] = $(WK_COMMON_OTHER_LDFLAGS) -lAccessibility -framework CoreText -framework Metal $(ANGLE_LDFLAGS) $(LIBWEBRTC_LDFLAGS) $(SOURCE_VERSION_LDFLAGS);
 OTHER_LDFLAGS[sdk=appletv*] = $(WK_COMMON_OTHER_LDFLAGS) -lAccessibility -framework CoreText -framework Metal $(ANGLE_LDFLAGS) $(LIBWEBRTC_LDFLAGS) $(SOURCE_VERSION_LDFLAGS);
 OTHER_LDFLAGS[sdk=xr*] = $(WK_COMMON_OTHER_LDFLAGS) -lAccessibility -framework CoreText -framework Metal $(ANGLE_LDFLAGS) $(LIBWEBRTC_LDFLAGS) $(SOURCE_VERSION_LDFLAGS);
 SECT_ORDER_FLAGS = ;

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -30,7 +30,11 @@
 
 #import "WebMockMediaDeviceRoute.h"
 #import <AVKit/AVKit.h>
+#import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
+
+SOFT_LINK_FRAMEWORK(AVKit)
+SOFT_LINK_CLASS(AVKit, AVPlaybackUserInterfaceMediaSelectionOption)
 
 namespace WebCore {
 
@@ -114,7 +118,7 @@ void MockMediaDeviceRoute::setAudioOptions(const Vector<AudioOption>& audioOptio
 {
     RetainPtr options = [NSMutableArray arrayWithCapacity:audioOptions.size()];
     for (auto& option : audioOptions) {
-        RetainPtr platformOption = adoptNS([[AVPlaybackUserInterfaceMediaSelectionOption alloc] initWithDisplayName:option.displayName.createNSString().get() identifier:option.identifier.createNSString().get() extendedLanguageTag:option.extendedLanguageTag.createNSString().get() mediaCharacteristics:@[]]);
+        RetainPtr platformOption = adoptNS([allocAVPlaybackUserInterfaceMediaSelectionOptionInstance() initWithDisplayName:option.displayName.createNSString().get() identifier:option.identifier.createNSString().get() extendedLanguageTag:option.extendedLanguageTag.createNSString().get() mediaCharacteristics:@[]]);
         [options addObject:platformOption.get()];
     }
     [m_platformRoute setAudioOptions:options.get()];

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -31,7 +31,11 @@
 #import "MockMediaDeviceRouteURLCallback.h"
 #import <WebCore/JSDOMPromise.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/SoftLinking.h>
 #import <wtf/WeakObjCPtr.h>
+
+SOFT_LINK_FRAMEWORK(AVKit)
+SOFT_LINK_CLASS(AVKit, AVPlaybackUserInterfacePlaybackPosition)
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -74,7 +78,7 @@ NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRou
 
 - (void)seekToPosition:(CMTime)position tolerance:(CMTime)tolerance
 {
-    RetainPtr playbackPosition = adoptNS([[AVPlaybackUserInterfacePlaybackPosition alloc] initWithPosition:position hostTime:CMClockGetTime(CMClockGetHostTimeClock()) rate:0]);
+    RetainPtr playbackPosition = adoptNS([allocAVPlaybackUserInterfacePlaybackPositionInstance() initWithPosition:position hostTime:CMClockGetTime(CMClockGetHostTimeClock()) rate:0]);
     self.playbackPosition = playbackPosition.get();
 }
 


### PR DESCRIPTION
#### a111b737af9b6c7007fc6b44a0650934339d03e2
<pre>
REGRESSION (315475@main): Linking AVKit in WebCoreTestSupport causes a dependency cycle
<a href="https://bugs.webkit.org/show_bug.cgi?id=317600">https://bugs.webkit.org/show_bug.cgi?id=317600</a>
<a href="https://rdar.apple.com/180306514">rdar://180306514</a>

Reviewed by Jean-Yves Avenard.

Soft-linked AVKit in WebCoreTestSupport to avoid a dependency cycle.

* Source/WebCore/Configurations/WebCoreTestSupport.xcconfig:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::setAudioOptions):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute seekToPosition:tolerance:]):

Canonical link: <a href="https://commits.webkit.org/315638@main">https://commits.webkit.org/315638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73507a3ece819d3154146faa66e10dae0ec06b2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127300 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dc90e5e-78c0-4b7c-9f45-5b537ce28b52) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171454 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43139 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132136 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 13 flakes 3 failures; Uploaded test results; layout-tests; Passed layout tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a15973a4-461d-4bc1-8a0c-5465e76e687b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172547 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152493 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112639 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/895df041-b631-4752-96f2-8fb585e7b590) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32274 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27644 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181546 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140584 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43166 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140420 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37799 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43855 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108075 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35689 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115620 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42365 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6957 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41758 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42013 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41901 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->