### PR TITLE
[Grid] Grid items with stretch preferred size have incorrect min content contributions.

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-item-min-contribution-fill-available-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-item-min-contribution-fill-available-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .inline-grid 1
+

--- a/LayoutTests/fast/css-grid-layout/grid-item-min-contribution-fill-available.html
+++ b/LayoutTests/fast/css-grid-layout/grid-item-min-contribution-fill-available.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link href="../css-intrinsic-dimensions/resources/width-keyword-classes.css" rel="stylesheet">
+<link href="resources/grid.css" rel="stylesheet">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/check-layout-th.js"></script>
+<style>
+.inline-grid {
+    grid-template-columns: minmax(auto, 50px);
+}
+
+.content {
+    width: 100px;
+    height: 25px;
+}
+</style>
+</head>
+<body onload="checkLayout('.inline-grid')">
+<div class="inline-grid" data-expected-width="50">
+    <div class="fill-available"><div class="content"></div></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-behaves-as-auto-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-behaves-as-auto-001-expected.txt
@@ -1,0 +1,5 @@
+
+PASS .inline-grid 1
+PASS .inline-grid 2
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-behaves-as-auto-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-behaves-as-auto-001.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grid item minimum contribution when preferred size depends on size of containing block.</title>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#algo-single-span-items">
+<meta name="assert" content="A grid item whose preferred size depends on the size of its containing block in the relevant axis should contribute its automatic minimum size, not its min-content contribution.">
+<link rel="stylesheet" href="/css/support/grid.css">
+<style>
+.inline-grid {
+    grid-template-columns: minmax(auto, 50px);
+}
+.content {
+    width: 100px;
+    height: 25px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.inline-grid')">
+<div id="log"></div>
+
+<div class="inline-grid" data-expected-width="50">
+    <div class="item" style="width: stretch;"><div class="content"></div></div>
+</div>
+
+<div class="inline-grid" data-expected-width="50">
+    <div class="item" style="width: auto;"><div class="content"></div></div>
+</div>
+
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-fit-content-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-fit-content-001-expected.txt
@@ -1,0 +1,3 @@
+
+PASS .inline-grid 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-fit-content-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-fit-content-001.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Grid item minimum contribution when preferred size is fit-content.</title>
+<link rel="author" title="Yulun Wu" href="mailto:yulun_wu@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#algo-single-span-items">
+<meta name="assert" content="A grid item whose preferred size is fit-content neither behaves as auto nor depends on the size of its containing block in the relevant axis, so its minimum contribution is its min-content contribution, not its automatic minimum size, even when that exceeds the fixed max track sizing function.">
+<link rel="stylesheet" href="/css/support/grid.css">
+<style>
+.inline-grid {
+    grid-template-columns: minmax(auto, 50px);
+}
+.content {
+    width: 100px;
+    height: 25px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.inline-grid')">
+<div id="log"></div>
+
+<div class="inline-grid" data-expected-width="100">
+    <div class="item" style="width: fit-content;"><div class="content"></div></div>
+</div>
+
+</body>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1191,7 +1191,25 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContributionForGridItem(RenderBo
         return { };
 
     auto& gridItemSize = isRowAxis ? gridItem.style().logicalWidth() : gridItem.style().logicalHeight();
-    if (!gridItemSize.isAuto() && !gridItemSize.isPercentOrCalculated())
+
+    auto behavesAsAuto = [&gridItemSize] {
+        // FIXME: fully implement behavesAsAuto.
+        // https://www.w3.org/TR/css-sizing-3/#behave-as-auto
+        return gridItemSize.isAuto();
+    };
+
+    auto dependsOnContainingBlockSize = [&gridItemSize] {
+        return gridItemSize.isPercentOrCalculated()
+            || gridItemSize.isStretch();
+    };
+
+    // https://drafts.csswg.org/css-grid/#algo-single-span-items
+    // Specifically, if the item’s computed preferred size behaves as auto
+    // or depends on the size of its containing block in the relevant axis,
+    // its minimum contribution is the outer size that would result from assuming
+    // the item’s used minimum size as its preferred size; else the item’s
+    // minimum contribution is its min-content contribution.
+    if (!behavesAsAuto() && !dependsOnContainingBlockSize())
         return minContentContributionForGridItem(gridItem, gridLayoutState);
 
     auto& gridItemMinSize = isRowAxis ? gridItem.style().logicalMinWidth() : gridItem.style().logicalMinHeight();


### PR DESCRIPTION
#### 0c5ae4f07adc83be7ce540665d2a0d68ece80ebf
<pre>
[Grid] Grid items with stretch preferred size have incorrect min content contributions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=317964">https://bugs.webkit.org/show_bug.cgi?id=317964</a>
&lt;<a href="https://rdar.apple.com/180748205">rdar://180748205</a>&gt;

Reviewed by Sammy Gill.

Grid items with stretch preferred sizes were not correctly implementing the spec:

<a href="https://www.w3.org/TR/css-grid-2/#algo-single-span-items">https://www.w3.org/TR/css-grid-2/#algo-single-span-items</a>

Specifically, if the item’s computed preferred size behaves as auto or depends
on the size of its containing block in the relevant axis, its minimum contribution
is the outer size that would result from assuming the item’s used minimum size as
its preferred size; else the item’s minimum contribution is its min-content contribution.

Specifically, we were not fully respecting/evaluating:

        &quot;depends on the size of its containing block in the relevant axis&quot;

As we were only handling isPercentOrCalculated() and incorrectly letting stretch slip by.

This PR split the check into two spec-named predicates, behavesAsAuto() and
dependsOnContainingBlockSize(), to clarify where and how we are following spec.

* LayoutTests/fast/css-grid-layout/grid-item-min-contribution-fill-available-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/grid-item-min-contribution-fill-available.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-behaves-as-auto-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-behaves-as-auto-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-fit-content-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-min-contribution-fit-content-001.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithmStrategy::minContributionForGridItem const):

Canonical link: <a href="https://commits.webkit.org/316296@main">https://commits.webkit.org/316296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3febe7d81543f2954f25148c068fffd211979fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181064 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129315 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51ff15ab-4ac5-424f-afc6-447dbe5253c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133638 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/338c9c12-d049-4f7e-ab0a-65aed62ce186) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114110 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30eeca7b-2bb1-4524-ac67-f585182de81e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35641 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33903 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29814 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183732 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142326 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142217 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46025 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110660 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26099 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37333 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117713 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44543 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8573 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43943 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44175 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->