### PR TITLE
Cherry-pick 315158@main (a484a181f9e1). https://bugs.webkit.org/show_bug.cgi?id=316861

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.h
@@ -45,7 +45,7 @@ struct _WebKitVideoSinkClass {
     GstVideoSinkClass parentClass;
 };
 
-GType webkit_video_sink_get_type() G_GNUC_CONST;
+GType webkit_video_sink_get_type();
 
 GstElement* webkitVideoSinkNew();
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h
@@ -67,14 +67,14 @@ private:
     // If we had no queue, the main thread would have to be awaken for every frame. On the other hand, if the
     // queue had unlimited size WebKit would end up requesting flushes more often than necessary when frames
     // in the future are re-appended. As a sweet spot between these extremes we choose to allow enqueueing a
-    // few seconds worth of samples.
+    // couple hundred milliseconds worth of samples.
 
     // `isReadyForMoreSamples` follows the classical two water levels strategy: initially it's true until the
     // high water level is reached, then it becomes false until the queue drains down to the low water level
     // and the cycle repeats. This way we avoid stalls and minimize context switches.
 
-    static const GstClockTime s_durationEnqueuedHighWaterLevel = 5 * GST_SECOND;
-    static const GstClockTime s_durationEnqueuedLowWaterLevel = 2 * GST_SECOND;
+    static const GstClockTime s_durationEnqueuedHighWaterLevel = 200 * GST_MSECOND;
+    static const GstClockTime s_durationEnqueuedLowWaterLevel = 100 * GST_MSECOND;
 
     GstClockTime durationEnqueued() const;
     void checkLowLevel();

--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
@@ -76,7 +76,7 @@ typedef enum {
 typedef struct _WebKitFeature WebKitFeature;
 
 WEBKIT_API GType
-webkit_feature_get_type          (void) G_GNUC_CONST;
+webkit_feature_get_type          (void);
 
 WEBKIT_API WebKitFeature *
 webkit_feature_ref               (WebKitFeature *feature);
@@ -109,7 +109,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(WebKitFeature, webkit_feature_unref)
 typedef struct _WebKitFeatureList WebKitFeatureList;
 
 WEBKIT_API GType
-webkit_feature_list_get_type     (void) G_GNUC_CONST;
+webkit_feature_list_get_type     (void);
 
 WEBKIT_API WebKitFeatureList *
 webkit_feature_list_ref          (WebKitFeatureList *feature_list);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMEventTarget.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMEventTarget.h
@@ -54,7 +54,7 @@ struct _WebKitDOMEventTargetIface {
 };
 
 
-WEBKIT_DEPRECATED GType     webkit_dom_event_target_get_type(void) G_GNUC_CONST;
+WEBKIT_DEPRECATED GType     webkit_dom_event_target_get_type(void);
 
 /**
  * webkit_dom_event_target_dispatch_event:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNodeFilter.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNodeFilter.h
@@ -229,7 +229,7 @@ struct _WebKitDOMNodeFilterIface {
 };
 
 
-WEBKIT_DEPRECATED GType webkit_dom_node_filter_get_type(void) G_GNUC_CONST;
+WEBKIT_DEPRECATED GType webkit_dom_node_filter_get_type(void);
 
 /**
  * webkit_dom_node_filter_accept_node:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMXPathNSResolver.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMXPathNSResolver.h
@@ -44,7 +44,7 @@ struct _WebKitDOMXPathNSResolverIface {
 };
 
 
-WEBKIT_DEPRECATED GType webkit_dom_xpath_ns_resolver_get_type(void) G_GNUC_CONST;
+WEBKIT_DEPRECATED GType webkit_dom_xpath_ns_resolver_get_type(void);
 
 /**
  * webkit_dom_xpath_ns_resolver_lookup_namespace_uri:

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -148,5 +148,12 @@
 #define PAS_USE_SPINLOCKS                1
 #endif
 
+// FIXME: Workaround for rdar://119319825
+#if !defined(__swift__)
+#define PAS_ENABLE_MALLOC_STACK_LOGGER 1
+#else
+#define PAS_ENABLE_MALLOC_STACK_LOGGER 0
+#endif
+
 #endif /* PAS_CONFIG_H */
 

--- a/Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h
@@ -57,11 +57,12 @@ PAS_END_EXTERN_C;
 #define PAS_HAVE_PTHREAD_PRIVATE 0
 #endif
 
-PAS_BEGIN_EXTERN_C;
+#endif /* PAS_OS(DARWIN) */
 
 /* From OSS libmalloc stack_logging.h
    https://github.com/apple-oss-distributions/libmalloc/blob/main/private/stack_logging.h */
 /*********    MallocStackLogging permanant SPIs  ************/
+// On non-darwin platforms, we just stub out this API.
 
 #define pas_stack_logging_type_free                           0
 #define pas_stack_logging_type_generic                        1    /* anything that is not allocation/deallocation */
@@ -85,8 +86,6 @@ VM_FLAGS_ALIAS_MASK);
 #define pas_stack_logging_flag_zone        8    /* NSZoneMalloc, etc... */
 #define pas_stack_logging_flag_cleared    64    /* for NewEmptyHandle */
 
-PAS_END_EXTERN_C;
-
 // In a build using clang modules, we must never redeclare items
 // from other headers, but instead include those headers.
 #if defined(__has_include) && __has_include(<stack_logging.h>)
@@ -104,14 +103,12 @@ typedef void(malloc_logger_t)(uint32_t type,
                               uintptr_t result,
                               uint32_t num_hot_frames_to_skip);
 // FIXME: Workaround for rdar://119319825
-#if !defined(__swift__)
+#if PAS_ENABLE_MALLOC_STACK_LOGGER
 extern malloc_logger_t* malloc_logger;
 #endif
 
 PAS_END_EXTERN_C;
 
 #endif /* defined(__has_include) && __has_include(<stack_logging.h>) */
-
-#endif /* PAS_OS(DARWIN) */
 
 #endif /* PAS_DARWIN_SPI_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.c
@@ -48,7 +48,13 @@ bool pas_compute_msl_is_enabled(void)
     return pas_msl_is_enabled_flag_value == pas_msl_is_enabled_flag_enabled;
 }
 
-#if PAS_OS(DARWIN)
+#if PAS_ENABLE_MALLOC_STACK_LOGGER
+
+#if !PAS_OS(DARWIN)
+/* On Darwin the system libmalloc owns this global; elsewhere libpas provides it
+   so an injected tool (e.g. via LD_PRELOAD) can install a logger callback. */
+PAS_API malloc_logger_t* malloc_logger = NULL;
+#endif
 
 PAS_NEVER_INLINE pas_allocation_result pas_msl_malloc_logging_slow(size_t size, pas_allocation_result result)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.h
@@ -44,10 +44,8 @@ typedef enum pas_msl_is_enabled_flag pas_msl_is_enabled_flag;
 extern pas_msl_is_enabled_flag pas_msl_is_enabled_flag_value;
 PAS_API bool pas_compute_msl_is_enabled(void);
 
-#if PAS_OS(DARWIN)
 PAS_API PAS_NEVER_INLINE pas_allocation_result pas_msl_malloc_logging_slow(size_t size, pas_allocation_result result);
 PAS_API PAS_NEVER_INLINE void pas_msl_free_logging_slow(void*);
-#endif
 
 static PAS_ALWAYS_INLINE bool pas_msl_is_enabled(void)
 {
@@ -64,7 +62,7 @@ static PAS_ALWAYS_INLINE bool pas_msl_is_enabled(void)
 
 static PAS_ALWAYS_INLINE pas_allocation_result pas_msl_malloc_logging(size_t size, pas_allocation_result result)
 {
-#if PAS_OS(DARWIN) && !defined(__swift__) // FIXME: Workaround for rdar://119319825
+#if PAS_ENABLE_MALLOC_STACK_LOGGER
     if (PAS_UNLIKELY(malloc_logger))
         return pas_msl_malloc_logging_slow(size, result); /* Keep it tail-call to avoid messing up the fast path code. */
 #else
@@ -75,8 +73,7 @@ static PAS_ALWAYS_INLINE pas_allocation_result pas_msl_malloc_logging(size_t siz
 
 static PAS_ALWAYS_INLINE void pas_msl_free_logging(void* ptr)
 {
-#if PAS_OS(DARWIN) && !defined(__swift__) // FIXME: Workaround for rdar://119319825
-
+#if PAS_ENABLE_MALLOC_STACK_LOGGER
     if (PAS_UNLIKELY(malloc_logger))
         return pas_msl_free_logging_slow(ptr); /* Keep it tail-call to avoid messing up the fast path code. */
 #else


### PR DESCRIPTION
#### 1e51488df23b74bdca0761934a9f321bb0e8e04b
<pre>
Cherry-pick 315158@main (a484a181f9e1). <a href="https://bugs.webkit.org/show_bug.cgi?id=316861">https://bugs.webkit.org/show_bug.cgi?id=316861</a>

    Support pleiades on linux
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316861">https://bugs.webkit.org/show_bug.cgi?id=316861</a>

    Reviewed by Yusuke Suzuki.

    This is a small workaround to get pleiades working on linux.

    Canonical link: <a href="https://commits.webkit.org/315158@main">https://commits.webkit.org/315158@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.781@webkitglib/2.52">https://commits.webkit.org/305877.781@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f28a44eb3f73bfc1e3f22e76721e8596120eef4d
<pre>
Cherry-pick 315219@main (82f3a3ac140f). <a href="https://bugs.webkit.org/show_bug.cgi?id=316412">https://bugs.webkit.org/show_bug.cgi?id=316412</a>

    [GStreamer][MSE] Reduce TrackQueue buffer size
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316412">https://bugs.webkit.org/show_bug.cgi?id=316412</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Currently, the TrackQueue used in MSE for GStreamer is rather large, up
    to 5 seconds, much larger than the ones used in the rest of the playback
    pipeline.

    By reducing the queue size more quality changes can be completed without
    a flush -- or in a flushless implementation, with lower latency.

    * Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.h:

    Canonical link: <a href="https://commits.webkit.org/315219@main">https://commits.webkit.org/315219@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.780@webkitglib/2.52">https://commits.webkit.org/305877.780@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b4dcfbced573e18f0aee3f500e707980668e5b4d
<pre>
Cherry-pick 315601@main (dd7e7858bd9c). <a href="https://bugs.webkit.org/show_bug.cgi?id=317588">https://bugs.webkit.org/show_bug.cgi?id=317588</a>

    [WPE][GTK] Remove incorrect use of G_GNUC_CONST for get_type() functions
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317588">https://bugs.webkit.org/show_bug.cgi?id=317588</a>

    Reviewed by Carlos Garcia Campos.

    GCC has become more aggressive about optimizing away the type
    initialization. Let&apos;s get ahead of this.

    Canonical link: <a href="https://commits.webkit.org/315601@main">https://commits.webkit.org/315601@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.779@webkitglib/2.52">https://commits.webkit.org/305877.779@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd292664b87f25e966a993531ca13be9b2ed6760

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169596 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/43518 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/36860 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178955 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127308 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171462 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/43977 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43147 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132146 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127308 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172555 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/43977 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/36860 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112649 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/43977 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43147 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27652 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/36860 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/43977 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/36860 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181554 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/30851 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34262 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/43147 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140594 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/43174 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/36860 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140430 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/43863 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/36860 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108084 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25854 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/43863 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115628 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202275 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/42373 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/36860 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54233 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/41766 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/42021 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/41909 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->