### PR TITLE
WebFullScreenManager::requestExitFullScreen should only call close if top document is present and has no fullscreen element

### DIFF
--- a/LayoutTests/http/tests/site-isolation/exit-fullscreen-from-ui-process-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/exit-fullscreen-from-ui-process-expected.txt
@@ -1,0 +1,3 @@
+ALERT: entered fullscreen
+ALERT: exited fullscreen
+ This test passes if it runs to completion.

--- a/LayoutTests/http/tests/site-isolation/exit-fullscreen-from-ui-process.html
+++ b/LayoutTests/http/tests/site-isolation/exit-fullscreen-from-ui-process.html
@@ -1,0 +1,9 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+</script>
+<iframe src="http://localhost:8000/site-isolation/resources/exit-fullscreen-from-ui-process.html" allowfullscreen></iframe>
+This test passes if it runs to completion.

--- a/LayoutTests/http/tests/site-isolation/resources/exit-fullscreen-from-ui-process.html
+++ b/LayoutTests/http/tests/site-isolation/resources/exit-fullscreen-from-ui-process.html
@@ -1,0 +1,14 @@
+<script>
+    onload = ()=>{
+        document.addEventListener('fullscreenchange', () => {
+            if (document.fullscreenElement) {
+                alert('entered fullscreen');
+                testRunner.requestExitFullscreenFromUIProcess();
+            } else {
+                alert('exited fullscreen');
+                testRunner.notifyDone();
+            }
+        });
+        internals.withUserGesture(()=>{ document.body.requestFullscreen() })
+    }
+</script>

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -774,7 +774,7 @@ void WebFullScreenManager::requestExitFullScreen()
 
     RefPtr localMainFrame = m_page->localMainFrame();
     RefPtr topDocument = localMainFrame ? localMainFrame->document() : nullptr;
-    if (!topDocument || !protect(topDocument->fullscreen())->fullscreenElement()) {
+    if (topDocument && !protect(topDocument->fullscreen())->fullscreenElement()) {
         ALWAYS_LOG(LOGIDENTIFIER, "top document not in fullscreen, closing");
         close();
         return;


### PR DESCRIPTION
#### 2f229114ef117f39ba1445ed660aea69d7f7312f
<pre>
WebFullScreenManager::requestExitFullScreen should only call close if top document is present and has no fullscreen element
<a href="https://bugs.webkit.org/show_bug.cgi?id=317605">https://bugs.webkit.org/show_bug.cgi?id=317605</a>
<a href="https://rdar.apple.com/160964600">rdar://160964600</a>

Reviewed by Andy Estes.

WebFullScreenManager::requestExitFullScreen has some code that basically says
&quot;if something has gone wrong, just close fullscreen&quot;.  However, this code was
hit during normal exiting of fullscreen driven by the UI process with site isolation
enabled because topDocument was null because the main frame was a RemoteFrame.
Adjust the condition to only hit if there is a top document and it has no fullscreen
element, instead of hitting if we haven&apos;t found a top document.

Test: http/tests/site-isolation/exit-fullscreen-from-ui-process.html

* LayoutTests/http/tests/site-isolation/exit-fullscreen-from-ui-process-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/exit-fullscreen-from-ui-process.html: Added.
* LayoutTests/http/tests/site-isolation/resources/exit-fullscreen-from-ui-process.html: Added.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::requestExitFullScreen):

Canonical link: <a href="https://commits.webkit.org/315633@main">https://commits.webkit.org/315633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f83b2ac64412eb7aaaa269b7f18249b61606cac4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127313 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fafa87d2-2110-492c-bafc-e7052edb71bd) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132150 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56eeaba4-e1ae-4020-b4d6-ff334d05fe0a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172560 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112653 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15eccba4-ab87-4175-bc94-749a53a0001d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32287 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27657 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144000 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31909 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 344 new passes 6 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181559 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140599 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140435 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43868 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108093 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25843 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35702 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115633 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42378 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6974 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41771 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42026 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->