### PR TITLE
DEVELOPER_MODE_FATAL_WARNINGS is broken on EWS

### DIFF
--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
@@ -184,18 +184,6 @@ WebCore::CertificateInfo::CertificateChain createCertificateChain(X509_STORE_CTX
     return pemDataFromCtx(StackOfX509(ctx));
 }
 
-static String toString(const ASN1_STRING* name)
-{
-    unsigned char* data { nullptr };
-    auto length = ASN1_STRING_to_UTF8(&data, name);
-    if (length <= 0)
-        return String();
-
-    String result({ byteCast<Latin1Character>(data), static_cast<size_t>(length) });
-    OPENSSL_free(data);
-    return result;
-}
-
 static String getSubjectEntry(const X509* x509, int nid)
 {
     auto subjectName = X509_get_subject_name(x509);

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -165,14 +165,9 @@ option(DEVELOPER_MODE_FATAL_WARNINGS "Build with warnings as errors if DEVELOPER
 set(DEVELOPER_MODE_CXX_FLAGS)
 if (DEVELOPER_MODE AND DEVELOPER_MODE_FATAL_WARNINGS)
     if (MSVC)
-        set(FATAL_WARNINGS_FLAG /WX)
-    else ()
-        set(FATAL_WARNINGS_FLAG -Werror)
-    endif ()
-
-    WEBKIT_CHECK_COMPILER_FLAGS(CXX CXX_COMPILER_SUPPORTS_WERROR ${FATAL_WARNINGS_FLAG})
-    if (CXX_COMPILER_SUPPORTS_WERROR)
-        set(DEVELOPER_MODE_CXX_FLAGS ${FATAL_WARNINGS_FLAG})
+        set(DEVELOPER_MODE_CXX_FLAGS "/WX")
+    elseif (COMPILER_IS_GCC_OR_CLANG)
+        set(DEVELOPER_MODE_CXX_FLAGS "-Werror")
     endif ()
 endif ()
 
@@ -196,10 +191,10 @@ if (COMPILER_IS_GCC_OR_CLANG)
 
     # FIXME: Remove once the strict-aliasing violations exposed by 315506@main are fixed.
     # Enabling strict aliasing (the compiler default at -O2) miscompiles type-punning code
-    # in the GTK and WPE ports, causing Release-only crashes and failures. https://webkit.org/b/317542
-    if (PORT STREQUAL "GTK" OR PORT STREQUAL "WPE")
-        WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-strict-aliasing)
-    endif ()
+    # in the GTK and WPE ports, causing Release-only crashes and failures. It also introduces
+    # -Wstrict-aliasing warnings when building with GCC.
+    # https://webkit.org/b/317542
+    WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-strict-aliasing)
 
     # clang-cl.exe impersonates cl.exe so some clang arguments like -fno-rtti are
     # represented using cl.exe's options and should not be passed as flags, so


### PR DESCRIPTION
#### 69d26bab209f29f7ae25706c5d78aae791d08210
<pre>
DEVELOPER_MODE_FATAL_WARNINGS is broken on EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=317606">https://bugs.webkit.org/show_bug.cgi?id=317606</a>

Reviewed by Carlos Garcia Campos.

Testing for -Werror is extremely likely to fail because configure tests
often trigger warnings, and, well, this is -Werror, after all. This
particular flag just inherently requires special handling. Since we are
already manually testing the compiler in order to choose the correct
flag to use, just get rid of the test for -Werror.

Also, fix some warnings. Remove an unused OpenSSLHelper function, and
build with -fno-strict-aliasing for all ports because WTFString.h
contains type punning code that requires it.

Canonical link: <a href="https://commits.webkit.org/315672@main">https://commits.webkit.org/315672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebfc894004f5784a2dc2d40a0d274690a2637f30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127327 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171481 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132164 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93091 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172574 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35047 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112667 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32300 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27671 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/997 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181573 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30870 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140613 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43193 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140449 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37840 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43882 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108110 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35714 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115647 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202294 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42392 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7051 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54236 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42040 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->