### PR TITLE
[HTML Tracks] Additional tests for untested areas of the HTML TextTrack specification

### DIFF
--- a/LayoutTests/http/tests/media/track/text-track-cross-origin-in-band-expected.txt
+++ b/LayoutTests/http/tests/media/track/text-track-cross-origin-in-band-expected.txt
@@ -1,0 +1,5 @@
+
+PASS same-origin: in-band text tracks are exposed
+PASS cross-origin without crossorigin attribute: tracks hidden
+PASS cross-origin with crossorigin=anonymous and CORS: tracks exposed
+

--- a/LayoutTests/http/tests/media/track/text-track-cross-origin-in-band.html
+++ b/LayoutTests/http/tests/media/track/text-track-cross-origin-in-band.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html>
+<head>
+    <title>In-band text tracks: cross-origin media exposure rules</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.7 "Text tracks", "Media resource with text tracks":
+//     https://html.spec.whatwg.org/multipage/media.html#media-resource-with-text-tracks
+//
+// Cross-origin media data does not expose its in-band text tracks: the
+// tracks are exposed only when the media data is CORS-same-origin (either
+// served from the same origin, or fetched with the crossorigin attribute
+// set and a passing CORS check).
+
+// Page is loaded from 127.0.0.1:8000; serve the captioned media from
+// localhost:8000 to make it cross-origin.
+const SAME_ORIGIN_SRC = "/media/resources/counting-captioned.mov";
+const CROSS_ORIGIN_NO_CORS = "http://localhost:8000/media/resources/serve_video.py?type=video/quicktime&name=counting-captioned.mov";
+const CROSS_ORIGIN_WITH_CORS = "http://localhost:8000/media/resources/serve_video_cors.py?type=video/quicktime&name=counting-captioned.mov";
+
+function loadAndCount(t, src, opts = {}) {
+    const video = document.createElement("video");
+    video.muted = true;
+    if (opts.crossOrigin)
+        video.crossOrigin = opts.crossOrigin;
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    video.src = src;
+
+    // Resolve with textTracks.length once the video has settled.
+    // Prefer 'canplaythrough' as the canonical "everything loaded" signal.
+    //
+    // For cross-origin media without CORS, WebKit may not advance the
+    // video to canplaythrough at all (the media element's loading path
+    // is more conservative when CORS is unavailable). In that case the
+    // safety-net at 5s reads textTracks.length anyway. Both outcomes
+    // are spec-conforming for the no-CORS case (the spec only requires
+    // tracks not be exposed); a regression where tracks ARE exposed
+    // would populate textTracks during loadedmetadata and produce
+    // length > 0 at the safety-net.
+    return new Promise((resolve, reject) => {
+        video.addEventListener("canplaythrough",
+            () => resolve(video.textTracks.length), { once: true });
+        video.addEventListener("error",
+            e => reject(new Error(`video error: ${video.error?.message ?? e.type}`)),
+            { once: true });
+        t.step_timeout(() => resolve(video.textTracks.length), 5000);
+    });
+}
+
+promise_test(async t => {
+    // Same-origin media: in-band tracks are exposed.
+    const count = await loadAndCount(t, SAME_ORIGIN_SRC);
+    assert_greater_than(count, 0,
+        "same-origin captioned media exposes its in-band text tracks");
+}, "same-origin: in-band text tracks are exposed");
+
+promise_test(async t => {
+    // Cross-origin media without crossorigin attribute: tracks NOT exposed.
+    const count = await loadAndCount(t, CROSS_ORIGIN_NO_CORS);
+    assert_equals(count, 0,
+        "cross-origin media without CORS does not expose in-band text tracks");
+}, "cross-origin without crossorigin attribute: tracks hidden");
+
+promise_test(async t => {
+    // Cross-origin media WITH crossorigin attribute and CORS-permitting
+    // server: tracks ARE exposed.
+    const count = await loadAndCount(t, CROSS_ORIGIN_WITH_CORS,
+        { crossOrigin: "anonymous" });
+    assert_greater_than(count, 0,
+        "cross-origin media with passing CORS exposes in-band text tracks");
+}, "cross-origin with crossorigin=anonymous and CORS: tracks exposed");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/media/track/track-removal-clears-pending-list-expected.txt
+++ b/LayoutTests/http/tests/media/track/track-removal-clears-pending-list-expected.txt
@@ -1,0 +1,3 @@
+
+PALL removing a loading <track> from its media element clears the pending-list entry
+

--- a/LayoutTests/http/tests/media/track/track-removal-clears-pending-list.html
+++ b/LayoutTests/http/tests/media/track/track-removal-clears-pending-list.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html>
+<head>
+    <title>Removing a loading track from its media element clears the pending-list entry</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard §4.8.13.7 "Text tracks", text-track-model:
+//   https://html.spec.whatwg.org/multipage/media.html#text-track-model
+//
+// "Whenever a track element's parent node changes, the user agent must
+//  remove its corresponding text track from any list of pending text tracks
+//  that the text track is in."
+//
+// Combined with §4.8.13.9 "media resource with text tracks" -- a media
+// element cannot reach HAVE_FUTURE_DATA while it has any pending text
+// tracks. So the observable signal: if a video element's readyState is
+// gated at HAVE_CURRENT_DATA because of a still-loading <track>, removing
+// that <track> from the video should release the gate and let the video
+// advance to HAVE_FUTURE_DATA.
+
+const stallEndpoint = "http://127.0.0.1:8000/resources/load-and-stall.py";
+const vttPath = "../../../media/track/captions-webvtt/captions-multiline-lf.vtt";
+// Stall for 3 seconds after byte 49. Long enough that the small mp4
+// will buffer (reaching HAVE_CURRENT_DATA) and the test can remove the
+// <track> well before the stall completes.
+const slowVttSrc = `${stallEndpoint}?name=${encodeURIComponent(vttPath)}&mimeType=text%2Fvtt&stallAt=49&stallFor=3`;
+const mediaSrc = "/media/resources/test-25fps.mp4";
+
+promise_test(async t => {
+    const video = document.createElement("video");
+    video.muted = true;
+    video.preload = "auto";
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.srclang = "en";
+    track.src = slowVttSrc;
+    video.appendChild(track);
+    track.track.mode = "hidden";
+
+    // Kick off media load.
+    video.src = mediaSrc;
+
+    // Wait for the video to have media data buffered; it should stall
+    // at HAVE_CURRENT_DATA because the track is still loading.
+    await new Promise((resolve, reject) => {
+        video.addEventListener("loadeddata", resolve, { once: true });
+        video.addEventListener("error",
+            () => reject(new Error("video failed to load")), { once: true });
+        t.step_timeout(
+            () => reject(new Error("video did not reach HAVE_CURRENT_DATA in 2s")),
+            2000);
+    });
+
+    // Confirm the track is still loading -- if not, the test isn't
+    // actually exercising the parent-change pending-list clearing.
+    assert_equals(track.readyState, track.LOADING,
+        "track is still LOADING (the gating window is being exercised)");
+    assert_less_than_equal(video.readyState, video.HAVE_CURRENT_DATA,
+        "video.readyState is gated at HAVE_CURRENT_DATA while track is LOADING");
+
+    // Now remove the <track> from the video. Per behavior 48, this must
+    // clear the corresponding text track from the media element's list
+    // of pending text tracks. The video should be free to advance.
+    video.removeChild(track);
+
+    // Wait for HAVE_FUTURE_DATA. If the parent-change didn't clear the
+    // pending-list entry, the video would stay gated until the track's
+    // 3-second stall expires; we time out at 2s to fail loudly in that
+    // case rather than silently waiting for the stall.
+    //
+    // Poll readyState directly (in addition to listening for canplay /
+    // progress) so that a future regression where readyState advances
+    // but the corresponding event isn't dispatched still resolves this
+    // promise — we want the failure mode to be unambiguous.
+    await new Promise((resolve, reject) => {
+        const check = () => {
+            if (video.readyState >= video.HAVE_FUTURE_DATA)
+                resolve();
+        };
+        video.addEventListener("canplay", check);
+        video.addEventListener("progress", check);
+        const pollId = setInterval(check, 100);
+        t.add_cleanup(() => clearInterval(pollId));
+        check();
+        t.step_timeout(
+            () => reject(new Error(
+                "video did not advance past HAVE_CURRENT_DATA within 2s of " +
+                "track removal -- pending-list entry was not cleared")),
+            2000);
+    });
+
+    assert_greater_than_equal(video.readyState, video.HAVE_FUTURE_DATA,
+        "video advanced to HAVE_FUTURE_DATA after track removal " +
+        "(parent-change cleared the pending-list entry)");
+}, "removing a loading <track> from its media element clears the pending-list entry");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/media/track/tracks-ready-and-have-future-data-expected.txt
+++ b/LayoutTests/http/tests/media/track/tracks-ready-and-have-future-data-expected.txt
@@ -1,0 +1,3 @@
+
+PASS HAVE_FUTURE_DATA gated by 'text tracks are ready'
+

--- a/LayoutTests/http/tests/media/track/tracks-ready-and-have-future-data.html
+++ b/LayoutTests/http/tests/media/track/tracks-ready-and-have-future-data.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html>
+<head>
+    <title>readyState gated by &quot;text tracks are ready&quot;</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.9 "Media resources with multiple media tracks" -- the
+//   "media resource with text tracks" readyState transition rules:
+//     https://html.spec.whatwg.org/multipage/media.html#media-resource-with-text-tracks
+//   §4.8.13.7 "Text tracks" -- "text tracks are ready" definition:
+//     https://html.spec.whatwg.org/multipage/media.html#text-tracks-are-ready
+//
+// HAVE_FUTURE_DATA (and HAVE_ENOUGH_DATA) require BOTH the underlying
+// media data conditions AND that "the text tracks are ready", i.e. the
+// media element's list of pending text tracks is empty.
+//
+// A <track> element with mode="hidden" or "showing" is placed on the
+// pending list while its readiness state is "loading"; the element is
+// removed from the pending list when loading completes (or fails).
+//
+// To exercise the gating we slow-serve a VTT resource so the track is
+// still LOADING while the video element would otherwise reach
+// HAVE_FUTURE_DATA. We poll readyState during the stall window and
+// confirm the video never exceeds HAVE_CURRENT_DATA before the track loads.
+
+const stallEndpoint = "http://127.0.0.1:8000/resources/load-and-stall.py";
+const vttPath = "../../../media/track/captions-webvtt/captions-multiline-lf.vtt";
+// Stall for 3 seconds after byte 49 (past the WEBVTT signature and first
+// cue header). 3s gives ample headroom for the small mp4 to buffer past
+// HAVE_CURRENT_DATA on any reasonable test environment, so the gating
+// assertion is exercised.
+const slowVttSrc = `${stallEndpoint}?name=${encodeURIComponent(vttPath)}&mimeType=text%2Fvtt&stallAt=49&stallFor=3`;
+const mediaSrc = "/media/resources/test-25fps.mp4";
+
+promise_test(async t => {
+    const video = document.createElement("video");
+    video.muted = true;
+    video.preload = "auto";
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+
+    const track = document.createElement("track");
+    track.kind = "subtitles";
+    track.srclang = "en";
+    track.src = slowVttSrc;
+    video.appendChild(track);
+    track.track.mode = "hidden";
+
+    const trackLoaded = new Promise((resolve, reject) => {
+        track.addEventListener("load", resolve, { once: true });
+        track.addEventListener("error",
+            () => reject(new Error("track failed to load")), { once: true });
+    });
+
+    // Kick off media load. The video should buffer past HAVE_CURRENT_DATA
+    // (loadeddata event) well before the 3-second VTT stall completes.
+    video.src = mediaSrc;
+
+    // Wait for the video to have media data buffered. If the track-ready
+    // gating works, the video must NOT advance past HAVE_CURRENT_DATA
+    // here -- it must stall at HAVE_CURRENT_DATA waiting for the track.
+    await new Promise((resolve, reject) => {
+        video.addEventListener("loadeddata", resolve, { once: true });
+        video.addEventListener("error",
+            () => reject(new Error("video failed to load")), { once: true });
+        // Bound the wait — if loadeddata never fires within 2s, the test
+        // can't assert anything meaningful.
+        t.step_timeout(
+            () => reject(new Error("video did not reach HAVE_CURRENT_DATA in 2s")),
+            2000);
+    });
+
+    // The video has media data buffered (HAVE_CURRENT_DATA). The track
+    // must still be loading at this point — otherwise we can't observe
+    // the gating. If track already loaded, the test environment was too
+    // fast / our stall too short.
+    assert_equals(track.readyState, track.LOADING,
+        "track is still LOADING at loadeddata (gating window is being exercised)");
+
+    // Hard assertion: while the track is LOADING, the video must NOT have
+    // advanced past HAVE_CURRENT_DATA. This is the spec-mandated gating.
+    assert_less_than_equal(video.readyState, video.HAVE_CURRENT_DATA,
+        "video.readyState must not exceed HAVE_CURRENT_DATA while track is LOADING");
+
+    // Now wait for the track to finish loading.
+    await trackLoaded;
+    assert_equals(track.readyState, track.LOADED, "track is LOADED");
+
+    // After the track is ready, the video should be able to advance.
+    if (video.readyState < video.HAVE_FUTURE_DATA) {
+        await new Promise(resolve => {
+            const check = () => {
+                if (video.readyState >= video.HAVE_FUTURE_DATA)
+                    resolve();
+            };
+            video.addEventListener("canplay", check);
+            video.addEventListener("progress", check);
+            check();
+        });
+    }
+    assert_greater_than_equal(video.readyState, video.HAVE_FUTURE_DATA,
+        "video can advance to HAVE_FUTURE_DATA once track is ready");
+}, "HAVE_FUTURE_DATA gated by 'text tracks are ready'");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/text-track-cue-mutation-expected.txt
+++ b/LayoutTests/media/track/text-track-cue-mutation-expected.txt
@@ -1,0 +1,7 @@
+
+PASS removeCue: throws NotFoundError when cue is not in the track's list
+PASS removeCue: throws NotFoundError when cue belongs to a different track
+PASS removeCue: removes the cue from the list and clears cue.track
+PASS removeCue: removing twice throws NotFoundError on the second call
+PASS removeCue: preserves order of remaining cues
+

--- a/LayoutTests/media/track/text-track-cue-mutation.html
+++ b/LayoutTests/media/track/text-track-cue-mutation.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+<head>
+    <title>TextTrack.removeCue: NotFoundError and list mutation</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard §4.8.13.10 "Text track API" -- TextTrack.removeCue:
+//   https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-removecue
+//
+// removeCue(cue) algorithm:
+//   1. If cue is not in the text track list of cues of the text track that
+//      the TextTrack object represents, then throw a NotFoundError
+//      DOMException.
+//   2. Remove cue from the text track list of cues.
+
+function makeShowingTrack() {
+    const video = document.createElement("video");
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+    return tt;
+}
+
+test(() => {
+    const tt = makeShowingTrack();
+    const cue = new VTTCue(0, 1, "not added");
+    assert_equals(cue.track, null,
+        "VTTCue starts unattached");
+    assert_throws_dom("NotFoundError", () => { tt.removeCue(cue); },
+        "removeCue throws NotFoundError when cue is not in the track's list");
+}, "removeCue: throws NotFoundError when cue is not in the track's list");
+
+test(() => {
+    const tt1 = makeShowingTrack();
+    const tt2 = makeShowingTrack();
+    const cue = new VTTCue(0, 1, "in tt1");
+    tt1.addCue(cue);
+    assert_equals(cue.track, tt1, "cue is attached to tt1");
+    assert_throws_dom("NotFoundError", () => { tt2.removeCue(cue); },
+        "removeCue on a different track throws NotFoundError");
+    // tt1 still has the cue; tt2 still doesn't.
+    assert_equals(tt1.cues.length, 1, "tt1 still has the cue");
+    assert_equals(tt2.cues.length, 0, "tt2 still has no cues");
+}, "removeCue: throws NotFoundError when cue belongs to a different track");
+
+test(() => {
+    const tt = makeShowingTrack();
+    const cue = new VTTCue(0, 1, "test");
+    tt.addCue(cue);
+    assert_equals(tt.cues.length, 1, "cue is in the list before removal");
+    assert_equals(cue.track, tt, "cue.track points to tt");
+
+    tt.removeCue(cue);
+    assert_equals(tt.cues.length, 0, "cue removed from the list");
+    assert_equals(cue.track, null,
+        "cue.track is null after removeCue (cue is unattached)");
+}, "removeCue: removes the cue from the list and clears cue.track");
+
+test(() => {
+    const tt = makeShowingTrack();
+    const cue = new VTTCue(0, 1, "test");
+    tt.addCue(cue);
+    tt.removeCue(cue);
+    assert_throws_dom("NotFoundError", () => { tt.removeCue(cue); },
+        "second removeCue of the same cue throws NotFoundError");
+}, "removeCue: removing twice throws NotFoundError on the second call");
+
+test(() => {
+    // Spec is order-preserving. Verify add A B C, remove B, list is [A, C].
+    const tt = makeShowingTrack();
+    const a = new VTTCue(0, 1, "A");
+    const b = new VTTCue(1, 2, "B");
+    const c = new VTTCue(2, 3, "C");
+    tt.addCue(a);
+    tt.addCue(b);
+    tt.addCue(c);
+    assert_array_equals([...tt.cues], [a, b, c], "initial order is [A, B, C]");
+
+    tt.removeCue(b);
+    assert_array_equals([...tt.cues], [a, c],
+        "after removing B, the list is [A, C]");
+}, "removeCue: preserves order of remaining cues");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/text-track-label-defaults-and-mode-expected.txt
+++ b/LayoutTests/media/track/text-track-label-defaults-and-mode-expected.txt
@@ -1,0 +1,9 @@
+
+PASS TextTrack.label: empty string when track was created without a label
+PASS TextTrack.label: returns the label set via addTextTrack
+PASS TextTrack.label: empty for <track> element with no label attribute
+PASS TextTrack.label: reflects the <track> element's label content attribute
+PASS TextTrack.label: empty label is not replaced by an auto-generated UI label
+PASS default mode: addTextTrack creates the track with mode='hidden'
+PASS default mode: <track>-element-backed track has mode='disabled'
+

--- a/LayoutTests/media/track/text-track-label-defaults-and-mode.html
+++ b/LayoutTests/media/track/text-track-label-defaults-and-mode.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html>
+<head>
+    <title>TextTrack.label and default mode for in-band/script-created tracks</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard:
+//   §4.8.13.7 "Text tracks" -- text track label, sourcing-in-band-text-tracks,
+//                              sourcing-out-of-band-text-tracks (label step)
+//     https://html.spec.whatwg.org/multipage/media.html#text-track-model
+//     https://html.spec.whatwg.org/multipage/media.html#sourcing-in-band-text-tracks
+//   §4.8.13.10 "Text track API" -- TextTrack.label
+//     https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-label
+//
+// - TextTrack.label returns the text track label (the human-readable label
+//   string), or the empty string when the label is empty.
+// - For tracks sourced from a <track> element, the text track label is the
+//   element's track label (i.e., the value of its label content attribute,
+//   or the empty string if the attribute is absent or empty).
+// - When the text track label is the empty string, the user agent should
+//   auto-generate a UI label; that auto-generated label is NOT exposed via
+//   the API (TextTrack.label remains empty).
+// - For an in-band text track, sourcing-in-band-text-tracks step 4 sets
+//   the new text track's mode consistent with user preferences and the
+//   relevant specification. In a layout-test environment with no user
+//   preferences expressed, this defaults to "hidden".
+
+test(() => {
+    const tt = document.createElement("video").addTextTrack("captions");
+    assert_equals(tt.label, "",
+        "addTextTrack with no label argument -> TextTrack.label is empty");
+}, "TextTrack.label: empty string when track was created without a label");
+
+test(() => {
+    const tt = document.createElement("video").addTextTrack("captions", "Hello", "en");
+    assert_equals(tt.label, "Hello",
+        "addTextTrack(kind, label) -> TextTrack.label is the label argument");
+}, "TextTrack.label: returns the label set via addTextTrack");
+
+test(() => {
+    // <track> element with no label attribute -> TextTrack.label empty.
+    const trackEl = document.createElement("track");
+    trackEl.kind = "subtitles";
+    assert_equals(trackEl.track.label, "",
+        "<track> with no label attribute -> TextTrack.label is empty");
+}, "TextTrack.label: empty for <track> element with no label attribute");
+
+test(() => {
+    const trackEl = document.createElement("track");
+    trackEl.kind = "subtitles";
+    trackEl.label = "English captions";
+    assert_equals(trackEl.track.label, "English captions",
+        "<track>.label = X -> TextTrack.label is X");
+}, "TextTrack.label: reflects the <track> element's label content attribute");
+
+test(() => {
+    // Empty-string label content attribute should produce empty TextTrack.label.
+    // Per spec, even when the UA auto-generates a UI label for empty cases,
+    // that auto-generated string must NOT be exposed via the API.
+    const trackEl = document.createElement("track");
+    trackEl.kind = "subtitles";
+    trackEl.setAttribute("label", "");
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    try {
+        video.appendChild(trackEl);
+        trackEl.track.mode = "showing";
+        assert_equals(trackEl.track.label, "",
+            "TextTrack.label stays empty even when the track is showing " +
+            "and the UA might auto-generate a UI label internally");
+    } finally {
+        video.remove();
+    }
+}, "TextTrack.label: empty label is not replaced by an auto-generated UI label");
+
+test(() => {
+    // addTextTrack creates the track with mode "hidden" per spec.
+    // (The "user preferences" branch of sourcing-in-band-text-tracks
+    // doesn't apply here -- this is a script-created track -- but the
+    // observable default mode is the same in a layout-test environment
+    // with no captions preference set.)
+    const tt = document.createElement("video").addTextTrack("captions");
+    assert_equals(tt.mode, "hidden",
+        "addTextTrack-created track has mode 'hidden' by default");
+}, "default mode: addTextTrack creates the track with mode='hidden'");
+
+test(() => {
+    // <track>-element-backed tracks default to mode "disabled" -- the
+    // load algorithm only fires when mode is hidden or showing, so the
+    // default must be disabled to avoid eager fetching.
+    const trackEl = document.createElement("track");
+    trackEl.kind = "subtitles";
+    assert_equals(trackEl.track.mode, "disabled",
+        "<track>-element-backed track has mode 'disabled' by default");
+}, "default mode: <track>-element-backed track has mode='disabled'");
+</script>
+</body>
+</html>

--- a/LayoutTests/media/track/text-track-time-marches-on-edges-expected.txt
+++ b/LayoutTests/media/track/text-track-time-marches-on-edges-expected.txt
@@ -1,0 +1,5 @@
+
+PASS time marches on (other cues): disabled-track cues never participate
+PASS time marches on (missed cues): seeking past a cue does not fire enter+exit
+PASS time marches on (early-exit): no duplicate enter when state is unchanged
+

--- a/LayoutTests/media/track/text-track-time-marches-on-edges.html
+++ b/LayoutTests/media/track/text-track-time-marches-on-edges.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html>
+<head>
+    <title>Time marches on: other-cues partition, missed cues only on monotonic advance, idempotent re-runs</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+// HTML Living Standard §4.8.13.9 "Playing the media resource", time marches on:
+//   https://html.spec.whatwg.org/multipage/media.html#time-marches-on
+//
+// Edge-case behaviors of the time-marches-on algorithm:
+//
+// - Step 1+2: "current cues" / "other cues" only contains cues from
+//   text tracks in hidden or showing mode (not disabled). A cue in a
+//   disabled track must never participate in the algorithm.
+//
+// - Step 4: "missed cues" is non-empty ONLY when the current playback
+//   position changed through monotonic increase during normal playback.
+//   On non-monotonic position changes (i.e. seeks), missed cues is empty
+//   -- the algorithm runs once at the new position, no enter+exit pair
+//   for cues that were entirely between the old and new positions.
+//
+// - Step 7: if all current cues are already active and no other cues are
+//   active and missed cues is empty, return early. Re-running the
+//   algorithm without any state change must not queue duplicate events.
+
+const MEDIA_SRC = "../content/test-25fps.mp4";
+
+function makeReadyVideo(t) {
+    const video = document.createElement("video");
+    video.muted = true;
+    document.body.appendChild(video);
+    t.add_cleanup(() => video.remove());
+    video.src = MEDIA_SRC;
+    return video;
+}
+
+function whenSeekedTo(video, time) {
+    return new Promise(resolve => {
+        video.addEventListener("seeked", resolve, { once: true });
+        if (video.readyState >= video.HAVE_METADATA)
+            video.currentTime = time;
+        else
+            video.addEventListener("loadedmetadata",
+                () => { video.currentTime = time; }, { once: true });
+    });
+}
+
+function nextTick(t) {
+    return new Promise(r => t.step_timeout(r, 50));
+}
+
+promise_test(async t => {
+    // Cues in a disabled track must NOT participate in time marches on:
+    // no 'enter' fires when their range covers currentTime, no 'exit'
+    // fires when leaving their range, and no 'cuechange' on the track.
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "disabled";
+    const cue = new VTTCue(0, 100, "in disabled track");
+    tt.addCue(cue);
+
+    let enterFired = false;
+    let exitFired = false;
+    let cuechangeFired = false;
+    cue.onenter = () => { enterFired = true; };
+    cue.onexit = () => { exitFired = true; };
+    tt.oncuechange = () => { cuechangeFired = true; };
+
+    await whenSeekedTo(video, 0.5);
+    await nextTick(t);
+    assert_false(enterFired,
+        "'enter' must not fire for a cue in a disabled track");
+    assert_false(cuechangeFired,
+        "'cuechange' must not fire for a disabled track");
+
+    // Move on; verify exit doesn't fire either.
+    await whenSeekedTo(video, 0.8);
+    await nextTick(t);
+    assert_false(exitFired,
+        "'exit' must not fire for a cue in a disabled track");
+}, "time marches on (other cues): disabled-track cues never participate");
+
+promise_test(async t => {
+    // Seeking past a cue (non-monotonic advance) must NOT generate
+    // enter+exit events for the cue. With a cue at [0.2, 0.4] and we
+    // seek from 0.05 directly to 0.6, the cue was never "current" --
+    // missed cues is empty for non-monotonic advance, so neither an
+    // enter nor an exit event should fire.
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+    const cue = new VTTCue(0.2, 0.4, "skipped over");
+    tt.addCue(cue);
+
+    // Park at t=0.05 (before the cue).
+    await whenSeekedTo(video, 0.05);
+    await nextTick(t);
+    assert_array_equals([...tt.activeCues], [],
+        "no cues active at t=0.05 (before cue range)");
+
+    let enterFired = false;
+    let exitFired = false;
+    cue.onenter = () => { enterFired = true; };
+    cue.onexit = () => { exitFired = true; };
+
+    // Seek past the cue range without crossing through it monotonically.
+    await whenSeekedTo(video, 0.6);
+    await nextTick(t);
+
+    assert_false(enterFired,
+        "'enter' must not fire when seeking past a cue (non-monotonic advance)");
+    assert_false(exitFired,
+        "'exit' must not fire when seeking past a cue (non-monotonic advance)");
+    assert_array_equals([...tt.activeCues], [],
+        "no cues active at t=0.6 (after cue range)");
+}, "time marches on (missed cues): seeking past a cue does not fire enter+exit");
+
+promise_test(async t => {
+    // Re-running the algorithm without state change must not duplicate
+    // events. Trigger time-marches-on by seeking to the same position
+    // twice; only the first should produce events.
+    const video = makeReadyVideo(t);
+    const tt = video.addTextTrack("captions", "test", "en");
+    tt.mode = "showing";
+    const cue = new VTTCue(0, 100, "covers t=0.5");
+    tt.addCue(cue);
+
+    let enterCount = 0;
+    let cuechangeCount = 0;
+    cue.onenter = () => { enterCount++; };
+    tt.oncuechange = () => { cuechangeCount++; };
+
+    await whenSeekedTo(video, 0.5);
+    await nextTick(t);
+    assert_equals(enterCount, 1, "'enter' fired once on first seek");
+
+    // Trigger another time-marches-on by seeking to a slightly different
+    // position still within the cue. State (cue active) is unchanged.
+    await whenSeekedTo(video, 0.6);
+    await nextTick(t);
+    assert_equals(enterCount, 1,
+        "'enter' did not fire again -- cue was already active (early-exit)");
+
+    await whenSeekedTo(video, 0.7);
+    await nextTick(t);
+    assert_equals(enterCount, 1,
+        "'enter' still has not fired again on a third no-state-change seek");
+}, "time marches on (early-exit): no duplicate enter when state is unchanged");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5602,6 +5602,9 @@ webkit.org/b/317119 fast/repaint/layer-repaint-with-layout-delta-2.html [ Pass I
 fast/dom/HTMLImageElement/sizes/image-sizes-js-change.html [ Pass Failure ]
 gamepad/gamepad-event-handlers.html [ Pass Timeout ]
 
+webkit.org/b/317607 http/tests/media/track/text-track-cross-origin-in-band.html [ Failure ]
+webkit.org/b/317607 http/tests/media/track/track-removal-clears-pending-list.html [ Failure ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -881,6 +881,8 @@ webkit.org/b/142726 fast/images/animated-png.html [ Skip ]
 webkit.org/b/145432 media/video-transformed-by-javascript.html [ Failure ]
 
 webkit.org/b/140022 http/tests/media/track-in-band-hls-metadata.html [ Pass Timeout Failure ]
+webkit.org/b/317607 http/tests/media/track/text-track-cross-origin-in-band.html [ Pass Failure ]
+webkit.org/b/317607 http/tests/media/track/track-removal-clears-pending-list.html [ Failure ]
 
 # <rdar://problem/21263363>
 http/tests/media/remove-while-loading.html [ Skip ]


### PR DESCRIPTION
#### 3c43301db2bf6f5476d55d2429bace12b5913be2
<pre>
[HTML Tracks] Additional tests for untested areas of the HTML TextTrack specification
<a href="https://rdar.apple.com/180334501">rdar://180334501</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317607">https://bugs.webkit.org/show_bug.cgi?id=317607</a>

Reviewed by Eric Carlson.

Add a third batch of TextTrack tests covering pending-list lifecycle, cross-origin in-band exposure,
removeCue list-mutation semantics, default mode and label fallback, and additional time-marches-on
edge cases.

track-removal-clears-pending-list.html records a FAIL baseline for a real spec deviation tracked by
<a href="https://rdar.apple.com/180330521">rdar://180330521</a>: removing a loading &lt;track&gt; from its media element clears the gating list entry
but does not re-evaluate readyState, so the video stays clamped at HAVE_CURRENT_DATA until the
orphaned track&apos;s network fetch completes.

The cross-origin in-band test verifies that a media element exposes its in-band text tracks only
when the media data is CORS-same-origin. The tracks-ready test verifies HAVE_FUTURE_DATA gating
against a slow-served VTT (uses the existing load-and-stall.py infrastructure).

text-track-cue-mutation covers removeCue&apos;s NotFoundError throw path and order-preserving list
mutation. text-track-label-defaults-and-mode covers the TextTrack.label getter behavior including
the empty-label / auto-generated-UI-label distinction (spec-mandated to not be exposed via the
API). text-track-time-marches-on-edges covers three algorithm-edge cases: disabled-track cues never
participating, missed-cues only on monotonic advance, and idempotent re-runs not duplicating
events.

* LayoutTests/http/tests/media/track/text-track-cross-origin-in-band-expected.txt: Added.
* LayoutTests/http/tests/media/track/text-track-cross-origin-in-band.html: Added.
* LayoutTests/http/tests/media/track/track-removal-clears-pending-list-expected.txt: Added.
* LayoutTests/http/tests/media/track/track-removal-clears-pending-list.html: Added.
* LayoutTests/http/tests/media/track/tracks-ready-and-have-future-data-expected.txt: Added.
* LayoutTests/http/tests/media/track/tracks-ready-and-have-future-data.html: Added.
* LayoutTests/media/track/text-track-cue-mutation-expected.txt: Added.
* LayoutTests/media/track/text-track-cue-mutation.html: Added.
* LayoutTests/media/track/text-track-label-defaults-and-mode-expected.txt: Added.
* LayoutTests/media/track/text-track-label-defaults-and-mode.html: Added.
* LayoutTests/media/track/text-track-time-marches-on-edges-expected.txt: Added.
* LayoutTests/media/track/text-track-time-marches-on-edges.html: Added.

Canonical link: <a href="https://commits.webkit.org/315659@main">https://commits.webkit.org/315659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caf7bdfc60aa20053524ba9146e3b2dc6f228fa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127369 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14733b14-642f-400d-816c-6cdcc40adefd) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132204 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0687c4b0-d70c-4d96-ba8c-70984c8bbbe1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172616 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152572 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112707 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52c3ebf5-946b-4c69-827d-c40fed7ce3c1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32343 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27713 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181615 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140652 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140488 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43924 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28951 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108158 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25850 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35754 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42434 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7043 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->