### PR TITLE
Refactor _endLiveResize to separate Responsive and Unresponsive Live-resize Updates

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3793,7 +3793,72 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     [self _ensureResizeAnimationView];
 }
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=317000
+#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
+- (void)_endLiveResizeWithResponsiveRelayout
+{
+    if (_liveResizeSnapshotState)
+        [self _removeLiveSnapshotState];
+
+    if (RefPtr drawingArea = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->drawingArea()))
+        _perProcessState.transactionIDForEndLiveResize = drawingArea->nextMainFrameLayerTreeTransactionID();
+
+    if (!_perProcessState.transactionIDForEndLiveResize)
+        return;
+
+    RetainPtr liveResizeSnapshotView = [self snapshotViewAfterScreenUpdates:NO];
+    [liveResizeSnapshotView setFrame:self.bounds];
+    [liveResizeSnapshotView layer].anchorPoint = CGPointZero;
+    [liveResizeSnapshotView layer].position = CGPointZero;
+    [self addSubview:liveResizeSnapshotView.get()];
+    auto transactionIDForEndLiveResize = *_perProcessState.transactionIDForEndLiveResize;
+    _liveResizeSnapshotState = { { transactionIDForEndLiveResize, { liveResizeSnapshotView, self.bounds.size.width } } };
+
+    _perProcessState.lastResizeTimestamp = [NSDate now];
+    _perProcessState.lastResizedViewWidth = self.bounds.size.width;
+
+    _perProcessState.liveResizeParameters = std::nullopt;
+
+    ASSERT(_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing);
+    [self _destroyResizeAnimationView];
+    [self _didStopDeferringGeometryUpdates];
+
+    // Ensure that the live resize snapshot is eventually removed, even if the webpage is unresponsive.
+    RunLoop::mainSingleton().dispatchAfter(1_s, [weakSelf = WeakObjCPtr<WKWebView>(self), transactionIDForEndLiveResize] {
+        RetainPtr strongSelf = weakSelf.get();
+        if (!strongSelf || !strongSelf->_liveResizeSnapshotState || strongSelf->_liveResizeSnapshotState->first != transactionIDForEndLiveResize)
+            return;
+        [strongSelf _removeLiveSnapshotState];
+        strongSelf->_perProcessState.transactionIDForEndLiveResize = std::nullopt;
+        strongSelf->_perProcessState.waitingForEndLiveResizePresentationUpdate = NO;
+    });
+}
+#endif
+
+- (void)_endLiveResizeDefault
+{
+    RetainPtr liveResizeSnapshotView = [self snapshotViewAfterScreenUpdates:NO];
+    [liveResizeSnapshotView setFrame:self.bounds];
+    [self addSubview:liveResizeSnapshotView];
+
+    _perProcessState.liveResizeParameters = std::nullopt;
+
+    ASSERT(_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing);
+    [self _destroyResizeAnimationView];
+    [self _didStopDeferringGeometryUpdates];
+
+    [self _doAfterNextVisibleContentRectUpdate:makeBlockPtr([liveResizeSnapshotView, weakSelf = WeakObjCPtr<WKWebView>(self)] mutable {
+        RetainPtr strongSelf = weakSelf.get();
+        [strongSelf _doAfterNextPresentationUpdate:makeBlockPtr([liveResizeSnapshotView] {
+            [liveResizeSnapshotView removeFromSuperview];
+        }).get()];
+    }).get()];
+
+    // Ensure that the live resize snapshot is eventually removed, even if the webpage is unresponsive.
+    RunLoop::mainSingleton().dispatchAfter(1_s, [liveResizeSnapshotView] {
+        [liveResizeSnapshotView removeFromSuperview];
+    });
+}
+
 - (void)_endLiveResize
 {
     WKWEBVIEW_RELEASE_LOG("%p (pageProxyID=%llu) -[WKWebView _endLiveResize]", self, _page->identifier().toUInt64());
@@ -3805,65 +3870,10 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     _endLiveResizeTimer = nil;
 
 #if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    if (_liveResizeSnapshotState)
-        [self _removeLiveSnapshotState];
-
-    if (RefPtr drawingArea = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->drawingArea()))
-        _perProcessState.transactionIDForEndLiveResize = drawingArea->nextMainFrameLayerTreeTransactionID();
-
-    if (!_perProcessState.transactionIDForEndLiveResize)
-        return;
-#endif
-
-    RetainPtr liveResizeSnapshotView = [self snapshotViewAfterScreenUpdates:NO];
-    [liveResizeSnapshotView setFrame:self.bounds];
-
-#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    [liveResizeSnapshotView layer].anchorPoint = CGPointZero;
-    [liveResizeSnapshotView layer].position = CGPointZero;
-    [self addSubview:liveResizeSnapshotView.get()];
-    auto transactionIDForEndLiveResize = *_perProcessState.transactionIDForEndLiveResize;
-    _liveResizeSnapshotState = { { transactionIDForEndLiveResize, { liveResizeSnapshotView, self.bounds.size.width } } };
-
-    _perProcessState.lastResizeTimestamp = [NSDate now];
-    _perProcessState.lastResizedViewWidth = self.bounds.size.width;
+    [self _endLiveResizeWithResponsiveRelayout];
 #else
-    [self addSubview:liveResizeSnapshotView.get()];
+    [self _endLiveResizeDefault];
 #endif
-
-    _perProcessState.liveResizeParameters = std::nullopt;
-
-    ASSERT(_perProcessState.dynamicViewportUpdateMode == WebKit::DynamicViewportUpdateMode::NotResizing);
-    [self _destroyResizeAnimationView];
-    [self _didStopDeferringGeometryUpdates];
-
-#if !ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-    [self _doAfterNextVisibleContentRectUpdate:makeBlockPtr([liveResizeSnapshotView, weakSelf = WeakObjCPtr<WKWebView>(self)] mutable {
-        RetainPtr strongSelf = weakSelf.get();
-        [strongSelf _doAfterNextPresentationUpdate:makeBlockPtr([liveResizeSnapshotView] {
-            [liveResizeSnapshotView removeFromSuperview];
-        }).get()];
-    }).get()];
-#endif
-
-    RunLoop::mainSingleton().dispatchAfter(1_s, [
-#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-        weakSelf = WeakObjCPtr<WKWebView>(self), transactionIDForEndLiveResize
-#else
-        liveResizeSnapshotView
-#endif
-    ] {
-#if ENABLE(RESPONSIVE_LIVE_RESIZE_UPDATE)
-        RetainPtr strongSelf = weakSelf.get();
-        if (!strongSelf || !strongSelf->_liveResizeSnapshotState || strongSelf->_liveResizeSnapshotState->first != transactionIDForEndLiveResize)
-            return;
-        [strongSelf _removeLiveSnapshotState];
-        strongSelf->_perProcessState.transactionIDForEndLiveResize = std::nullopt;
-        strongSelf->_perProcessState.waitingForEndLiveResizePresentationUpdate = NO;
-#else
-        [liveResizeSnapshotView removeFromSuperview];
-#endif
-    });
 }
 
 #endif // HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)


### PR DESCRIPTION
#### 18516999f3aaadfb069eb833799e73fe8719815c
<pre>
Refactor _endLiveResize to separate Responsive and Unresponsive Live-resize Updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=317000">https://bugs.webkit.org/show_bug.cgi?id=317000</a>
<a href="https://rdar.apple.com/179498356">rdar://179498356</a>

Reviewed by Abrar Rahman Protyasha.

This PR separates the logic for the responsive live resize for _endLiveResize
to make the code more readable and maintainable. The underlying logic should be
the same with no changes.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _endLiveResizeWithResponsiveRelayout]):
Add an internal function for the end live resize flow when we are responsively updating
web view layout

(-[WKWebView _endLiveResizeDefault]):
Add an internal function for end live resize behavior in the general case without responsive
relayout

(-[WKWebView _endLiveResize]):
Update the function to call the above two internal functions rather than directly adding
if-defs into the function.

Canonical link: <a href="https://commits.webkit.org/315636@main">https://commits.webkit.org/315636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/361168eec623ce4ad1ffc2ba05833bf62bdd3345

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127331 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43170 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172578 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112671 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27675 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181577 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34285 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43197 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140456 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37796 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43886 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108118 "Hash 361168ee for PR 67626 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35720 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42396 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/6999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41789 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42044 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->