### PR TITLE
WKColorExtensionView can outlive its WKWebView

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
@@ -92,8 +92,6 @@
     [animation setFromValue:(__bridge id)fromColor.get()];
     [animation setToValue:(__bridge id)toColor.get()];
     [animation setDuration:animationDuration];
-    [animation setFillMode:kCAFillModeForwards];
-    [animation setRemovedOnCompletion:NO];
     [animation setDelegate:self];
 
     [self.layer addAnimation:animation.get() forKey:@"WKColorExtensionViewFade"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm
@@ -38,6 +38,7 @@
 #import <WebKit/_WKFeature.h>
 #import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
 #import <wtf/text/StringBuilder.h>
 
 #if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
@@ -1098,6 +1099,59 @@ TEST(SampledPageTopColor, TopColorExtensionHeightDoesNotIncreaseWithoutRefreshCo
     [scrollView setContentOffset:CGPointMake(0, -75) animated:NO];
     [webView waitForNextPresentationUpdate];
     EXPECT_EQ(colorExtensionViewHeight(), 75.f);
+}
+
+TEST(SampledPageTopColor, ColorExtensionViewDeallocatesWithWebView)
+{
+    WeakObjCPtr<UIView> weakWebViewPtr;
+    WeakObjCPtr<UIView> weakColorExtensionViewPtr;
+
+    @autoreleasepool {
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+
+        auto insets = UIEdgeInsetsMake(75, 0, 0, 0);
+        auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
+        [webView _setObscuredInsets:insets];
+        RetainPtr scrollView = [webView scrollView];
+
+        [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+        [scrollView setContentInset:insets];
+
+        RetainPtr refreshControl = adoptNS([[UIRefreshControl alloc] init]);
+        [scrollView setRefreshControl:refreshControl];
+
+        [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
+
+        [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+        [webView waitForNextPresentationUpdate];
+
+        weakColorExtensionViewPtr = [webView _colorExtensionViewForTesting:UIRectEdgeTop];
+        EXPECT_NOT_NULL(weakColorExtensionViewPtr.get());
+
+        [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@""];
+        [webView waitForNextPresentationUpdate];
+
+        weakWebViewPtr = webView;
+        [webView removeFromTestWindow];
+    }
+
+    while (true) {
+        @autoreleasepool {
+            if (!weakWebViewPtr.get())
+                break;
+
+            TestWebKitAPI::Util::spinRunLoop();
+        }
+    }
+
+    while (true) {
+        @autoreleasepool {
+            if (!weakColorExtensionViewPtr.get())
+                break;
+
+            TestWebKitAPI::Util::spinRunLoop();
+        }
+    }
 }
 
 #endif // PLATFORM(IOS_FAMILY) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)


### PR DESCRIPTION
#### 374db8069358c8c82eb223f460a6ed91b1bfaab1
<pre>
WKColorExtensionView can outlive its WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=317608">https://bugs.webkit.org/show_bug.cgi?id=317608</a>
<a href="https://rdar.apple.com/180334423">rdar://180334423</a>

Reviewed by Wenson Hsieh.

In some flows, WKColorExtensionView can stay retained for the lifetime of
the process, long after its owning WKWebView has deallocated. In this state,
the view is retained by CoreAnimation since it serves as the delegate for
the &quot;WKColorExtensionViewFade&quot; animation, which doesn&apos;t get explicitly
removed in all cases.

Prevent this eternal retain cycle by restoring the CAAnimation default
behavior of &quot;removedOnCompletion&quot; == YES, ensuring that the cycle is broken
when the animation completes (or when the view is removed from the hierarchy
when tearing down a web view). This class doesn&apos;t refer to the animation
after its completion (and would just create a new animation instance when
the color changes again), so there was no value in retaining it.

While here, remove a redundant usage of kCAFillModeForwards. This ensured
that after the animation had completed, the layer would keep the backgroundColor
as specified by the &quot;to value&quot; of the animation, instead of reverting to the
color from the model layer. But since the code to set up the animation already
sets the backgroundColor of the model layer to same color as the animation,
explicitly requesting to keep that &quot;to value&quot; makes no visual difference.
Furthermore, this fill mode becomes inconsequential with this change -- it
doesn&apos;t matter what post-completion effect the animation would have on the
layer&apos;s appearance if the animation gets removed upon its completion.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm

* Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm:
(-[WKColorExtensionView _updateColor:visible:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm:
(TestWebKitAPI::TEST(SampledPageTopColor, ColorExtensionViewDeallocatesWithWebView)):

Canonical link: <a href="https://commits.webkit.org/315678@main">https://commits.webkit.org/315678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41590e769eb8da418d0dad696ae106446fc46396

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127329 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40db3c39-afe5-4fee-a92e-412ca7f84d72) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171483 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132166 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93089 "1 flakes 9 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b216e310-40e5-4be2-b589-81e5c2f6ff1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172576 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35052 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112669 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b05b1e67-c2f5-470f-9fe4-b7f9ff4ebb4b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27673 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181575 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140615 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43195 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140451 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37851 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43884 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108114 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35718 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115649 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42394 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7034 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41787 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41930 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->