### PR TITLE
Document leak in MutationObserver

### DIFF
--- a/LayoutTests/fast/dom/MutationObserver/no-document-leak-expected.txt
+++ b/LayoutTests/fast/dom/MutationObserver/no-document-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that a MutationObserver with a pending mutation record does not leak its document when the document is stopped (e.g. its frame is removed).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Document did not leak
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/MutationObserver/no-document-leak.html
+++ b/LayoutTests/fast/dom/MutationObserver/no-document-leak.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/gc.js"></script>
+<script>
+description("Tests that a MutationObserver with a pending mutation record does not leak its document when the document is stopped (e.g. its frame is removed).");
+
+if (window.internals) {
+    jsTestIsAsync = true;
+
+    window.onload = function () {
+        testDocumentIsNotLeaked(
+            async function initAndRemove(frameCount)
+            {
+                let frames = await new Promise((resolve, reject) => {
+                    let frames = [];
+                    let counter = 0;
+                    function onLoad() {
+                        counter++;
+                        if (counter == frameCount)
+                            resolve(frames);
+                    }
+                    for (let i = 0; i < frameCount; ++i) {
+                        let frame = document.createElement('iframe');
+                        frame.src = "resources/no-document-leak-frame.html";
+                        frame.onload = onLoad;
+                        document.body.appendChild(frame);
+                        frames.push(frame);
+                    }
+                });
+                let frameIdentifiers = [];
+                for (let i = 0; i < frameCount; ++i) {
+                    let frame = frames[i];
+                    frameIdentifiers.push(internals.documentIdentifier(frame.contentDocument));
+                    let frameTarget = frame.contentDocument.getElementById("target");
+                    frameTarget.setAttribute("data-x", String(i));
+                    frame.remove();
+                }
+                nukeArray(frames);
+                frames = null;
+                return frameIdentifiers;
+            },
+            {
+                documentCount: 100
+            }
+        ).then(
+            () => testPassed("Document did not leak"),
+            (error) => testFailed(error.message)
+        ).finally(finishJSTest);
+    };
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/MutationObserver/resources/no-document-leak-frame.html
+++ b/LayoutTests/fast/dom/MutationObserver/resources/no-document-leak-frame.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<div id="target"></div>
+
+<script>
+var target = document.getElementById("target");
+var observer = new MutationObserver(function() { });
+observer.observe(target, { attributes: true, childList: true, characterData: true, subtree: true });
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3836,6 +3836,9 @@ void Document::stopActiveDOMObjects()
     ScriptExecutionContext::stopActiveDOMObjects();
     platformSuspendOrStopActiveDOMObjects();
 
+    if (RefPtr eventLoop = m_eventLoop)
+        eventLoop->removeMutationObserversForContext(*this);
+
     // https://www.w3.org/TR/screen-wake-lock/#handling-document-loss-of-full-activity
     if (m_wakeLockManager)
         m_wakeLockManager->releaseAllLocks(WakeLockType::Screen);

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -27,11 +27,13 @@
 #include "WindowEventLoop.h"
 
 #include "CommonVM.h"
+#include "ContextDestructionObserverInlines.h"
 #include "CustomElementReactionQueue.h"
 #include "DocumentPage.h"
 #include "HTMLSlotElement.h"
 #include "IdleCallbackController.h"
 #include "Microtasks.h"
+#include "MutationCallback.h"
 #include "MutationObserver.h"
 #include "OpportunisticTaskScheduler.h"
 #include "SecurityOrigin.h"
@@ -260,6 +262,31 @@ void WindowEventLoop::queueMutationObserverCompoundMicrotask()
         protectedThis->m_deliveringMutationRecords = true;
         MutationObserver::notifyMutationObservers(*protectedThis);
         protectedThis->m_deliveringMutationRecords = false;
+    });
+}
+
+void WindowEventLoop::removeMutationObserversForContext(ScriptExecutionContext& context)
+{
+    if (m_activeObservers.isEmpty() && m_suspendedObservers.isEmpty() && m_signalSlotList.isEmpty())
+        return;
+
+    auto disconnectMatching = [&](HashSet<Ref<MutationObserver>>& observers) {
+        observers.removeIf([&](auto& observer) {
+            auto* observerContext = observer->callback().scriptExecutionContext();
+            if (observerContext && observerContext != &context)
+                return false;
+            observer->disconnect();
+            return true;
+        });
+    };
+    disconnectMatching(m_activeObservers);
+    disconnectMatching(m_suspendedObservers);
+
+    m_signalSlotList.removeAllMatching([&](auto& slot) {
+        if (&slot->document() != &context)
+            return false;
+        slot->didRemoveFromSignalSlotList();
+        return true;
     });
 }
 

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -41,6 +41,7 @@ class Document;
 class HTMLSlotElement;
 class MutationObserver;
 class Page;
+class ScriptExecutionContext;
 class SecurityOrigin;
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#window-event-loop
@@ -56,6 +57,7 @@ public:
     Vector<GCReachableRef<HTMLSlotElement>>& signalSlotList() LIFETIME_BOUND { return m_signalSlotList; }
     HashSet<Ref<MutationObserver>>& activeMutationObservers() LIFETIME_BOUND { return m_activeObservers; }
     HashSet<Ref<MutationObserver>>& suspendedMutationObservers() LIFETIME_BOUND { return m_suspendedObservers; }
+    void removeMutationObserversForContext(ScriptExecutionContext&);
 
     CustomElementQueue& backupElementQueue();
 


### PR DESCRIPTION
#### cffe1bb496638c3ba8ceb32be54023e52e0b8513
<pre>
Document leak in MutationObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=317618">https://bugs.webkit.org/show_bug.cgi?id=317618</a>
<a href="https://rdar.apple.com/178665935">rdar://178665935</a>

Reviewed by Chris Dumez.

Previously, stopping a document didn&apos;t remove its MutationObservers from
the shared WindowEventLoop&apos;s observer sets, so an observer left parked there
with a pending mutation record keeps its target nodes, and therefore the
whole document, alive forever.

This is resolved by draining a stopped context&apos;s MutationObservers from those
sets in Document::stopActiveDOMObjects().

Test: fast/dom/MutationObserver/no-document-leak.html

* LayoutTests/fast/dom/MutationObserver/no-document-leak-expected.txt: Added.
* LayoutTests/fast/dom/MutationObserver/no-document-leak.html: Added.
* LayoutTests/fast/dom/MutationObserver/resources/no-document-leak-frame.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::stopActiveDOMObjects):
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::removeMutationObserversForContext):
* Source/WebCore/dom/WindowEventLoop.h:

Canonical link: <a href="https://commits.webkit.org/315752@main">https://commits.webkit.org/315752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/175d00437104a8f2ebc5da041f29625a761bddc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171768 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172861 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112918 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27959 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181860 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140869 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140700 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37899 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44169 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108464 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35969 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115934 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42680 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7315 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->