### PR TITLE
SVG `<textPath>` discards the per-character `rotate` attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt
@@ -28,25 +28,25 @@ PASS 'text-orientation: mixed' - horizontal-tb
 PASS 'text-orientation: upright' - horizontal-tb
 PASS 'text-orientation: sideways' - horizontal-tb
 PASS Rotation attribute - horizontal-tb
-FAIL <textPath> - horizontal-tb assert_equals: r expected 70 but got 45
+PASS <textPath> - horizontal-tb
 PASS 'text-orientation: mixed' - vertical-rl
 PASS 'text-orientation: upright' - vertical-rl
 PASS 'text-orientation: sideways' - vertical-rl
 PASS Rotation attribute - vertical-rl
-FAIL <textPath> - vertical-rl assert_equals: r expected 70 but got 45
+PASS <textPath> - vertical-rl
 PASS 'text-orientation: mixed' - vertical-lr
 PASS 'text-orientation: upright' - vertical-lr
 PASS 'text-orientation: sideways' - vertical-lr
 PASS Rotation attribute - vertical-lr
-FAIL <textPath> - vertical-lr assert_equals: r expected 70 but got 45
+PASS <textPath> - vertical-lr
 PASS 'text-orientation: mixed' - sideways-rl
 PASS 'text-orientation: upright' - sideways-rl
 PASS 'text-orientation: sideways' - sideways-rl
 PASS Rotation attribute - sideways-rl
-FAIL <textPath> - sideways-rl assert_equals: r expected 70 but got 45
+PASS <textPath> - sideways-rl
 PASS 'text-orientation: mixed' - sideways-lr
 PASS 'text-orientation: upright' - sideways-lr
 PASS 'text-orientation: sideways' - sideways-lr
 PASS Rotation attribute - sideways-lr
-FAIL <textPath> - sideways-lr assert_equals: r expected 250 but got 225
+PASS <textPath> - sideways-lr
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -605,7 +605,8 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
             x = point.x();
             y = point.y();
 
-            angle = traversalState.normalAngle();
+            // Compose with rotate attribute per SVG 2 §11.2.1.
+            angle += traversalState.normalAngle();
 
             // For vertical text on path, the actual angle has to be rotated 90 degrees anti-clockwise, not the orientation angle!
             if (m_isVerticalText)


### PR DESCRIPTION
#### 00af18f3806bce0e60e24978fd354f1fe622d481
<pre>
SVG `&lt;textPath&gt;` discards the per-character `rotate` attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=315192">https://bugs.webkit.org/show_bug.cgi?id=315192</a>
<a href="https://rdar.apple.com/178044478">rdar://178044478</a>

Reviewed by Taher Ali.

When a &lt;text rotate=&quot;…&quot;&gt; contained a &lt;textPath&gt;, the per-character
supplemental rotation was silently discarded: the path-tangent angle
overwrote the rotate-attribute value already accumulated in `angle`,
so getRotationOfChar() reported only the path tangent and rendered
glyphs missed their per-character offset.

SVG 2 §11.2.1 (rotate attribute on &lt;text&gt;/&lt;tspan&gt;) requires that &quot;this
supplemental rotation [...] is supplemental to any rotation due to text
on a path and to text-orientation, glyph-orientation-horizontal, or
glyph-orientation-vertical&quot;.
<a href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementRotateAttribute">https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementRotateAttribute</a>

Flips 5 subtests of svg/text/scripted/getrotationofchar.html from FAIL
to PASS:
- &lt;textPath&gt; - horizontal-tb     (r: 45 -&gt; 70)
- &lt;textPath&gt; - vertical-rl       (r: 45 -&gt; 70)
- &lt;textPath&gt; - vertical-lr       (r: 45 -&gt; 70)
- &lt;textPath&gt; - sideways-rl       (r: 45 -&gt; 70)
- &lt;textPath&gt; - sideways-lr       (r: 225 -&gt; 250)

* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getrotationofchar-expected.txt: Progression
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):

Canonical link: <a href="https://commits.webkit.org/315786@main">https://commits.webkit.org/315786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2754dcb9a92445eb50cf9e99e683bf1631aaa8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127342 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/046c73e7-b4a0-4dfa-bee7-9f29b73853f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132177 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93098 "9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112680 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32314 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27686 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181588 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140628 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43208 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140464 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37915 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43897 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108129 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35730 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115662 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42407 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7016 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41800 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42055 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->