### PR TITLE
[JSC] Use `IntlCache` for Temporal pattern generation in `Intl.DateTimeFormat`

### DIFF
--- a/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-instant.js
+++ b/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-instant.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const instant = new Temporal.Instant(1705314645000000000n);
+for (var i = 0; i < 1e3; ++i)
+    new Intl.DateTimeFormat("en-US").format(instant);

--- a/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-date-time.js
+++ b/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-date-time.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const plainDateTime = new Temporal.PlainDateTime(2024, 1, 15, 10, 30, 0);
+for (var i = 0; i < 1e3; ++i)
+    new Intl.DateTimeFormat("en-US").format(plainDateTime);

--- a/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-date.js
+++ b/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-date.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const plainDate = new Temporal.PlainDate(2024, 1, 15);
+for (var i = 0; i < 1e3; ++i)
+    new Intl.DateTimeFormat("en-US").format(plainDate);

--- a/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-time.js
+++ b/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-time.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const plainTime = new Temporal.PlainTime(10, 30, 0);
+for (var i = 0; i < 1e3; ++i)
+    new Intl.DateTimeFormat("en-US").format(plainTime);

--- a/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-style.js
+++ b/JSTests/microbenchmarks/intl-datetimeformat-format-temporal-style.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useTemporal=1")
+const plainDate = new Temporal.PlainDate(2024, 1, 15);
+for (var i = 0; i < 1e3; ++i)
+    new Intl.DateTimeFormat("en-US", { dateStyle: "full", timeStyle: "long" }).format(plainDate);

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -819,7 +819,8 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         if (!impl->m_numberingSystem.isNull())
             localeBuilder.append("-nu-"_s, impl->m_numberingSystem);
     }
-    CString dataLocaleWithExtensions = localeBuilder.toString().utf8();
+    impl->m_dataLocaleWithExtensions = localeBuilder.toString().utf8();
+    const CString& dataLocaleWithExtensions = impl->m_dataLocaleWithExtensions;
 
     JSValue tzValue = jsUndefined();
     if (options) {
@@ -2098,7 +2099,7 @@ UDateFormat* IntlDateTimeFormat::getTemporalFormatter(VM& vm, TemporalFieldKind 
     }
     auto& cached = m_impl->m_temporalFormatterCache->m_formatters[static_cast<size_t>(kind)];
     if (!cached) {
-        cached = computeTemporalFormatter(kind);
+        cached = computeTemporalFormatter(vm, kind);
         if (cached)
             vm.heap.reportExtraMemoryAllocated(this, estimatedUDateFormatSize);
     }
@@ -2109,7 +2110,7 @@ UDateFormat* IntlDateTimeFormat::getTemporalFormatter(VM& vm, TemporalFieldKind 
 // https://tc39.es/proposal-temporal/#sec-createdatetimeformat (dispatch)
 // CreateDateTimeFormat calls AdjustDateTimeStyleFormat/GetDateTimeFormat eagerly at construction.
 // We implement them lazily here on first use, dispatching based on the same conditions.
-std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeTemporalFormatter(TemporalFieldKind kind) const
+std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeTemporalFormatter(VM& vm, TemporalFieldKind kind) const
 {
     ASSERT(kind != TemporalFieldKind::ZonedDateTime);
     Vector<char16_t, 32> patternBuf;
@@ -2134,15 +2135,15 @@ std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTim
             if (kind == TemporalFieldKind::PlainTime && m_impl->m_timeStyle == DateTimeStyle::None)
                 return nullptr; // Step i: timeStyle undefined -> null.
         }
-        return computeAdjustDateTimeStyleFormat(kind, skeleton);
+        return computeAdjustDateTimeStyleFormat(vm, kind, skeleton);
     }
     // CreateDateTimeFormat -> GetDateTimeFormat.
-    return computeGetDateTimeFormat(kind);
+    return computeGetDateTimeFormat(vm, kind);
 }
 
 
 // https://tc39.es/proposal-temporal/#sec-adjustdatetimestyleformat
-std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeAdjustDateTimeStyleFormat(TemporalFieldKind kind, const Vector<char16_t, 32>& skeleton) const
+std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeAdjustDateTimeStyleFormat(VM& vm, TemporalFieldKind kind, const Vector<char16_t, 32>& skeleton) const
 {
     ASSERT(kind != TemporalFieldKind::ZonedDateTime);
 
@@ -2189,16 +2190,7 @@ std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTim
         return nullptr;
 
     // Steps 7-8: BestFitFormatMatcher(formatOptions, formats).
-    String generatorLocale = m_impl->m_dataLocale;
-    if (!m_impl->m_calendar.isEmpty())
-        generatorLocale = makeString(generatorLocale, "-u-ca-"_s, m_impl->m_calendar);
-    auto generator = std::unique_ptr<UDateTimePatternGenerator, ICUDeleter<udatpg_close>>(udatpg_open(generatorLocale.utf8().data(), &status));
-    if (U_FAILURE(status))
-        return nullptr;
-    Vector<char16_t, 32> bestPattern;
-    status = callBufferProducingFunction(udatpg_getBestPatternWithOptions, generator.get(),
-        filteredSkeleton.span().data(), filteredSkeleton.size(),
-        UDATPG_MATCH_HOUR_FIELD_LENGTH, bestPattern);
+    Vector<char16_t, 32> bestPattern = vm.intlCache().getBestDateTimePattern(m_impl->m_dataLocaleWithExtensions, filteredSkeleton.span(), status);
     if (U_FAILURE(status) || bestPattern.isEmpty())
         return nullptr;
     if (m_impl->m_hourCycle != HourCycle::None)
@@ -2219,7 +2211,7 @@ std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTim
 }
 
 // https://tc39.es/proposal-temporal/#sec-getdatetimeformat
-std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeGetDateTimeFormat(TemporalFieldKind kind) const
+std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTimeFormat::computeGetDateTimeFormat(VM& vm, TemporalFieldKind kind) const
 {
     ASSERT(kind != TemporalFieldKind::ZonedDateTime);
     UErrorCode status = U_ZERO_ERROR;
@@ -2337,16 +2329,7 @@ std::unique_ptr<UDateFormat, IntlDateTimeFormat::UDateFormatDeleter> IntlDateTim
     // Steps 18-19: BestFitFormatMatcher(formatOptions, formats).
     // We always use best-fit (spec also allows basicFormatMatcher but best-fit is the default).
     // The hourCycle field from step 12 is applied post-pattern via replaceHourCycleInPattern.
-    String generatorLocale = m_impl->m_dataLocale;
-    if (!m_impl->m_calendar.isEmpty())
-        generatorLocale = makeString(generatorLocale, "-u-ca-"_s, m_impl->m_calendar);
-    auto generator = std::unique_ptr<UDateTimePatternGenerator, ICUDeleter<udatpg_close>>(udatpg_open(generatorLocale.utf8().data(), &status));
-    if (U_FAILURE(status))
-        return nullptr;
-    Vector<char16_t, 32> bestPattern;
-    status = callBufferProducingFunction(udatpg_getBestPatternWithOptions, generator.get(),
-        formatOptions.span().data(), formatOptions.size(),
-        UDATPG_MATCH_HOUR_FIELD_LENGTH, bestPattern);
+    Vector<char16_t, 32> bestPattern = vm.intlCache().getBestDateTimePattern(m_impl->m_dataLocaleWithExtensions, formatOptions.span(), status);
     if (U_FAILURE(status) || bestPattern.isEmpty())
         return nullptr;
     if (m_impl->m_hourCycle != HourCycle::None)

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -30,6 +30,7 @@
 #include "JSObject.h"
 #include <unicode/udat.h>
 #include <unicode/uformattedvalue.h>
+#include <wtf/text/CString.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 struct UDateIntervalFormat;
@@ -147,9 +148,9 @@ public:
 
     using UDateFormatDeleter = ICUDeleter<udat_close>;
     UDateFormat* getTemporalFormatter(VM&, TemporalFieldKind) const; // Non-owning; no clone needed (single-threaded JS).
-    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeTemporalFormatter(TemporalFieldKind) const;
-    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeAdjustDateTimeStyleFormat(TemporalFieldKind, const Vector<char16_t, 32>& skeleton) const;
-    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeGetDateTimeFormat(TemporalFieldKind) const;
+    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeTemporalFormatter(VM&, TemporalFieldKind) const;
+    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeAdjustDateTimeStyleFormat(VM&, TemporalFieldKind, const Vector<char16_t, 32>& skeleton) const;
+    std::unique_ptr<UDateFormat, UDateFormatDeleter> computeGetDateTimeFormat(VM&, TemporalFieldKind) const;
     std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter> createTemporalIntervalFormat(UDateFormat*, TemporalFieldKind, UErrorCode&) const;
 
     struct DateRangePreamble {
@@ -232,6 +233,7 @@ public:
 
     String m_locale;
     String m_dataLocale;
+    CString m_dataLocaleWithExtensions;
     mutable String m_calendar;
     mutable String m_numberingSystem;
     TimeZone m_timeZone;


### PR DESCRIPTION
#### cde1f2154e51f70ec57fdbda493f10af88a7e291
<pre>
[JSC] Use `IntlCache` for Temporal pattern generation in `Intl.DateTimeFormat`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317624">https://bugs.webkit.org/show_bug.cgi?id=317624</a>

Reviewed by Yusuke Suzuki.

computeAdjustDateTimeStyleFormat and computeGetDateTimeFormat call
udatpg_open directly every time a Temporal-specific UDateFormat is
created. udatpg_open loads the full set of CLDR patterns for the
locale and is one of the most expensive ICU calls.

initializeDateTimeFormat already uses vm.intlCache().getBestDateTimePattern
for the same purpose, which keeps a per-VM single-slot
UDateTimePatternGenerator cache. This patch makes the Temporal path
use the same helper.

Because IntlCache is a single-slot cache keyed by locale string, the
key built here must match the one used in initializeDateTimeFormat to
get a hit. m_calendar / m_numberingSystem are mutable and may be
filled in lazily by resolvedOptions() (since 312029@main), so
rebuilding the locale string at format time can produce a different
key and cause the cache to thrash. To avoid this, store the
dataLocaleWithExtensions CString computed in initializeDateTimeFormat
and reuse it as-is.

                                                   Baseline                  Patched

intl-datetimeformat-format-temporal-style
                                              102.6755+-1.6859     ^     34.4036+-0.4870        ^ definitely 2.9844x faster
intl-datetimeformat-format-temporal-plain-date
                                               92.4857+-1.0609     ^     24.7306+-0.3581        ^ definitely 3.7397x faster
intl-datetimeformat-format-temporal-instant
                                               95.9066+-0.9344     ^     28.4459+-0.3793        ^ definitely 3.3715x faster
intl-datetimeformat-format-temporal-plain-date-time
                                               96.6132+-1.8707     ^     29.0148+-0.1834        ^ definitely 3.3298x faster
intl-datetimeformat-format-temporal-plain-time
                                               92.9727+-0.5586     ^     24.8714+-0.2904        ^ definitely 3.7381x faster

Tests: JSTests/microbenchmarks/intl-datetimeformat-format-temporal-instant.js
       JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-date-time.js
       JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-date.js
       JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-time.js
       JSTests/microbenchmarks/intl-datetimeformat-format-temporal-style.js

* JSTests/microbenchmarks/intl-datetimeformat-format-temporal-instant.js: Added.
* JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-date-time.js: Added.
* JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-date.js: Added.
* JSTests/microbenchmarks/intl-datetimeformat-format-temporal-plain-time.js: Added.
* JSTests/microbenchmarks/intl-datetimeformat-format-temporal-style.js: Added.
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
(JSC::IntlDateTimeFormat::getTemporalFormatter const):
(JSC::IntlDateTimeFormat::computeTemporalFormatter const):
(JSC::IntlDateTimeFormat::computeAdjustDateTimeStyleFormat const):
(JSC::IntlDateTimeFormat::computeGetDateTimeFormat const):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:

Canonical link: <a href="https://commits.webkit.org/317208@main">https://commits.webkit.org/317208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab6689284a0e2263660bcc70eebb596cd066fb44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132352 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135741 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36193 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32542 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5046 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186487 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35746 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39720 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40390 "Found 1 new test failure: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resource-popup.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144656 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48084 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144514 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38987 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48763 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32649 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114357 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39416 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120731 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211537 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47270 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10993 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55186 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->