### PR TITLE
[JSC] Replace fixup-inserted RegExp primordial `TryGetById` chains with a single `CheckStructure`

### DIFF
--- a/JSTests/microbenchmarks/regexp-prototype-symbol-match-primordial-check.js
+++ b/JSTests/microbenchmarks/regexp-prototype-symbol-match-primordial-check.js
@@ -1,0 +1,12 @@
+var symbolMatch = RegExp.prototype[Symbol.match];
+
+function match(regexp, string)
+{
+    return symbolMatch.call(regexp, string);
+}
+noInline(match);
+
+var string = "abc";
+var regexp = /x/;
+for (var i = 0; i < 1e7; ++i)
+    match(regexp, string);

--- a/JSTests/microbenchmarks/regexp-prototype-symbol-split-primordial-check.js
+++ b/JSTests/microbenchmarks/regexp-prototype-symbol-split-primordial-check.js
@@ -1,0 +1,12 @@
+var symbolSplit = RegExp.prototype[Symbol.split];
+
+function split(regexp, string)
+{
+    return symbolSplit.call(regexp, string);
+}
+noInline(split);
+
+var string = "abc";
+var regexp = /x/;
+for (var i = 0; i < 2e6; ++i)
+    split(regexp, string);

--- a/JSTests/microbenchmarks/string-replace-regexp-primordial-check.js
+++ b/JSTests/microbenchmarks/string-replace-regexp-primordial-check.js
@@ -1,0 +1,14 @@
+// String.prototype.replace with a cached primordial RegExp argument and a no-match
+// pattern, so the per-iteration cost is dominated by the primordial-property checks
+// that fixup inserts in front of StringReplace(RegExp).
+
+function replace(string, regexp, replacement)
+{
+    return string.replace(regexp, replacement);
+}
+noInline(replace);
+
+var string = "abc";
+var regexp = /x/;
+for (var i = 0; i < 1e7; ++i)
+    replace(string, regexp, "y");

--- a/JSTests/stress/string-replace-regexp-with-own-property.js
+++ b/JSTests/stress/string-replace-regexp-with-own-property.js
@@ -1,0 +1,24 @@
+//@ runDefault("--validateOptions=true", "--useConcurrentJIT=0")
+
+// FixupPhase guards StringReplace(RegExp) with a CheckStructure on the original
+// RegExp structure. Passing a RegExp that carries an unrelated own property fails
+// that check (BadCache exit). The recompile must not loop and must keep producing
+// the spec result via the runtime path.
+
+function replace(string, regexp, replacement)
+{
+    return string.replace(regexp, replacement);
+}
+noInline(replace);
+
+var regexp = /a/;
+regexp.unrelatedOwnProperty = 42;
+
+for (var i = 0; i < 1e5; ++i) {
+    var result = replace("abc", regexp, "X");
+    if (result !== "Xbc")
+        throw new Error("bad result at " + i + ": " + result);
+}
+
+if (numberOfDFGCompiles(replace) > 2)
+    throw new Error("too many recompiles: " + numberOfDFGCompiles(replace));

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3679,6 +3679,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
                 return CallOptimizationResult::DidNothing;
 
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache))
+                return CallOptimizationResult::DidNothing;
+
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, ExoticObjectMode))
                 return CallOptimizationResult::DidNothing;
 
@@ -4013,6 +4016,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
             // Don't inline intrinsic if we exited due to one of the primordial RegExp checks failing.
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache))
                 return CallOptimizationResult::DidNothing;
 
             JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1183,7 +1183,7 @@ private:
         case StringMatch: {
             if (node->child2()->shouldSpeculateRegExpObject()) {
                 if (m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node)) {
-                    addStringMatchAndSearchPrimordialChecks(node->child2().node());
+                    addRegExpPrimordialStructureCheck(node->child2().node());
 
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                     Node* globalObjectNode = m_insertionSet.insertNode(
@@ -1209,7 +1209,7 @@ private:
         case StringSearch: {
             if (node->child2()->shouldSpeculateRegExpObject()) {
                 if (m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node)) {
-                    addStringMatchAndSearchPrimordialChecks(node->child2().node());
+                    addRegExpPrimordialStructureCheck(node->child2().node());
 
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                     Node* globalObjectNode = m_insertionSet.insertNode(
@@ -1897,7 +1897,7 @@ private:
         case RegExpSearch: {
             fixEdge<KnownCellUse>(node->child1());
             if (m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node))
-                addRegExpSearchPrimordialChecks(node->child2().node());
+                addRegExpPrimordialStructureCheck(node->child2().node());
             else
                 m_insertionSet.insertNode(m_indexInBlock, SpecNone, ForceOSRExit, node->origin);
             fixEdge<RegExpObjectUse>(node->child2());
@@ -1909,7 +1909,7 @@ private:
         case RegExpMatchFast: {
             fixEdge<KnownCellUse>(node->child1());
             if (m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node))
-                addRegExpMatchPrimordialChecks(node->child2().node());
+                addRegExpPrimordialStructureCheck(node->child2().node());
             else
                 m_insertionSet.insertNode(m_indexInBlock, SpecNone, ForceOSRExit, node->origin);
             fixEdge<RegExpObjectUse>(node->child2());
@@ -1919,7 +1919,7 @@ private:
 
         case RegExpSplitFast: {
             if (m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node) && m_graph.isWatchingRegExpSpeciesWatchpoint(node))
-                addRegExpSplitPrimordialChecks(node->child1().node());
+                addRegExpPrimordialStructureCheck(node->child1().node());
             else
                 m_insertionSet.insertNode(m_indexInBlock, SpecNone, ForceOSRExit, node->origin);
             fixEdge<RegExpObjectUse>(node->child1());
@@ -1957,8 +1957,8 @@ private:
 
             if (op == StringReplace || op == StringReplaceAll) {
                 if (node->child2()->shouldSpeculateRegExpObject() && m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node))
-                    addStringReplacePrimordialChecks(node->child2().node());
-                else 
+                    addRegExpPrimordialStructureCheck(node->child2().node());
+                else
                     m_insertionSet.insertNode(m_indexInBlock, SpecNone, ForceOSRExit, node->origin);
             }
 
@@ -4614,57 +4614,7 @@ private:
         m_insertionSet.execute(block);
     }
     
-    void addStringReplacePrimordialChecks(Node* searchRegExp)
-    {
-        Node* node = m_currentNode;
-
-        // Check that structure of searchRegExp is RegExp object
-        m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, Check, node->origin,
-            Edge(searchRegExp, RegExpObjectUse));
-
-        // Check that searchRegExp.lastIndex is a number
-        Node* lastIndexProperty = m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, GetRegExpObjectLastIndex, node->origin,
-            Edge(searchRegExp, RegExpObjectUse));
-        m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, Check, node->origin,
-            Edge(lastIndexProperty, NumberUse));
-
-        auto emitPrimordialCheckFor = [&] (JSValue primordialProperty, UniquedStringImpl* propertyUID) {
-            m_graph.identifiers().ensure(propertyUID);
-            auto* data = m_graph.m_getByIdData.add(GetByIdData { CacheableIdentifier::createFromImmortalIdentifier(propertyUID), CacheType::GetByIdPrototype });
-            Node* actualProperty = m_insertionSet.insertNode(m_indexInBlock, SpecNone, TryGetById, node->origin, OpInfo(data), OpInfo(SpecFunction), Edge(searchRegExp, CellUse));
-            m_insertionSet.insertNode(m_indexInBlock, SpecNone, CheckIsConstant, node->origin, OpInfo(m_graph.freeze(primordialProperty)), Edge(actualProperty, CellUse));
-        };
-
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
-
-        // Check that searchRegExp.exec is the primordial RegExp.prototype.exec
-        emitPrimordialCheckFor(globalObject->regExpProtoExecFunction(), vm().propertyNames->exec.impl());
-        // Check that searchRegExp.flags is the primordial RegExp.prototype.flags
-        emitPrimordialCheckFor(globalObject->regExpProtoFlagsGetter(), vm().propertyNames->flags.impl());
-        // Check that searchRegExp.dotAll is the primordial RegExp.prototype.dotAll
-        emitPrimordialCheckFor(globalObject->regExpProtoDotAllGetter(), vm().propertyNames->dotAll.impl());
-        // Check that searchRegExp.global is the primordial RegExp.prototype.global
-        emitPrimordialCheckFor(globalObject->regExpProtoGlobalGetter(), vm().propertyNames->global.impl());
-        // Check that searchRegExp.hasIndices is the primordial RegExp.prototype.hasIndices
-        emitPrimordialCheckFor(globalObject->regExpProtoHasIndicesGetter(), vm().propertyNames->hasIndices.impl());
-        // Check that searchRegExp.ignoreCase is the primordial RegExp.prototype.ignoreCase
-        emitPrimordialCheckFor(globalObject->regExpProtoIgnoreCaseGetter(), vm().propertyNames->ignoreCase.impl());
-        // Check that searchRegExp.multiline is the primordial RegExp.prototype.multiline
-        emitPrimordialCheckFor(globalObject->regExpProtoMultilineGetter(), vm().propertyNames->multiline.impl());
-        // Check that searchRegExp.sticky is the primordial RegExp.prototype.sticky
-        emitPrimordialCheckFor(globalObject->regExpProtoStickyGetter(), vm().propertyNames->sticky.impl());
-        // Check that searchRegExp.unicode is the primordial RegExp.prototype.unicode
-        emitPrimordialCheckFor(globalObject->regExpProtoUnicodeGetter(), vm().propertyNames->unicode.impl());
-        // Check that searchRegExp.unicodeSets is the primordial RegExp.prototype.unicodeSets
-        emitPrimordialCheckFor(globalObject->regExpProtoUnicodeSetsGetter(), vm().propertyNames->unicodeSets.impl());
-        // Check that searchRegExp[Symbol.replace] is the primordial RegExp.prototype[Symbol.replace]
-        emitPrimordialCheckFor(globalObject->regExpProtoSymbolReplaceFunction(), vm().propertyNames->replaceSymbol.impl());
-    }
-
-    void addStringMatchAndSearchPrimordialChecks(Node* regExp)
+    void addRegExpPrimordialStructureCheck(Node* regExp)
     {
         Node* node = m_currentNode;
         JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
@@ -4683,107 +4633,6 @@ private:
         m_insertionSet.insertNode(
             m_indexInBlock, SpecNone, Check, node->origin,
             Edge(lastIndexProperty, NumberUse));
-    }
-
-    void addRegExpSearchPrimordialChecks(Node* regExp)
-    {
-        Node* node = m_currentNode;
-
-        // Check that structure of regExp is RegExp object
-        m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, Check, node->origin,
-            Edge(regExp, RegExpObjectUse));
-
-        // Check that regExp.lastIndex is a number
-        Node* lastIndexProperty = m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, GetRegExpObjectLastIndex, node->origin,
-            Edge(regExp, RegExpObjectUse));
-        m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, Check, node->origin,
-            Edge(lastIndexProperty, NumberUse));
-
-        // Check that regExp.exec is the primordial RegExp.prototype.exec
-        auto emitPrimordialCheckFor = [&] (JSValue primordialProperty, UniquedStringImpl* propertyUID) {
-            m_graph.identifiers().ensure(propertyUID);
-            auto* data = m_graph.m_getByIdData.add(GetByIdData { CacheableIdentifier::createFromImmortalIdentifier(propertyUID), CacheType::GetByIdPrototype });
-            Node* actualProperty = m_insertionSet.insertNode(m_indexInBlock, SpecNone, TryGetById, node->origin, OpInfo(data), OpInfo(SpecFunction), Edge(regExp, CellUse));
-            m_insertionSet.insertNode(m_indexInBlock, SpecNone, CheckIsConstant, node->origin, OpInfo(m_graph.freeze(primordialProperty)), Edge(actualProperty, CellUse));
-        };
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
-        emitPrimordialCheckFor(globalObject->regExpProtoExecFunction(), vm().propertyNames->exec.impl());
-    }
-
-    void addRegExpMatchPrimordialChecks(Node* regExp)
-    {
-        Node* node = m_currentNode;
-
-        // Check that structure of regExp is RegExp object
-        m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, Check, node->origin,
-            Edge(regExp, RegExpObjectUse));
-
-        // Check that regExp.lastIndex is a number
-        Node* lastIndexProperty = m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, GetRegExpObjectLastIndex, node->origin,
-            Edge(regExp, RegExpObjectUse));
-        m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, Check, node->origin,
-            Edge(lastIndexProperty, NumberUse));
-
-        auto emitPrimordialCheckFor = [&] (JSValue primordialProperty, UniquedStringImpl* propertyUID) {
-            m_graph.identifiers().ensure(propertyUID);
-            auto* data = m_graph.m_getByIdData.add(GetByIdData { CacheableIdentifier::createFromImmortalIdentifier(propertyUID), CacheType::GetByIdPrototype });
-            Node* actualProperty = m_insertionSet.insertNode(m_indexInBlock, SpecNone, TryGetById, node->origin, OpInfo(data), OpInfo(SpecFunction), Edge(regExp, CellUse));
-            m_insertionSet.insertNode(m_indexInBlock, SpecNone, CheckIsConstant, node->origin, OpInfo(m_graph.freeze(primordialProperty)), Edge(actualProperty, CellUse));
-        };
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
-
-        // Symbol.match reads the "flags" getter on the receiver, which in turn reads
-        // each individual flag getter. The fast path bypasses all of these by reading the
-        // RegExp's internal flag bits directly, so the regex must not have any own
-        // property that would shadow these accessors on RegExp.prototype.
-        emitPrimordialCheckFor(globalObject->regExpProtoExecFunction(), vm().propertyNames->exec.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoFlagsGetter(), vm().propertyNames->flags.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoDotAllGetter(), vm().propertyNames->dotAll.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoGlobalGetter(), vm().propertyNames->global.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoHasIndicesGetter(), vm().propertyNames->hasIndices.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoIgnoreCaseGetter(), vm().propertyNames->ignoreCase.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoMultilineGetter(), vm().propertyNames->multiline.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoStickyGetter(), vm().propertyNames->sticky.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoUnicodeGetter(), vm().propertyNames->unicode.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoUnicodeSetsGetter(), vm().propertyNames->unicodeSets.impl());
-    }
-
-    void addRegExpSplitPrimordialChecks(Node* regExp)
-    {
-        Node* node = m_currentNode;
-
-        // Check that structure of regExp is RegExp object.
-        m_insertionSet.insertNode(
-            m_indexInBlock, SpecNone, Check, node->origin,
-            Edge(regExp, RegExpObjectUse));
-
-        // Unlike Symbol.match, split's spec does NOT read or write the receiver's lastIndex
-
-        auto emitPrimordialCheckFor = [&] (JSValue primordialProperty, UniquedStringImpl* propertyUID) {
-            m_graph.identifiers().ensure(propertyUID);
-            auto* data = m_graph.m_getByIdData.add(GetByIdData { CacheableIdentifier::createFromImmortalIdentifier(propertyUID), CacheType::GetByIdPrototype });
-            Node* actualProperty = m_insertionSet.insertNode(m_indexInBlock, SpecNone, TryGetById, node->origin, OpInfo(data), OpInfo(SpecFunction), Edge(regExp, CellUse));
-            m_insertionSet.insertNode(m_indexInBlock, SpecNone, CheckIsConstant, node->origin, OpInfo(m_graph.freeze(primordialProperty)), Edge(actualProperty, CellUse));
-        };
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
-
-        emitPrimordialCheckFor(globalObject->regExpProtoExecFunction(), vm().propertyNames->exec.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoFlagsGetter(), vm().propertyNames->flags.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoDotAllGetter(), vm().propertyNames->dotAll.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoGlobalGetter(), vm().propertyNames->global.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoHasIndicesGetter(), vm().propertyNames->hasIndices.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoIgnoreCaseGetter(), vm().propertyNames->ignoreCase.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoMultilineGetter(), vm().propertyNames->multiline.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoStickyGetter(), vm().propertyNames->sticky.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoUnicodeGetter(), vm().propertyNames->unicode.impl());
-        emitPrimordialCheckFor(globalObject->regExpProtoUnicodeSetsGetter(), vm().propertyNames->unicodeSets.impl());
-        emitPrimordialCheckFor(globalObject->regExpConstructor(), vm().propertyNames->constructor.impl());
     }
 
     Node* checkArray(ArrayMode arrayMode, const NodeOrigin& origin, Node* array, Node* index, bool (*storageCheck)(const ArrayMode&) = canCSEStorage)


### PR DESCRIPTION
#### a46d2fe1b35a6aec5aa3451331d7036dfd3818af
<pre>
[JSC] Replace fixup-inserted RegExp primordial `TryGetById` chains with a single `CheckStructure`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317627">https://bugs.webkit.org/show_bug.cgi?id=317627</a>

Reviewed by Yusuke Suzuki.

addStringReplacePrimordialChecks and friends emit up to eleven
TryGetById+CheckIsConstant pairs to prove the RegExp receiver does not shadow
exec/flags/.../@@replace. Fixup-inserted TryGetByIds carry no bytecode profile,
so in FTL each one survives as an opaque IC patchpoint.

regExpPrimordialPropertiesWatchpoint already guarantees RegExp.prototype is
primordial, so a single CheckStructure against the original RegExp structure is
enough (matching RegExpObject::isSymbol*FastAndNonObservable). Fold the four
helpers into addRegExpPrimordialStructureCheck and add the missing BadCache bail
to StringPrototypeReplace{,All}Intrinsic / RegExpSearchIntrinsic.

                                                     prev                    patched

regexp-prototype-symbol-match-primordial-check
                                              129.4573+-1.9302     ^     80.9818+-1.7268        ^ definitely 1.5986x faster
regexp-prototype-symbol-split-primordial-check
                                               50.0416+-0.4732     ^     39.4040+-0.4457        ^ definitely 1.2700x faster
string-replace-regexp-primordial-check        156.3021+-1.5530     ^    102.9366+-0.8520        ^ definitely 1.5184x faster

Tests: JSTests/microbenchmarks/regexp-prototype-symbol-match-primordial-check.js
       JSTests/microbenchmarks/regexp-prototype-symbol-split-primordial-check.js
       JSTests/microbenchmarks/string-replace-regexp-primordial-check.js
       JSTests/stress/string-replace-regexp-with-own-property.js

* JSTests/microbenchmarks/regexp-prototype-symbol-match-primordial-check.js: Added.
(match):
* JSTests/microbenchmarks/regexp-prototype-symbol-split-primordial-check.js: Added.
(split):
* JSTests/microbenchmarks/string-replace-regexp-primordial-check.js: Added.
(replace):
* JSTests/stress/string-replace-regexp-with-own-property.js: Added.
(replace):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::addRegExpPrimordialStructureCheck):
(JSC::DFG::FixupPhase::addStringReplacePrimordialChecks): Deleted.
(JSC::DFG::FixupPhase::addStringMatchAndSearchPrimordialChecks): Deleted.
(JSC::DFG::FixupPhase::addRegExpSearchPrimordialChecks): Deleted.
(JSC::DFG::FixupPhase::addRegExpMatchPrimordialChecks): Deleted.
(JSC::DFG::FixupPhase::addRegExpSplitPrimordialChecks): Deleted.

Canonical link: <a href="https://commits.webkit.org/315724@main">https://commits.webkit.org/315724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dce59ec927c30739305304b54a439edc566d6b16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132203 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93119 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172615 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112706 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32341 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27712 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1064 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181614 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/30911 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140651 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43234 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140487 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37880 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43923 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108157 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35753 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115688 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202335 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42433 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7119 "") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54249 "Found 1 new JSC stress test failure: stress/string-replace-regexp-with-own-property.js.default (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->