### PR TITLE
[GStreamer][WebRTC] Advertise additional H.264 profiles and levels for encoding

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoCommon.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoCommon.cpp
@@ -53,8 +53,28 @@ std::vector<webrtc::SdpVideoFormat> supportedH264Formats()
     return {
         createH264Format(webrtc::H264Profile::kProfileBaseline, webrtc::H264Level::kLevel3_1, "1"),
         createH264Format(webrtc::H264Profile::kProfileBaseline, webrtc::H264Level::kLevel3_1, "0"),
+        createH264Format(webrtc::H264Profile::kProfileBaseline, webrtc::H264Level::kLevel4, "1"),
+        createH264Format(webrtc::H264Profile::kProfileBaseline, webrtc::H264Level::kLevel4, "0"),
         createH264Format(webrtc::H264Profile::kProfileConstrainedBaseline, webrtc::H264Level::kLevel3_1, "1"),
         createH264Format(webrtc::H264Profile::kProfileConstrainedBaseline, webrtc::H264Level::kLevel3_1, "0"),
+        createH264Format(webrtc::H264Profile::kProfileConstrainedBaseline, webrtc::H264Level::kLevel4, "1"),
+        createH264Format(webrtc::H264Profile::kProfileConstrainedBaseline, webrtc::H264Level::kLevel4, "0"),
+        createH264Format(webrtc::H264Profile::kProfileMain, webrtc::H264Level::kLevel3_1, "1"),
+        createH264Format(webrtc::H264Profile::kProfileMain, webrtc::H264Level::kLevel3_1, "0"),
+        createH264Format(webrtc::H264Profile::kProfileMain, webrtc::H264Level::kLevel4, "1"),
+        createH264Format(webrtc::H264Profile::kProfileMain, webrtc::H264Level::kLevel4, "0"),
+        createH264Format(webrtc::H264Profile::kProfileConstrainedHigh, webrtc::H264Level::kLevel3_1, "1"),
+        createH264Format(webrtc::H264Profile::kProfileConstrainedHigh, webrtc::H264Level::kLevel3_1, "0"),
+        createH264Format(webrtc::H264Profile::kProfileConstrainedHigh, webrtc::H264Level::kLevel4, "1"),
+        createH264Format(webrtc::H264Profile::kProfileConstrainedHigh, webrtc::H264Level::kLevel4, "0"),
+        createH264Format(webrtc::H264Profile::kProfileHigh, webrtc::H264Level::kLevel3_1, "1"),
+        createH264Format(webrtc::H264Profile::kProfileHigh, webrtc::H264Level::kLevel3_1, "0"),
+        createH264Format(webrtc::H264Profile::kProfileHigh, webrtc::H264Level::kLevel4, "1"),
+        createH264Format(webrtc::H264Profile::kProfileHigh, webrtc::H264Level::kLevel4, "0"),
+        createH264Format(webrtc::H264Profile::kProfilePredictiveHigh444, webrtc::H264Level::kLevel3_1, "1"),
+        createH264Format(webrtc::H264Profile::kProfilePredictiveHigh444, webrtc::H264Level::kLevel3_1, "0"),
+        createH264Format(webrtc::H264Profile::kProfilePredictiveHigh444, webrtc::H264Level::kLevel4, "1"),
+        createH264Format(webrtc::H264Profile::kProfilePredictiveHigh444, webrtc::H264Level::kLevel4, "0"),
     };
 }
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
@@ -25,6 +25,7 @@
 
 #include "FloatSize.h"
 #include "GStreamerRegistryScanner.h"
+#include "GStreamerVideoCommon.h"
 #include "GStreamerVideoFrameLibWebRTC.h"
 #include "LibWebRTCUtils.h"
 #include "LibWebRTCVideoFrameUtilities.h"
@@ -313,8 +314,10 @@ std::vector<webrtc::SdpVideoFormat> GStreamerVideoEncoderFactory::GetSupportedFo
     if (scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Encoding, "vp8"_s))
         supportedFormats.push_back(webrtc::SdpVideoFormat::VP8());
 
-    if (scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Encoding, "avc1"_s))
-        supportedFormats.push_back(webrtc::SdpVideoFormat::H264());
+    if (scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Encoding, "avc1"_s)) {
+        for (auto& format : supportedH264Formats())
+            supportedFormats.push_back(WTF::move(format));
+    }
 
     if (m_isSupportingVP9Profile0)
         supportedFormats.push_back(webrtc::SdpVideoFormat::VP9Profile0());


### PR DESCRIPTION
#### fbd28f975e493904d6b5de1e4531a8993a396c5f
<pre>
[GStreamer][WebRTC] Advertise additional H.264 profiles and levels for encoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=317630">https://bugs.webkit.org/show_bug.cgi?id=317630</a>

Reviewed by Philippe Normand.

Patch by Krishna Priya Kanagaraj &lt;krishnapriya_kanagaraj@comcast.com&gt; on 2026-06-23

Previously the GStreamer-based WebRTC encoder factory only advertised a
single Constrained Baseline (level 3.1) H.264 format, which limited
negotiation to the most basic profile, while the decoder factory already
exposed the full set.

Make the encoder factory reuse the shared supportedH264Formats() helper
(already used by the decoder factory) instead of pushing a lone
SdpVideoFormat::H264(), so both ends advertise the same Baseline,
Constrained Baseline, Main, Constrained High, High and Predictive High
4:4:4 profiles, each at levels 3.1 and 4, and can negotiate
higher-quality H.264 streams.

The profile-level-id strings are derived from the webrtc H264Profile and
H264Level enums via H264ProfileLevelIdToString(), so no changes to the
imported libwebrtc sources are needed and the patch survives a libwebrtc
resync.

* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoCommon.cpp:
(WebCore::supportedH264Formats):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp:
(WebCore::GStreamerVideoEncoderFactory::GetSupportedFormats const):

Canonical link: <a href="https://commits.webkit.org/315666@main">https://commits.webkit.org/315666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e31b0b80e461c27ff522501136c500eff19bf0d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171575 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132255 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172668 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152640 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112758 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27765 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181667 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34375 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140702 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43287 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140537 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37826 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43976 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108237 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35805 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115741 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42487 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7112 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41879 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->