### PR TITLE
NetworkBroadcastChannelRegistry crashes on a BroadcastChannel message with a null name

### DIFF
--- a/LayoutTests/ipc/coreipc.js
+++ b/LayoutTests/ipc/coreipc.js
@@ -728,6 +728,8 @@ export class ArgumentSerializer {
                 }
                 throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is neither a number nor a bigint`);
             case 'String':
+                if (argument === null)
+                    return {value: null, type: 'String'};
                 if (typeof argument != 'string') {
                     throw new SerializationError(`Primitive value is not a string`);
                 }

--- a/LayoutTests/ipc/register-broadcast-channel-malformed-client-origin-crash-expected.txt
+++ b/LayoutTests/ipc/register-broadcast-channel-malformed-client-origin-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/ipc/register-broadcast-channel-malformed-client-origin-crash.html
+++ b/LayoutTests/ipc/register-broadcast-channel-malformed-client-origin-crash.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+ window.testRunner?.dumpAsText();
+ window.testRunner?.waitUntilDone();
+ if (window.IPC) {
+     import('./coreipc.js').then(({ CoreIPC }) => {
+         const channelIdentifier = 0;
+         const hostString = unescape('nn%01%23KpUJ%21%09%3CC%3Ad0E%12seZVh%3BZ-%5D@%00E%3D%3Ctbl-%04I%08T%25H%07%00%15N1SX%18B%02%18%0EkRg%040%7B%01%7Ck/Q%05%02J');
+         CoreIPC.Networking.NetworkBroadcastChannelRegistry.RegisterChannel(channelIdentifier, {
+             origin : {
+                 topOrigin : {
+                     data : {
+                         variantType : 'WebCore::OpaqueOriginIdentifierProcessQualified',
+                         variant : { object : 262144, processIdentifier : 262145 }
+                     }
+                 },
+                 clientOrigin : {
+                     data : {
+                         variantType : 'WebCore::SecurityOriginData::Tuple',
+                         variant : { protocol : location.href, host : hostString, port : { optionalValue : 54711 } }
+                     }
+                 }
+             },
+             name : null
+         });
+     });
+ }
+ function callDone() {
+     window.testRunner?.notifyDone();
+ }
+</script>
+<body onload="setTimeout(callDone, 200)">
+    <p>This test passes if it doesn't crash.</p>
+</body>

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -62,6 +62,7 @@ NetworkBroadcastChannelRegistry::~NetworkBroadcastChannelRegistry() = default;
 void NetworkBroadcastChannelRegistry::registerChannel(IPC::Connection& connection, const WebCore::ClientOrigin& origin, const String& name)
 {
     MESSAGE_CHECK(isValidClientOrigin(origin), connection);
+    MESSAGE_CHECK(!name.isNull(), connection);
 
     auto& channelsForOrigin = m_broadcastChannels.ensure(origin, [] { return NameToConnectionIdentifiersMap { }; }).iterator->value;
     auto& connectionIdentifiersForName = channelsForOrigin.ensure(name, [] { return Vector<IPC::Connection::UniqueID> { }; }).iterator->value;
@@ -72,6 +73,7 @@ void NetworkBroadcastChannelRegistry::registerChannel(IPC::Connection& connectio
 void NetworkBroadcastChannelRegistry::unregisterChannel(IPC::Connection& connection, const WebCore::ClientOrigin& origin, const String& name)
 {
     MESSAGE_CHECK(isValidClientOrigin(origin), connection);
+    MESSAGE_CHECK(!name.isNull(), connection);
 
     auto channelsForOriginIterator = m_broadcastChannels.find(origin);
     ASSERT(channelsForOriginIterator != m_broadcastChannels.end());
@@ -89,6 +91,7 @@ void NetworkBroadcastChannelRegistry::unregisterChannel(IPC::Connection& connect
 void NetworkBroadcastChannelRegistry::postMessage(IPC::Connection& connection, const WebCore::ClientOrigin& origin, const String& name, WebCore::MessageWithMessagePorts&& message, CompletionHandler<void()>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(isValidClientOrigin(origin), connection, completionHandler());
+    MESSAGE_CHECK_COMPLETION(!name.isNull(), connection, completionHandler());
 
     auto channelsForOriginIterator = m_broadcastChannels.find(origin);
     ASSERT(channelsForOriginIterator != m_broadcastChannels.end());


### PR DESCRIPTION
#### e85a1ea1850262cda430f44560768619cbd3f2be
<pre>
NetworkBroadcastChannelRegistry crashes on a BroadcastChannel message with a null name
<a href="https://bugs.webkit.org/show_bug.cgi?id=317629">https://bugs.webkit.org/show_bug.cgi?id=317629</a>
<a href="https://rdar.apple.com/180280584">rdar://180280584</a>

Reviewed by Per Arne Vollan.

NetworkBroadcastChannelRegistry uses the IPC-supplied channel name as a
HashMap&lt;String, ...&gt; key in registerChannel() (via ensure()) and in
unregisterChannel() / postMessage() (via find()). A compromised or
malformed WebProcess could send a null String for the name. Looking up a
null String key dereferences a null StringImpl while hashing the key
(StringHash::hash() calls key.impl()-&gt;hash()), crashing the network
process before HashTable::validateKey() ever runs.

Reject a null name with a MESSAGE_CHECK in all three endpoints, matching
the existing origin validation.

Test: ipc/register-broadcast-channel-malformed-client-origin-crash.html

* LayoutTests/ipc/coreipc.js:
(export.ArgumentSerializer):
* LayoutTests/ipc/register-broadcast-channel-malformed-client-origin-crash-expected.txt: Added.
* LayoutTests/ipc/register-broadcast-channel-malformed-client-origin-crash.html: Added.
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp:
(WebKit::NetworkBroadcastChannelRegistry::registerChannel):
(WebKit::NetworkBroadcastChannelRegistry::unregisterChannel):
(WebKit::NetworkBroadcastChannelRegistry::postMessage):

Canonical link: <a href="https://commits.webkit.org/315706@main">https://commits.webkit.org/315706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b25bd477d971278c0744ed68ff1d45c06bd4afc7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127389 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea295d0a-2927-45ae-8650-7d5b9292d7a0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132224 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93137 "10 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4cec4dab-7d90-4ded-afd8-ffa6b58bdec6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172636 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112727 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce403df3-11e2-499a-be76-4ccc2395e0f8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32363 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27733 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181635 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36529 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140671 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37863 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43944 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28979 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108190 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35772 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115709 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42454 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7072 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41847 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42102 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->