### PR TITLE
Wrong character encoding of local reponse override when mapped to file (interpreted as Latin1/ISO-8859-1)

### DIFF
--- a/LayoutTests/http/tests/inspector/network/local-resource-override-mapped-to-file-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/local-resource-override-mapped-to-file-expected.txt
@@ -10,6 +10,14 @@ PASS: Resource Loaded.
 Resource Content: 'PASS: Should load from file.'
 Local Resource Override Content: 'PASS: Should load from file.'
 
+-- Running test case: LocalResourceOverride.MappedToFile.UTF8
+Creating Local Resource Override for: http://127.0.0.1:8000/inspector/network/resources/override.txt
+Linking to file...
+Triggering load...
+PASS: Resource Loaded.
+Resource Content: 'PASS: Should load from file with UTF-8 characters: café 日本語 🎉'
+Local Resource Override Content: 'PASS: Should load from file with UTF-8 characters: café 日本語 🎉'
+
 -- Running test case: LocalResourceOverride.MappedToFile.MappedFileChanged
 Creating Local Resource Override for: http://127.0.0.1:8000/inspector/network/resources/override.txt
 Linking to file...

--- a/LayoutTests/http/tests/inspector/network/local-resource-override-mapped-to-file.html
+++ b/LayoutTests/http/tests/inspector/network/local-resource-override-mapped-to-file.html
@@ -65,6 +65,43 @@ function test()
     });
 
     suite.addTestCase({
+        name: "LocalResourceOverride.MappedToFile.UTF8",
+        description: "Test that `WI.LocalResource.prototype.mapToFile` loads a file containing non-Latin1 characters as UTF-8.",
+        async test() {
+            const url = "http://127.0.0.1:8000/inspector/network/resources/override.txt";
+
+            InspectorTest.log("Creating Local Resource Override for: " + url);
+            let localResourceOverride = WI.LocalResourceOverride.create(url, WI.LocalResourceOverride.InterceptType.Response, {
+                responseMIMEType: "text/plain",
+                responseContent: "FAIL: Should load from file.",
+            });
+            WI.networkManager.addLocalResourceOverride(localResourceOverride);
+
+            InspectorTest.log("Linking to file...");
+            localResourceOverride.localResource.mappedFilePath = await InspectorTest.evaluateInPage(`createTemporaryFile("LocalResourceOverride_MappedToFile_UTF8", "PASS: Should load from file with UTF-8 characters: café 日本語 🎉")`);
+
+            InspectorTest.log("Triggering load...");
+            let [resourceWasAddedEvent, responseReceivedEvent, loadCompleteEvent] = await Promise.all([
+                WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded),
+                WI.Resource.awaitEvent(WI.Resource.Event.ResponseReceived),
+                InspectorTest.awaitEvent("LoadComplete"),
+                InspectorTest.evaluateInPage(`triggerOverrideLoad()`),
+            ]);
+
+            InspectorTest.pass("Resource Loaded.");
+            let resource = resourceWasAddedEvent.data.resource;
+            let {rawContent, rawBase64Encoded} = await resource.requestContent();
+            InspectorTest.log(`Resource Content: '${rawBase64Encoded ? "[base64] " : ""}${rawContent}'`);
+
+            let localResourceCurrentRevision = localResourceOverride.localResource.currentRevision;
+            InspectorTest.log(`Local Resource Override Content: '${localResourceCurrentRevision.base64Encoded ? "[base64] " : ""}${localResourceCurrentRevision.content}'`)
+
+            WI.networkManager.removeLocalResourceOverride(localResourceOverride);
+            WI.LocalResource.resetPathsThatFailedToLoadFromFileSystem();
+        }
+    });
+
+    suite.addTestCase({
         name: "LocalResourceOverride.MappedToFile.MappedFileChanged",
         description: "Test that `WI.LocalResource.prototype.mapToFile` correctly re-loads the mapped file.",
         async test() {

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -183,7 +183,7 @@ void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::Sav
 void RemoteWebInspectorUIProxy::platformLoad(const String& path, CompletionHandler<void(const String&)>&& completionHandler)
 {
     if (auto contents = FileSystem::readEntireFile(path))
-        completionHandler(String { byteCast<Latin1Character>(contents->span()) });
+        completionHandler(String::fromUTF8ReplacingInvalidSequences(byteCast<Latin1Character>(contents->span())));
     else
         completionHandler(nullString());
 }

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -717,7 +717,7 @@ void WebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::SaveData>
 void WebInspectorUIProxy::platformLoad(const String& path, CompletionHandler<void(const String&)>&& completionHandler)
 {
     if (auto contents = FileSystem::readEntireFile(path))
-        completionHandler(String { byteCast<Latin1Character>(contents->span()) });
+        completionHandler(String::fromUTF8ReplacingInvalidSequences(byteCast<Latin1Character>(contents->span())));
     else
         completionHandler(nullString());
 }


### PR DESCRIPTION
#### 21ae2b0e4d3313ed711aa3898a5ab88e877ccec0
<pre>
Wrong character encoding of local reponse override when mapped to file (interpreted as Latin1/ISO-8859-1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=291623">https://bugs.webkit.org/show_bug.cgi?id=291623</a>
&lt;<a href="https://rdar.apple.com/problem/149847746">rdar://problem/149847746</a>&gt;

Reviewed by Qianlang Chen.

Convert the local file&apos;s contents to UTF-8 instead of assuming that it&apos;s Latin1.

* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::platformLoad):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformLoad):

* LayoutTests/http/tests/inspector/network/local-resource-override-mapped-to-file.html:
* LayoutTests/http/tests/inspector/network/local-resource-override-mapped-to-file-expected.txt:

Canonical link: <a href="https://commits.webkit.org/316074@main">https://commits.webkit.org/316074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dbebed2e7ed47be8e20a2642c0dc570a1abdc5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127403 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132238 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93153 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34525 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32376 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181649 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140685 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43269 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152087 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140520 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38148 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43958 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28996 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108209 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35787 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115723 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42469 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7089 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->