### PR TITLE
Nullptr dereference in ReadableStream::createIterator

### DIFF
--- a/LayoutTests/streams/values-removed-iframe-crash-expected.txt
+++ b/LayoutTests/streams/values-removed-iframe-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ReadableStream values() does not crash when the stream's iframe has been detached
+

--- a/LayoutTests/streams/values-removed-iframe-crash.html
+++ b/LayoutTests/streams/values-removed-iframe-crash.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+test(() => {
+    const iframe = document.body.appendChild(document.createElement('iframe'));
+    const stream = new iframe.contentWindow.ReadableStream({
+        start(c) { c.enqueue("hello"); }
+    });
+
+    iframe.remove();
+
+    try {
+        stream.values();
+    } catch (e) {
+        assert_equals(e.name, "InvalidStateError");
+    }
+}, "ReadableStream values() does not crash when the stream's iframe has been detached");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -809,8 +809,11 @@ Ref<DOMPromise> ReadableStream::Iterator::returnSteps(JSDOMGlobalObject& globalO
 // https://streams.spec.whatwg.org/#rs-asynciterator
 ExceptionOr<Ref<ReadableStream::Iterator>> ReadableStream::createIterator(ScriptExecutionContext* context, std::optional<IteratorOptions>&& options)
 {
-    auto& globalObject = *downcast<JSDOMGlobalObject>(context->globalObject());
-    auto readerOrException = ReadableStreamDefaultReader::create(globalObject, *this);
+    auto* globalObject = context ? downcast<JSDOMGlobalObject>(context->globalObject()) : nullptr;
+    if (!globalObject)
+        return Exception { ExceptionCode::InvalidStateError, "Context is detached"_s };
+
+    auto readerOrException = ReadableStreamDefaultReader::create(*globalObject, *this);
     if (readerOrException.hasException())
         return readerOrException.releaseException();
 


### PR DESCRIPTION
#### 0a87f67fd066cd35ac7bba9f22788277fde01ac6
<pre>
Nullptr dereference in ReadableStream::createIterator
<a href="https://rdar.apple.com/180240531">rdar://180240531</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317634">https://bugs.webkit.org/show_bug.cgi?id=317634</a>

Reviewed by Chris Dumez.

ReadableStream::createIterator can be called from a detached context.
We throw an InvalidStateError in that case.
Covered by added test.

* LayoutTests/streams/values-removed-iframe-crash-expected.txt: Added.
* LayoutTests/streams/values-removed-iframe-crash.html: Added.

Canonical link: <a href="https://commits.webkit.org/315664@main">https://commits.webkit.org/315664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b497480f5cfa1017f823369306d159ec69c16749

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127408 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b530cee-c4a0-453e-b394-a51d1238c041) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171562 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132243 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4b37d22-77dd-4fd4-bd9d-a722caea6577) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172655 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112746 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10de3926-4121-4d83-8379-3b81eade7269) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32381 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27752 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181654 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140690 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140525 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37825 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43963 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108217 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35792 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115728 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42474 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7096 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41866 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42009 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->