### PR TITLE
Cherry-pick 315192@main (8993810b37fe). https://bugs.webkit.org/show_bug.cgi?id=317042

### DIFF
--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -107,7 +107,7 @@ void ResourceMonitor::didReceiveResponse(const URL& url, OptionSet<ContentExtens
         return;
 
     RefPtr frame = m_frame.get();
-    RefPtr page = frame ? frame->mainFrame().page() : nullptr;
+    RefPtr page = frame ? frame->page() : nullptr;
     if (!page)
         return;
 
@@ -134,7 +134,7 @@ static ASCIILiteral eligibilityToString(ResourceMonitorEligibility eligibility)
 void ResourceMonitor::continueAfterDidReceiveEligibility(Eligibility eligibility, const URL& url, OptionSet<ContentExtensions::ResourceType> resourceType)
 {
     RefPtr frame = m_frame.get();
-    RefPtr page = frame ? frame->mainFrame().page() : nullptr;
+    RefPtr page = frame ? frame->page() : nullptr;
     if (!page)
         return;
 

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -96,7 +96,7 @@ private:
         ShouldNotThrottle
     };
 
-    int m_timeoutId;
+    int m_timeoutId { 0 };
     int m_nestingLevel;
     EventLoopTimerHandle m_timer;
     Function<void(ScriptExecutionContext&)> m_action;

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -306,7 +306,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitializeContext()
     eglContextAttributes.append(0);
 #endif
 
-    if (contains(unsafeSpan(displayExtensions), "EGL_ANGLE_power_preference"_span)) {
+    if (WTF::contains(unsafeSpan(displayExtensions), "EGL_ANGLE_power_preference"_span)) {
         eglContextAttributes.append(EGL_POWER_PREFERENCE_ANGLE);
         // EGL_LOW_POWER_ANGLE is the default. Change to
         // EGL_HIGH_POWER_ANGLE if desired.

--- a/Source/WebInspectorUI/UserInterface/Views/FolderizedTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FolderizedTreeElement.js
@@ -287,7 +287,7 @@ WI.FolderizedTreeElement = class FolderizedTreeElement extends WI.GeneralTreeEle
             return folder;
 
         folder = new WI.FolderTreeElement(settings.displayName, settings.representedObject, {
-            id: `${settings.type}-${settings._folderSettingsKey}`,
+            id: `${settings.type}-${this._folderSettingsKey}`,
         });
         this._folderTypeMap.set(settings.type, folder);
         return folder;

--- a/Source/WebKit/Shared/WebContextMenuItem.cpp
+++ b/Source/WebKit/Shared/WebContextMenuItem.cpp
@@ -54,7 +54,7 @@ Ref<WebContextMenuItem> WebContextMenuItem::create(const String& title, bool ena
 
     bool checked = false;
     unsigned indentationLevel = 0;
-    return adoptRef(*new WebContextMenuItem(WebContextMenuItemData(WebCore::ContextMenuItemType::Submenu, WebCore::ContextMenuItemTagNoAction, String { title }, enabled, checked, indentationLevel, WTF::move(submenu)))).leakRef();
+    return adoptRef(*new WebContextMenuItem(WebContextMenuItemData(WebCore::ContextMenuItemType::Submenu, WebCore::ContextMenuItemTagNoAction, String { title }, enabled, checked, indentationLevel, WTF::move(submenu))));
 }
 
 WebContextMenuItem* WebContextMenuItem::separatorItem()

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -199,7 +199,7 @@ bool WebGeolocationManager::isHighAccuracyEnabled(const PageSets& pageSets) cons
 void WebGeolocationManager::resetPermissions(const WebCore::RegistrableDomain& registrableDomain)
 {
     auto it = m_pageSets.find(registrableDomain);
-    if (it != m_pageSets.end())
+    if (it == m_pageSets.end())
         return;
 
     for (auto& page : copyToVector(it->value.pageSet)) {


### PR DESCRIPTION
#### d7b4b5b3de370a07141d2676f00df9656c941fe7
<pre>
Cherry-pick 315192@main (8993810b37fe). <a href="https://bugs.webkit.org/show_bug.cgi?id=317042">https://bugs.webkit.org/show_bug.cgi?id=317042</a>

    Fix uninitialized member in DOMTimer
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317042">https://bugs.webkit.org/show_bug.cgi?id=317042</a>
    <a href="https://rdar.apple.com/179524644">rdar://179524644</a>

    Reviewed by Per Arne Vollan.

    The member is not initialized in the constructor, so we&apos;ll initialize it in the
    class declaration.

    * Source/WebCore/page/DOMTimer.h:

    Canonical link: <a href="https://commits.webkit.org/315192@main">https://commits.webkit.org/315192@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.787@webkitglib/2.52">https://commits.webkit.org/305877.787@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 22f6024cd4ec7dcbb29c5e05b6f636e50b8f466d
<pre>
Cherry-pick 315259@main (ba40f4667ee0). <a href="https://bugs.webkit.org/show_bug.cgi?id=317157">https://bugs.webkit.org/show_bug.cgi?id=317157</a>

    Possible fix to possible null dereference crash in ResourceMonitor::continueAfterDidReceiveEligibility
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317157">https://bugs.webkit.org/show_bug.cgi?id=317157</a>
    <a href="https://rdar.apple.com/179753540">rdar://179753540</a>

    Reviewed by Charlie Wolfe and Ben Nham.

    A Frame&apos;s page should always be the same as its main frame&apos;s page.
    There&apos;s a chance we&apos;ve seen some crashes from a frame whose main frame has been
    destroyed, in which case calling Frame::mainFrame would dereference null.
    Since there&apos;s no reason to go to the main frame, omit the call to see if
    this fixes the crash.

    * Source/WebCore/loader/ResourceMonitor.cpp:
    (WebCore::ResourceMonitor::didReceiveResponse):
    (WebCore::ResourceMonitor::continueAfterDidReceiveEligibility):

    Canonical link: <a href="https://commits.webkit.org/315259@main">https://commits.webkit.org/315259@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.786@webkitglib/2.52">https://commits.webkit.org/305877.786@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 85cf344393ccc2f6f7d98d42ab67310d734b05ce
<pre>
Cherry-pick 315287@main (b425ed981e56). <a href="https://bugs.webkit.org/show_bug.cgi?id=317161">https://bugs.webkit.org/show_bug.cgi?id=317161</a>

    WebGeolocationManager::resetPermissions has an inverted iterator check
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317161">https://bugs.webkit.org/show_bug.cgi?id=317161</a>
    <a href="https://rdar.apple.com/179755180">rdar://179755180</a>

    Reviewed by Rupin Mittal.

    resetPermissions() looked up the registrable domain and then did
    &quot;if (it != m_pageSets.end()) return;&quot;, which returns when the entry is found (making the reset a
    no-op) and falls through to dereference a past-the-end iterator when it is not found. Every other
    method in this file uses the correct &quot;if (it == end()) return;&quot;. Flip the comparison.

    * Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
    (WebKit::WebGeolocationManager::resetPermissions):

    Canonical link: <a href="https://commits.webkit.org/315287@main">https://commits.webkit.org/315287@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.785@webkitglib/2.52">https://commits.webkit.org/305877.785@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 53fdca5b5b9ad7c26ef00f6a24b6b8c3945edfcb
<pre>
Cherry-pick 315444@main (1120fc57b402). <a href="https://bugs.webkit.org/show_bug.cgi?id=317341">https://bugs.webkit.org/show_bug.cgi?id=317341</a>

    Memory leak in `WebContextMenuItem::create()`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317341">https://bugs.webkit.org/show_bug.cgi?id=317341</a>
    <a href="https://rdar.apple.com/179965723">rdar://179965723</a>

    Reviewed by Rupin Mittal.

    * Source/WebKit/Shared/WebContextMenuItem.cpp:
    (WebKit::WebContextMenuItem::create):

    Canonical link: <a href="https://commits.webkit.org/315444@main">https://commits.webkit.org/315444@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.784@webkitglib/2.52">https://commits.webkit.org/305877.784@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 770ede920f3753435538a910315526832f6e0175
<pre>
Cherry-pick 315584@main (ab796394361f). <a href="https://bugs.webkit.org/show_bug.cgi?id=317547">https://bugs.webkit.org/show_bug.cgi?id=317547</a>

    REGRESSION(276357@main): Web Inspector: `settings._folderSettingsKey` is undefined
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317547">https://bugs.webkit.org/show_bug.cgi?id=317547</a>

    Reviewed by Qianlang Chen.

    * Source/WebInspectorUI/UserInterface/Views/FolderizedTreeElement.js:
    (WI.FolderizedTreeElement.prototype._parentTreeElementForRepresentedObject):

    Canonical link: <a href="https://commits.webkit.org/315584@main">https://commits.webkit.org/315584@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.783@webkitglib/2.52">https://commits.webkit.org/305877.783@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 0ba7a94dcd764c7dd50a769c744fdac9255ac6c9
<pre>
Cherry-pick 315589@main (f69cd004ede2). <a href="https://bugs.webkit.org/show_bug.cgi?id=317580">https://bugs.webkit.org/show_bug.cgi?id=317580</a>

    Qualify contains() as WTF::contains() in GraphicsContextGLTextureMapperANGLE
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317580">https://bugs.webkit.org/show_bug.cgi?id=317580</a>

    Unreviewed build fix.

    315410@main added an #include &quot;SimpleRange.h&quot; to WebCorePrefix.h, making
    WebCore&apos;s contains() overloads shadow WTF::contains() during unqualified
    lookup and breaking the build. Qualify the call as WTF::contains(),
    matching GraphicsContextGLCocoa.mm.

    Canonical link: <a href="https://commits.webkit.org/315589@main">https://commits.webkit.org/315589@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.782@webkitglib/2.52">https://commits.webkit.org/305877.782@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c521068615b3d05e54bafa7933cb4dc56d006ffe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169715 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/43637 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37009 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179074 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127427 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171581 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44171 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43266 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132261 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127427 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172674 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44171 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/37009 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112764 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44171 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43266 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27771 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/37009 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/44171 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37009 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181673 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34381 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/43266 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140708 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/43293 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/37009 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140543 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/43982 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37009 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108245 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25869 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/43982 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115747 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/42493 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/37009 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/41885 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/42140 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/42028 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->