### PR TITLE
[MSE] MediaSource::hasCurrentTime/hasBufferedTime/hasFutureTime should be done through MediaSourcePrivate

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -111,7 +111,12 @@ void ManagedMediaSource::ensurePrefsRead()
 
 void ManagedMediaSource::monitorSourceBuffers()
 {
+    if (isClosed())
+        return;
+
     MediaSource::monitorSourceBuffers();
+
+    Ref msp = *mediaSourcePrivate();
 
     if (!activeSourceBuffers()->length()) {
         setStreaming(true);
@@ -127,15 +132,16 @@ void ManagedMediaSource::monitorSourceBuffers()
         MediaTime aheadTime = currentTime + MediaTime::createWithDouble(upper);
         return isEnded() ? std::min(duration(), aheadTime) : aheadTime;
     };
+
     if (!m_streaming) {
         PlatformTimeRanges neededBufferedRange { currentTime, std::max(currentTime, limitAhead(*m_lowThreshold)) };
-        if (!isBuffered(neededBufferedRange))
+        if (!msp->isBuffered(neededBufferedRange))
             setStreaming(true);
         return;
     }
 
     if (auto ahead = limitAhead(*m_highThreshold); currentTime < ahead) {
-        if (isBuffered({ currentTime,  ahead }))
+        if (msp->isBuffered({ currentTime,  ahead }))
             setStreaming(false);
     } else
         setStreaming(false);

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -417,51 +417,6 @@ bool MediaSource::contentTypeShouldGenerateTimestamps(const ContentType& content
     return contentType.containerType() == "audio/aac"_s || contentType.containerType() == "audio/mpeg"_s;
 }
 
-bool MediaSource::hasBufferedTime(const MediaTime& time)
-{
-    if (isClosed())
-        return false;
-
-    if (time.isInvalid())
-        return false;
-
-    if (time > duration())
-        return false;
-
-    Ref msp = *m_private;
-    auto ranges = msp->buffered();
-    if (!ranges.length())
-        return false;
-
-    return abs(ranges.nearest(time) - time) <= msp->timeFudgeFactor();
-}
-
-bool MediaSource::hasCurrentTime()
-{
-    return hasBufferedTime(currentTime());
-}
-
-bool MediaSource::hasFutureTime()
-{
-    if (isClosed())
-        return false;
-
-    Ref msp = *m_private;
-
-    return msp->hasFutureTime(currentTime(), msp->timeIsProgressing() ? MediaTime::zeroTime() : MediaSourcePrivate::futureDataThreshold());
-}
-
-bool MediaSource::isBuffered(const PlatformTimeRanges& ranges) const
-{
-    if (isClosed())
-        return true;
-
-    Ref msp = *m_private;
-
-    auto bufferedRanges = msp->buffered();
-    return bufferedRanges.containWithEpsilon(ranges, msp->timeFudgeFactor());
-}
-
 void MediaSource::monitorSourceBuffers()
 {
     if (isClosed())
@@ -481,7 +436,7 @@ void MediaSource::monitorSourceBuffers()
     }
 
     // ↳ If HTMLMediaElement.buffered does not contain a TimeRange for the current playback position:
-    if (!hasCurrentTime()) {
+    if (!msp->hasCurrentTime()) {
         // 1. Set the HTMLMediaElement.readyState attribute to HAVE_METADATA.
         // 2. If this is the first transition to HAVE_METADATA, then queue a task to fire a simple event
         // named loadedmetadata at the media element.
@@ -503,7 +458,7 @@ void MediaSource::monitorSourceBuffers()
     };
     PlatformTimeRanges neededBufferedRange { currentTime, std::max(currentTime, limitAhead(kHaveEnoughDataThreshold)) };
 
-    if (isBuffered(neededBufferedRange)) {
+    if (msp->isBuffered(neededBufferedRange)) {
         // 1. Set the HTMLMediaElement.readyState attribute to HAVE_ENOUGH_DATA.
         // 2. Queue a task to fire a simple event named canplaythrough at the media element.
         // 3. Playback may resume at this point if it was previously suspended by a transition to HAVE_CURRENT_DATA.
@@ -515,7 +470,7 @@ void MediaSource::monitorSourceBuffers()
 
     // ↳ If HTMLMediaElement.buffered contains a TimeRange that includes the current playback
     //  position and some time beyond the current playback position, then run the following steps:
-    if (hasFutureTime()) {
+    if (msp->hasFutureTime()) {
         // 1. Set the HTMLMediaElement.readyState attribute to HAVE_FUTURE_DATA.
         // 2. If the previous value of HTMLMediaElement.readyState was less than HAVE_FUTURE_DATA, then queue a task to fire a simple event named canplay at the media element.
         // 3. Playback may resume at this point if it was previously suspended by a transition to HAVE_CURRENT_DATA.

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -175,8 +175,6 @@ public:
 protected:
     MediaSource(ScriptExecutionContext&, MediaSourceInit&&);
 
-    bool isBuffered(const PlatformTimeRanges&) const;
-
     void scheduleEvent(const AtomString& eventName);
     void notifyElementUpdateMediaState() const;
     void ensureWeakOnHTMLMediaElementContext(Function<void(HTMLMediaElement&)>&&) const;
@@ -224,10 +222,6 @@ private:
 
     void regenerateActiveSourceBuffers();
     void updateBufferedIfNeeded(bool forced = false);
-
-    bool hasBufferedTime(const MediaTime&);
-    bool hasCurrentTime();
-    bool hasFutureTime();
 
     static URLRegistry* s_registry;
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -43,6 +43,14 @@ bool MediaSourcePrivate::hasFutureTime(const MediaTime& currentTime) const
     return hasFutureTime(currentTime, futureDataThreshold());
 }
 
+bool MediaSourcePrivate::hasFutureTime() const
+{
+    if (m_readyState.load() == MediaSourceReadyState::Closed)
+        return false;
+    auto threshold = timeIsProgressing() ? MediaTime::zeroTime() : futureDataThreshold();
+    return hasFutureTime(currentTime(), threshold);
+}
+
 bool MediaSourcePrivate::hasFutureTime(const MediaTime& currentTime, const MediaTime& threshold) const
 {
     if (currentTime >= duration())
@@ -69,6 +77,37 @@ bool MediaSourcePrivate::hasFutureTime(const MediaTime& currentTime, const Media
     // So we check if currentTime could progress further from its current value by at least one
     // video frame if paused, or if currentTime could go still progress.
     return localEnd - currentTime > threshold;
+}
+
+bool MediaSourcePrivate::hasBufferedTime(const MediaTime& time) const
+{
+    if (m_readyState.load() == MediaSourceReadyState::Closed)
+        return false;
+
+    if (time.isInvalid())
+        return false;
+
+    if (time > duration())
+        return false;
+
+    auto ranges = buffered();
+    if (!ranges.length())
+        return false;
+
+    return abs(ranges.nearest(time) - time) <= timeFudgeFactor();
+}
+
+bool MediaSourcePrivate::hasCurrentTime() const
+{
+    return hasBufferedTime(currentTime());
+}
+
+bool MediaSourcePrivate::isBuffered(const PlatformTimeRanges& ranges) const
+{
+    if (m_readyState.load() == MediaSourceReadyState::Closed)
+        return false;
+
+    return buffered().containWithEpsilon(ranges, timeFudgeFactor());
 }
 
 MediaSourcePrivate::MediaSourcePrivate(MediaSourcePrivateClient& client)
@@ -141,22 +180,14 @@ void MediaSourcePrivate::cancelPendingWaitForTarget()
 bool MediaSourcePrivate::canCompleteWaitForTarget() const
 {
     assertIsCurrent(m_dispatcher.get());
-    SeekTarget target;
+    MediaTime targetTime;
     {
         Locker locker { m_lock };
         if (!m_pendingSeekTarget)
             return false;
-        target = *m_pendingSeekTarget;
+        targetTime = m_pendingSeekTarget->time;
     }
-    if (target.time.isInvalid())
-        return false;
-    auto totalDuration = duration();
-    if (totalDuration.isValid() && target.time > totalDuration)
-        return false;
-    auto ranges = buffered();
-    if (!ranges.length())
-        return false;
-    return abs(ranges.nearest(target.time) - target.time) <= timeFudgeFactor();
+    return hasBufferedTime(targetTime);
 }
 
 void MediaSourcePrivate::completeWaitForTarget()

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -130,9 +130,12 @@ public:
     // m_buffered into the caller. Useful for short-circuit checks on the main
     // thread which would otherwise pay a full PlatformTimeRanges copy via buffered().
     bool isBufferedEqual(const PlatformTimeRanges&) const;
+    bool isBuffered(const PlatformTimeRanges&) const;
     PlatformTimeRanges seekable() const;
 
     bool hasBufferedData() const;
+    bool hasCurrentTime() const;
+    bool hasFutureTime() const;
     bool hasFutureTime(const MediaTime& currentTime) const;
     static constexpr MediaTime futureDataThreshold() { return MediaTime { 1001, 24000 }; }
     bool hasFutureTime(const MediaTime& currentTime, const MediaTime& threshold) const;
@@ -168,6 +171,7 @@ private:
     bool canCompleteWaitForTarget() const WTF_REQUIRES_CAPABILITY(m_dispatcher.get());
     void completeWaitForTarget() WTF_REQUIRES_CAPABILITY(m_dispatcher.get());
     void tryCompleteWaitForTarget() WTF_REQUIRES_CAPABILITY(m_dispatcher.get());
+    bool hasBufferedTime(const MediaTime&) const;
 
     MediaTime m_duration WTF_GUARDED_BY_LOCK(m_lock) { MediaTime::invalidTime() };
     PlatformTimeRanges m_buffered WTF_GUARDED_BY_LOCK(m_lock);


### PR DESCRIPTION
#### 36c254f935945ad99802874254c6c1013719470b
<pre>
[MSE] MediaSource::hasCurrentTime/hasBufferedTime/hasFutureTime should be done through MediaSourcePrivate
<a href="https://bugs.webkit.org/show_bug.cgi?id=317642">https://bugs.webkit.org/show_bug.cgi?id=317642</a>
<a href="https://rdar.apple.com/180389872">rdar://180389872</a>

Reviewed by Youenn Fablet.

We move all the buffered ranges check in MediaSourcePrivate as it&apos;s the
source of truth.

No functional changes.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::monitorSourceBuffers):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::monitorSourceBuffers):
(WebCore::MediaSource::hasBufferedTime): Deleted.
(WebCore::MediaSource::hasCurrentTime): Deleted.
(WebCore::MediaSource::hasFutureTime): Deleted.
(WebCore::MediaSource::isBuffered const): Deleted.
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::hasFutureTime const):
(WebCore::MediaSourcePrivate::hasBufferedTime const):
(WebCore::MediaSourcePrivate::hasCurrentTime const):
(WebCore::MediaSourcePrivate::isBuffered const): Original method was returning true when the MediaSource was closed.
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:

Canonical link: <a href="https://commits.webkit.org/315691@main">https://commits.webkit.org/315691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/036229ac60c00ce99cba38713d3fdc4ef77840a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43659 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127449 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51c13586-9de2-40e7-93ca-cf196f19d13e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171603 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132283 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f7d32ea-38c5-4d04-bb0b-46961b330808) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172696 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112786 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/978286c8-b196-40e6-9aaa-8ad56a1ec099) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32419 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27793 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144233 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181695 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140731 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43315 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37859 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44004 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108276 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35831 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115769 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42515 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41907 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42162 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->