### PR TITLE
[Navigation API] Crash in MethodTrackerRegistry::promoteUpcomingTraverseToOngoing with null destination key

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -914,6 +914,8 @@ NavigationAPIMethodTracker* Navigation::MethodTrackerRegistry::upcomingTraverse(
 {
     assertIsMainThread();
     Locker locker { m_lock };
+    if (key.isNull())
+        return nullptr;
     return m_upcomingTraverse.get(key);
 }
 
@@ -949,6 +951,8 @@ NavigationAPIMethodTracker* Navigation::MethodTrackerRegistry::promoteUpcomingTr
     Locker locker { m_lock };
     // FIXME: We should be able to assert m_ongoing is unset.
     ASSERT(destinationKey.isNull() || !destinationKey.isEmpty());
+    if (destinationKey.isNull())
+        return nullptr;
     m_ongoing = m_upcomingTraverse.take(destinationKey);
     return m_ongoing.get();
 }


### PR DESCRIPTION
#### 984f3c499a525b20dec24480796813d87ee665f7
<pre>
[Navigation API] Crash in MethodTrackerRegistry::promoteUpcomingTraverseToOngoing with null destination key
<a href="https://bugs.webkit.org/show_bug.cgi?id=317623">https://bugs.webkit.org/show_bug.cgi?id=317623</a>
<a href="https://rdar.apple.com/180282129">rdar://180282129</a>

Reviewed by Per Arne Vollan.

Navigation::dispatchTraversalNavigateEvent constructs a NavigationDestination
whose key() returns a null String when the destination has no associated
NavigationHistoryEntry, or when the entry&apos;s document is no longer fully
active. innerDispatchNavigateEvent then forwards that null key into
MethodTrackerRegistry::promoteUpcomingTraverseToOngoing(), which calls
HashMap&lt;String, ...&gt;::take() with it. HashTraits&lt;String&gt;::isEmptyValue(s)
is defined as s.isNull(), so a null String is the HashTable empty-value
sentinel; passing it to take() violates the HashTable invariant and ends
up running StringHash::hash() on a null StringImpl*, producing a null
deref reading m_hashAndFlags at offset 16 (ASan SEGV at 0x10).

Guard the MethodTrackerRegistry boundary so a null key never reaches the
HashMap, mirroring the existing null-key guard in unregister(). Returning
nullptr is the correct semantic: callers in innerDispatchNavigateEvent
already handle apiMethodTracker == nullptr.

Covered by existing tests.

* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::MethodTrackerRegistry::upcomingTraverse const):
(WebCore::Navigation::MethodTrackerRegistry::promoteUpcomingTraverseToOngoing):

Canonical link: <a href="https://commits.webkit.org/315685@main">https://commits.webkit.org/315685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fa5dd7cc430df8cc3023b2e41bece76ee94488c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127447 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4897f804-e20d-4b57-a0f1-2ba6146dbdff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171601 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc9d723e-2497-436b-aa75-590386456ac5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172694 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112784 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e563f438-e694-433d-b7f9-e9f4b45cfff5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32418 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27791 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181693 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140729 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43313 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140563 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/37856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44002 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29053 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108274 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35827 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115767 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42513 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7146 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41905 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42160 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42048 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->