### PR TITLE
SVGLengthValue::setValueAsString should parse in a single MetaConsumer pass

### DIFF
--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -369,12 +369,8 @@ ExceptionOr<void> SVGLengthValue::setValueAsString(StringView string)
     // CSS::Range only clamps to boundaries, but we historically handled
     // overflow values like "-45e58" to 0 instead of FLT_MAX.
     // FIXME: Consider setting to a proper value
-    auto isFloatOverflow = [](const auto& parsedValue) {
-        if (auto raw = parsedValue.raw()) {
-            double value = raw->value;
-            return value > FLT_MAX || value < -FLT_MAX;
-        }
-        return true;
+    auto isFloatOverflow = [](const auto& value) {
+        return value > FLT_MAX || value < -FLT_MAX;
     };
 
     auto parserContext = CSSParserContext { SVGAttributeMode };
@@ -385,30 +381,27 @@ ExceptionOr<void> SVGLengthValue::setValueAsString(StringView string)
     CSSTokenizer tokenizer(trimmedString.toString());
     auto tokenRange = tokenizer.tokenRange();
 
-    if (auto number = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<>>::consume(tokenRange, parserState, { })) {
-        if (!tokenRange.atEnd())
-            return Exception { ExceptionCode::SyntaxError };
+    auto parsedValue = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<>, CSS::LengthPercentage<>>::consume(tokenRange, parserState, { });
+    if (!parsedValue || !tokenRange.atEnd())
+        return Exception { ExceptionCode::SyntaxError };
 
-        m_value = isFloatOverflow(*number) ? CSS::Number<>(0) : WTF::move(*number);
-
-        return { };
-    }
-
-    tokenRange = tokenizer.tokenRange();
-    if (auto length = CSSPropertyParserHelpers::MetaConsumer<CSS::LengthPercentage<>>::consume(tokenRange, parserState, { })) {
-        if (!tokenRange.atEnd())
-            return Exception { ExceptionCode::SyntaxError };
-
-        // FIXME: Add support for calculated lengths.
-        if (length->isCalc())
-            return Exception { ExceptionCode::SyntaxError };
-
-        m_value = WTF::move(*length);
-
-        return { };
-    }
-
-    return Exception { ExceptionCode::SyntaxError };
+    return WTF::switchOn(WTF::move(*parsedValue),
+        [&](CSS::Number<>&& number) -> ExceptionOr<void> {
+            auto raw = number.raw();
+            if (!raw || isFloatOverflow(raw->value))
+                m_value = CSS::Number<>(0);
+            else
+                m_value = WTF::move(number);
+            return { };
+        },
+        [&](CSS::LengthPercentage<>&& length) -> ExceptionOr<void> {
+            // FIXME: Add support for calculated lengths.
+            if (length.isCalc())
+                return Exception { ExceptionCode::SyntaxError };
+            m_value = WTF::move(length);
+            return { };
+        }
+    );
 }
 
 ExceptionOr<void> SVGLengthValue::convertToSpecifiedUnits(const SVGLengthContext& context, SVGLengthType targetType)


### PR DESCRIPTION
#### 686eb0601bfc18e2476ea13e3af2d424a54e60c4
<pre>
SVGLengthValue::setValueAsString should parse in a single MetaConsumer pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=317653">https://bugs.webkit.org/show_bug.cgi?id=317653</a>
<a href="https://rdar.apple.com/180414239">rdar://180414239</a>

Reviewed by Simon Fraser.

setValueAsString() ran two separate MetaConsumer passes over the same token
range: it first tried MetaConsumer&lt;CSS::Number&lt;&gt;&gt;, and on failure reset the
range and tried MetaConsumer&lt;CSS::LengthPercentage&lt;&gt;&gt;.

Replace the two-pass into a single MetaConsumer&lt;CSS::Number&lt;&gt;, CSS::LengthPercentage&lt;&gt;&gt;
pass, which tries &lt;number&gt; then &lt;length-percentage&gt; in one walk.

There is now exactly one tokenization and one parse pass instead of up to two.

* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::setValueAsString):

Canonical link: <a href="https://commits.webkit.org/315694@main">https://commits.webkit.org/315694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87b14ab6767f4cdde1713f6844a472874d2cde57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127448 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e94fa7f7-840c-4785-8c57-9e6757a73648) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171602 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132282 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87713007-faf4-474f-8d8e-ce67016524be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172695 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112785 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd6894c2-4b87-42f8-8da1-1b8551c58616) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32420 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27792 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181694 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140730 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43314 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140564 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44003 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108275 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25865 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35829 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115768 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42514 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7147 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41906 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42049 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->