### PR TITLE
[OpenXR] Instance is never released when no session is started

### DIFF
--- a/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
@@ -81,6 +81,8 @@ public:
     virtual void startSession(WebPageProxy&, WeakPtr<PlatformXRCoordinatorSessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) = 0;
     virtual void endSessionIfExists(WebPageProxy&) = 0;
 
+    virtual void stopWhenIdle() { }
+
     // Session display loop.
     virtual void scheduleAnimationFrame(WebPageProxy&, std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&) = 0;
 #if USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -74,8 +74,14 @@ void PlatformXRSystem::invalidate(InvalidationReason reason)
     if (!page)
         return;
 
-    if (m_immersiveSessionState == ImmersiveSessionState::Idle)
+    // Multi-view case is handled: if two views have enumerated devices (so the coordinator is Idle), when one view is torn down, the
+    // instance would be destroyed for the other view. This is not a problem, as the remaining view will re-create an instance either
+    // in getPrmiaryDeviceInfo() or in startSession().
+    if (m_immersiveSessionState == ImmersiveSessionState::Idle) {
+        if (reason == InvalidationReason::State && xrCoordinator())
+            xrCoordinator()->stopWhenIdle();
         return;
+    }
 
     if (xrCoordinator())
         xrCoordinator()->endSessionIfExists(*page);

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -431,6 +431,17 @@ void OpenXRCoordinator::endSessionIfExists(WebPageProxy& page)
         });
 }
 
+void OpenXRCoordinator::stopWhenIdle()
+{
+    ASSERT(RunLoop::isMain());
+    LOG(XR, "OpenXRCoordinator::stopWhenIdle");
+    if (std::holds_alternative<Active>(m_state)) {
+        LOG(XR, "... skipping, a session is active");
+        return;
+    }
+    cleanupInstanceAndAssociatedResources();
+}
+
 void OpenXRCoordinator::scheduleAnimationFrame(WebPageProxy& page, std::optional<PlatformXR::RequestData>&& requestData, PlatformXR::Device::RequestFrameCallback&& onFrameUpdateCallback)
 {
     WTF::switchOn(m_state,

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -64,6 +64,7 @@ public:
 
     void startSession(WebPageProxy&, WeakPtr<PlatformXRCoordinatorSessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) override;
     void endSessionIfExists(WebPageProxy&) override;
+    void stopWhenIdle() override;
 
     void scheduleAnimationFrame(WebPageProxy&, std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&& onFrameUpdateCallback) override;
     void submitFrame(WebPageProxy&, Vector<PlatformXR::DeviceLayer>&&) override;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestOpenXRInstanceLifecycle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestOpenXRInstanceLifecycle.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "WebViewTest.h"
+#include "WebXRTestHelpers.h"
+#include <dlfcn.h>
+#include <wtf/glib/GUniquePtr.h>
+
+// This test exercises the UIProcess OpenXR instance lifecycle against an in-process mock
+// OpenXR runtime (Tools/TestWebKitAPI/openxr-mock), selected via XR_RUNTIME_JSON so the
+// production loader/dispatch path is unchanged.
+struct MockEventState {
+    int created { 0 };
+    int destroyed { 0 };
+    GMainLoop* loopToQuitOnDestroy { nullptr };
+    bool timedOut { false };
+};
+
+static void mockEventCallback(const char* event, void* userData)
+{
+    auto* state = static_cast<MockEventState*>(userData);
+    if (!g_strcmp0(event, "instance-created"))
+        ++state->created;
+    else if (!g_strcmp0(event, "instance-destroyed")) {
+        ++state->destroyed;
+        if (state->loopToQuitOnDestroy)
+            g_main_loop_quit(state->loopToQuitOnDestroy);
+    }
+}
+
+static gboolean destroyWaitTimeout(gpointer userData)
+{
+    auto* state = static_cast<MockEventState*>(userData);
+    state->timedOut = true;
+    if (state->loopToQuitOnDestroy)
+        g_main_loop_quit(state->loopToQuitOnDestroy);
+    return G_SOURCE_REMOVE;
+}
+
+using MockEventCallback = void (*)(const char* event, void* userData);
+
+// Handle + the one entry point the test needs from the mock's exported control API.
+struct MockOpenXRControl {
+    void* handle { nullptr };
+    void (*setEventCallback)(MockEventCallback, void*) { nullptr };
+};
+
+static MockOpenXRControl openMockOpenXRControl()
+{
+    // Load the OpenXR mock runtime before the OpenXR loader uses it for enumeration.
+    GUniquePtr<char> manifestDir(g_path_get_dirname(MOCK_OPENXR_RUNTIME_JSON));
+    GUniquePtr<char> modulePath(g_build_filename(manifestDir.get(), "libMockOpenXRRuntime.so", nullptr));
+    void* handle = dlopen(modulePath.get(), RTLD_NOW);
+    g_assert_nonnull(handle);
+
+    void* setEventCallback = dlsym(handle, "mock_openxr_set_event_callback");
+    g_assert_nonnull(setEventCallback);
+
+    MockOpenXRControl control;
+    control.handle = handle;
+    control.setEventCallback = reinterpret_cast<void(*)(MockEventCallback, void*)>(setEventCallback);
+    return control;
+}
+
+class WebXRInstanceLifecycleTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(WebXRInstanceLifecycleTest);
+
+    WebXRInstanceLifecycleTest()
+    {
+        relaxDMABufRequirement(webkit_web_view_get_settings(m_webView.get()));
+    }
+
+    // Web process termination runs WebPageProxy::resetState, which calls PlatformXRSystem::invalidate(State).
+    void terminateWebProcess()
+    {
+        m_expectedWebProcessCrash = true;
+        webkit_web_view_terminate_web_process(m_webView.get());
+    }
+
+    bool waitForInstanceDestroyed(MockEventState& state)
+    {
+        if (state.destroyed)
+            return true;
+        state.loopToQuitOnDestroy = m_mainLoop;
+        unsigned timeoutID = g_timeout_add_seconds(5, destroyWaitTimeout, &state);
+        g_main_loop_run(m_mainLoop);
+        if (!state.timedOut)
+            g_source_remove(timeoutID);
+        state.loopToQuitOnDestroy = nullptr;
+        return state.destroyed;
+    }
+};
+
+static void testOpenXRInstanceReleasedOnTeardown(WebXRInstanceLifecycleTest* test, gconstpointer)
+{
+    MockEventState events;
+    auto control = openMockOpenXRControl();
+    control.setEventCallback(mockEventCallback, &events);
+
+    test->showInWindow();
+
+    test->loadHtml("<html><body></body></html>", "https://foo.com/");
+    test->waitUntilLoadFinished();
+
+    // Device enumeration: creates an OpenXR instance in the UIProcess but starts no session, leaving PlatformXRSystem in the Idle state.
+    test->runJavaScriptAndWaitUntilFinished(
+        "navigator.xr.isSessionSupported('immersive-vr')"
+        "  .then(s => { document.title = 'done:' + s; })"
+        "  .catch(e => { document.title = 'error:' + e; });", nullptr);
+    test->waitUntilTitleChanged();
+
+    g_assert_cmpint(events.created, ==, 1);
+    g_assert_cmpint(events.destroyed, ==, 0);
+
+    // With no active session, invalidate(State) must release the instance.
+    test->terminateWebProcess();
+
+    g_assert_true(test->waitForInstanceDestroyed(events));
+    g_assert_cmpint(events.destroyed, ==, 1);
+    g_assert_cmpint(events.created, ==, 1);
+
+    control.setEventCallback(nullptr, nullptr);
+    dlclose(control.handle);
+}
+
+void beforeAll()
+{
+    // Select the in-process mock OpenXR runtime for this process before any OpenXR use.
+    g_setenv("XR_RUNTIME_JSON", MOCK_OPENXR_RUNTIME_JSON, TRUE);
+
+    WebXRInstanceLifecycleTest::add("OpenXR", "instance-released-on-teardown", testOpenXRInstanceReleasedOnTeardown);
+}
+
+void afterAll()
+{
+}

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebXR.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebXR.cpp
@@ -21,6 +21,7 @@
 
 #include "WebKitTestServer.h"
 #include "WebViewTest.h"
+#include "WebXRTestHelpers.h"
 #include <wtf/text/MakeString.h>
 
 static WebKitTestServer* kHttpsServer = nullptr;
@@ -38,24 +39,6 @@ static const char indexHTML[] =
 "  }).catch(err => console.error(`XR session failed to start: ${err}`));"
 "});"
 "</script></body></html>";
-
-static WebKitFeature* findFeature(WebKitFeatureList *featureList, const char *identifier)
-{
-    for (gsize i = 0; i < webkit_feature_list_get_length(featureList); i++) {
-        WebKitFeature* feature = webkit_feature_list_get(featureList, i);
-        if (!g_ascii_strcasecmp(identifier, webkit_feature_get_identifier(feature)))
-            return feature;
-    }
-    return nullptr;
-}
-
-static void relaxDMABufRequirement(WebKitSettings* settings)
-{
-    g_autoptr(WebKitFeatureList) featureList = webkit_settings_get_development_features();
-    WebKitFeature* feature = findFeature(featureList, "OpenXRDMABufRelaxedForTesting");
-    g_assert_nonnull(feature);
-    webkit_settings_set_feature_enabled(settings, feature, true);
-}
 
 class WebXRTest : public WebViewTest {
 public:
@@ -272,7 +255,7 @@ static void testWebKitXRHitTest(WebXRTest* test, gconstpointer)
 
     // Enable WebXRHitTestModule
     g_autoptr(WebKitFeatureList) featureList = webkit_settings_get_experimental_features();
-    WebKitFeature* feature = findFeature(featureList, "WebXRHitTestModule");
+    WebKitFeature* feature = webkit_feature_list_find(featureList, "WebXRHitTestModule");
     g_assert_nonnull(feature);
     auto settings = webkit_web_view_get_settings(test->webView());
     webkit_settings_set_feature_enabled(settings, feature, true);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/WebXRTestHelpers.h
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/WebXRTestHelpers.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebKitFeature.h>
+#include <WebKitSettings.h>
+
+static void relaxDMABufRequirement(WebKitSettings* settings)
+{
+    g_autoptr(WebKitFeatureList) featureList = webkit_settings_get_development_features();
+    WebKitFeature* feature = webkit_feature_list_find(featureList, "OpenXRDMABufRelaxedForTesting");
+    g_assert_nonnull(feature);
+    webkit_settings_set_feature_enabled(settings, feature, true);
+}

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -165,6 +165,24 @@ ADD_WK2_TEST(TestInputMethodContext ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKPa
 
 if (ENABLE_WEBXR AND USE_OPENXR)
     ADD_WK2_TEST(TestWebKitWebXR ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebXR.cpp)
+
+    # In-process mock OpenXR runtime: a module the real loader dlopens (selected via
+    # XR_RUNTIME_JSON), so the test exercises the production OpenXR path.
+    add_library(MockOpenXRRuntime MODULE ${TOOLS_DIR}/TestWebKitAPI/openxr-mock/MockOpenXRRuntime.cpp)
+    target_include_directories(MockOpenXRRuntime PRIVATE ${OPENXR_INCLUDE_DIRS})
+    set_target_properties(MockOpenXRRuntime PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${TEST_BINARY_DIR})
+
+    file(GENERATE
+        OUTPUT ${TEST_BINARY_DIR}/mock_openxr_runtime.json
+        CONTENT "{ \"file_format_version\": \"1.0.0\", \"runtime\": { \"library_path\": \"./libMockOpenXRRuntime.so\" } }\n"
+    )
+
+    ADD_WK2_TEST(TestOpenXRInstanceLifecycle ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestOpenXRInstanceLifecycle.cpp)
+    add_dependencies(TestOpenXRInstanceLifecycle MockOpenXRRuntime)
+    target_link_libraries(TestOpenXRInstanceLifecycle ${CMAKE_DL_LIBS})
+    target_compile_definitions(TestOpenXRInstanceLifecycle PRIVATE
+        MOCK_OPENXR_RUNTIME_JSON="${TEST_BINARY_DIR}/mock_openxr_runtime.json"
+    )
 endif ()
 
 if (ENABLE_2022_GLIB_API)

--- a/Tools/TestWebKitAPI/openxr-mock/MockOpenXRRuntime.cpp
+++ b/Tools/TestWebKitAPI/openxr-mock/MockOpenXRRuntime.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cstring>
+#include <openxr/openxr.h>
+#include <openxr/openxr_loader_negotiation.h>
+#include <string_view>
+
+namespace {
+
+// WebKit only checks against XR_NULL_HANDLE
+int g_mockInstanceStorage = 0;
+XrInstance mockInstanceHandle() { return reinterpret_cast<XrInstance>(&g_mockInstanceStorage); }
+
+constexpr XrSystemId kMockSystemId = 1;
+
+void (*g_eventCallback)(const char* event, void* userData) = nullptr;
+void* g_eventCallbackUserData = nullptr;
+
+void notifyEvent(const char* event)
+{
+    if (g_eventCallback)
+        g_eventCallback(event, g_eventCallbackUserData);
+}
+
+template<typename T>
+XrResult enumerate(const T* values, uint32_t count, uint32_t capacityInput, uint32_t* countOutput, T* buffer)
+{
+    if (countOutput)
+        *countOutput = count;
+    if (!capacityInput)
+        return XR_SUCCESS;
+    if (capacityInput < count)
+        return XR_ERROR_SIZE_INSUFFICIENT;
+    for (uint32_t i = 0; i < count; ++i)
+        buffer[i] = values[i];
+    return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrEnumerateInstanceExtensionProperties(const char*, uint32_t capacityInput, uint32_t* propertyCountOutput, XrExtensionProperties* properties)
+{
+    static const char* const kExtensions[] = { "XR_KHR_opengl_es_enable" };
+    const uint32_t count = 1;
+
+    if (propertyCountOutput)
+        *propertyCountOutput = count;
+    if (!capacityInput)
+        return XR_SUCCESS;
+    if (capacityInput < count)
+        return XR_ERROR_SIZE_INSUFFICIENT;
+
+    for (uint32_t i = 0; i < count; ++i) {
+        properties[i].type = XR_TYPE_EXTENSION_PROPERTIES;
+        properties[i].next = nullptr;
+        std::strncpy(properties[i].extensionName, kExtensions[i], XR_MAX_EXTENSION_NAME_SIZE - 1);
+        properties[i].extensionName[XR_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
+        properties[i].extensionVersion = 1;
+    }
+    return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrCreateInstance(const XrInstanceCreateInfo*, XrInstance* instance)
+{
+    if (!instance)
+        return XR_ERROR_VALIDATION_FAILURE;
+    *instance = mockInstanceHandle();
+    notifyEvent("instance-created");
+    return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrDestroyInstance(XrInstance)
+{
+    notifyEvent("instance-destroyed");
+    return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrGetSystem(XrInstance, const XrSystemGetInfo*, XrSystemId* systemId)
+{
+    if (!systemId)
+        return XR_ERROR_VALIDATION_FAILURE;
+    *systemId = kMockSystemId;
+    return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrGetSystemProperties(XrInstance, XrSystemId, XrSystemProperties* properties)
+{
+    if (!properties)
+        return XR_ERROR_VALIDATION_FAILURE;
+    properties->vendorId = 0xCAFE;
+    std::strncpy(properties->systemName, "WebKit Mock OpenXR Runtime", XR_MAX_SYSTEM_NAME_SIZE - 1);
+    properties->systemName[XR_MAX_SYSTEM_NAME_SIZE - 1] = '\0';
+    properties->trackingProperties.orientationTracking = XR_TRUE;
+    properties->trackingProperties.positionTracking = XR_TRUE;
+    properties->graphicsProperties.maxLayerCount = 1;
+    properties->graphicsProperties.maxSwapchainImageWidth = 4096;
+    properties->graphicsProperties.maxSwapchainImageHeight = 4096;
+    // Leave properties->next untouched: WebKit chains XrSystemHandTrackingPropertiesEXT
+    // and pre-sets supportsHandTracking = XR_FALSE.
+    return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrEnumerateViewConfigurations(XrInstance, XrSystemId, uint32_t capacityInput, uint32_t* countOutput, XrViewConfigurationType* buffer)
+{
+    static const XrViewConfigurationType configs[] = { XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO };
+    return enumerate(configs, 1, capacityInput, countOutput, buffer);
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrEnumerateViewConfigurationViews(XrInstance, XrSystemId, XrViewConfigurationType, uint32_t capacityInput, uint32_t* countOutput, XrViewConfigurationView* buffer)
+{
+    if (countOutput)
+        *countOutput = 2;
+    if (!capacityInput)
+        return XR_SUCCESS;
+    if (capacityInput < 2)
+        return XR_ERROR_SIZE_INSUFFICIENT;
+    for (uint32_t i = 0; i < 2; ++i) {
+        buffer[i].recommendedImageRectWidth = 1024;
+        buffer[i].maxImageRectWidth = 2048;
+        buffer[i].recommendedImageRectHeight = 1024;
+        buffer[i].maxImageRectHeight = 2048;
+        buffer[i].recommendedSwapchainSampleCount = 1;
+        buffer[i].maxSwapchainSampleCount = 1;
+    }
+    return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrEnumerateEnvironmentBlendModes(XrInstance, XrSystemId, XrViewConfigurationType, uint32_t capacityInput, uint32_t* countOutput, XrEnvironmentBlendMode* buffer)
+{
+    static const XrEnvironmentBlendMode modes[] = { XR_ENVIRONMENT_BLEND_MODE_OPAQUE };
+    return enumerate(modes, 1, capacityInput, countOutput, buffer);
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrGetOpenGLESGraphicsRequirementsKHR(XrInstance, XrSystemId, void*)
+{
+    notifyEvent("GetOpenGLESGraphicsRequirementsKHR");
+    return XR_SUCCESS;
+}
+
+XRAPI_ATTR XrResult XRAPI_CALL mock_xrGetInstanceProcAddr(XrInstance, const char* name, PFN_xrVoidFunction* function)
+{
+    if (!name || !function)
+        return XR_ERROR_VALIDATION_FAILURE;
+
+    std::string_view requested(name);
+    auto bind = [&](PFN_xrVoidFunction fn) {
+        *function = fn;
+        return XR_SUCCESS;
+    };
+
+    if (requested == "xrGetInstanceProcAddr")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrGetInstanceProcAddr));
+    if (requested == "xrEnumerateInstanceExtensionProperties")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrEnumerateInstanceExtensionProperties));
+    if (requested == "xrCreateInstance")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrCreateInstance));
+    if (requested == "xrDestroyInstance")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrDestroyInstance));
+    if (requested == "xrGetSystem")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrGetSystem));
+    if (requested == "xrGetSystemProperties")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrGetSystemProperties));
+    if (requested == "xrEnumerateViewConfigurations")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrEnumerateViewConfigurations));
+    if (requested == "xrEnumerateViewConfigurationViews")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrEnumerateViewConfigurationViews));
+    if (requested == "xrEnumerateEnvironmentBlendModes")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrEnumerateEnvironmentBlendModes));
+    if (requested == "xrGetOpenGLESGraphicsRequirementsKHR")
+        return bind(reinterpret_cast<PFN_xrVoidFunction>(mock_xrGetOpenGLESGraphicsRequirementsKHR));
+
+    // Everything else (session, frame loop, spaces, input, ...) is unimplemented.
+    *function = nullptr;
+    return XR_ERROR_FUNCTION_UNSUPPORTED;
+}
+
+} // namespace
+
+#define MOCK_EXPORT extern "C" __attribute__((visibility("default")))
+
+// Register a listener invoked synchronously on the calling thread. It is called back with
+// the event ("instance-created", "instance-destroyed"...) and the set user data.
+MOCK_EXPORT void mock_openxr_set_event_callback(void (*callback)(const char* event, void* userData), void* userData)
+{
+    g_eventCallback = callback;
+    g_eventCallbackUserData = userData;
+}
+
+MOCK_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrNegotiateLoaderRuntimeInterface(const XrNegotiateLoaderInfo* loaderInfo, XrNegotiateRuntimeRequest* runtimeRequest)
+{
+    if (!loaderInfo || !runtimeRequest)
+        return XR_ERROR_INITIALIZATION_FAILED;
+    if (loaderInfo->structType != XR_LOADER_INTERFACE_STRUCT_LOADER_INFO
+        || runtimeRequest->structType != XR_LOADER_INTERFACE_STRUCT_RUNTIME_REQUEST)
+        return XR_ERROR_INITIALIZATION_FAILED;
+    if (XR_CURRENT_LOADER_RUNTIME_VERSION < loaderInfo->minInterfaceVersion
+        || XR_CURRENT_LOADER_RUNTIME_VERSION > loaderInfo->maxInterfaceVersion)
+        return XR_ERROR_INITIALIZATION_FAILED;
+
+    runtimeRequest->runtimeInterfaceVersion = XR_CURRENT_LOADER_RUNTIME_VERSION;
+    runtimeRequest->runtimeApiVersion = XR_CURRENT_API_VERSION;
+    runtimeRequest->getInstanceProcAddr = mock_xrGetInstanceProcAddr;
+    return XR_SUCCESS;
+}


### PR DESCRIPTION
#### da5ff6caa5e892f109769af060b1e2e0761134e7
<pre>
[OpenXR] Instance is never released when no session is started
<a href="https://bugs.webkit.org/show_bug.cgi?id=317657">https://bugs.webkit.org/show_bug.cgi?id=317657</a>

Reviewed by Dan Glastonbury and Sergio Villar Senin.

When enumerating OpenXR devices, an OpenXR instance is created and kept
idle. If the page never starts a session, this instance is leaked, even
after the view is closed.

Destroy the idle instance on teardown, adding a test and a mock OpenXR
runtime to help verify creation / destruction parity.

* Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h:
(WebKit::PlatformXRCoordinator::stopWhenIdle):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::invalidate):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::stopWhenIdle):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestOpenXRInstanceLifecycle.cpp: Added.
(mockEventCallback):
(destroyWaitTimeout):
(MockOpenXRControl::setEventCallback):
(openMockOpenXRControl):
(WebXRInstanceLifecycleTest::WebXRInstanceLifecycleTest):
(WebXRInstanceLifecycleTest::terminateWebProcess):
(WebXRInstanceLifecycleTest::waitForInstanceDestroyed):
(testOpenXRInstanceReleasedOnTeardown):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebXR.cpp:
(testWebKitXRHitTest):
(findFeature): Deleted.
(relaxDMABufRequirement): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/WebXRTestHelpers.h: Added.
(relaxDMABufRequirement):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
* Tools/TestWebKitAPI/openxr-mock/MockOpenXRRuntime.cpp: Added.
(mock_openxr_set_event_callback):
(xrNegotiateLoaderRuntimeInterface):

Canonical link: <a href="https://commits.webkit.org/316809@main">https://commits.webkit.org/316809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c4054d73e65d290b1bac307170d6d565e2b0c88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47403 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183044 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134886 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36956 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35309 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31529 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185469 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143755 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47071 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38761 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47750 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112873 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38558 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119539 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46256 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10016 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->