### PR TITLE
Model element: get() used in places where ptr() should be used

### DIFF
--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -192,7 +192,7 @@ static WebCore::ContentsFormat contentsFormatForDynamicRange(bool isStandard)
 
 void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size, bool)
 {
-    RefPtr corePage = m_page.get();
+    RefPtr corePage = m_page.ptr();
     if (!corePage)
         return;
     m_modelLoader = nil;
@@ -333,7 +333,7 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
     if (!currentModel)
         return;
 
-    RefPtr corePage = m_page.get();
+    RefPtr corePage = m_page.ptr();
     if (!corePage)
         return;
     RefPtr document = corePage->localTopDocument();
@@ -580,7 +580,7 @@ void WebModelPlayer::scheduleUpdateIfNeeded()
     if (!m_isUpdateLoopRunning || m_isUpdateScheduled)
         return;
 
-    RefPtr corePage = m_page.get();
+    RefPtr corePage = m_page.ptr();
     if (!corePage)
         return;
 
@@ -966,7 +966,7 @@ void WebModelPlayer::updateContentsHeadroom()
 
 void WebModelPlayer::updateScreenHeadroomFromPage()
 {
-    RefPtr page = m_page.get();
+    RefPtr page = m_page.ptr();
     if (!page)
         return;
 


### PR DESCRIPTION
#### ca1771c2c9764dfe8efefc4e12a389678e0be88a
<pre>
Model element: get() used in places where ptr() should be used
<a href="https://bugs.webkit.org/show_bug.cgi?id=317660">https://bugs.webkit.org/show_bug.cgi?id=317660</a>
<a href="https://rdar.apple.com/180421888">rdar://180421888</a>

Reviewed by Simon Fraser.

Calling .get() on a WeakRef which is nullptr will trigger a
debug assertion.

We proceeded to store the result in a RefPtr and then check
that result for nullptr, so effectively this change is a no-op
but it relied on UB as it would effectively assume:

   if (RefPtr r = &amp;(*(nullptr)))

evaluated to false, but that is UB in C++

* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::sizeDidChange):
(WebKit::WebModelPlayer::scheduleUpdateIfNeeded):
(WebKit::WebModelPlayer::updateScreenHeadroomFromPage):

Canonical link: <a href="https://commits.webkit.org/315710@main">https://commits.webkit.org/315710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b64011533fb0d01c52a885818d90339c70ed8d67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127462 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/debe5335-c43f-4518-8fb3-1118a32e55fa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132293 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d4933cf-0459-4f3e-b8f1-9785053ff4fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172709 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112796 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/835d7396-eda4-4d20-91cf-be40809c1d68) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32431 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27806 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144439 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181708 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140740 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43328 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140574 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/37874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44017 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108293 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35838 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115782 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42528 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7157 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41920 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42175 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->