### PR TITLE
Apply swift format over Tools/SwiftBrowser

### DIFF
--- a/Tools/SwiftBrowser/Source/SwiftBrowser.swift
+++ b/Tools/SwiftBrowser/Source/SwiftBrowser.swift
@@ -54,10 +54,11 @@ struct SwiftBrowserApp: App {
             )
         } defaultValue: {
             // FIXME: <https://webkit.org/b/293859> BrowserView does not reflect URL argument passed to SwiftBrowser.app.
-            let parsedURL = CommandLine.value(for: "--url").flatMap {
-                let withProtocol = Self.addProtocolIfNecessary(to: $0)
-                return URL(string: withProtocol)
-            }
+            let parsedURL = CommandLine.value(for: "--url")
+                .flatMap {
+                    let withProtocol = Self.addProtocolIfNecessary(to: $0)
+                    return URL(string: withProtocol)
+                }
             let url = parsedURL ?? URL(string: homepage)!
             return CodableURLRequest(.init(url: url))
         }

--- a/Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift
@@ -65,15 +65,26 @@ final class DialogPresenter: WebPage.DialogPresenting {
         }
     }
 
-    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult {
+    func handleJavaScriptPrompt(
+        message: String,
+        defaultText: String?,
+        initiatedBy frame: WebPage.FrameInfo
+    ) async -> WebPage.JavaScriptPromptResult {
         await withCheckedContinuation { continuation in
             owner?.currentDialog = Dialog(configuration: .prompt(message, defaultText: defaultText, continuation.resume(returning:)))
         }
     }
 
-    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult {
+    func handleFileInputPrompt(
+        parameters: WKOpenPanelParameters,
+        initiatedBy frame: WebPage.FrameInfo
+    ) async -> WebPage.FileInputPromptResult {
         await withCheckedContinuation { continuation in
-            owner?.currentFilePicker = FilePicker(allowsMultipleSelection: parameters.allowsMultipleSelection, allowsDirectories: parameters.allowsDirectories, completion: continuation.resume(returning:))
+            owner?.currentFilePicker = FilePicker(
+                allowsMultipleSelection: parameters.allowsMultipleSelection,
+                allowsDirectories: parameters.allowsDirectories,
+                completion: continuation.resume(returning:)
+            )
         }
     }
 }

--- a/Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift
@@ -30,7 +30,10 @@ import WebKit
 final class NavigationDecider: WebPage.NavigationDeciding {
     weak var owner: BrowserViewModel? = nil
 
-    func decidePolicy(for action: WebPage.NavigationAction, preferences: inout WebPage.NavigationPreferences) async -> WKNavigationActionPolicy {
+    func decidePolicy(
+        for action: WebPage.NavigationAction,
+        preferences: inout WebPage.NavigationPreferences
+    ) async -> WKNavigationActionPolicy {
         if action.shouldPerformDownload {
             return .download
         }

--- a/Tools/SwiftBrowser/Source/Views/BrowserView.swift
+++ b/Tools/SwiftBrowser/Source/Views/BrowserView.swift
@@ -54,9 +54,13 @@ struct BrowserView: View {
 }
 
 #Preview {
-    @Previewable @State var viewModel = BrowserViewModel()
+    @Previewable
+    @State
+    var viewModel = BrowserViewModel()
 
-    @Previewable @State var url: URL? = nil
+    @Previewable
+    @State
+    var url: URL? = nil
 
     let request = {
         let url = URL(string: "https://www.apple.com")!

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -29,22 +29,23 @@ import WebKit
 private struct DialogActionsView: View {
     private let dialog: DialogPresenter.Dialog
 
-    @State private var promptText = ""
+    @State
+    private var promptText = ""
 
     init(dialog: DialogPresenter.Dialog) {
         self.dialog = dialog
 
-        if case let .prompt(_, defaultText, _) = dialog.configuration, let defaultText {
+        if case .prompt(_, let defaultText, _) = dialog.configuration, let defaultText {
             _promptText = State(initialValue: defaultText)
         }
     }
 
     var body: some View {
         switch dialog.configuration {
-        case let .alert(_, dismissAlert):
+        case .alert(_, let dismissAlert):
             Button("Close", action: dismissAlert)
 
-        case let .confirm(_, dismissConfirm):
+        case .confirm(_, let dismissConfirm):
             Button("OK") {
                 dismissConfirm(.ok)
             }
@@ -53,7 +54,7 @@ private struct DialogActionsView: View {
                 dismissConfirm(.cancel)
             }
 
-        case let .prompt(_, _, dismissPrompt):
+        case .prompt(_, _, let dismissPrompt):
             TextField("Text", text: $promptText)
 
             Button("OK") {
@@ -73,13 +74,13 @@ private struct DialogMessageView: View {
 
     var body: some View {
         switch dialog.configuration {
-        case let .alert(message, _):
+        case .alert(let message, _):
             Text(message)
 
-        case let .confirm(message, _):
+        case .confirm(let message, _):
             Text(message)
 
-        case let .prompt(message, _, _):
+        case .prompt(let message, _, _):
             Text(message)
         }
     }
@@ -111,7 +112,8 @@ struct ContentView: View {
 
     var body: some View {
         NavigationStack {
-            @Bindable var viewModel = viewModel
+            @Bindable
+            var viewModel = viewModel
 
             WebView(viewModel.page)
                 .webViewBackForwardNavigationGestures(.enabled)
@@ -145,13 +147,27 @@ struct ContentView: View {
                 }
                 .navigationTitle(viewModel.page.title)
                 #if os(iOS)
-                .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleDisplayMode(.inline)
                 #endif
                 .focusedSceneValue(viewModel)
                 .onOpenURL(perform: viewModel.openURL(_:))
-                .fileExporter(isPresented: $viewModel.pdfExporterIsPresented, item: viewModel.exportedPDF, defaultFilename: viewModel.exportedPDF?.title, onCompletion: viewModel.didExportPDF(result:))
-                .fileImporter(isPresented: $viewModel.isPresentingFilePicker, allowedContentTypes: [.png, .pdf], allowsMultipleSelection: viewModel.currentFilePicker?.allowsMultipleSelection ?? false, onCompletion: viewModel.didImportFiles(result:))
-                .alert("\(url?.absoluteString ?? "") says:", isPresented: $viewModel.isPresentingDialog, presenting: viewModel.currentDialog) { dialog in
+                .fileExporter(
+                    isPresented: $viewModel.pdfExporterIsPresented,
+                    item: viewModel.exportedPDF,
+                    defaultFilename: viewModel.exportedPDF?.title,
+                    onCompletion: viewModel.didExportPDF(result:)
+                )
+                .fileImporter(
+                    isPresented: $viewModel.isPresentingFilePicker,
+                    allowedContentTypes: [.png, .pdf],
+                    allowsMultipleSelection: viewModel.currentFilePicker?.allowsMultipleSelection ?? false,
+                    onCompletion: viewModel.didImportFiles(result:)
+                )
+                .alert(
+                    "\(url?.absoluteString ?? "") says:",
+                    isPresented: $viewModel.isPresentingDialog,
+                    presenting: viewModel.currentDialog
+                ) { dialog in
                     DialogActionsView(dialog: dialog)
                 } message: { dialog in
                     DialogMessageView(dialog: dialog)
@@ -169,9 +185,13 @@ struct ContentView: View {
 }
 
 #Preview {
-    @Previewable @State var viewModel = BrowserViewModel()
+    @Previewable
+    @State
+    var viewModel = BrowserViewModel()
 
-    @Previewable @State var url: URL? = nil
+    @Previewable
+    @State
+    var url: URL? = nil
 
     let request = {
         let url = URL(string: "https://www.apple.com")!


### PR DESCRIPTION
#### 2491dbe7351197b3bc14f2563e2451373c2fc7d8
<pre>
Apply swift format over Tools/SwiftBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=317639">https://bugs.webkit.org/show_bug.cgi?id=317639</a>
<a href="https://rdar.apple.com/180387513">rdar://180387513</a>

Reviewed by Richard Robinson.

On a recent PR, the style checker suggested that I apply `swift format`
over a couple of SwiftBrowser source files, so we just do the entire
subtree in this patch.

* Tools/SwiftBrowser/Source/SwiftBrowser.swift:
(SwiftBrowserApp.body):
* Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift:
(handleJavaScriptPrompt(_:defaultText:initiatedBy:)): Deleted.
(handleFileInputPrompt(_:initiatedBy:)): Deleted.
* Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift:
(NavigationDecider.decidePolicy(for:preferences:)): Deleted.
* Tools/SwiftBrowser/Source/Views/BrowserView.swift:
(url):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(DialogActionsView.body):
(DialogMessageView.body):
(ContentView.body):
(url):

Canonical link: <a href="https://commits.webkit.org/315835@main">https://commits.webkit.org/315835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79cb1e6094f57e36b536aaf9f8ad0fb93bc420fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127466 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/930acb1a-4003-4d57-8fa2-2c9c44910e8f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132296 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93207 "1 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f74c0cd-e708-4f1e-9019-2fa642c946bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112799 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7f8bf41-8e26-4292-8bf2-a4b56dd0653d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32434 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27810 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181712 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140744 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43332 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140578 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44021 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29070 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108297 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25956 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35842 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42532 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7163 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41924 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42179 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->