### PR TITLE
Add support for searching text track cues for matching text

### DIFF
--- a/LayoutTests/media/track/text-track-find-expected.txt
+++ b/LayoutTests/media/track/text-track-find-expected.txt
@@ -1,0 +1,41 @@
+
+Tests that internals.findCueMatches finds all matching cues across a text track with Lorem.
+
+
+** Verify track loaded all 100 cues.
+EXPECTED (cues.length == '100') OK
+
+** Search for a string that appears in every cue.
+RUN(matches = internals.findCueMatches('Lorem', []))
+EXPECTED (matches.length == '30') OK
+
+** Verify timestamps for the first 10 seconds.
+EXPECTED (matches.includes(1) == 'true') OK
+EXPECTED (matches.includes(2) == 'true') OK
+EXPECTED (matches.includes(3) == 'true') OK
+EXPECTED (matches.includes(4) == 'true') OK
+EXPECTED (matches.includes(5) == 'true') OK
+EXPECTED (matches.includes(6) == 'true') OK
+EXPECTED (matches.includes(7) == 'true') OK
+EXPECTED (matches.includes(8) == 'true') OK
+EXPECTED (matches.includes(9) == 'true') OK
+EXPECTED (matches.includes(10) == 'true') OK
+
+** Verify timestamps at every 10 second interval up to 100.
+** Timestamps after 30 should return false as the cue start time is longer than the duration of the video.
+EXPECTED (matches.includes(20) == 'true') OK
+EXPECTED (matches.includes(30) == 'true') OK
+EXPECTED (matches.includes(40) == 'false') OK
+EXPECTED (matches.includes(50) == 'false') OK
+EXPECTED (matches.includes(60) == 'false') OK
+EXPECTED (matches.includes(70) == 'false') OK
+EXPECTED (matches.includes(80) == 'false') OK
+EXPECTED (matches.includes(90) == 'false') OK
+EXPECTED (matches.includes(100) == 'false') OK
+
+** Verify a string that does not appear returns no matches.
+RUN(matches = internals.findCueMatches('zzzzz', []))
+EXPECTED (matches.length == '0') OK
+
+END OF TEST
+

--- a/LayoutTests/media/track/text-track-find.html
+++ b/LayoutTests/media/track/text-track-find.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+        <script src=../video-test.js></script>
+        <script>
+
+            async function runTest()
+            {
+                if (!window.internals) {
+                    failTest("This test requires window.internals.");
+                    return;
+                }
+
+                findMediaElement();
+
+                const trackEl = document.querySelector('track');
+                await Promise.all([
+                    video.readyState >= HTMLMediaElement.HAVE_METADATA
+                        ? Promise.resolve()
+                        : new Promise(r => video.addEventListener('loadedmetadata', r, { once: true })),
+                    trackEl.readyState === HTMLTrackElement.LOADED
+                        ? Promise.resolve()
+                        : new Promise(r => trackEl.addEventListener('load', r, { once: true }))
+                ]);
+
+                track = video.textTracks[0];
+                cues = track.cues;
+
+                // findCueMatches only searches tracks that are showing.
+                track.mode = "showing";
+
+                consoleWrite("** Verify track loaded all 100 cues.");
+                testExpected("cues.length", 100);
+
+                consoleWrite("<br>** Search for a string that appears in every cue.");
+                run("matches = internals.findCueMatches('Lorem', [])");
+                testExpected("matches.length", 30);
+
+                consoleWrite("<br>** Verify timestamps for the first 10 seconds.");
+                for (var t = 1; t <= 10; t++)
+                    testExpected("matches.includes(" + t + ")", true);
+
+                consoleWrite("<br>** Verify timestamps at every 10 second interval up to 100.");
+                consoleWrite("** Timestamps after 30 should return false as the cue start time is longer than the duration of the video.");
+                for (var t = 20; t <= 30; t += 10)
+                    testExpected("matches.includes(" + t + ")", true);
+                for (var t = 40; t <= 100; t += 10)
+                    testExpected("matches.includes(" + t + ")", false);
+
+                consoleWrite("<br>** Verify a string that does not appear returns no matches.");
+                run("matches = internals.findCueMatches('zzzzz', [])");
+                testExpected("matches.length", 0);
+
+                consoleWrite("");
+                endTest();
+            }
+
+            setCaptionDisplayMode('Automatic');
+
+        </script>
+    </head>
+    <body onload="runTest()">
+        <p><br/>Tests that internals.findCueMatches finds all matching cues across a text track with Lorem.</p>
+        <video controls width="800">
+            <source src="../content/long-test.mp4" type="video/mp4">
+            <track src="captions-webvtt/captions-long.vtt" kind="captions" default>
+        </video>
+    </body>
+</html>

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7126,6 +7126,7 @@
 		EB3C29B72729C38C00FB65B4 /* PushSubscriptionChangeEventInit.h in Headers */ = {isa = PBXBuildFile; fileRef = EB3C29B12729C36D00FB65B4 /* PushSubscriptionChangeEventInit.h */; };
 		EB7CE1272CFBCFBE00BECB13 /* ResourceMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7CE1262CFBCFA300BECB13 /* ResourceMonitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB83220A2D70DC7F009515DA /* FetchingWorkerIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = EB8322092D70DC7F009515DA /* FetchingWorkerIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EB8B7D722FDB23010008B670 /* CueMatch.h in Headers */ = {isa = PBXBuildFile; fileRef = EB8B7D712FDB23010008B670 /* CueMatch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB9AD8CB27646E9400D893A4 /* PushDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = EB9AD8C827646E9000D893A4 /* PushDatabase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EBA75C46275EC61A00D6D31C /* PushCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = EBA75C42275EBDAB00D6D31C /* PushCrypto.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EBA75C47275EC62100D6D31C /* PushMessageCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = EBA75C40275EBDAA00D6D31C /* PushMessageCrypto.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -23151,6 +23152,7 @@
 		EB7CE1252CFBCF9900BECB13 /* ResourceMonitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceMonitor.cpp; sourceTree = "<group>"; };
 		EB7CE1262CFBCFA300BECB13 /* ResourceMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceMonitor.h; sourceTree = "<group>"; };
 		EB8322092D70DC7F009515DA /* FetchingWorkerIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FetchingWorkerIdentifier.h; sourceTree = "<group>"; };
+		EB8B7D712FDB23010008B670 /* CueMatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CueMatch.h; sourceTree = "<group>"; };
 		EB9AD8C827646E9000D893A4 /* PushDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PushDatabase.h; sourceTree = "<group>"; };
 		EB9AD8CA27646E9100D893A4 /* PushDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PushDatabase.cpp; sourceTree = "<group>"; };
 		EBA75C3E275EBDAA00D6D31C /* PushMessageCrypto.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PushMessageCrypto.cpp; sourceTree = "<group>"; };
@@ -30967,6 +30969,7 @@
 				975CA288130365F800E99AD9 /* Crypto.h */,
 				975CA289130365F800E99AD9 /* Crypto.idl */,
 				94077C6F2B92B0570012E357 /* CryptoClient.h */,
+				EB8B7D712FDB23010008B670 /* CueMatch.h */,
 				1ACB2B211A5733F400333392 /* DatabaseProvider.cpp */,
 				1ACB2B221A5733F400333392 /* DatabaseProvider.h */,
 				BC4A532C256056D50028C592 /* DebugOverlayRegions.h */,
@@ -44903,6 +44906,7 @@
 				71ED24B62B1E345300B3EFAB /* CSSViewValue.h in Headers */,
 				BC6AFC412DFC83840065FA1D /* CSSWideKeyword.h in Headers */,
 				BCB272192CC1F21B00265123 /* CSSXywhFunction.h in Headers */,
+				EB8B7D722FDB23010008B670 /* CueMatch.h in Headers */,
 				AEBAFFB52D65D537008311A5 /* CurrentUserDetailsOptions.h in Headers */,
 				93F1992F08245E59001E9ABC /* Cursor.h in Headers */,
 				7173694C275E0BAB003ADA9B /* CustomAnimationOptions.h in Headers */,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -82,6 +82,7 @@
 #include "DebugPageOverlays.h"
 #include "DeprecatedGlobalSettings.h"
 #include "DocumentFontLoader.h"
+#include "DocumentFragment.h"
 #include "DocumentFullscreen.h"
 #include "DocumentInlines.h"
 #include "DocumentLoader.h"
@@ -333,9 +334,13 @@
 #include "SystemPreviewInfo.h"
 #include "TextAutoSizing.h"
 #include "TextEvent.h"
+#include "TextIterator.h"
 #include "TextManipulationController.h"
 #include "TextNodeTraversal.h"
 #include "TextResourceDecoder.h"
+#include "TextTrack.h"
+#include "TextTrackCueList.h"
+#include "TextTrackList.h"
 #include "TouchAction.h"
 #include "TransformSource.h"
 #include "TreeScopeInlines.h"
@@ -345,6 +350,7 @@
 #include "UndoManager.h"
 #include "UserGestureIndicator.h"
 #include "UserMediaController.h"
+#include "VTTCue.h"
 #include "ValidationMessage.h"
 #include "ValidationMessageClient.h"
 #include "ViewTransition.h"
@@ -449,6 +455,7 @@
 
 #if ENABLE(VIDEO)
 #include "CaptionUserPreferences.h"
+#include "CueMatch.h"
 #include "LazyLoadVideoObserver.h"
 #endif
 
@@ -2641,6 +2648,73 @@ void Document::forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement
     m_mediaElements.forEach([&](auto& element) {
         function(element);
     });
+}
+
+Vector<CueMatch> Document::findCueMatches(const String& target, FindOptions options)
+{
+    Vector<CueMatch> results;
+    if (target.isEmpty())
+        return results;
+
+    // Order this document's media elements by tree position.
+    Vector<Ref<HTMLMediaElement>> elements;
+    forEachMediaElement([&](HTMLMediaElement& element) {
+        if (element.isConnected())
+            elements.append(element);
+    });
+    std::sort(elements.begin(), elements.end(), [](auto& a, auto& b) {
+        return is_lt(treeOrder<ComposedTree>(a.get(), b.get()));
+    });
+
+    // FIXME: Decisions still need to be made on whether we should only include videos that are paused, that have been interacted with, etc.
+    for (Ref element : elements) {
+        size_t firstMatchForElement = results.size();
+
+        RefPtr tracks = element->textTracks();
+        if (!tracks)
+            continue;
+        MediaTime duration = element->durationMediaTime();
+        for (unsigned i = 0; i < tracks->length(); ++i) {
+            RefPtr track = tracks->item(i);
+            if (!track)
+                continue;
+            // Only search tracks that are currently rendered on screen.
+            if (track->mode() != TextTrack::Mode::Showing)
+                continue;
+            // Only search tracks whose cues carry text the user reads or hears, skip chapters and metadata tracks.
+            switch (track->kind()) {
+            case TextTrack::Kind::Subtitles:
+            case TextTrack::Kind::Captions:
+            case TextTrack::Kind::Descriptions:
+                break;
+            default:
+                continue;
+            }
+            RefPtr cues = track->cues();
+            if (!cues)
+                continue;
+
+            for (unsigned j = 0; j < cues->length(); ++j) {
+                RefPtr cue = cues->item(j);
+                // Only VTTCue carries searchable caption text.
+                RefPtr vttCue = dynamicDowncast<VTTCue>(cue.get());
+                if (!vttCue)
+                    continue;
+                if (duration.isValid() && vttCue->startMediaTime() >= duration)
+                    break;
+                RefPtr cueAsHTML = vttCue->getCueAsHTML();
+                if (cueAsHTML && containsPlainText(cueAsHTML->textContent(), target, options))
+                    results.append({ element.get(), vttCue->startMediaTime() });
+            }
+        }
+
+        // One element can carry several active text tracks (captions, subtitles, etc.), so sort by cue time.
+        std::ranges::stable_sort(results.mutableSubspan(firstMatchForElement), [](auto& a, auto& b) {
+            return a.seekTime < b.seekTime;
+        });
+    }
+
+    return results;
 }
 
 #endif

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -36,6 +36,7 @@
 #include <WebCore/DocumentEventTiming.h>
 #include <WebCore/Element.h>
 #include <WebCore/ExceptionOr.h>
+#include <WebCore/FindOptions.h>
 #include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FontSelectorClient.h>
 #include <WebCore/FrameDestructionObserver.h>
@@ -296,6 +297,7 @@ struct BoundaryPoint;
 struct CSSParserContext;
 struct CaretPositionFromPointOptions;
 struct ClientOrigin;
+struct CueMatch;
 struct ElementCreationOptions;
 struct FocusOptions;
 struct ImportNodeOptions;
@@ -1912,6 +1914,7 @@ public:
 
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT void forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement&)>&);
+    WEBCORE_EXPORT Vector<CueMatch> findCueMatches(const String&, FindOptions);
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebCore/page/CueMatch.h
+++ b/Source/WebCore/page/CueMatch.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(VIDEO)
+
+#include <wtf/MediaTime.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class HTMLMediaElement;
+
+struct CueMatch {
+    WeakPtr<HTMLMediaElement> mediaElement;
+    MediaTime seekTime;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(VIDEO)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -55,6 +55,7 @@
 #include "CookieJar.h"
 #include "CredentialRequestCoordinator.h"
 #include "CryptoClient.h"
+#include "CueMatch.h"
 #include "DOMRect.h"
 #include "DOMRectList.h"
 #include "DOMTimer.h"
@@ -1291,6 +1292,28 @@ auto Page::findTextMatches(const String& target, FindOptions options, unsigned l
 
     return result;
 }
+
+#if ENABLE(VIDEO)
+Vector<CueMatch> Page::findCueMatches(const String& target, FindOptions options)
+{
+    Vector<CueMatch> results;
+    if (target.isEmpty())
+        return results;
+
+    // Walk frames in document order and searches each document independently. Cue ordering is therefore correct within a document
+    // and grouped by frame across documents, matching how DOM text matches are ordered.
+    RefPtr frame { &mainFrame() };
+    do {
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get())) {
+            if (RefPtr document = localFrame->document())
+                results.appendVector(document->findCueMatches(target, options));
+        }
+        frame = incrementFrame(frame.get(), true, CanWrap::No);
+    } while (frame);
+
+    return results;
+}
+#endif // ENABLE(VIDEO)
 
 std::optional<SimpleRange> Page::rangeOfString(const String& target, const std::optional<SimpleRange>& referenceRange, FindOptions options)
 {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -231,6 +231,7 @@ struct ApplePayAMSUIRequest;
 struct AttributedString;
 struct CharacterRange;
 struct ClientOrigin;
+struct CueMatch;
 struct DocumentSyncSerializationData;
 struct FixedContainerEdges;
 struct ResolvedCaptionDisplaySettingsOptions;
@@ -585,6 +586,10 @@ public:
         std::optional<uint32_t> indexForSelection;
     };
     WEBCORE_EXPORT MatchingRanges findTextMatches(const String&, FindOptions, unsigned maxCount, bool markMatches = true);
+
+#if ENABLE(VIDEO)
+    WEBCORE_EXPORT Vector<CueMatch> findCueMatches(const String&, FindOptions);
+#endif
 
 #if PLATFORM(COCOA)
     void platformInitialize();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -61,6 +61,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "CookieJar.h"
 #include "CrossOriginPreflightResultCache.h"
+#include "CueMatch.h"
 #include "Cursor.h"
 #include "DOMAsyncIterator.h"
 #include "DOMPointReadOnly.h"
@@ -3360,6 +3361,24 @@ ExceptionOr<unsigned> Internals::countFindMatches(const String& text, const Vect
 
     return document->page()->countFindMatches(text, parsedOptions.releaseReturnValue(), 1000);
 }
+
+#if ENABLE(VIDEO)
+ExceptionOr<Vector<double>> Internals::findCueMatches(const String& text, const Vector<String>& findOptions)
+{
+    Document* document = contextDocument();
+    if (!document || !document->page())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    auto parsedOptions = parseFindOptions(findOptions);
+    if (parsedOptions.hasException())
+        return parsedOptions.releaseException();
+
+    auto matches = document->page()->findCueMatches(text, parsedOptions.releaseReturnValue());
+    return WTF::map(matches, [](const auto& match) -> double {
+        return match.seekTime.toDouble();
+    });
+}
+#endif
 
 unsigned Internals::numberOfIDBTransactions() const
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -539,6 +539,9 @@ public:
     ExceptionOr<RefPtr<Range>> rangeOfString(const String&, RefPtr<Range>&&, const Vector<String>& findOptions);
     ExceptionOr<unsigned> countMatchesForText(const String&, const Vector<String>& findOptions, const String& markMatches);
     ExceptionOr<unsigned> countFindMatches(const String&, const Vector<String>& findOptions);
+#if ENABLE(VIDEO)
+    ExceptionOr<Vector<double>> findCueMatches(const String&, const Vector<String>& findOptions);
+#endif
 
     unsigned numberOfScrollableAreas();
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -669,6 +669,7 @@ enum ContentsFormat {
     Range? rangeOfString(DOMString text, Range? referenceRange, sequence<DOMString> findOptions);
     unsigned long countMatchesForText(DOMString text, sequence<DOMString> findOptions, DOMString markMatches);
     unsigned long countFindMatches(DOMString text, sequence<DOMString> findOptions);
+    [Conditional=VIDEO] sequence<unrestricted double> findCueMatches(DOMString text, sequence<DOMString> findOptions);
 
     DOMString autofillFieldName(Element formControlElement);
     boolean isSpellcheckDisabledExceptTextReplacement(HTMLInputElement inputElement);


### PR DESCRIPTION
#### 1ca6238d344811a546b74fe31d49e240a040d215
<pre>
Add support for searching text track cues for matching text
<a href="https://bugs.webkit.org/show_bug.cgi?id=317049">https://bugs.webkit.org/show_bug.cgi?id=317049</a>
<a href="https://rdar.apple.com/179530437">rdar://179530437</a>

Reviewed by NOBODY (OOPS!).

It adds Document::findCueMatches, which iterates the document&apos;s connected media elements, and for each showing subtitles, captions, or descriptions track matches the target string against every VTTCue&apos;s plain text, returning a CueMatch (the media element and the cue&apos;s start time) for each hit. Results are ordered by media element in composed-tree order, then by cue start time within each element. Cues whose start time is at or beyond the media&apos;s duration are skipped, and tracks that are not currently showing, or whose kind is chapters or metadata, are ignored.

::findCueMatches is a thin walker that visits frames in document order, mirroring Page::findTextMatches, and aggregates each document&apos;s results. Searching one document at a time keeps cue ordering consistent with DOM text matches and avoids comparing media elements across documents.

upport matching, VTTCue::plainText is added to expose a cue&apos;s flattened, markup-stripped text, so searches run against the rendered words rather than the raw WebVTT payload.

ching is currently limited to showing tracks, and this scope is subject to change as the feature evolves.

 does not yet alter any find UI. The search is exposed to tests via internals.findCueMatches, and wiring cue matches into the find result list and seeking the video on navigation will follow in a later patch.

w layout test, media/track/text-track-find.html, loads a hundred-cue WebVTT track on a video and verifies that matching cues are returned with the correct timestamps, that cues past the media duration are excluded, and that a query with no matches returns nothing.

Test: media/track/text-track-find.html

* LayoutTests/media/track/text-track-find-expected.txt: Added.
* LayoutTests/media/track/text-track-find.html: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::findCueMatches):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/CueMatch.h: Added.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::findCueMatches):
* Source/WebCore/page/Page.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::findCueMatches):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ca6238d344811a546b74fe31d49e240a040d215

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169764 "Failed to checkout and rebase branch from PR 67683") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43686 "Failed to checkout and rebase branch from PR 67683") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37069 "Failed to checkout and rebase branch from PR 67683") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179123 "Failed to checkout and rebase branch from PR 67683") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171630 "Failed to checkout and rebase branch from PR 67683") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44260 "Failed to checkout and rebase branch from PR 67683") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43315 "Failed to checkout and rebase branch from PR 67683") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132149 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172723 "Failed to checkout and rebase branch from PR 67683") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112652 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/44260 "Failed to checkout and rebase branch from PR 67683") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27820 "Failed to checkout and rebase branch from PR 67683") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/143998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31908 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/181722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140598 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43342 "Failed to checkout and rebase branch from PR 67683") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37792 "Built successfully and passed tests") | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44031 "Failed to checkout and rebase branch from PR 67683") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108310 "Failed to checkout and rebase branch from PR 67683") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35700 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42542 "Failed to checkout and rebase branch from PR 67683") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6973 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41934 "Failed to checkout and rebase branch from PR 67683") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42189 "Failed to checkout and rebase branch from PR 67683") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42077 "Failed to checkout and rebase branch from PR 67683") | | | 
<!--EWS-Status-Bubble-End-->