### PR TITLE
[Cocoa] Transient device rotation can result in incorrect video frame orientation

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -60,6 +60,8 @@ public:
     void rootLayerBoundsDidChange();
 
     CGRect bounds() const;
+    CGRect sampleLayerBoundsForTesting() const;
+    void setVideoFrameRotationForTesting(WebCore::VideoFrameRotation);
 
     PlatformLayer* NODELETE displayLayer();
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -292,6 +292,16 @@ CGRect LocalSampleBufferDisplayLayer::bounds() const
     return m_rootLayer.get().bounds;
 }
 
+CGRect LocalSampleBufferDisplayLayer::sampleLayerBoundsForTesting() const
+{
+    return m_sampleBufferDisplayLayer.get().bounds;
+}
+
+void LocalSampleBufferDisplayLayer::setVideoFrameRotationForTesting(VideoFrameRotation rotation)
+{
+    m_videoFrameRotation = rotation;
+}
+
 void LocalSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, std::optional<WTF::MachSendRightAnnotated>&&)
 {
     updateSampleLayerBoundsAndPosition(bounds);
@@ -305,18 +315,21 @@ void LocalSampleBufferDisplayLayer::updateSampleLayerBoundsAndPosition(std::opti
             return;
 
         RetainPtr rootLayer = protectedThis->m_rootLayer;
-        auto layerBounds = bounds.value_or(rootLayer.get().bounds);
-        CGPoint layerPosition { layerBounds.size.width / 2, layerBounds.size.height / 2 };
-        if (rotation == VideoFrame::Rotation::Right || rotation == VideoFrame::Rotation::Left)
-            std::swap(layerBounds.size.width, layerBounds.size.height);
+        RetainPtr sampleBufferDisplayLayer = protectedThis->m_sampleBufferDisplayLayer;
         runWithoutAnimations([&] {
-            if (bounds) {
-                rootLayer.get().position = { bounds->size.width / 2, bounds->size.height / 2 };
-                rootLayer.get().bounds = *bounds;
-            }
-
-            RetainPtr sampleBufferDisplayLayer = protectedThis->m_sampleBufferDisplayLayer;
             sampleBufferDisplayLayer.get().affineTransform = affineTransform;
+            // Without explicit bounds, only update the transform. Swapping the stale root
+            // layer bounds here would produce a wrong-sized frame; the caller will provide
+            // correct explicit bounds via updateBoundsAndPosition once the rotation change
+            // has propagated through the media pipeline.
+            if (!bounds)
+                return;
+            auto layerBounds = *bounds;
+            CGPoint layerPosition { layerBounds.size.width / 2, layerBounds.size.height / 2 };
+            if (rotation == VideoFrame::Rotation::Right || rotation == VideoFrame::Rotation::Left)
+                std::swap(layerBounds.size.width, layerBounds.size.height);
+            rootLayer.get().position = { bounds->size.width / 2, bounds->size.height / 2 };
+            rootLayer.get().bounds = *bounds;
             sampleBufferDisplayLayer.get().position = layerPosition;
             sampleBufferDisplayLayer.get().bounds = layerBounds;
         });

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -63,7 +63,7 @@ String RealtimeMediaSourceSettings::convertFlagsToString(const OptionSet<Realtim
 
     builder.append("[ "_s);
     for (auto flag : flags) {
-        if (!builder.isEmpty())
+        if (builder.length() > 2)
             builder.append(", "_s);
 
         switch (flag) {

--- a/Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm
@@ -1362,8 +1362,8 @@ void AVVideoCaptureSource::orientationChanged(IntDegrees orientation)
 {
     ASSERT(orientation == 0 || orientation == 90 || orientation == -90 || orientation == 180);
     m_deviceOrientation = orientation;
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "orientation = ", m_deviceOrientation);
     computeVideoFrameRotation();
-    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "rotation = ", m_videoFrameRotation, ", orientation = ", m_deviceOrientation);
 }
 
 void AVVideoCaptureSource::rotationAngleForHorizonLevelDisplayChanged(const String& devicePersistentId, VideoFrameRotation videoFrameRotation)
@@ -1376,8 +1376,8 @@ void AVVideoCaptureSource::rotationAngleForHorizonLevelDisplayChanged(const Stri
     if (videoFrameRotation == m_videoFrameRotation)
         return;
 
-    m_videoFrameRotation = videoFrameRotation;
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "rotation = ", m_videoFrameRotation);
+    m_videoFrameRotation = videoFrameRotation;
     notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height });
 }
 
@@ -1411,6 +1411,7 @@ void AVVideoCaptureSource::computeVideoFrameRotation()
     if (videoFrameRotation == m_videoFrameRotation)
         return;
 
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "rotation was ", videoFrameRotation, ", is now ", m_videoFrameRotation);
     m_videoFrameRotation = videoFrameRotation;
     notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height });
 }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2563,6 +2563,14 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)_dispatchSetOrientationForMediaCapture:(WebCore::IntDegrees)orientationForMediaCapture
 {
+    // orientation=0 maps to both UIInterfaceOrientationPortrait and UIInterfaceOrientationUnknown.
+    // When windowScene is nil the view has no valid scene (e.g. during initialisation before being
+    // added to a window), so 0 means Unknown, not Portrait. Dispatching it would broadcast to all
+    // GPU process connections and corrupt the orientation of any running camera source on other pages.
+    // didMoveToWindow will send the correct orientation once the view is placed in a scene.
+    if (!orientationForMediaCapture && !self.window.windowScene)
+        return;
+
     if (_perProcessState.lastSentOrientationForMediaCapture && _perProcessState.lastSentOrientationForMediaCapture.value() == orientationForMediaCapture)
         return;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/LocalSampleBufferDisplayLayerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/LocalSampleBufferDisplayLayerTests.mm
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if PLATFORM(COCOA)
+
+#include "Helpers/PlatformUtilities.h"
+#include <WebCore/LocalSampleBufferDisplayLayer.h>
+#include <WebCore/VideoFrame.h>
+
+namespace TestWebKitAPI {
+
+class MockSampleBufferDisplayLayerClient : public WebCore::SampleBufferDisplayLayerClient {
+public:
+    void sampleBufferDisplayLayerStatusDidFail() override { }
+    void updateVideoFrameCounters(uint64_t, uint64_t) override { }
+#if PLATFORM(IOS_FAMILY)
+    bool canShowWhileLocked() const override { return false; }
+#endif
+};
+
+// Verify that a rotation change arriving via updateSampleLayerBoundsAndPosition
+// without explicit bounds does not immediately swap the stale root-layer bounds
+// onto the sample buffer display layer, which would produce a transient
+// wrong-orientation frame. The correct bounds must come from an explicit
+// updateBoundsAndPosition call.
+TEST(LocalSampleBufferDisplayLayer, RotationChangeShouldNotSwapStaleBounds)
+{
+    MockSampleBufferDisplayLayerClient client;
+    auto layer = WebCore::LocalSampleBufferDisplayLayer::create(client);
+    ASSERT_TRUE(layer);
+
+    // Set landscape bounds via the explicit-bounds path.
+    layer->updateBoundsAndPosition(CGRectMake(0, 0, 960, 720), std::nullopt);
+    Util::runFor(0.1_s);
+
+    EXPECT_EQ(layer->sampleLayerBoundsForTesting().size.width, 960);
+    EXPECT_EQ(layer->sampleLayerBoundsForTesting().size.height, 720);
+
+    // Simulate what enqueueVideoFrame does when it detects a rotation change to Left:
+    // update the stored rotation then call with no explicit bounds. The transform should
+    // be applied immediately but bounds must not be swapped using stale root layer geometry.
+    layer->setVideoFrameRotationForTesting(WebCore::VideoFrameRotation::Left);
+    layer->updateSampleLayerBoundsAndPosition(std::nullopt);
+    Util::runFor(0.1_s);
+
+    EXPECT_EQ(layer->sampleLayerBoundsForTesting().size.width, 960);
+    EXPECT_EQ(layer->sampleLayerBoundsForTesting().size.height, 720);
+
+    // The explicit-bounds path must apply transform and swap bounds correctly for Left rotation.
+    layer->updateBoundsAndPosition(CGRectMake(0, 0, 960, 720), std::nullopt);
+    Util::runFor(0.1_s);
+
+    EXPECT_EQ(layer->sampleLayerBoundsForTesting().size.width, 720);
+    EXPECT_EQ(layer->sampleLayerBoundsForTesting().size.height, 960);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### d8266c6d0ba999557510ce09aa76750affcfc4cd
<pre>
[Cocoa] Transient device rotation can result in incorrect video frame orientation
<a href="https://bugs.webkit.org/show_bug.cgi?id=317671">https://bugs.webkit.org/show_bug.cgi?id=317671</a>
<a href="https://rdar.apple.com/180429147">rdar://180429147</a>

Reviewed by Youenn Fablet.

When a WKWebView is created (e.g. for a new tab or background page), _setupScrollAndContentViews
calls _dispatchSetOrientationForMediaCapture before the view has been placed in a window. At
that point windowScene is nil, so _deviceOrientationIgnoringOverrides returns
UIInterfaceOrientationUnknown (mapped to 0°). GPUProcess::setOrientationForMediaCapture
broadcasts this value to every connection, overwriting the correct landscape orientation of
any camera source running on a different page. The camera then produces permanently rotated
frames until the user physically rotates the device.

Guard _dispatchSetOrientationForMediaCapture against dispatching orientation=0 when windowScene
is nil: in that state 0 means Unknown rather than Portrait, so there is nothing useful to send.
didMoveToWindow fires with a valid scene once the view is placed in a window, at which point the
correct orientation is dispatched.

Also fix a secondary issue in LocalSampleBufferDisplayLayer: when enqueueVideoFrame detects a
rotation change it calls updateSampleLayerBoundsAndPosition without explicit bounds. Previously
this swapped the stale root-layer bounds on the sample buffer display layer immediately, producing
a transient wrong-sized frame. Now only the affine transform is applied in the no-bounds path;
the caller provides correct bounds via updateBoundsAndPosition once the rotation change has
propagated through the media pipeline.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _dispatchSetOrientationForMediaCapture:]): Skip dispatch when orientation is 0
and windowScene is nil.
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
(LocalSampleBufferDisplayLayer::setVideoFrameRotationForTesting):
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(LocalSampleBufferDisplayLayer::sampleLayerBoundsForTesting):
(LocalSampleBufferDisplayLayer::updateSampleLayerBoundsAndPosition): Apply transform but
skip bounds update when called without explicit bounds.
(LocalSampleBufferDisplayLayer::enqueueVideoFrame): Restore call to
updateSampleLayerBoundsAndPosition when rotation changes so the transform is applied promptly.
* Source/WebCore/platform/mediastream/cocoa/AVVideoCaptureSource.mm:
(AVVideoCaptureSource::orientationChanged): Log incoming orientation before computing rotation.
(AVVideoCaptureSource::rotationAngleForHorizonLevelDisplayChanged): Fix log to record the
previous rotation before the update.
(AVVideoCaptureSource::computeVideoFrameRotation): Log the rotation transition.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::convertFlagsToString): Fix empty-prefix check.
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/LocalSampleBufferDisplayLayerTests.mm: Added.
(TestWebKitAPI::TEST(LocalSampleBufferDisplayLayer, RotationChangeShouldNotSwapStaleBounds)):

Canonical link: <a href="https://commits.webkit.org/315821@main">https://commits.webkit.org/315821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5a588f6664d2aa6954b992623489c12955a94c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127760 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fc69c0c-cdd5-4c18-982d-3d7cacd2b9a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132545 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bd9639b-c68b-48ee-9b87-b6dbe944f0ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173007 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113047 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4194398b-dc1d-4e1c-9fb7-c79151030ffc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32686 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28106 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182007 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140995 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43626 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140826 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37951 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44315 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29359 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108665 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36094 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116197 "Found 77 new failures in dfg/DFGNode.cpp, dfg/DFGByteCodeParser.cpp, platform/SharedStringHash.cpp, dfg/DFGDCEPhase.cpp, editing/TextIterator.cpp, rendering/RenderLayerCompositor.cpp, style/values/grid/StyleGridPositionsResolver.cpp, html/HTMLTableElement.cpp, page/LocalFrameView.cpp, style/PseudoElementUtilities.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42826 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7458 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42218 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->