### PR TITLE
[git-webkit] `git-webkit pr` should warn before posting an un-reviewed PR with a "Reviewed-by" line

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -611,6 +611,10 @@ nothing to commit, working tree clean
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.commit(amend=True, env=kwargs.get('env', dict())),
             ), mocks.Subprocess.Route(
+                self.executable, 'commit', '--amend', '-m', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.commit(amend=True, message=args[4]),
+            ), mocks.Subprocess.Route(
                 self.executable, 'commit', '-a', '-m', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.commit(message=args[4], env=kwargs.get('env', dict())),
@@ -1194,9 +1198,12 @@ nothing to commit, working tree clean
         if message:
             self.head.message = message
         else:
-            self.head.message = '{}{}\nReviewed by Jonathan Bedard\n\n * {}\n{}'.format(
-                env.get('COMMIT_MESSAGE_TITLE', '') or '[Testing] {} commits'.format('Amending' if amend else 'Creating'),
+            title = env.get('COMMIT_MESSAGE_TITLE', '') or '[Testing] {} commits'.format('Amending' if amend else 'Creating')
+            reviewed_by = '' if re.match(r'(Unreviewed|Versioning.)', title, re.IGNORECASE) else '\nReviewed by Jonathan Bedard'
+            self.head.message = '{}{}{}\n\n * {}\n{}'.format(
+                title,
                 ('\n' + env.get('COMMIT_MESSAGE_BUG', '')) if env.get('COMMIT_MESSAGE_BUG', '') else '',
+                reviewed_by,
                 '\n * '.join(self.staged.keys()),
                 env.get('COMMIT_MESSAGE_CONTENT', '')
             )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -500,6 +500,24 @@ class PullRequest(Command):
             for issue in commit.issues
         ]
 
+        unreviewed_match = re.compile(r'(Unreviewed|Versioning.)', re.IGNORECASE)
+        bad_commits = [c for c in commits if c.message and unreviewed_match.search(c.message) and 'Reviewed by' in c.message]
+        if bad_commits:
+            if len(bad_commits) > 1:
+                sys.stderr.write("Multiple commits are marked 'Unreviewed' or 'Versioning' but contain a 'Reviewed by' line, please fix before posting\n")
+                return 1
+            response = Terminal.choose(
+                "Commit message is marked 'Unreviewed' or 'Versioning' but contains a 'Reviewed by' line. Remove it?",
+                options=('Yes', 'No'),
+                default='Yes',
+            )
+            if response == 'Yes':
+                cleaned = re.sub(r'Reviewed by .+\n?', '', bad_commits[0].message)
+                if run([repository.executable(), 'commit', '--amend', '-m', cleaned], cwd=repository.root_path).returncode:
+                    sys.stderr.write("Failed to amend commit message\n")
+                    return 1
+                commits = list(repository.commits(begin={'hash': branch_point.hash}, end={'branch': repository.branch}))
+
         radar_issue = next(iter(filter(lambda issue: isinstance(issue.tracker, radar.Tracker), issues)), None)
         not_radar = next(iter(filter(lambda issue: not isinstance(issue.tracker, radar.Tracker), issues)), None)
         radar_cc_default = repository.config().get('webkitscmpy.cc-radar', 'true') == 'true'

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -24,6 +24,7 @@ import logging
 import os
 import time
 import unittest
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from webkitbugspy import Tracker, bugzilla, github, radar
@@ -925,6 +926,60 @@ No pre-PR checks to run""")
                 "Creating pull-request for 'eng/Adopt-LIFETIME_BOUND-for-WTF-Ref'...",
             ],
         )
+
+    @contextmanager
+    def _unreviewed_with_reviewed_by_repo(self, message='Unreviewed, fix the build.\n\nReviewed by NOBODY (OOPS!)\n', extra_commits=None):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
+            bad_commit = Commit(
+                hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                branch='eng/pr-branch',
+                author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                identifier='5.1@eng/pr-branch',
+                timestamp=int(time.time()),
+                message=message,
+            )
+            repo.commits['eng/pr-branch'] = [repo.commits[repo.default_branch][-1], bad_commit] + (extra_commits or [])
+            repo.head = repo.commits['eng/pr-branch'][-1]
+            yield repo, captured
+
+    def test_unreviewed_with_reviewed_by(self):
+        with self._unreviewed_with_reviewed_by_repo() as (repo, captured), MockTerminal.input('y'):
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+            self.assertNotIn('Reviewed by', repo.head.message)
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+        with self._unreviewed_with_reviewed_by_repo() as (repo, captured), MockTerminal.input('n'):
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+            self.assertIn('Reviewed by', repo.head.message)
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+        extra = Commit(
+            hash='17de5d56554e693db72313f4ca1fb969c30b8ccb',
+            branch='eng/pr-branch',
+            author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+            identifier='5.2@eng/pr-branch',
+            timestamp=int(time.time()),
+            message='Unreviewed, fix the build again.\n\nReviewed by NOBODY (OOPS!)\n',
+        )
+        with self._unreviewed_with_reviewed_by_repo(extra_commits=[extra]) as (repo, captured):
+            self.assertEqual(1, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+        self.assertIn(
+            "Multiple commits are marked 'Unreviewed' or 'Versioning' but contain a 'Reviewed by' line, please fix before posting\n",
+            captured.stderr.getvalue(),
+        )
+
 
     def test_github_bugzilla(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(


### PR DESCRIPTION
#### fddb5a3c6e47dc89ee2025089f5fe47dc030d733
<pre>
[git-webkit] `git-webkit pr` should warn before posting an un-reviewed PR with a &quot;Reviewed-by&quot; line
<a href="https://bugs.webkit.org/show_bug.cgi?id=293152">https://bugs.webkit.org/show_bug.cgi?id=293152</a>
<a href="https://rdar.apple.com/151488850">rdar://151488850</a>

Reviewed by Sam Sneddon.

If a PR claims to be &quot;Un-reviewed&quot; (with no dash) or &quot;Version-ing&quot;
(with no dash) but includes a &quot;Reviewed-by&quot; line, warn the user and
prompt to automatically remove the &quot;Reviewed-by&quot; line in the case of a
single commit or manually fix it in the case of multiple commits.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/317647@main">https://commits.webkit.org/317647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebed21f134f8b1fd322b296feac10a3b1862335c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175913 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/49846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/43630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185506 "Failed to checkout and rebase branch from PR 67685") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51138 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/185506 "Failed to checkout and rebase branch from PR 67685") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178869 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/40450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/43630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/185506 "Failed to checkout and rebase branch from PR 67685") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/175236 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/39092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/49528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/185506 "Failed to checkout and rebase branch from PR 67685") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/43630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/149511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/33976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/49528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/187927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/175316 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/49513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/43630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/187927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50193 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/43630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/187927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26729 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116252 "Failed to checkout and rebase branch from PR 67685") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48700 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/43630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/48102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/48334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/48159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->