### PR TITLE
[Smart Lists] Backspace after Smart Lists formatting removes entire list line instead of just formatting

### DIFF
--- a/LayoutTests/editing/smart-lists/backspace-after-typing-in-smart-list-does-not-undo-list-expected.txt
+++ b/LayoutTests/editing/smart-lists/backspace-after-typing-in-smart-list-does-not-undo-list-expected.txt
@@ -1,0 +1,10 @@
+Once any other input follows the Smart Lists conversion, the immediate-undo window closes. Typing a character and then pressing Backspace should remove just that character; the list itself stays intact, with the second list item empty.
+| <ul>
+|   class="Apple-disc-list"
+|   style="list-style-type: disc;"
+|   <li>
+|     "A"
+|     <br>
+|   <li>
+|     <#selection-caret>
+|     <br>

--- a/LayoutTests/editing/smart-lists/backspace-after-typing-in-smart-list-does-not-undo-list.html
+++ b/LayoutTests/editing/smart-lists/backspace-after-typing-in-smart-list-does-not-undo-list.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SmartListsAvailable=true ] -->
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<div id="test" contenteditable></div>
+<script>
+Markup.description('Once any other input follows the Smart Lists conversion, the immediate-undo window closes. Typing a character and then pressing Backspace should remove just that character; the list itself stays intact, with the second list item empty.');
+
+const test = document.getElementById('test');
+test.focus();
+[...'* A\n* '].forEach(typeCharacterCommand);
+typeCharacterCommand('x');
+deleteCommand();
+Markup.dump('test');
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/smart-lists/backspace-immediately-after-smart-list-creation-undoes-list-expected.txt
+++ b/LayoutTests/editing/smart-lists/backspace-immediately-after-smart-list-creation-undoes-list-expected.txt
@@ -1,0 +1,6 @@
+Pressing Backspace immediately after Smart Lists converts two consecutive lines into a list should undo the conversion, restoring the original markers and the trigger space.
+| <div>
+|   "* A"
+| <div>
+|   "* "
+|   <#selection-caret>

--- a/LayoutTests/editing/smart-lists/backspace-immediately-after-smart-list-creation-undoes-list.html
+++ b/LayoutTests/editing/smart-lists/backspace-immediately-after-smart-list-creation-undoes-list.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SmartListsAvailable=true ] -->
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<div id="test" contenteditable></div>
+<script>
+Markup.description('Pressing Backspace immediately after Smart Lists converts two consecutive lines into a list should undo the conversion, restoring the original markers and the trigger space.');
+
+const test = document.getElementById('test');
+test.focus();
+[...'* A\n* '].forEach(typeCharacterCommand);
+deleteCommand();
+Markup.dump('test');
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/smart-lists/backspace-immediately-after-third-list-item-does-not-undo-list-expected.txt
+++ b/LayoutTests/editing/smart-lists/backspace-immediately-after-third-list-item-does-not-undo-list-expected.txt
@@ -1,0 +1,9 @@
+Reaching a third list item necessarily closes the immediate-undo window (typing the second item's content and then pressing Enter both invalidate it). Pressing Backspace from the empty third list item should therefore fall through to the normal break-out-of-empty-list behavior, leaving the original list intact with its two non-empty items.
+| <ul>
+|   class="Apple-disc-list"
+|   style="list-style-type: disc;"
+|   <li>
+|     "A"
+|     <br>
+|   <li>
+|     "B<#selection-caret>"

--- a/LayoutTests/editing/smart-lists/backspace-immediately-after-third-list-item-does-not-undo-list.html
+++ b/LayoutTests/editing/smart-lists/backspace-immediately-after-third-list-item-does-not-undo-list.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SmartListsAvailable=true ] -->
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<div id="test" contenteditable></div>
+<script>
+Markup.description('Reaching a third list item necessarily closes the immediate-undo window (typing the second item\'s content and then pressing Enter both invalidate it). Pressing Backspace from the empty third list item should therefore fall through to the normal break-out-of-empty-list behavior, leaving the original list intact with its two non-empty items.');
+
+const test = document.getElementById('test');
+test.focus();
+[...'* A\n* B\n'].forEach(typeCharacterCommand);
+deleteCommand();
+Markup.dump('test');
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1546,22 +1546,7 @@ editing/async-clipboard/clipboard-change-data-while-reading.html [ Skip ]
 editing/async-clipboard/clipboard-read-text-from-platform.html [ Skip ]
 
 # These tests are intended to exercise Smart Lists support specific to Apple ports.
-editing/smart-lists/different-list-styles-do-not-merge.html [ Skip ]
-editing/smart-lists/inserting-space-after-bullet-point-generates-empty-list.html [ Skip ]
-editing/smart-lists/inserting-space-after-em-dash-generates-dashed-list.html [ Skip ]
-editing/smart-lists/inserting-space-after-en-dash-generates-dashed-list.html [ Skip ]
-editing/smart-lists/inserting-space-after-hyphen-minus-generates-dashed-list.html [ Skip ]
-editing/smart-lists/inserting-space-after-multi-digit-number-generates-ordered-list.html [ Skip ]
-editing/smart-lists/inserting-space-after-number-generates-ordered-list.html [ Skip ]
-editing/smart-lists/inserting-space-after-unicode-hyphen-generates-dashed-list.html [ Skip ]
-editing/smart-lists/inserting-space-and-text-after-bullet-point-generates-list-with-text.html [ Skip ]
-editing/smart-lists/list-merges-with-previous-list-if-possible.html [ Skip ]
-editing/smart-lists/list-preserves-typing-style.html [ Skip ]
-editing/smart-lists/newline-on-empty-list-element-removes-plain-text-markers.html [ Skip ]
-editing/smart-lists/ordered-list-starting-from-non-one-sets-start-attribute.html [ Skip ]
-editing/smart-lists/ordered-markers-with-different-delimiters-generate-list.html [ Skip ]
-editing/smart-lists/ordered-smart-list-rtl.html [ Skip ]
-editing/smart-lists/space-inside-list-element-does-not-activate-smart-lists.html [ Skip ]
+editing/smart-lists/ [ Skip ]
 
 webkit.org/b/186099 editing/caret/caret-in-empty-cell.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -251,6 +251,12 @@ bool InsertTextCommand::applySmartListsIfNeeded()
     if (!styleToPreserve->isEmpty())
         m_styleToPreserveForSmartList = WTF::move(styleToPreserve);
 
+    m_smartListUndoData =  {
+        previousLineText,
+        currentLineText,
+        listElement,
+    };
+
     return true;
 }
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/editing/InsertTextCommand.h
+++ b/Source/WebCore/editing/InsertTextCommand.h
@@ -40,6 +40,12 @@ protected:
     TextInsertionMarkerSupplier() = default;
 };
 
+struct SmartListUndoData {
+    String previousLineText;
+    String currentLineText;
+    RefPtr<HTMLElement> listElement;
+};
+
 class InsertTextCommand : public CompositeEditCommand {
 public:
     enum RebalanceType {
@@ -85,6 +91,7 @@ private:
     RebalanceType m_rebalanceType;
     RefPtr<TextInsertionMarkerSupplier> m_markerSupplier;
     RefPtr<EditingStyle> m_styleToPreserveForSmartList;
+    std::optional<SmartListUndoData> m_smartListUndoData;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -503,6 +503,8 @@ bool TypingCommand::willAddTypingToOpenCommand(Type commandType, TextGranularity
     m_currentTextToInsert = text;
     m_currentTypingEditAction = editActionForTypingCommand(commandType, granularity, m_compositionType, m_isAutocompletion);
 
+    m_smartListUndoData = std::nullopt;
+
     if (!shouldDeferWillApplyCommandUntilAddingTypingCommand())
         return true;
 
@@ -563,6 +565,8 @@ void TypingCommand::insertTextRunWithoutNewlines(const String& text, bool select
 
     applyCommandToComposite(WTF::move(command), endingSelection());
     typingAddedToOpenCommand(Type::InsertText);
+
+    m_smartListUndoData = WTF::move(insertTextCommand->m_smartListUndoData);
 
     if (insertTextCommand->m_styleToPreserveForSmartList)
         document().selection().setTypingStyle(WTF::move(insertTextCommand->m_styleToPreserveForSmartList));
@@ -658,6 +662,9 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
     RefPtr protectedFrame = document().frame();
 
     protect(document())->editor().updateMarkersForWordsAffectedByEditing(false);
+
+    if (performSmartListUndo(granularity))
+        return;
 
     VisibleSelection selectionToDelete;
     VisibleSelection selectionAfterUndo;
@@ -772,6 +779,46 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
     CompositeEditCommand::deleteSelection(selectionToDelete, m_smartDelete, /* mergeBlocksAfterDelete*/ true, /* replace*/ false, expandForSpecialElements, /*sanitizeMarkup*/ true);
     setSmartDelete(false);
     typingAddedToOpenCommand(Type::DeleteKey);
+}
+
+bool TypingCommand::performSmartListUndo(TextGranularity granularity)
+{
+    auto undoData = std::exchange(m_smartListUndoData, std::nullopt);
+    if (!undoData)
+        return false;
+
+    RefPtr listElement = undoData->listElement;
+    if (!listElement || !listElement->isConnected())
+        return false;
+
+    if (!endingSelection().isCaret())
+        return false;
+
+    RefPtr secondItem = enclosingListChild(endingSelection().base().anchorNode());
+    if (!secondItem || secondItem->parentNode() != listElement.get())
+        return false;
+
+    if (secondItem->nextSibling() || !secondItem->previousSibling())
+        return false;
+
+    if (!willAddTypingToOpenCommand(Type::DeleteKey, granularity, { }, { }))
+        return true;
+
+    Ref document = this->document();
+    auto firstParagraph = createDefaultParagraphElement(document);
+    auto secondParagraph = createDefaultParagraphElement(document);
+
+    insertNodeBefore(firstParagraph.copyRef(), *listElement);
+    insertNodeAt(document->createEditingTextNode(WTF::move(undoData->previousLineText)), firstPositionInNode(firstParagraph));
+
+    insertNodeBefore(secondParagraph.copyRef(), *listElement);
+    insertNodeAt(document->createEditingTextNode(makeString(WTF::move(undoData->currentLineText), ' ')), firstPositionInNode(secondParagraph));
+
+    removeNode(*listElement);
+
+    setEndingSelection(VisibleSelection(lastPositionInNode(secondParagraph), Affinity::Downstream, endingSelection().directionality()));
+    typingAddedToOpenCommand(Type::DeleteKey);
+    return true;
 }
 
 void TypingCommand::forwardDeleteKeyPressed(TextGranularity granularity, bool shouldAddToKillRing)

--- a/Source/WebCore/editing/TypingCommand.h
+++ b/Source/WebCore/editing/TypingCommand.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "InsertTextCommand.h"
 #include "SimpleRange.h"
 #include "TextInsertionBaseCommand.h"
 #include <wtf/CheckedRef.h>
@@ -125,6 +126,8 @@ private:
     RefPtr<DataTransfer> inputEventDataTransfer() const final;
     bool isBeforeInputEventCancelable() const final;
 
+    bool performSmartListUndo(TextGranularity);
+
     static void updateSelectionIfDifferentFromCurrentSelection(TypingCommand*, Document&);
 
     void NODELETE updatePreservesTypingStyle(Type);
@@ -166,6 +169,8 @@ private:
     bool m_shouldRetainAutocorrectionIndicator;
     bool m_shouldPreventSpellChecking;
     bool m_triggeringEventIsUntrusted { false };
+
+    std::optional<SmartListUndoData> m_smartListUndoData;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e9768a95677440dc108fcf26db2af5cd82b8b902
<pre>
[Smart Lists] Backspace after Smart Lists formatting removes entire list line instead of just formatting
<a href="https://bugs.webkit.org/show_bug.cgi?id=317665">https://bugs.webkit.org/show_bug.cgi?id=317665</a>
<a href="https://rdar.apple.com/177210669">rdar://177210669</a>

Reviewed by Wenson Hsieh.

Currently, when backspacing immediately from the second list item of a smart list,
the selection moves back to the first list item. Instead, the entire list formatting
should be removed. This should be the case because a user could have accidently triggered
list formatting and need a way out.

So, if it is currently on the second list item of a newly created smart list, there is no text
yet and a backspace is hit, then WebKit should remove the list formatting. This is the window
in which the undo operation via backspace will be valid.

To ensure this, a SmartListUndoData struct is created that stores all the information needed for the
undo operation. This data is only set during that small window and will be a nullopt otherwise for all
other operations. In performSmartListUndo, conditions are checked whether the undo operation is valid here.
If so, divs are created and the text is then put in the divs that are located in the DOM right where the
list element would be. The list element is then removed. If the user is on any other list item and backspaces,
the list formatting is not removed because the conditions would not be met.

Add three layout tests that cover these cases:
1. Backspace immediately once at the second list item of a smart list
2. Backspace after typing a character at the second list item of a smart list
3, Backspace immediately once at the third list item of a smart list

* LayoutTests/editing/smart-lists/backspace-after-typing-in-smart-list-does-not-undo-list-expected.txt: Added.
* LayoutTests/editing/smart-lists/backspace-after-typing-in-smart-list-does-not-undo-list.html: Added.
* LayoutTests/editing/smart-lists/backspace-immediately-after-smart-list-creation-undoes-list-expected.txt: Added.
* LayoutTests/editing/smart-lists/backspace-immediately-after-smart-list-creation-undoes-list.html: Added.
* LayoutTests/editing/smart-lists/backspace-immediately-after-third-list-item-does-not-undo-list-expected.txt: Added.
* LayoutTests/editing/smart-lists/backspace-immediately-after-third-list-item-does-not-undo-list.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::applySmartListsIfNeeded):
* Source/WebCore/editing/InsertTextCommand.h:
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::willAddTypingToOpenCommand):
(WebCore::TypingCommand::insertTextRunWithoutNewlines):
(WebCore::TypingCommand::deleteKeyPressed):
(WebCore::TypingCommand::performSmartListUndo):
* Source/WebCore/editing/TypingCommand.h:

Canonical link: <a href="https://commits.webkit.org/315904@main">https://commits.webkit.org/315904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d846e069f321437d4bab432654954a2a346a96c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128021 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a70fefa8-ce57-4902-8246-15632f90d50b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132789 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf591e9a-fd37-431c-98c9-77670c881baa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113289 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de3d2b58-8de9-4153-b6c4-33ee0b1cba02) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28367 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182268 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141237 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141057 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44578 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109003 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36326 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116460 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43088 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7699 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42494 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42734 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->