### PR TITLE
Include video caption cues in Find-in-Page navigation on macOS

### DIFF
--- a/LayoutTests/media/track/text-track-find.html
+++ b/LayoutTests/media/track/text-track-find.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ FindInVideoEnabled=true ] -->
 <!DOCTYPE html>
 <html>
     <head>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3157,6 +3157,21 @@ FilterLinkDecorationByDefaultEnabled:
     WebCore:
       default: false
 
+FindInVideoEnabled:
+  type: bool
+  status: testable
+  category: media
+  humanReadableName: "Find in Video"
+  humanReadableDescription: "Include video subtitle/caption cues in Find-in-Page results"
+  condition: ENABLE(VIDEO)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 FixedFontFamily:
   type: String
   status: embedder

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1977,6 +1977,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/ContextMenuProvider.h
     page/CrossSiteNavigationDataTransfer.h
     page/CryptoClient.h
+    page/CueMatch.h
     page/DOMSelection.h
     page/DOMTimer.h
     page/DOMWindow.h

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2653,10 +2653,11 @@ void Document::forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement
 Vector<CueMatch> Document::findCueMatches(const String& target, FindOptions options)
 {
     Vector<CueMatch> results;
+    if (!settings().findInVideoEnabled())
+        return results;
     if (target.isEmpty())
         return results;
 
-    // Order this document's media elements by tree position.
     Vector<Ref<HTMLMediaElement>> elements;
     forEachMediaElement([&](HTMLMediaElement& element) {
         if (element.isConnected())
@@ -2678,7 +2679,6 @@ Vector<CueMatch> Document::findCueMatches(const String& target, FindOptions opti
             RefPtr track = tracks->item(i);
             if (!track)
                 continue;
-            // Only search tracks that are currently rendered on screen.
             if (track->mode() != TextTrack::Mode::Showing)
                 continue;
             // Only search tracks whose cues carry text the user reads or hears, skip chapters and metadata tracks.
@@ -2712,6 +2712,14 @@ Vector<CueMatch> Document::findCueMatches(const String& target, FindOptions opti
         std::ranges::stable_sort(results.mutableSubspan(firstMatchForElement), [](auto& a, auto& b) {
             return a.seekTime < b.seekTime;
         });
+
+        // Collapse cues that share a start time
+        MediaTime previousSeekTime = MediaTime::invalidTime();
+        results.removeAllMatching([&previousSeekTime](auto& match) {
+            bool isDuplicate = match.seekTime == previousSeekTime;
+            previousSeekTime = match.seekTime;
+            return isDuplicate;
+        }, firstMatchForElement);
     }
 
     return results;

--- a/Source/WebCore/page/CueMatch.h
+++ b/Source/WebCore/page/CueMatch.h
@@ -37,6 +37,8 @@ class HTMLMediaElement;
 struct CueMatch {
     WeakPtr<HTMLMediaElement> mediaElement;
     MediaTime seekTime;
+
+    friend bool operator==(const CueMatch&, const CueMatch&) = default;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -47,6 +47,7 @@
 #include <WebCore/FrameSelection.h>
 #include <WebCore/GeometryUtilities.h>
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/HTMLMediaElement.h>
 #include <WebCore/ImageAnalysisQueue.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/ImageOverlay.h>
@@ -68,6 +69,86 @@ namespace WebKit {
 using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FindController);
+
+#if ENABLE(VIDEO)
+static Vector<FindMatch> mergeByDocumentOrder(Page& page, Vector<SimpleRange>&& domRanges, Vector<CueMatch>&& cueMatches)
+{
+    Vector<FindMatch> merged;
+    merged.reserveInitialCapacity(domRanges.size() + cueMatches.size());
+
+    size_t rangeIndex = 0;
+    size_t cueIndex = 0;
+    page.forEachDocument([&](Document& document) {
+        auto rangeBelongsToDocument = [&] {
+            return rangeIndex < domRanges.size() && &domRanges[rangeIndex].start.document() == &document;
+        };
+        auto nextCueElementInDocument = [&]() -> RefPtr<HTMLMediaElement> {
+            while (cueIndex < cueMatches.size()) {
+                RefPtr mediaElement = cueMatches[cueIndex].mediaElement.get();
+                if (!mediaElement) {
+                    ++cueIndex;
+                    continue;
+                }
+                return &mediaElement->document() == &document ? mediaElement : nullptr;
+            }
+            return nullptr;
+        };
+
+        bool haveRange = rangeBelongsToDocument();
+        RefPtr cueElement = nextCueElementInDocument();
+        while (haveRange || cueElement) {
+            bool takeRange = haveRange && (!cueElement || is_lt(treeOrder<ComposedTree>(domRanges[rangeIndex].start, makeBoundaryPointBeforeNodeContents(*cueElement))));
+            if (takeRange)
+                merged.append(WTF::move(domRanges[rangeIndex++]));
+            else
+                merged.append(WTF::move(cueMatches[cueIndex++]));
+            haveRange = rangeBelongsToDocument();
+            cueElement = nextCueElementInDocument();
+        }
+    });
+
+    return merged;
+}
+
+static std::optional<size_t> indexOfCursor(const Vector<FindMatch>& merged, const std::optional<FindMatch>& cursor)
+{
+    if (!cursor)
+        return std::nullopt;
+    for (size_t matchIndex = 0; matchIndex < merged.size(); ++matchIndex) {
+        if (merged[matchIndex] == *cursor)
+            return matchIndex;
+    }
+    return std::nullopt;
+}
+
+static std::optional<size_t> indexClosestToSelection(const Vector<FindMatch>& merged, const std::optional<SimpleRange>& selection, bool backwards)
+{
+    if (merged.isEmpty() || !selection)
+        return std::nullopt;
+
+    auto positionOf = [](const FindMatch& match) -> std::optional<BoundaryPoint> {
+        if (auto* range = std::get_if<SimpleRange>(&match))
+            return range->start;
+        if (RefPtr mediaElement = std::get<CueMatch>(match).mediaElement.get())
+            return makeBoundaryPointBeforeNodeContents(*mediaElement);
+        return std::nullopt;
+    };
+
+    auto anchor = selection->start;
+    if (!backwards) {
+        for (size_t matchIndex = 0; matchIndex < merged.size(); ++matchIndex) {
+            if (auto position = positionOf(merged[matchIndex]); position && is_gteq(treeOrder<ComposedTree>(*position, anchor)))
+                return matchIndex;
+        }
+        return std::nullopt;
+    }
+    for (size_t matchIndex = merged.size(); matchIndex > 0; --matchIndex) {
+        if (auto position = positionOf(merged[matchIndex - 1]); position && is_lteq(treeOrder<ComposedTree>(*position, anchor)))
+            return matchIndex - 1;
+    }
+    return std::nullopt;
+}
+#endif // ENABLE(VIDEO)
 
 FindController::FindController(WebPage* webPage)
     : m_webPage(webPage)
@@ -114,6 +195,9 @@ void FindController::countStringMatches(const String& string, OptionSet<FindOpti
             matchCount = protect(webPage->corePage())->countFindMatches(string, core(options), maxMatchCount + 1);
             protect(webPage->corePage())->unmarkAllTextMatches();
         }
+#if ENABLE(VIDEO)
+        matchCount += protect(webPage->corePage())->findCueMatches(string, core(options)).size();
+#endif
 
         updateFindPageOverlay(shouldShowOverlay);
     }
@@ -159,7 +243,47 @@ RefPtr<LocalFrame> FindController::frameWithSelection(Page* page)
     return nullptr;
 }
 
-void FindController::updateFindUIAfterIncrementalFind(bool found, const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, WebCore::DidWrap didWrap, std::optional<FrameIdentifier> idOfFrameContainingString, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<IntRect>&&, uint32_t, int32_t, bool)>&& completionHandler)
+std::optional<FrameIdentifier> FindController::applyFindMatch(const FindMatch& match, OptionSet<FindOptions> options)
+{
+    RefPtr webPage { m_webPage.get() };
+    if (!webPage)
+        return std::nullopt;
+
+    if (auto* range = std::get_if<SimpleRange>(&match)) {
+        RefPtr frame = range->start.document().frame();
+        if (!frame || !range->start.container->isConnected())
+            return std::nullopt;
+        if (!options.contains(FindOptions::DoNotSetSelection)) {
+            if (RefPtr previousFrame = dynamicDowncast<LocalFrame>(protect(webPage->corePage())->focusController().focusedFrame()); previousFrame && previousFrame != frame)
+                protect(previousFrame->selection())->clear();
+            protect(frame->selection())->setSelection(*range);
+            protect(webPage->corePage())->focusController().setFocusedFrame(frame.get());
+        }
+        return frame->frameID();
+    }
+
+#if ENABLE(VIDEO)
+    auto& cue = std::get<CueMatch>(match);
+    RefPtr media = cue.mediaElement.get();
+    if (!media)
+        return std::nullopt;
+    RefPtr frame = media->document().frame();
+    if (!frame)
+        return std::nullopt;
+    if (!options.contains(FindOptions::DoNotSetSelection)) {
+        // Clear any prior text selection so it isn't left highlighted while parked on the video.
+        if (RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get()))
+            protect(selectedFrame->selection())->clear();
+        media->setCurrentTime(cue.seekTime.toDouble());
+        media->scrollIntoViewIfNeeded();
+    }
+    return frame->frameID();
+#else
+    return std::nullopt;
+#endif
+}
+
+void FindController::updateFindUIAfterIncrementalFind(bool found, const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, unsigned cueMatchCount, WebCore::DidWrap didWrap, std::optional<FrameIdentifier> idOfFrameContainingString, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<IntRect>&&, uint32_t, int32_t, bool)>&& completionHandler)
 {
     RefPtr webPage { m_webPage.get() };
     RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get());
@@ -187,9 +311,9 @@ void FindController::updateFindUIAfterIncrementalFind(bool found, const String& 
 
     // marking implicitly counts, so we try not to double count here
     if (needsMarking)
-        matchCount = markMatches(string, options, maxMatchCount);
+        matchCount = markMatches(string, options, maxMatchCount, cueMatchCount);
     else if (needsCount)
-        matchCount = getMatchCount(string, options, maxMatchCount);
+        matchCount = getMatchCount(string, options, maxMatchCount, cueMatchCount);
 
     if (matchCount > maxMatchCount)
         matchCount = static_cast<unsigned>(kWKMoreThanMaximumMatchCount);
@@ -204,7 +328,7 @@ void FindController::updateFindUIAfterIncrementalFind(bool found, const String& 
     completionHandler(idOfFrameContainingString, WTF::move(matchRects), matchCount, m_foundStringMatchIndex.value_or(0), didWrap == WebCore::DidWrap::Yes);
 }
 
-unsigned FindController::markMatches(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount)
+unsigned FindController::markMatches(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, unsigned cueMatchCount)
 {
     maxMatchCount = std::min(std::numeric_limits<unsigned>::max() - 1, maxMatchCount);
 
@@ -217,10 +341,11 @@ unsigned FindController::markMatches(const String& string, OptionSet<FindOptions
     bool shouldShowHighlight = options.contains(FindOptions::ShowHighlight);
 
     protect(webPage->corePage())->unmarkAllTextMatches();
-    return protect(webPage->corePage())->markAllMatchesForText(string, core(options), shouldShowHighlight, maxMatchCount + 1);
+    unsigned matchCount = protect(webPage->corePage())->markAllMatchesForText(string, core(options), shouldShowHighlight, maxMatchCount + 1);
+    return matchCount + cueMatchCount;
 }
 
-unsigned FindController::getMatchCount(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount)
+unsigned FindController::getMatchCount(const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, unsigned cueMatchCount)
 {
 #if ENABLE(PDF_PLUGIN)
     if (RefPtr pluginView = mainFramePlugIn(); pluginView)
@@ -228,7 +353,8 @@ unsigned FindController::getMatchCount(const String& string, OptionSet<FindOptio
 #endif
 
     RefPtr webPage { m_webPage.get() };
-    return protect(webPage->corePage())->countFindMatches(string, core(options), maxMatchCount + 1);
+    unsigned matchCount = protect(webPage->corePage())->countFindMatches(string, core(options), maxMatchCount + 1);
+    return matchCount + cueMatchCount;
 }
 
 void FindController::updateMatchIndex(unsigned matchCount, OptionSet<FindOptions> options)
@@ -364,15 +490,26 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
     protect(protect(m_webPage.get())->corePage())->removeAllActiveTextMatches();
 
     RefPtr webPage { m_webPage.get() };
+#if ENABLE(VIDEO)
+    Vector<CueMatch> cueMatches;
+#endif
+    unsigned cueMatchCount = 0;
 #if ENABLE(PDF_PLUGIN)
     if (!pluginView)
 #endif
     {
-        if (RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get())) {
-            if (protect(selectedFrame->selection())->selectionBounds().isEmpty()) {
-                auto result = protect(webPage->corePage())->findTextMatches(string, coreOptions, maxMatchCount);
-                m_foundStringMatchIndex = result.indexForSelection;
-                options.add(FindOptions::NoIndexChange);
+#if ENABLE(VIDEO)
+        cueMatches = protect(webPage->corePage())->findCueMatches(string, coreOptions);
+        cueMatchCount = cueMatches.size();
+        if (cueMatches.isEmpty())
+#endif
+        {
+            if (RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get())) {
+                if (protect(selectedFrame->selection())->selectionBounds().isEmpty()) {
+                    auto result = protect(webPage->corePage())->findTextMatches(string, coreOptions, maxMatchCount);
+                    m_foundStringMatchIndex = result.indexForSelection;
+                    options.add(FindOptions::NoIndexChange);
+                }
             }
         }
     }
@@ -390,24 +527,79 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
 #endif
     {
         if (shouldReuseLastFoundRange == ShouldReuseLastFoundRange::Yes && m_lastFoundRange) {
-            RefPtr frame = m_lastFoundRange->start.document().frame();
-            if (frame && m_lastFoundRange->start.container->isConnected()) {
-                if (RefPtr previousFrame = dynamicDowncast<LocalFrame>(protect(webPage->corePage())->focusController().focusedFrame()); previousFrame && previousFrame != frame)
-                    protect(previousFrame->selection())->clear();
-                protect(frame->selection())->setSelection(*m_lastFoundRange);
-                protect(webPage->corePage())->focusController().setFocusedFrame(frame.get());
-                idOfFrameContainingString = frame->frameID();
+            if (auto frameID = applyFindMatch(*m_lastFoundRange, options)) {
+                idOfFrameContainingString = frameID;
                 found = true;
                 didWrap = m_lastFoundRangeDidWrap ? WebCore::DidWrap::Yes : WebCore::DidWrap::No;
             }
         }
 
         if (!found) {
-            auto [frameID, range] = protect(webPage->corePage())->findString(string, coreOptions, &didWrap);
-            idOfFrameContainingString = frameID;
-            found = idOfFrameContainingString.has_value();
-            m_lastFoundRange = WTF::move(range);
-            m_lastFoundRangeDidWrap = didWrap == WebCore::DidWrap::Yes;
+#if ENABLE(VIDEO)
+            if (!cueMatches.isEmpty()) {
+                // Step through page text and captions together, in the order they appear on screen.
+                auto domRanges = protect(webPage->corePage())->findTextMatches(string, coreOptions, maxMatchCount, false).ranges;
+                auto merged = mergeByDocumentOrder(*protect(webPage->corePage()), WTF::move(domRanges), WTF::move(cueMatches));
+
+                bool backwards = options.contains(FindOptions::Backwards);
+                bool wrapAround = options.contains(FindOptions::WrapAround);
+                auto cursorIndex = indexOfCursor(merged, m_lastFoundRange);
+
+                std::optional<size_t> nextIndex;
+                bool wrapped = false;
+                if (merged.isEmpty()) {
+                } else if (!cursorIndex) {
+                    auto selection = protect(webPage->corePage())->selection().firstRange();
+                    nextIndex = indexClosestToSelection(merged, selection, backwards);
+                    if (!nextIndex && wrapAround) {
+                        nextIndex = backwards ? merged.size() - 1 : 0;
+                        wrapped = selection.has_value();
+                    }
+                } else if (backwards) {
+                    if (*cursorIndex)
+                        nextIndex = *cursorIndex - 1;
+                    else if (wrapAround) {
+                        nextIndex = merged.size() - 1;
+                        wrapped = true;
+                    }
+                } else {
+                    if (*cursorIndex + 1 < merged.size())
+                        nextIndex = *cursorIndex + 1;
+                    else if (wrapAround) {
+                        nextIndex = 0;
+                        wrapped = true;
+                    }
+                }
+
+                if (nextIndex) {
+                    if (auto frameID = applyFindMatch(merged[*nextIndex], options)) {
+                        idOfFrameContainingString = frameID;
+                        found = true;
+                        didWrap = wrapped ? WebCore::DidWrap::Yes : WebCore::DidWrap::No;
+                        m_lastFoundRange = WTF::move(merged[*nextIndex]);
+                        m_lastFoundRangeDidWrap = wrapped;
+
+                        m_foundStringMatchIndex = *nextIndex;
+                        options.add(FindOptions::NoIndexChange);
+                    }
+                }
+
+                if (!found && (merged.isEmpty() || !cursorIndex)) {
+                    m_lastFoundRange = std::nullopt;
+                    m_lastFoundRangeDidWrap = false;
+                }
+            } else
+#endif // ENABLE(VIDEO)
+            {
+                auto [frameID, range] = protect(webPage->corePage())->findString(string, coreOptions, &didWrap);
+                idOfFrameContainingString = frameID;
+                found = idOfFrameContainingString.has_value();
+                if (range)
+                    m_lastFoundRange = FindMatch { WTF::move(*range) };
+                else
+                    m_lastFoundRange = std::nullopt;
+                m_lastFoundRangeDidWrap = didWrap == WebCore::DidWrap::Yes;
+            }
         }
     }
 
@@ -421,8 +613,8 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
         }
     }
 
-    protect(webPage->drawingArea())->dispatchAfterEnsuringUpdatedScrollPosition([webPage, found, string, options, maxMatchCount, didWrap, idOfFrameContainingString, completionHandler = WTF::move(completionHandler)]() mutable {
-        webPage->findController().updateFindUIAfterIncrementalFind(found, string, options, maxMatchCount, didWrap, idOfFrameContainingString, WTF::move(completionHandler));
+    protect(webPage->drawingArea())->dispatchAfterEnsuringUpdatedScrollPosition([webPage, found, string, options, maxMatchCount, cueMatchCount, didWrap, idOfFrameContainingString, completionHandler = WTF::move(completionHandler)]() mutable {
+        webPage->findController().updateFindUIAfterIncrementalFind(found, string, options, maxMatchCount, cueMatchCount, didWrap, idOfFrameContainingString, WTF::move(completionHandler));
     });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -27,6 +27,7 @@
 
 #include "FindIndicator.h"
 #include "WebFindOptions.h"
+#include <WebCore/CueMatch.h>
 #include <WebCore/FindOptions.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
@@ -38,6 +39,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Variant.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -51,6 +53,12 @@ namespace WebKit {
 class CallbackID;
 class PluginView;
 class WebPage;
+
+#if ENABLE(VIDEO)
+using FindMatch = Variant<WebCore::SimpleRange, WebCore::CueMatch>;
+#else
+using FindMatch = Variant<WebCore::SimpleRange>;
+#endif
 
 class FindController final : private WebCore::PageOverlayClient {
     WTF_MAKE_TZONE_ALLOCATED(FindController);
@@ -96,19 +104,21 @@ private:
     Vector<WebCore::FloatRect> rectsForTextMatchesInRect(WebCore::IntRect clipRect);
 
     void updateFindUIAfterFindingAllMatches(bool found, const String&, OptionSet<FindOptions>, unsigned maxMatchCount);
-    void updateFindUIAfterIncrementalFind(bool found, const String&, OptionSet<FindOptions>, unsigned maxMatchCount, WebCore::DidWrap, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<WebCore::IntRect>&&, uint32_t, int32_t, bool)>&&);
+    void updateFindUIAfterIncrementalFind(bool found, const String&, OptionSet<FindOptions>, unsigned maxMatchCount, unsigned cueMatchCount, WebCore::DidWrap, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<WebCore::IntRect>&&, uint32_t, int32_t, bool)>&&);
 
     enum class ShouldReuseLastFoundRange : bool { No, Yes };
     void findString(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, ShouldReuseLastFoundRange, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, Vector<WebCore::IntRect>&&, uint32_t, int32_t, bool)>&&);
 
     void updateFindPageOverlay(bool shouldShowOverlay);
     void updateFindIndicatorIfNeeded(bool found, OptionSet<FindOptions>, bool shouldShowOverlay);
-    unsigned markMatches(const String&, OptionSet<FindOptions>, unsigned maxMatchCount);
-    unsigned getMatchCount(const String&, OptionSet<FindOptions>, unsigned maxMatchCount);
+    unsigned markMatches(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, unsigned cueMatchCount);
+    unsigned getMatchCount(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, unsigned cueMatchCount);
     void NODELETE updateMatchIndex(unsigned matchCount, OptionSet<FindOptions>);
     void didScrollAffectingFindIndicatorPosition();
 
     RefPtr<WebCore::LocalFrame> frameWithSelection(WebCore::Page*);
+
+    std::optional<WebCore::FrameIdentifier> applyFindMatch(const FindMatch&, OptionSet<FindOptions>);
 
 #if ENABLE(PDF_PLUGIN)
     PluginView* mainFramePlugIn();
@@ -118,7 +128,7 @@ private:
     WeakPtr<WebCore::PageOverlay> m_findPageOverlay;
     std::optional<uint32_t> m_foundStringMatchIndex;
     Vector<WebCore::SimpleRange> m_findMatches;
-    std::optional<WebCore::SimpleRange> m_lastFoundRange;
+    std::optional<FindMatch> m_lastFoundRange;
     bool m_lastFoundRangeDidWrap { false };
     std::unique_ptr<FindIndicator> m_findIndicator;
 };


### PR DESCRIPTION
#### e24c704e89a1182de0db8f9373f9c50668b9b4d2
<pre>
Include video caption cues in Find-in-Page navigation on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=317672">https://bugs.webkit.org/show_bug.cgi?id=317672</a>
<a href="https://rdar.apple.com/180430525">rdar://180430525</a>

Reviewed by Megan Gardner.

Extend Find-in-Page on macOS so that a search also matches text in
showing WebVTT caption/subtitle cues. Navigating to a cue match seeks the
associated media element to the cue&apos;s start time and scrolls it into
view, so Cmd+F / Cmd+G can step through spoken dialogue the same way it
steps through page text.

DOM text matches and cue matches are unified through a FindMatch variant
(SimpleRange or CueMatch) and merged in document order, so the find
cursor and next/previous navigation move across both kinds of match in a
single ordered sequence.

The behavior is gated behind the new FindInVideoEnabled feature flag,
which defaults to off.

* LayoutTests/media/track/text-track-find.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::findCueMatches):
* Source/WebCore/page/CueMatch.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::mergeByDocumentOrder):
(WebKit::indexOfCursor):
(WebKit::FindController::countStringMatches):
(WebKit::FindController::applyFindMatch):
(WebKit::FindController::markMatches):
(WebKit::FindController::getMatchCount):
(WebKit::FindController::findString):
(WebKit::FindController::updateFindUIAfterIncrementalFind):
(WebKit::indexClosestToSelection):
* Source/WebKit/WebProcess/WebPage/FindController.h:

Canonical link: <a href="https://commits.webkit.org/316289@main">https://commits.webkit.org/316289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4eae4d7df9e94cd4f8d3ff0fd4be808896b8210

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45867 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181254 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45507 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174908 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/114243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30003 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/2820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183922 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33209 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45534 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/153869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142375 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38399 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46214 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110874 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37474 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44732 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54636 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44132 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->