### PR TITLE
Use-after-free in LocalFrameView::scrollToAnchorFragment via NavigateEvent:finish

### DIFF
--- a/LayoutTests/navigation-api/navigation-api-fragment-intercept-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-api-fragment-intercept-crash-expected.txt
@@ -1,0 +1,3 @@
+This tests intercepting a fragment navigation. WebKit should not hit assertions or crash under ASAN.
+
+PASS

--- a/LayoutTests/navigation-api/navigation-api-fragment-intercept-crash.html
+++ b/LayoutTests/navigation-api/navigation-api-fragment-intercept-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests intercepting a fragment navigation. WebKit should not hit assertions or crash under ASAN.</p>
+<iframe src="resources/navigation-api-fragment-intercept-crash-inner.html"></iframe>
+<div id="result"></div>
+<script>
+
+if (window.testRunner) {
+  testRunner.waitUntilDone();
+  testRunner.dumpAsText();
+}
+
+function scheduleFinish() {
+  setTimeout(() => {
+    result.textContent = 'PASS';
+    if (window.testRunner)
+      testRunner.notifyDone();
+  }, 0);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/navigation-api/resources/navigation-api-fragment-intercept-crash-inner.html
+++ b/LayoutTests/navigation-api/resources/navigation-api-fragment-intercept-crash-inner.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<span id="target" hidden="until-found">trigger text</span>
+<script>
+document.addEventListener('beforematch', function (event) {
+  parent.document.querySelector('iframe').remove();
+}, {once: true});
+
+navigation.addEventListener('navigate', function (event) {
+  if (event.destination.url.includes('#target'));
+    event.intercept();
+});
+
+onload = () => {
+  setTimeout(() => {
+    navigation.navigate(location.href + '#target');
+    parent.scheduleFinish();
+  }, 0);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -240,7 +240,6 @@ page/LocalFrame.cpp
 page/LocalFrameView.cpp
 page/LocalFrameViewLayoutContext.cpp
 page/MemoryRelease.cpp
-page/NavigateEvent.cpp
 [ iOS ] page/Page.cpp
 page/PageSerializer.cpp
 page/Performance.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -242,7 +242,6 @@ page/LocalDOMWindow.cpp
 page/LocalFrame.cpp
 page/LocalFrameView.cpp
 page/LocalFrameViewLayoutContext.cpp
-page/NavigateEvent.cpp
 page/NavigationDestination.h
 page/PartitionedSecurityOrigin.h
 page/Performance.cpp

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -154,7 +154,6 @@ void NavigateEvent::processScrollBehavior(Document& document)
 
     if (m_navigationType == NavigationNavigationType::Traverse) {
         document.frame()->loader().history().restoreScrollPositionAndViewState();
-
         return;
     }
 
@@ -162,8 +161,7 @@ void NavigateEvent::processScrollBehavior(Document& document)
         if (m_navigationType == NavigationNavigationType::Reload)
             document.frame()->loader().history().restoreScrollPositionAndViewState();
         else
-            protect(document)->frame()->view()->setScrollPosition({ 0, 0 });
-
+            protect(protect(document)->frame()->view())->setScrollPosition({ 0, 0 });
         return;
     }
 
@@ -172,14 +170,13 @@ void NavigateEvent::processScrollBehavior(Document& document)
     if (!document.findAnchor(document.url().fragmentIdentifier())) {
         if (m_navigationType == NavigationNavigationType::Reload)
             document.frame()->loader().history().restoreScrollPositionAndViewState();
-
         return;
     }
 
     if (!document.haveStylesheetsLoaded())
         document.setGotoAnchorNeededAfterStylesheetsLoad(true);
     else
-        protect(document)->frame()->view()->scrollToFragment(document.url());
+        protect(protect(document)->frame()->view())->scrollToFragment(document.url());
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-scroll


### PR DESCRIPTION
#### 7b7429195b075c5c4332d5a436cf605516912c23
<pre>
Use-after-free in LocalFrameView::scrollToAnchorFragment via NavigateEvent:finish
<a href="https://bugs.webkit.org/show_bug.cgi?id=313606">https://bugs.webkit.org/show_bug.cgi?id=313606</a>

Reviewed by Anne van Kesteren and Rupin Mittal.

Deployed more smart pointers to fix the bug.

Test: navigation-api/navigation-api-fragment-intercept-crash.html

* LayoutTests/navigation-api/navigation-api-fragment-intercept-crash-expected.txt: Added.
* LayoutTests/navigation-api/navigation-api-fragment-intercept-crash.html: Added.
* LayoutTests/navigation-api/resources/navigation-api-fragment-intercept-crash-inner.html: Added.

Originally-landed-as: 305413.777@safari-7624-branch (0e113df3124c). <a href="https://rdar.apple.com/180428609">rdar://180428609</a>
Canonical link: <a href="https://commits.webkit.org/316500@main">https://commits.webkit.org/316500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01ac1bd3efe44eeb853bbdea0fa3e4247b4e1199

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134119 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36172 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34471 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30494 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184425 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142891 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142769 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38576 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46705 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111462 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37811 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118456 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45222 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9100 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->