### PR TITLE
[web-animations] use-after-free in AnimationTimelinesController::suspendAnimations: m_timelines rehashes during iteration when DocumentTimeline::suspendAnimations forces layout

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-suspension-crash-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animation-suspension-crash-expected.txt
@@ -1,0 +1,2 @@
+PASS if this does not crash.
+

--- a/LayoutTests/webanimations/accelerated-animation-suspension-crash.html
+++ b/LayoutTests/webanimations/accelerated-animation-suspension-crash.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<style>
+
+#target {
+    width:100px;
+    height:100px;
+    background:red;
+}
+
+.scroller {
+    overflow:scroll;
+    width:50px;
+    height:50px;
+}
+
+.scroller > div {
+    height:400px;
+}
+
+</style>
+
+<div id="target">PASS if this does not crash.</div>
+
+<script>
+
+(async function() {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    // (A) Seed m_timelines with extra entries so DocumentTimeline is not the last-iterated bucket.
+    let extraTimelines = [];
+    for (let i = 0; i < 32; i++) {
+      const source = document.createElement('div');
+      source.className='scroller';
+      source.appendChild(document.createElement('div'));
+      document.body.appendChild(source);
+      extraTimelines.push(new ScrollTimeline({ source }));   // each calls addTimeline()
+    }
+
+    // (B) Elements whose scroll-timeline-name will be dirtied later.
+    let pending = [];
+    for (let i = 0; i < 200; i++) {
+        const scroller = document.createElement('div');
+        scroller.className = 'scroller';
+        scroller.appendChild(document.createElement('div'));
+        document.body.appendChild(scroller);
+        pending.push(scroller);
+    }
+
+    // (C) Accelerated, width-dependent transform animation (translateX(%)).
+    let animation = target.animate(
+        { transform: 'translateX(50%)' },
+        1e6
+    );
+
+    // Wait two frames so the animation ticks, gets AcceleratedAction::Play, and runs accelerated.
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+
+    // (D) Re-arm m_needsForcedLayout.
+    animation.effect.setKeyframes({ transform: 'translateX(100%)' });
+    getComputedStyle(target).transform;      // flush style only
+    target.offsetWidth;                      // ensure renderer/layout up-to-date
+
+    // (E) Dirty style with new scroll-timeline-name on many elements WITHOUT flushing.
+    for (let i = 0; i < pending.length; i++)
+        pending[i].style.scrollTimelineName = '--st' + i;
+
+    // (F) Trigger AnimationTimelinesController::suspendAnimations() — the live m_timelines
+    //     iteration will reach DocumentTimeline, force layout via applyPendingAcceleratedAnimations(),
+    //     which calls addTimeline() for each dirtied element, rehashing the backing buffer mid-iteration.
+    window.internals?.suspendAnimations();
+    window.testRunner?.notifyDone();
+})();
+
+</script>

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -294,7 +294,7 @@ void AnimationTimelinesController::suspendAnimations()
 
     m_cachedCurrentTimeClearanceTimer.stop();
 
-    for (Ref timeline : m_timelines)
+    for (auto& timeline : copyToVectorOf<Ref<AnimationTimeline>>(m_timelines))
         timeline->suspendAnimations();
 
     m_isSuspended = true;


### PR DESCRIPTION
#### 5c9eba910d588525ef83eca05fb5ad76218d6d4c
<pre>
[web-animations] use-after-free in AnimationTimelinesController::suspendAnimations: m_timelines rehashes during iteration when DocumentTimeline::suspendAnimations forces layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=313961">https://bugs.webkit.org/show_bug.cgi?id=313961</a>
<a href="https://rdar.apple.com/175759878">rdar://175759878</a>

Reviewed by Simon Fraser.

Calling `AnimationTimelinesController::suspendAnimations()` ends up calling
`DocumentTimeline::applyPendingAcceleratedAnimations()` which may trigger
a style recalculation for the targets of accelerated animations.

Such style recalculations may update the animation-to-timeline relationships
due to the `scroll-timeline` and `view-timeline` set of properties. This, in
turn, will cause `AnimationTimelinesController::suspendAnimations()` to have
the list of timelines it iterates over mutate. As such we now make a copy of
that list prior to iteration.

The new test was generated with AI assistance and adapted.

Test: webanimations/accelerated-animation-suspension-crash.html

* LayoutTests/webanimations/accelerated-animation-suspension-crash-expected.txt: Added.
* LayoutTests/webanimations/accelerated-animation-suspension-crash.html: Added.
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::suspendAnimations):

Originally-landed-as: 305413.836@safari-7624-branch (f0d08798b749). <a href="https://rdar.apple.com/180429306">rdar://180429306</a>
Canonical link: <a href="https://commits.webkit.org/316031@main">https://commits.webkit.org/316031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11ed3446bac3df64479b78eb003f15a2543bfe38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132313 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93222 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112816 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34278 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32451 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27830 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144772 "Found 1 new API test failure: TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181732 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140761 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152180 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140595 "Found 1 new API test failure: WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38111 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44041 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108327 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35859 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115806 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42552 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->