### PR TITLE
Write a common CSS file for WebVTT rendering WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-expected.html
@@ -1,27 +1,9 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, basic</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<div class="video">
+    <div class="cue">
+        <span class="cue-background">This is a test subtitle</span>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-ref.html
@@ -1,27 +1,9 @@
 <!DOCTYPE html>
 <title>Reference for WebVTT rendering, basic</title>
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-.video {
-    display: inline-block;
-    width: 320px;
-    height: 180px;
-    position: relative;
-    font-size: 9px;
-}
-.cue {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    text-align: center;
-    font-family: Ahem, sans-serif;
-    color: green;
-}
-.cue > span {
-    background: rgba(0,0,0,0.8);
-}
-</style>
-<div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<div class="video">
+    <div class="cue">
+        <span class="cue-background">This is a test subtitle</span>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html
@@ -2,17 +2,10 @@
 <html class="reftest-wait">
 <title>WebVTT rendering, basic</title>
 <link rel="match" href="basic-ref.html">
-<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
-<style>
-html { overflow:hidden }
-body { margin:0 }
-::cue {
-    font-family: Ahem, sans-serif;
-    color: green
-}
-</style>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay>
+<video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
     <track src="support/test.vtt">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-ref.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-ref.css
@@ -1,0 +1,75 @@
+html { overflow: hidden }
+body { margin: 0 }
+.video {
+    display: inline-block;
+    width: 320px;
+    height: 180px;
+    position: relative;
+    outline: 1px solid black;
+}
+
+/* The following CSS comes from 7.4. Applying CSS properties to WebVTT Node Objects. */
+
+.cue {
+    position: absolute;
+    unicode-bidi: plaintext;
+    writing-mode: horizontal-tb;
+    overflow-wrap: break-word;
+    text-wrap: balance;
+    text-align: center;
+    color: green;
+    white-space: pre-line;
+    opacity: 1;
+    visibility: visibile;
+    text-decoration: none;
+    text-shadow: none;
+    outline: none;
+    font: 9px Ahem, sans-serif; /* Use Ahem because it improves test reliability. */
+    bottom: 0;
+    left: 0;
+    right: 0;
+}
+.cue-background {
+    background: rgba(0,0,0,0.8);
+}
+
+.i {
+    font-style: italic;
+}
+
+.b {
+    font-weight: bold;
+}
+
+.u {
+    text-decoration: underline;
+}
+
+.ruby {
+    display: ruby;
+}
+
+.rubyText {
+    display: ruby-text;
+}
+
+.region {
+    position: absolute;
+    writing-mode: horizontal-tb;
+    background: rgba(0,0,0,0.8);
+    overflow-wrap: break-word;
+    font: 9px Ahem, sans-serif;
+    color: green;
+    overflow: hidden;
+    min-height: 0px;
+    display: inline-flex;
+    flex-flow: column;
+    justify-content: flex-end;
+}
+
+.region-child {
+    position: relative;
+    unicode-bidi: plaintext;
+    width: auto;
+    text-align: center;
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-test.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-test.css
@@ -1,0 +1,24 @@
+html { overflow: hidden }
+body { margin: 0 }
+video {
+    display: inline-block;
+    width: 320px;
+    height: 180px;
+    position: relative;
+    outline: 1px solid black;
+}
+
+/* Reset all css properties that can possibly be set on ::cue (8.2.1. The ::cue pseudo-element) to override any system styles. */
+::cue {
+    color: green;
+    opacity: 1;
+    visibility: visibile;
+    text-decoration: none;
+    text-shadow: none;
+    background: rgba(0,0,0,0.8);
+    outline: none;
+    font: 9px Ahem, sans-serif; /* Use Ahem because it improves test reliability. */
+    white-space: pre-line;
+    text-combine-upright: none;
+    ruby-position: alternate;
+}


### PR DESCRIPTION
#### 76ed4311400702157e21515a9ceae93f59ce4eee
<pre>
Write a common CSS file for WebVTT rendering WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=317674">https://bugs.webkit.org/show_bug.cgi?id=317674</a>
<a href="https://rdar.apple.com/180431157">rdar://180431157</a>

Reviewed by Eric Carlson.

This patch creates webvtt-ref.css and webvtt-test.css, which contain the css in common among
webvtt rendering tests. For now, only utilize it in basic.html. Adoption in more complex
tests will come in future patches.

* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-ref.css: Added.
(html):
(body):
(.video):
(.cue):
(.cue-background):
(.i):
(.b):
(.u):
(.ruby):
(.rubyText):
(.region):
(.region-child):
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-test.css: Added.
(html):
(body):
(video):
(::cue):

Canonical link: <a href="https://commits.webkit.org/315714@main">https://commits.webkit.org/315714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/604a43793a9948180a5bd48bb9a5ffed68d6b8e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179214 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cffe0ced-abfd-4352-9042-affb5f3f8d25) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/44843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43407 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a0ec586-eef9-43c6-aaf1-cfac3e6462ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172814 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/44843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112881 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22fc57c6-67cc-42d0-a7eb-d0d5ec0d8113) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/44843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27912 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/44843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181813 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140660 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44122 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108417 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25881 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35929 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42633 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42025 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42280 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->