### PR TITLE
[CoreIPC] RemoteVideoFrameObjectHeap::convertFrameBuffer uninitialized GPUP heap disclosure via SharedVideoFrameInfo bytesPerRow

### DIFF
--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -174,6 +174,8 @@ static std::span<const uint8_t> copyToCVPixelBufferPlane(CVPixelBufferRef pixelB
     uint32_t bytesPerRowDestination = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
     for (unsigned i = 0; i < height; ++i) {
         memcpySpan(destination, source.first(std::min(bytesPerRowSource, bytesPerRowDestination)));
+        if (bytesPerRowSource < bytesPerRowDestination)
+            memsetSpan(destination.subspan(bytesPerRowSource, bytesPerRowDestination - bytesPerRowSource), 0);
         skip(source, bytesPerRowSource);
         skip(destination, bytesPerRowDestination);
     }

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -177,6 +177,8 @@ static std::span<const uint8_t> copyToCVPixelBufferPlane(CVPixelBufferRef pixelB
         skip(source, bytesPerRowSource);
         skip(destination, bytesPerRowDestination);
     }
+    memsetSpan(destination, 0);
+
     return source;
 }
 


### PR DESCRIPTION
#### 7c03dc511c70a90534618e5592a4bc07d91f70a3
<pre>
[CoreIPC] RemoteVideoFrameObjectHeap::convertFrameBuffer uninitialized GPUP heap disclosure via SharedVideoFrameInfo bytesPerRow
<a href="https://rdar.apple.com/174529502">rdar://174529502</a>

Reviewed by Jean-Yves Avenard.

If crafting an IPC message containing a SharedVideoFrameInfo with bytesPerRow=0, a WebProcess can learn about uninitialized memory.
To prevent this, we memset the allocated CVPixelBuffer data to 0.

* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::copyToCVPixelBufferPlane):

Originally-landed-as: 305413.837@safari-7624-branch (b61fc5f3853e). <a href="https://rdar.apple.com/180427261">rdar://180427261</a>
Canonical link: <a href="https://commits.webkit.org/316033@main">https://commits.webkit.org/316033@main</a>
</pre>
----------------------------------------------------------------------
#### 5d977a0a03600c676749065916a89af91ec2d687
<pre>
[CoreIPC] RemoteVideoFrameObjectHeap::convertFrameBuffer uninitialized GPUP heap disclosure via SharedVideoFrameInfo bytesPerRow
<a href="https://rdar.apple.com/174529502">rdar://174529502</a>

Reviewed by Jean-Yves Avenard.

If crafting an IPC message containing a SharedVideoFrameInfo with bytesPerRow=0, a WebProcess can learn about uninitialized memory.
To prevent this, we memset the allocated CVPixelBuffer data to 0.

* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::copyToCVPixelBufferPlane):

Originally-landed-as: 305413.766@safari-7624-branch (4d49c876befa). <a href="https://rdar.apple.com/180427261">rdar://180427261</a>
Canonical link: <a href="https://commits.webkit.org/316032@main">https://commits.webkit.org/316032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/856a4bbac401d0341026083bddcc0d7a8d65ed19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132317 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93225 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34272 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32457 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27836 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181738 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140767 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43358 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140599 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38112 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44047 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108334 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35862 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115812 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42558 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->