### PR TITLE
[IndexedDB] IDBKeyData validation on CoreIPC should reject invalid key types

### DIFF
--- a/LayoutTests/ipc/networkstoragemanager-putoradd-nullptr-key-expected.txt
+++ b/LayoutTests/ipc/networkstoragemanager-putoradd-nullptr-key-expected.txt
@@ -1,0 +1,2 @@
+This test passes if the Network process does not crash when receiving a PutOrAdd message with an IDBKeyData using the std::nullptr_t variant (the empty sentinel of IDBKeyDataHashTraits).
+PASS

--- a/LayoutTests/ipc/networkstoragemanager-putoradd-nullptr-key.html
+++ b/LayoutTests/ipc/networkstoragemanager-putoradd-nullptr-key.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html>
+<body>This test passes if the Network process does not crash when receiving a PutOrAdd message with an IDBKeyData using the std::nullptr_t variant (the empty sentinel of IDBKeyDataHashTraits).
+<div id="result">FAIL</div>
+<script>
+async function runTest()
+{
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    if (!window.IPC) {
+        document.getElementById('result').textContent = 'PASS';
+        testRunner?.notifyDone();
+        return;
+    }
+
+    const { CoreIPC, IPCWireTap } = await import('./coreipc.js');
+
+    const tap = new IPCWireTap('Networking', 'Outgoing');
+    const captured = new Promise(resolve => {
+        tap.tapNext(IPC.messages.NetworkStorageManager_PutOrAdd.name, (...args) => resolve(args));
+    });
+
+    const db = await new Promise((resolve, reject) => {
+        const req = indexedDB.open('putoradd_nullptr_key_test', 1);
+        req.onupgradeneeded = e => e.target.result.createObjectStore('store');
+        req.onsuccess = e => resolve(e.target.result);
+        req.onerror = () => reject(req.error);
+    });
+
+    const tx = db.transaction('store', 'readwrite');
+    const store = tx.objectStore('store');
+    store.put('value', 1.0);
+    // Keep the transaction alive past the await below by holding an in-flight
+    // cursor request that we never advance.
+    store.openCursor();
+
+    const [, connectionID, , , msgArguments] = await captured;
+
+    // The wiretap parser unwraps Markable<T> down to its raw value, but the
+    // serializer expects { optionalValue: <raw> } for non-empty Markables, so
+    // we rebuild requestData with Markables explicitly wrapped.
+    const cap = msgArguments.requestData;
+    const requestData = {
+        m_serverConnectionIdentifier: cap.m_serverConnectionIdentifier,
+        m_requestIdentifier: {
+            m_idbConnectionIdentifier: { optionalValue: cap.m_requestIdentifier.m_idbConnectionIdentifier },
+            m_resourceNumber: { optionalValue: cap.m_requestIdentifier.m_resourceNumber },
+        },
+        m_transactionIdentifier: {
+            m_idbConnectionIdentifier: { optionalValue: cap.m_transactionIdentifier.m_idbConnectionIdentifier },
+            m_resourceNumber: { optionalValue: cap.m_transactionIdentifier.m_resourceNumber },
+        },
+        m_cursorIdentifier: {},
+        m_objectStoreIdentifier: { optionalValue: cap.m_objectStoreIdentifier },
+        m_indexIdentifier: {},
+        m_indexRecordType: cap.m_indexRecordType,
+        m_requestedVersion: cap.m_requestedVersion,
+        m_requestType: cap.m_requestType,
+    };
+
+    // Without the validator fix, this PutOrAdd passes IPC decoding and
+    // reaches MemoryObjectStore::addRecord, which inserts the key into a
+    // HashMap whose empty sentinel is exactly std::nullptr_t — crashing the
+    // Network process via key validation.
+    CoreIPC.Networking.NetworkStorageManager.PutOrAdd(connectionID, {
+        requestData,
+        key: {
+            isPlaceholder: false,
+            value: { variantType: 'std::nullptr_t', variant: null },
+        },
+        value: {
+            data: { m_impl: {} },
+            blobURLs: [],
+            blobFilePaths: [],
+            fileSystemHandleGlobalIdentifiers: [],
+        },
+        indexKeys: { alias: [] },
+        overwriteMode: 0, // Overwrite
+    });
+
+    // Wait briefly so the Network process has a chance to crash, then make a
+    // round-trip request to confirm it is still responsive.
+    await new Promise(r => setTimeout(r, 200));
+
+    const verifyDB = await new Promise((resolve, reject) => {
+        const req = indexedDB.open('putoradd_nullptr_key_test_2', 1);
+        req.onsuccess = e => resolve(e.target.result);
+        req.onerror = () => reject(req.error);
+    });
+
+    document.getElementById('result').textContent = 'PASS';
+    verifyDB.close();
+    db.close();
+    indexedDB.deleteDatabase('putoradd_nullptr_key_test');
+    indexedDB.deleteDatabase('putoradd_nullptr_key_test_2');
+    testRunner?.notifyDone();
+}
+runTest().catch(e => {
+    document.getElementById('result').textContent = 'FAIL: ' + e;
+    testRunner?.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.h
@@ -97,7 +97,7 @@ public:
     WEBCORE_EXPORT String loggingString() const;
 
     bool isNull() const { return std::holds_alternative<std::nullptr_t>(m_value); }
-    bool isValid() const;
+    WEBCORE_EXPORT bool isValid() const;
     WEBCORE_EXPORT static bool isValidValue(const ValueVariant&);
     WEBCORE_EXPORT IndexedDB::KeyType type() const;
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2193,6 +2193,13 @@ void NetworkStorageManager::renameIndex(IPC::Connection& connection, const WebCo
 void NetworkStorageManager::putOrAdd(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBKeyData& keyData, const WebCore::IDBValue& value, const WebCore::IndexIDToIndexKeyMap& indexKeys, WebCore::IndexedDB::ObjectStoreOverwriteMode overwriteMode)
 {
     assertIsCurrent(workQueue());
+    // keyData is used as a key in IDBKeyData-keyed containers (e.g. the
+    // MemoryObjectStore key/value HashMap). A null or Invalid variant would
+    // collide with IDBKeyDataHashTraits's empty-value sentinel. Placeholders
+    // are the legitimate exception: IDBTransaction::putOrAdd sends a
+    // placeholder (nullptr_t + isPlaceholder=true) for auto-generated keys,
+    // which are replaced server-side before the key reaches the HashMap.
+    MESSAGE_CHECK(keyData.isPlaceholder() || keyData.isValid(), connection);
     RefPtr transaction = idbTransaction(requestData, connection);
     if (!transaction)
         return;


### PR DESCRIPTION
#### 937bbd7aea09c489b1aa36657ed464bc8bcfb64f
<pre>
[IndexedDB] IDBKeyData validation on CoreIPC should reject invalid key types
<a href="https://bugs.webkit.org/show_bug.cgi?id=314538">https://bugs.webkit.org/show_bug.cgi?id=314538</a>
<a href="https://rdar.apple.com/174499511">rdar://174499511</a>

Reviewed by Sihui Liu.

IDBKeyData implements CustomHashTraits, and IDBKeyDataHashTraits uses the
std::nullptr_t variant (IDBKeyData::isNull()) as the HashMap empty value.
A compromised WebContent process can send PutOrAdd with an IDBKeyData
whose variant is std::nullptr_t; the message passes IPC decoding and
reaches MemoryObjectStore::addRecord, which inserts the key into
m_keyValueStore — a HashMap whose empty sentinel is exactly that value —
crashing the Network process via the HashMap key validation RELEASE_ASSERT.
The IDBKeyData::Invalid variant is similarly unusable as a HashMap key.

Add a MESSAGE_CHECK at the putOrAdd handler that keyData is either a
placeholder or a valid key. IDBTransaction::putOrAdd sends a placeholder
(nullptr_t + isPlaceholder=true) for auto-generated keys, which is
replaced with the generated key on the server side before any HashMap
insertion, so placeholders are exempt. The check cannot be hoisted into
the IDBKeyData IPC validator because std::nullptr_t and Invalid variants
have legitimate non-placeholder IPC uses (e.g. IDBCursor::advance sends
a null IDBKeyData as the &quot;no search key&quot; sentinel; Invalid IDBKeyData
can come from detached-ArrayBuffer index keys in multi-entry indexes).

Test: ipc/networkstoragemanager-putoradd-nullptr-key.html

* LayoutTests/ipc/networkstoragemanager-putoradd-nullptr-key-expected.txt: Added.
* LayoutTests/ipc/networkstoragemanager-putoradd-nullptr-key.html: Added.
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::putOrAdd):

Originally-landed-as: 305413.887@safari-7624-branch (7cf0b2823ce9). <a href="https://rdar.apple.com/180428546">rdar://180428546</a>
Canonical link: <a href="https://commits.webkit.org/316061@main">https://commits.webkit.org/316061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6944b33b5ce6483b84ab75eba0d39a0ef64a61b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133216 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173750 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113707 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35051 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33368 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28850 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182756 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141673 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38138 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45062 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109761 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36753 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116953 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43573 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8139 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->