### PR TITLE
The Network process should not create form data sandbox extensions

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -103,6 +103,7 @@
 #include <wtf/ProcessPrivilege.h>
 #include <wtf/RunLoop.h>
 #include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/SafeStrerror.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/UniqueRef.h>
@@ -121,6 +122,7 @@
 #include "CookieStorageUtilsCF.h"
 #include "LaunchServicesDatabaseObserver.h"
 #include "NetworkSessionCocoa.h"
+#include "PathsBlockedForSandboxExtensions.h"
 #include <wtf/cocoa/AuditToken.h>
 #include <wtf/cocoa/Entitlements.h>
 #include <wtf/spi/darwin/SandboxSPI.h>
@@ -533,6 +535,90 @@ auto NetworkProcess::allowsFirstPartyForCookies(WebCore::ProcessIdentifier proce
     return result ? AllowCookieAccess::Allow : terminateOrDisallow;
 }
 
+#if PLATFORM(COCOA)
+#if PLATFORM(MAC)
+static String getDarwinCacheDir()
+{
+    char temp[PATH_MAX];
+    size_t length = confstr(_CS_DARWIN_USER_CACHE_DIR, temp, sizeof(temp));
+    if (!length) {
+        RELEASE_LOG_ERROR(Sandbox, "Could not retrieve cache directory path: %s\n", safeStrerror(errno).data());
+        return { };
+    }
+    RELEASE_ASSERT(length <= sizeof(temp));
+    char resolvedPath[PATH_MAX];
+    if (!realpath(temp, resolvedPath)) {
+        RELEASE_LOG_ERROR(Sandbox, "Could not canonicalize cache directory path: %s\n", safeStrerror(errno).data());
+        return { };
+    }
+    return String::fromUTF8(resolvedPath);
+}
+#endif // PLATFORM(MAC)
+
+static String getDarwinTempDir()
+{
+    char temp[PATH_MAX];
+    size_t length = confstr(_CS_DARWIN_USER_TEMP_DIR, temp, sizeof(temp));
+    if (!length) {
+        RELEASE_LOG_ERROR(Sandbox, "Could not retrieve temporary directory path: %s\n", safeStrerror(errno).data());
+        return { };
+    }
+    RELEASE_ASSERT(length <= sizeof(temp));
+    char resolvedPath[PATH_MAX];
+    if (!realpath(temp, resolvedPath)) {
+        RELEASE_LOG_ERROR(Sandbox, "Could not canonicalize temporary directory path: %s\n", safeStrerror(errno).data());
+        return { };
+    }
+    return String::fromUTF8(resolvedPath);
+}
+
+static void addPathsBlockedForSandboxExtensions(const WebsiteDataStoreParameters& parameters)
+{
+    String cacheDirectory = FileSystem::parentPath(parameters.networkSessionParameters.networkCacheDirectory);
+    String websiteDataDirectory = FileSystem::parentPath(parameters.networkSessionParameters.indexedDBDirectory);
+#if PLATFORM(MAC)
+    String homeDirectory = AuxiliaryProcess::getHomeDirectory();
+    String homeRelativeHTTPStoragesDirectory = makeString(homeDirectory, "/Library/HTTPStorages"_s);
+    String homeRelativeKeychainDirectory = makeString(homeDirectory, "/Library/Keychains"_s);
+#else
+    String homeDirectory = "/var/mobile"_s;
+    String containerCachesDirectory = parameters.containerCachesDirectory;
+#endif
+    String homeRelativePreferencesDirectory = makeString(homeDirectory, "/Library/Preferences"_s);
+
+    Vector<String> subPathsBlocked = {
+        "/Library/Keychains"_s,
+        "/Library/Preferences"_s,
+        "/private/var/db"_s,
+        cacheDirectory,
+#if PLATFORM(MAC)
+        getDarwinTempDir(),
+        getDarwinCacheDir(),
+        homeRelativeHTTPStoragesDirectory,
+        homeRelativeKeychainDirectory,
+#else
+        "/private/var/Managed Preferences"_s,
+        "/private/var/MobileAsset"_s,
+        "/private/var/preferences"_s,
+        getDarwinTempDir(),
+        containerCachesDirectory,
+#endif
+        homeRelativePreferencesDirectory,
+        parameters.cookieStoragePath,
+        websiteDataDirectory
+    };
+    addSubPathsBlockedForSandboxExtension(WTF::move(subPathsBlocked));
+
+    Vector<String> pathsBlocked = {
+#if PLATFORM(MAC)
+        "/private/etc/services"_s,
+        "/private/etc/hosts"_s,
+#endif
+    };
+    addPathsBlockedForSandboxExtension(WTF::move(pathsBlocked));
+}
+#endif // PLATFORM(COCOA)
+
 void NetworkProcess::addStorageSession(PAL::SessionID sessionID, const WebsiteDataStoreParameters& parameters)
 {
     auto addResult = m_networkStorageSessions.add(sessionID, nullptr);
@@ -565,6 +651,8 @@ void NetworkProcess::addStorageSession(PAL::SessionID sessionID, const WebsiteDa
         if (!uiProcessCookieStorage && storageSession)
             uiProcessCookieStorage = adoptCF(_CFURLStorageSessionCopyCookieStorage(kCFAllocatorDefault, storageSession.get()));
     }
+
+    addPathsBlockedForSandboxExtensions(parameters);
 
     addResult.iterator->value = makeUnique<NetworkStorageSession>(sessionID, WTF::move(storageSession), WTF::move(uiProcessCookieStorage));
 #elif USE(CURL)

--- a/Source/WebKit/Platform/IPC/FormDataReference.h
+++ b/Source/WebKit/Platform/IPC/FormDataReference.h
@@ -27,8 +27,13 @@
 
 #include "Decoder.h"
 #include "Encoder.h"
+#include "Logging.h"
 #include "SandboxExtension.h"
 #include <WebCore/FormData.h>
+
+#if PLATFORM(COCOA)
+#include "PathsBlockedForSandboxExtensions.h"
+#endif
 
 namespace IPC {
 
@@ -54,7 +59,26 @@ private:
 inline FormDataReference::FormDataReference(RefPtr<WebCore::FormData>&& data, Vector<WebKit::SandboxExtensionHandle>&& sandboxExtensionHandles)
     : m_data(WTF::move(data))
 {
-    WebKit::SandboxExtension::consumePermanently(WTF::move(sandboxExtensionHandles));
+    if (!m_data)
+        return;
+
+#if PLATFORM(COCOA)
+    for (auto& element : m_data->elements()) {
+        if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
+            const String& path = fileData->filename;
+            if (WebKit::pathIsBlockedForSandboxExtensions(path)) {
+                RELEASE_LOG(Process, "Form data file path was blocked for sandbox extension: %{private}s", path.utf8().data());
+                m_data = nullptr;
+                break;
+            }
+        }
+    }
+#endif // PLATFORM(COCOA)
+
+    if (m_data && !WebKit::SandboxExtension::consumePermanently(sandboxExtensionHandles)) {
+        RELEASE_LOG_ERROR(IPC, "FormDataReference: dropping body because a file sandbox extension could not be consumed");
+        m_data = nullptr;
+    }
 }
 
 inline Vector<WebKit::SandboxExtensionHandle> FormDataReference::sandboxExtensionHandles() const
@@ -65,6 +89,12 @@ inline Vector<WebKit::SandboxExtensionHandle> FormDataReference::sandboxExtensio
     return WTF::compactMap(m_data->elements(), [](auto& element) -> std::optional<WebKit::SandboxExtensionHandle> {
         if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
             const String& path = fileData->filename;
+#if PLATFORM(COCOA)
+            if (WebKit::pathIsBlockedForSandboxExtensions(path)) {
+                RELEASE_LOG(Process, "Form data file path was blocked for sandbox extension: %{private}s", path.utf8().data());
+                return std::nullopt;
+            }
+#endif // PLATFORM(COCOA)
             if (auto handle = WebKit::SandboxExtension::createHandle(path, WebKit::SandboxExtension::Type::ReadOnly))
                 return { WTF::move(*handle) };
         }

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -116,6 +116,10 @@ public:
 #endif
     static void setNotifyOptions();
 
+#if PLATFORM(MAC)
+    static String getHomeDirectory();
+#endif
+
 protected:
     explicit AuxiliaryProcess();
     virtual ~AuxiliaryProcess();

--- a/Source/WebKit/Shared/Cocoa/PathsBlockedForSandboxExtensions.h
+++ b/Source/WebKit/Shared/Cocoa/PathsBlockedForSandboxExtensions.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+namespace WebKit {
+
+void addPathsBlockedForSandboxExtension(Vector<String>&& paths);
+void addSubPathsBlockedForSandboxExtension(Vector<String>&& paths);
+
+bool pathIsBlockedForSandboxExtensions(const String& path);
+
+}

--- a/Source/WebKit/Shared/Cocoa/PathsBlockedForSandboxExtensions.mm
+++ b/Source/WebKit/Shared/Cocoa/PathsBlockedForSandboxExtensions.mm
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "PathsBlockedForSandboxExtensions.h"
+
+#include <wtf/FileSystem.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Vector.h>
+
+namespace WebKit {
+
+static Vector<String>& pathsBlockedForSandboxExtension()
+{
+    static NeverDestroyed<Vector<String>> pathsBlocked;
+    return pathsBlocked;
+}
+
+static Vector<String>& subPathsBlockedForSandboxExtension()
+{
+    static NeverDestroyed<Vector<String>> subPathsBlocked;
+    return subPathsBlocked;
+}
+
+void addPathsBlockedForSandboxExtension(Vector<String>&& paths)
+{
+    for (auto& path : paths) {
+        String normalizedPath = FileSystem::realPath(path);
+        path = FileSystem::lexicallyNormal(normalizedPath);
+    }
+    pathsBlockedForSandboxExtension().appendVector(WTF::move(paths));
+}
+
+void addSubPathsBlockedForSandboxExtension(Vector<String>&& paths)
+{
+    for (auto& path : paths) {
+        String normalizedPath = FileSystem::realPath(path);
+        path = FileSystem::lexicallyNormal(normalizedPath);
+    }
+    subPathsBlockedForSandboxExtension().appendVector(WTF::move(paths));
+}
+
+bool pathIsBlockedForSandboxExtensions(const String& path)
+{
+    String normalizedPath = FileSystem::realPath(path);
+    normalizedPath = FileSystem::lexicallyNormal(normalizedPath);
+
+    for (auto& pathBlocked : pathsBlockedForSandboxExtension()) {
+        if (pathBlocked == normalizedPath)
+            return true;
+    }
+
+    for (auto& pathBlocked : subPathsBlockedForSandboxExtension()) {
+        if (FileSystem::isAncestor(pathBlocked, normalizedPath))
+            return true;
+    }
+
+    return false;
+}
+
+}

--- a/Source/WebKit/Shared/WebsiteDataStoreParameters.h
+++ b/Source/WebKit/Shared/WebsiteDataStoreParameters.h
@@ -36,11 +36,13 @@ namespace WebKit {
 
 struct WebsiteDataStoreParameters {
     Vector<uint8_t> uiProcessCookieStorageIdentifier;
+    String cookieStoragePath;
     SandboxExtension::Handle cookieStoragePathExtensionHandle;
     NetworkSessionCreationParameters networkSessionParameters;
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<SandboxExtension::Handle> cookieStorageDirectoryExtensionHandle;
+    String containerCachesDirectory;
     std::optional<SandboxExtension::Handle> containerCachesDirectoryExtensionHandle;
     std::optional<SandboxExtension::Handle> parentBundleDirectoryExtensionHandle;
     std::optional<SandboxExtension::Handle> tempDirectoryExtensionHandle;

--- a/Source/WebKit/Shared/WebsiteDataStoreParameters.serialization.in
+++ b/Source/WebKit/Shared/WebsiteDataStoreParameters.serialization.in
@@ -24,11 +24,13 @@ header: "WebsiteDataFetchOption.h"
 
 [RValue] struct WebKit::WebsiteDataStoreParameters {
     Vector<uint8_t> uiProcessCookieStorageIdentifier;
+    String cookieStoragePath;
     WebKit::SandboxExtensionHandle cookieStoragePathExtensionHandle;
     WebKit::NetworkSessionCreationParameters networkSessionParameters;
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<WebKit::SandboxExtensionHandle> cookieStorageDirectoryExtensionHandle;
+    String containerCachesDirectory;
     std::optional<WebKit::SandboxExtensionHandle> containerCachesDirectoryExtensionHandle;
     std::optional<WebKit::SandboxExtensionHandle> parentBundleDirectoryExtensionHandle;
     std::optional<WebKit::SandboxExtensionHandle> tempDirectoryExtensionHandle;

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -638,7 +638,7 @@ static String getUserDirectorySuffix(const AuxiliaryProcessInitializationParamet
     return makeString([[NSBundle mainBundle] bundleIdentifier], '+', clientIdentifier);
 }
 
-static String getHomeDirectory()
+String AuxiliaryProcess::getHomeDirectory()
 {
     // According to the man page for getpwuid_r, we should use sysconf(_SC_GETPW_R_SIZE_MAX) to determine the size of the buffer.
     // However, a buffer size of 4096 should be sufficient, since PATH_MAX is 1024.
@@ -683,7 +683,7 @@ static void populateSandboxInitializationParameters(SandboxInitializationParamet
     sandboxParameters.addConfDirectoryParameter("DARWIN_USER_TEMP_DIR"_s, _CS_DARWIN_USER_TEMP_DIR);
     sandboxParameters.addConfDirectoryParameter("DARWIN_USER_CACHE_DIR"_s, _CS_DARWIN_USER_CACHE_DIR);
 
-    auto homeDirectory = getHomeDirectory();
+    auto homeDirectory = AuxiliaryProcess::getHomeDirectory();
     
     sandboxParameters.addPathParameter("HOME_DIR"_s, homeDirectory.utf8().data());
     String path = FileSystem::pathByAppendingComponents(homeDirectory, std::initializer_list<StringView>({ "Library"_s, "Preferences"_s }));

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -142,6 +142,19 @@ WebCore::ThirdPartyCookieBlockingMode WebsiteDataStore::thirdPartyCookieBlocking
     return *m_thirdPartyCookieBlockingMode;
 }
 
+#if PLATFORM(MAC)
+static String libraryRootDirectory()
+{
+    static NeverDestroyed<RetainPtr<NSURL>> libraryDirectory = [] {
+        RetainPtr libraryDirectory = [[NSFileManager defaultManager] URLForDirectory:NSLibraryDirectory inDomain:NSUserDomainMask appropriateForURL:nullptr create:NO error:nullptr];
+        RELEASE_ASSERT(libraryDirectory);
+        return libraryDirectory;
+    }();
+
+    return libraryDirectory.get().get().absoluteURL.path;
+}
+#endif // PLATFORM(MAC)
+
 void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& parameters)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
@@ -221,6 +234,15 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.manualPrevalentResource = WTF::move(resourceLoadStatisticsManualPrevalentResource);
 
     auto cookieFile = directories.cookieStorageFile;
+#if PLATFORM(MAC)
+    if (cookieFile.isEmpty())
+        parameters.cookieStoragePath = FileSystem::parentPath(defaultCookieStorageFile(libraryRootDirectory()));
+    else
+        parameters.cookieStoragePath = FileSystem::parentPath(cookieFile);
+#else
+    parameters.cookieStoragePath = resolvedCookieStorageDirectory();
+#endif
+
     createHandleFromResolvedPathIfPossible(FileSystem::parentPath(cookieFile), parameters.cookieStoragePathExtensionHandle);
 
     if (m_uiProcessCookieStorageIdentifier.isEmpty()) {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2289,6 +2289,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
         createHandleFromResolvedPathIfPossible(resolvedCookieStorageDirectory(), cookieStorageDirectoryExtensionHandle);
         parameters.cookieStorageDirectoryExtensionHandle = WTF::move(cookieStorageDirectoryExtensionHandle);
 
+        parameters.containerCachesDirectory = resolvedContainerCachesNetworkingDirectory();
         SandboxExtension::Handle containerCachesDirectoryExtensionHandle;
         createHandleFromResolvedPathIfPossible(resolvedContainerCachesNetworkingDirectory(), containerCachesDirectoryExtensionHandle);
         parameters.containerCachesDirectoryExtensionHandle = WTF::move(containerCachesDirectoryExtensionHandle);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2506,6 +2506,7 @@
 		E3E1B33D2F85043E00B584C4 /* com.apple.WebProcess.x86.sb in Resources */ = {isa = PBXBuildFile; fileRef = E3E1B33C2F85021400B584C4 /* com.apple.WebProcess.x86.sb */; };
 		E3E6297E2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = E3E6297C2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.h */; };
 		E3E6297F2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E6297D2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.cpp */; };
+		E3E844882F9BAC4E00ABD79C /* PathsBlockedForSandboxExtensions.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3E844872F9BAC4E00ABD79C /* PathsBlockedForSandboxExtensions.mm */; };
 		E3E84BDA2AE0AAE50091B3C2 /* XPCEndpoint.h in Copy Testing Headers */ = {isa = PBXBuildFile; fileRef = C14D306724B794E700480387 /* XPCEndpoint.h */; };
 		E3E84BDB2AE0AAE50091B3C2 /* XPCEndpointClient.h in Copy Testing Headers */ = {isa = PBXBuildFile; fileRef = C14D306824B794E700480387 /* XPCEndpointClient.h */; };
 		E3E84BEE2AE1AA5A0091B3C2 /* ExtensionKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E3E84BED2AE1AA5A0091B3C2 /* ExtensionKitSPI.h */; };
@@ -8773,6 +8774,8 @@
 		E3E1B3412F85274B00B584C4 /* xpc-self.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "xpc-self.plist"; sourceTree = "<group>"; };
 		E3E6297C2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDebuggableProxy.h; sourceTree = "<group>"; };
 		E3E6297D2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDebuggableProxy.cpp; sourceTree = "<group>"; };
+		E3E844862F9B1D5100ABD79C /* PathsBlockedForSandboxExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PathsBlockedForSandboxExtensions.h; sourceTree = "<group>"; };
+		E3E844872F9BAC4E00ABD79C /* PathsBlockedForSandboxExtensions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PathsBlockedForSandboxExtensions.mm; sourceTree = "<group>"; };
 		E3E84BED2AE1AA5A0091B3C2 /* ExtensionKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtensionKitSPI.h; sourceTree = "<group>"; };
 		E3EA8E7C2F3F61EA006CC6B3 /* SiteIsolatedActivity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SiteIsolatedActivity.h; sourceTree = "<group>"; };
 		E3EA8E7D2F3F72BD006CC6B3 /* SiteIsolatedActivity.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SiteIsolatedActivity.cpp; sourceTree = "<group>"; };
@@ -13416,6 +13419,8 @@
 				489B47702FED6E0100884EE7 /* LibAccessibilitySoftLink.h */,
 				489B47712FED6E0100884EE7 /* LibAccessibilitySoftLink.mm */,
 				2D1087621D2C641B00B85F82 /* LoadParametersCocoa.mm */,
+				E3E844862F9B1D5100ABD79C /* PathsBlockedForSandboxExtensions.h */,
+				E3E844872F9BAC4E00ABD79C /* PathsBlockedForSandboxExtensions.mm */,
 				2D440B8325EF235E00A98D87 /* PDFKitSoftLink.h */,
 				2D440B8225EF235E00A98D87 /* PDFKitSoftLink.mm */,
 				442E7BEA27B4581300C69AC1 /* RevealItem.h */,
@@ -22164,6 +22169,7 @@
 				41E242E026E0C908009A8C64 /* NetworkRTCUtilitiesCocoa.mm in Sources */,
 				FA5AAE9C2E6A217A00FE693D /* NetworkSoftLink.mm in Sources */,
 				DD4BDE7B2CA38213001A3339 /* ObjectiveCBlockConversions.swift in Sources */,
+				E3E844882F9BAC4E00ABD79C /* PathsBlockedForSandboxExtensions.mm in Sources */,
 				1CB9138F2E8C6D500002BCB7 /* PlatformUnifiedSource1-ARC.mm in Sources */,
 				1CB913932E8C71920002BCB7 /* PlatformUnifiedSource2-ARC.mm in Sources */,
 				A1B849382F3D9F02004256A1 /* PlaybackSessionInterfaceAVKit.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UploadDirectory.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UploadDirectory.mm
@@ -72,7 +72,7 @@ TEST(WebKit, UploadDirectory)
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSError *error = nil;
-    NSURL *directory = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"UploadDirectory"] isDirectory:YES];
+    NSURL *directory = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"/UploadDirectory"] isDirectory:YES];
     [fileManager removeItemAtPath:directory.path error:nil];
     EXPECT_TRUE([fileManager createDirectoryAtURL:directory withIntermediateDirectories:YES attributes:nil error:&error]);
     EXPECT_FALSE(error);
@@ -94,6 +94,60 @@ TEST(WebKit, UploadDirectory)
                         size_t headerEnd = find(request.span(), "\r\n\r\n"_span);
                         EXPECT_TRUE(headerEnd != notFound);
                         EXPECT_EQ(request.size() - (headerEnd + strlen("\r\n\r\n")), 543u);
+                        constexpr auto secondResponse =
+                        "HTTP/1.1 200 OK\r\n"
+                        "Content-Length: 0\r\n\r\n"_s;
+                        connection.send(secondResponse);
+                    });
+                });
+            });
+        });
+
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+        RetainPtr delegate = adoptNS([[UploadDelegate alloc] initWithDirectory:directory]);
+        [webView setUIDelegate:delegate.get()];
+
+        [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
+
+        auto chooseFileButtonLocation = NSMakePoint(10, 590);
+        [webView sendClickAtPoint:chooseFileButtonLocation];
+        while (![delegate sentDirectory])
+            TestWebKitAPI::Util::spinRunLoop();
+        Util::runFor(50_ms);
+        [webView evaluateJavaScript:@"document.getElementById('form').submit()" completionHandler:nil];
+        [webView _test_waitForDidFinishNavigation];
+    }
+
+    EXPECT_TRUE([fileManager removeItemAtPath:directory.path error:&error]);
+    EXPECT_FALSE(error);
+}
+
+TEST(WebKit, BlockedUploadDirectory)
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *error = nil;
+    NSURL *directory = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"/com.apple.WebKit.Networking+com.apple.WebKit.TestWebKitAPI/UploadDirectory"] isDirectory:YES];
+    [fileManager removeItemAtPath:directory.path error:nil];
+    EXPECT_TRUE([fileManager createDirectoryAtURL:directory withIntermediateDirectories:YES attributes:nil error:&error]);
+    EXPECT_FALSE(error);
+    NSData *testData = [@"testdata" dataUsingEncoding:NSUTF8StringEncoding];
+    EXPECT_TRUE([fileManager createFileAtPath:[directory.path stringByAppendingPathComponent:@"testfile"] contents:testData attributes:nil]);
+
+    {
+        using namespace TestWebKitAPI;
+        HTTPServer server([] (Connection connection) {
+            connection.receiveHTTPRequest([=](Vector<char>&&) {
+                constexpr auto response =
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: text/html\r\n"
+                "Content-Length: 123\r\n\r\n"
+                "<form id='form' action='/upload.php' method='post' enctype='multipart/form-data'><input type='file' name='testname'></form>"_s;
+                connection.send(response, [=] {
+                    connection.receiveHTTPRequest([=](Vector<char>&& request) {
+                        EXPECT_FALSE(contains(request.span(), "Content-Length: 543\r\n"_span));
+                        size_t headerEnd = find(request.span(), "\r\n\r\n"_span);
+                        EXPECT_TRUE(headerEnd != notFound);
+                        EXPECT_EQ(request.size() - (headerEnd + strlen("\r\n\r\n")), 0u);
                         constexpr auto secondResponse =
                         "HTTP/1.1 200 OK\r\n"
                         "Content-Length: 0\r\n\r\n"_s;


### PR DESCRIPTION
#### 022bc68dc5f93a364c8a30b093664e6fb16ae565
<pre>
The Network process should not create form data sandbox extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=312846">https://bugs.webkit.org/show_bug.cgi?id=312846</a>
<a href="https://rdar.apple.com/174670487">rdar://174670487</a>

Reviewed by Brent Fulgham.

The Network process should not create form data sandbox extensions for a set
of locations that it has read access to in the sandbox. This patch defines
that set, and prevents sandbox extensions from being created and consumed
when these unexpected locations are being used in form data.

Test: WebKit.BlockedUploadDirectory

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::getDarwinCacheDir):
(WebKit::getDarwinTempDir):
(WebKit::addPathsBlockedForSandboxExtensions):
(WebKit::NetworkProcess::addStorageSession):
* Source/WebKit/Platform/IPC/FormDataReference.h:
(IPC::FormDataReference::FormDataReference):
(IPC::FormDataReference::sandboxExtensionHandles const):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/WebsiteDataStoreParameters.h:
* Source/WebKit/Shared/WebsiteDataStoreParameters.serialization.in:
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::AuxiliaryProcess::getHomeDirectory):
(WebKit::populateSandboxInitializationParameters):
(WebKit::getHomeDirectory): Deleted.
* Source/WebKit/Shared/Cocoa/PathsBlockedForSandboxExtensions.h: Added.
* Source/WebKit/Shared/Cocoa/PathsBlockedForSandboxExtensions.mm: Added.
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::libraryRootDirectory):
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm:
(TEST(WebKit, UploadDirectory)):
(TEST(WebKit, BlockedUploadDirectory)):

Originally-landed-as: 305413.785@safari-7624-branch (f6680b7bcc5c). <a href="https://rdar.apple.com/180427740">rdar://180427740</a>
Canonical link: <a href="https://commits.webkit.org/316251@main">https://commits.webkit.org/316251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1996663c820cb0d2c8e926ba6a60d10f0388774d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180888 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133590 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35506 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29637 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183556 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142172 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45169 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142066 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45848 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110483 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26087 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37271 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44367 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8504 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->