### PR TITLE
[WebCore] heap use-after-free in SWClientConnection::updateBackgroundFetchRegistration due to live HashTable iterator invalidation during synchronous progress event dispatch

### DIFF
--- a/LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event-sw.js
+++ b/LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event-sw.js
@@ -1,0 +1,2 @@
+self.addEventListener('install', e => self.skipWaiting());
+self.addEventListener('activate', e => self.clients.claim());

--- a/LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window-expected.txt
+++ b/LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS change-documents-in-progress-event
+

--- a/LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window.html
+++ b/LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window.js
+++ b/LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window.js
@@ -1,0 +1,27 @@
+promise_test(async t => {
+    // Pre-populate allDocumentsMap so the matching Document is not the only entry.
+    let preDocs = [];
+    for (let i = 0; i < 8; i++)
+        preDocs.push(document.implementation.createHTMLDocument());
+
+    const swr = await navigator.serviceWorker.register('change-documents-in-progress-event-sw.js', { scope: './' });
+    await navigator.serviceWorker.ready;
+
+    const request = await swr.backgroundFetch.fetch('repro-' + Date.now(), ['change-documents-in-progress-event-sw.js']);
+
+    let newDocs = [];
+    let fired = false;
+
+    let resolveCallback;
+    const promise = new Promise(resolve => resolveCallback = resolve);
+    request.onprogress = () => {
+        if (fired)
+            return;
+        fired = true;
+        for (let i = 0; i < 512; i++)
+           newDocs.push(document.implementation.createHTMLDocument());
+        resolveCallback();
+    };
+
+    return promise;
+});

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
@@ -236,8 +236,9 @@ void BackgroundFetchRegistration::updateInformation(const BackgroundFetchInforma
     m_information.result = information.result;
     m_information.failureReason = information.failureReason;
     m_information.recordsAvailable = information.recordsAvailable;
-    
-    dispatchEvent(Event::create(eventNames().progressEvent, Event::CanBubble::No, Event::IsCancelable::No));
+
+    // FIXME: We should update m_information as part of the task that fires the event.
+    queueTaskToDispatchEvent(*this, TaskSource::Networking, Event::create(eventNames().progressEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 ScriptExecutionContext* BackgroundFetchRegistration::scriptExecutionContext() const


### PR DESCRIPTION
#### bbd73ca6e43642eb61c6ec6e6f1b56d7cfb189b4
<pre>
[WebCore] heap use-after-free in SWClientConnection::updateBackgroundFetchRegistration due to live HashTable iterator invalidation during synchronous progress event dispatch
<a href="https://rdar.apple.com/175673953">rdar://175673953</a>

Reviewed by Chris Dumez.

Firing an event synchronously while iterating through documents is unsafe.
Instead we queue a task to fire the events in their own task.
This way we can iterate through documents without risking to mutate documents.

Test: http/wpt/background-fetch/change-documents-in-progress-event.window.html

* LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event-sw.js: Added.
* LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window-expected.txt: Added.
* LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window.html: Added.
* LayoutTests/http/wpt/background-fetch/change-documents-in-progress-event.window.js: Added.
(promise_test.async t):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp:
(WebCore::BackgroundFetchRegistration::updateInformation):

Originally-landed-as: 305413.782@safari-7624-branch (1b0af7fe2393). <a href="https://rdar.apple.com/180427961">rdar://180427961</a>
Canonical link: <a href="https://commits.webkit.org/316035@main">https://commits.webkit.org/316035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4914132dcbff8574b2dde6ba24967d4903604eee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132329 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93236 "1 flakes 10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34280 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32467 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181751 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140779 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140610 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38114 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44060 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29109 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108352 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35875 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115825 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42571 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7202 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41963 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->