### PR TITLE
Fix NSInvalidArgumentException when running cmake MiniBrowser on sites with media

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -12,6 +12,13 @@ add_definitions(-DWEBRTC_WEBKIT_BUILD=1)
 # Suppress all warnings for third-party libwebrtc code.
 add_compile_options(-w)
 
+# Match the Xcode build (Configurations/Base.xcconfig: CLANG_ENABLE_OBJC_ARC = YES).
+# The webkit_sdk Objective-C(++) sources rely on ARC for block/object ownership —
+# e.g. RTCVideoEncoderH264 stores its callback blocks via plain ivar assignment,
+# which only retains/copies under ARC. Compiling them MRR produces immediate
+# use-after-free of the GPU-process encoder callback blocks.
+add_compile_options("$<$<COMPILE_LANGUAGE:OBJC,OBJCXX>:-fobjc-arc>")
+
 if (NOT APPLE)
     find_package(LibEvent)
     if (NOT LIBEVENT_FOUND)
@@ -2087,7 +2094,6 @@ if (APPLE)
         Source/webrtc/webkit_sdk/WebKit/WebKitEncoder.mm
         Source/webrtc/webkit_sdk/WebKit/WebKitDecoderReceiver.cpp
 
-        Source/webrtc/webkit_sdk/objc/api/peerconnection/RTCVideoEncoderSettings+Private.mm
         Source/webrtc/webkit_sdk/objc/api/video_codec/RTCVideoCodecConstants.mm
         Source/webrtc/webkit_sdk/objc/api/video_codec/RTCVideoDecoderVP8.mm
         Source/webrtc/webkit_sdk/objc/api/video_codec/RTCVideoDecoderVP9.mm
@@ -2444,6 +2450,31 @@ endif ()
 target_include_directories(webrtc ${webrtc_INCLUDE_DIRECTORIES})
 WEBKIT_ADD_PREFIX_HEADER(webrtc WebRTCPrefix.h PREFIX_LANGUAGES CXX)
 WEBKIT_ADD_PREFIX_HEADER(webrtc WebRTCObjCPrefix.h PREFIX_LANGUAGES OBJCXX)
+
+if (APPLE)
+    # ObjC categories whose object files export no external symbols. If these
+    # lived inside the static archive, ld would never load them (nothing
+    # references a symbol they define) and category methods such as
+    # -[RTCVideoCodecInfo initWithNativeSdpVideoFormat:] would be missing at
+    # runtime, breaking webrtc::createLocalEncoder. Build them as an OBJECT
+    # library so consumers (WebCore) link the objects directly.
+    add_library(webrtc_objc_categories OBJECT
+        Source/webrtc/webkit_sdk/objc/api/peerconnection/RTCEncodedImage+Private.mm
+        Source/webrtc/webkit_sdk/objc/api/peerconnection/RTCVideoCodecInfo+Private.mm
+        Source/webrtc/webkit_sdk/objc/api/peerconnection/RTCVideoEncoderSettings+Private.mm
+        Source/webrtc/webkit_sdk/objc/helpers/NSString+StdString.mm
+    )
+    target_compile_options(webrtc_objc_categories PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-std=c++2b>")
+    target_compile_definitions(webrtc_objc_categories PRIVATE
+        WEBRTC_POSIX
+        WEBRTC_ARCH_LITTLE_ENDIAN
+        WEBRTC_USE_H265=1
+        RTC_ENABLE_H265
+        RTC_ENABLE_VP9
+    )
+    target_include_directories(webrtc_objc_categories ${webrtc_INCLUDE_DIRECTORIES})
+endif ()
+
 set_source_files_properties(Source/third_party/libyuv/util/color.cc PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 set_source_files_properties(Source/webrtc/rtc_base/logging.cc PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 if (LIBPULSE_FOUND)

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -129,7 +129,7 @@ if (ACCESSIBILITYSUPPORT_LIBRARY)
 endif ()
 
 if (USE_LIBWEBRTC)
-    list(APPEND WebCore_PRIVATE_LIBRARIES webrtc opus vpx webm yuv libsrtp)
+    list(APPEND WebCore_PRIVATE_LIBRARIES webrtc opus vpx webm yuv libsrtp webrtc_objc_categories)
 else ()
     set(_webm_parser_dir "${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser")
     file(GLOB _webm_parser_srcs "${_webm_parser_dir}/src/*.cc")


### PR DESCRIPTION
#### ce73b886a6e182bd1f9acaf0dda830e41172d804
<pre>
Fix NSInvalidArgumentException when running cmake MiniBrowser on sites with media
<a href="https://bugs.webkit.org/show_bug.cgi?id=317680">https://bugs.webkit.org/show_bug.cgi?id=317680</a>
<a href="https://rdar.apple.com/180438345">rdar://180438345</a>

Reviewed by Pascoe.

When opening pages with media with cmake minibrowser on macOS, I get crashes like this:

*** Terminating app due to uncaught exception &apos;NSInvalidArgumentException&apos;, reason: &apos;-[WK_RTCVideoCodecInfo nativeSdpVideoFormat]: unrecognized selector sent to instance

This is because we weren&apos;t even compiling nativeSdpVideoFormat.  As suggested by Simon Lewis,
we put the Private.mm files in their own library so that they are actually loaded by the linker,
which otherwise continues to ignore them.

* Source/ThirdParty/libwebrtc/CMakeLists.txt:
* Source/WebCore/PlatformCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/315765@main">https://commits.webkit.org/315765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0d46bdd28ee2708946737fc48bc4e0d07415bc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127656 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6da4d27-f3c3-42bf-80eb-2589eeaa1875) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171810 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45047 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2495531-daa4-492a-ad0c-b283896c9e31) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172903 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112959 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b89b5d8c-375b-48cd-befc-dc68ad269503) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28001 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181902 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140907 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43522 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140738 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44211 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29261 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108526 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25905 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36006 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115976 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42722 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7361 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42114 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42369 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->