### PR TITLE
[web-animations] accelerated animation with view progress timeline range but no timeline yields a crash

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline.html
+++ b/LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<body>
+<div id="target">PASS if this does not crash.</div>
+<script>
+
+window.testRunner?.dumpAsText();
+
+document.getElementById("target").animate({ offset: "cover 0%", transform: "scale(2)" }, 1000);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2617,6 +2617,9 @@ bool KeyframeEffect::computeExtentOfTransformAnimation(LayoutRect& bounds) const
             continue;
 
         auto offset = keyframe.offset();
+        if (std::isnan(offset))
+            return false;
+
         if (!offset)
             computedBoundsForFromKeyframe = true;
         if (offset == 1.0)


### PR DESCRIPTION
#### 06319c3a2573192333d4816893560010cd8c75f7
<pre>
[web-animations] accelerated animation with view progress timeline range but no timeline yields a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=314086">https://bugs.webkit.org/show_bug.cgi?id=314086</a>
<a href="https://rdar.apple.com/175530372">rdar://175530372</a>

Reviewed by Ryosuke Niwa.

Ensure we only attempt to resolve animated styles for keyframes with a computed
offset in `KeyframeEffect::computeExtentOfTransformAnimation()`.

Test: webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline.html

* LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline-expected.txt: Added.
* LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeExtentOfTransformAnimation const):

Originally-landed-as: 305413.835@safari-7624-branch (347b3963d6ca). <a href="https://rdar.apple.com/180438252">rdar://180438252</a>
Canonical link: <a href="https://commits.webkit.org/316036@main">https://commits.webkit.org/316036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/055cd3eefeb023967c4f00e821e7a47b862aaece

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132335 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93242 "9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112837 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34268 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32474 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27857 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1230 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181759 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140784 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140615 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38115 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44068 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29193 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108363 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35881 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115833 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42579 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7293 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->