### PR TITLE
[css-values-5 random-item()] parse-time support for the argument grammar

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-invalid-expected.txt
@@ -1,0 +1,16 @@
+
+PASS e.style['font-family'] = "random-item()" should not set the property value
+PASS e.style['font-family'] = "random-item( )" should not set the property value
+PASS e.style['font-family'] = "random-item(auto)" should not set the property value
+PASS e.style['font-family'] = "random-item(, serif, sans-serif)" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, !)" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, ;)" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, })" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, ])" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, {serif)" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, serif})" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, {Times, serif)" should not set the property value
+PASS e.style['font-family'] = "random-item({auto, serif, sans-serif)" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, {Times, serif} extra)" should not set the property value
+PASS e.style['font-family'] = "random-item(auto, extra {Times, serif})" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-invalid.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+// random-item() is an arbitrary substitution function, so only its argument grammar is
+// validated at parse time:
+//   <random-item-args> = random-item( <declaration-value>, [ <declaration-value>? ]# )
+// See https://drafts.csswg.org/css-values-5/#funcdef-random-item
+
+// The first argument (<random-key>) is required, and a comma-separated item list must follow.
+test_invalid_value('font-family', 'random-item()');
+test_invalid_value('font-family', 'random-item( )');
+test_invalid_value('font-family', 'random-item(auto)');
+test_invalid_value('font-family', 'random-item(, serif, sans-serif)');
+
+// Forbidden tokens in <declaration-value>.
+// https://drafts.csswg.org/css-syntax/#typedef-declaration-value
+test_invalid_value('font-family', 'random-item(auto, !)');
+test_invalid_value('font-family', 'random-item(auto, ;)');
+test_invalid_value('font-family', 'random-item(auto, })');
+test_invalid_value('font-family', 'random-item(auto, ])');
+
+// Badly closed / unbalanced curly braces.
+test_invalid_value('font-family', 'random-item(auto, {serif)');
+test_invalid_value('font-family', 'random-item(auto, serif})');
+test_invalid_value('font-family', 'random-item(auto, {Times, serif)');
+test_invalid_value('font-family', 'random-item({auto, serif, sans-serif)');
+
+// A non-{}-wrapped item may not be mixed with a {}-wrapped block.
+test_invalid_value('font-family', 'random-item(auto, {Times, serif} extra)');
+test_invalid_value('font-family', 'random-item(auto, extra {Times, serif})');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-valid-expected.txt
@@ -1,0 +1,23 @@
+
+PASS e.style['font-family'] = "random-item(auto, serif)" should set the property value
+PASS e.style['font-family'] = "random-item(auto, serif, sans-serif, monospace)" should set the property value
+PASS e.style['font-family'] = "random-item(auto ,serif ,sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(auto , serif , sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(auto, )" should set the property value
+PASS e.style['font-family'] = "random-item(auto, serif,)" should set the property value
+PASS e.style['font-family'] = "random-item(auto, , serif)" should set the property value
+PASS e.style['font-family'] = "random-item(auto, ,)" should set the property value
+PASS e.style['font-family'] = "random-item(auto, {Times, serif}, {Arial, sans-serif})" should set the property value
+PASS e.style['font-family'] = "random-item(auto, {Times, serif}, sans-serif, {monospace})" should set the property value
+PASS e.style['font-family'] = "random-item(auto, {Times, serif})" should set the property value
+PASS e.style['font-family'] = "random-item(auto, { Times, serif }, { Arial, sans-serif })" should set the property value
+PASS e.style['font-family'] = "random-item(auto, {Times, serif}, { Arial, sans-serif })" should set the property value
+PASS e.style['font-family'] = "random-item(auto, { monospace })" should set the property value
+PASS e.style['font-family'] = "random-item(--x, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(fixed 0.5, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(foo, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(fixed -0.5, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(property-scoped, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(var(--key), serif, sans-serif)" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-valid.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+// random-item() is an arbitrary substitution function, so only its argument grammar is
+// validated at parse time:
+//   <random-item-args> = random-item( <declaration-value>, [ <declaration-value>? ]# )
+// The first argument is parsed as a <random-key> and an item is selected at computed-value
+// time, not here. See https://drafts.csswg.org/css-values-5/#funcdef-random-item
+
+// A non-empty first argument followed by a comma-separated list of items is valid.
+test_valid_value('font-family', 'random-item(auto, serif)');
+test_valid_value('font-family', 'random-item(auto, serif, sans-serif, monospace)');
+test_valid_value('font-family', 'random-item(auto ,serif ,sans-serif)');
+test_valid_value('font-family', 'random-item(auto , serif , sans-serif)');
+
+// Items may be empty: [ <declaration-value>? ]#.
+test_valid_value('font-family', 'random-item(auto, )');
+test_valid_value('font-family', 'random-item(auto, serif,)');
+test_valid_value('font-family', 'random-item(auto, , serif)');
+test_valid_value('font-family', 'random-item(auto, ,)');
+
+// Comma-containing items are grouped with {}, including with whitespace around the braces.
+// https://drafts.csswg.org/css-values-5/#component-function-commas
+test_valid_value('font-family', 'random-item(auto, {Times, serif}, {Arial, sans-serif})');
+test_valid_value('font-family', 'random-item(auto, {Times, serif}, sans-serif, {monospace})');
+test_valid_value('font-family', 'random-item(auto, {Times, serif})');
+test_valid_value('font-family', 'random-item(auto, { Times, serif }, { Arial, sans-serif })');
+test_valid_value('font-family', 'random-item(auto, {Times, serif}, { Arial, sans-serif })');
+test_valid_value('font-family', 'random-item(auto, { monospace })');
+
+// The first argument is NOT parsed as <random-key> at parse time, so any non-empty
+// <declaration-value> is accepted here. These resolve (or become invalid) at computed-value time.
+test_valid_value('font-family', 'random-item(--x, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(fixed 0.5, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(serif, sans-serif)');
+test_valid_value('font-family', 'random-item(foo, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(fixed -0.5, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(property-scoped, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(var(--key), serif, sans-serif)');
+
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1357,6 +1357,20 @@ CSSRandomFunctionEnabled:
     WebCore:
       default: true
 
+CSSRandomItemFunctionEnabled:
+  type: bool
+  category: css
+  status: testable
+  humanReadableName: "CSS random-item()"
+  humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 random-item()"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSRhythmicSizingEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -985,6 +985,7 @@ exclude
 //
 var
 env
+random-item
 -internal-auto-base
 
 //

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -114,6 +114,7 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , targetTextPseudoElementEnabled { settings.targetTextPseudoElementEnabled() }
     , htmlEnhancedSelectEnabled { settings.htmlEnhancedSelectEnabled() }
     , cssRandomFunctionEnabled { settings.cssRandomFunctionEnabled() }
+    , cssRandomItemFunctionEnabled { settings.cssRandomItemFunctionEnabled() }
     , cssRubyDisplayTypesEnabled { settings.cssRubyDisplayTypesInAuthorStylesEnabled() }
     , cssTreeCountingFunctionsEnabled { settings.cssTreeCountingFunctionsEnabled() }
     , cssURLModifiersEnabled { settings.cssURLModifiersEnabled() }
@@ -161,6 +162,7 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.targetTextPseudoElementEnabled,
         context.htmlEnhancedSelectEnabled,
         context.cssRandomFunctionEnabled,
+        context.cssRandomItemFunctionEnabled,
         context.cssRubyDisplayTypesEnabled,
         context.cssTreeCountingFunctionsEnabled,
         context.cssURLModifiersEnabled,

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -76,6 +76,7 @@ struct CSSParserContext {
     bool targetTextPseudoElementEnabled : 1 { false };
     bool htmlEnhancedSelectEnabled : 1 { false };
     bool cssRandomFunctionEnabled : 1 { false };
+    bool cssRandomItemFunctionEnabled : 1 { false };
     bool cssRubyDisplayTypesEnabled : 1 { false };
     bool cssTreeCountingFunctionsEnabled : 1 { false };
     bool cssURLModifiersEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
+++ b/Source/WebCore/css/parser/CSSSubstitutionParser.cpp
@@ -65,6 +65,7 @@ static bool isValidVariableReference(CSSParserTokenRange, const CSSParserContext
 static bool isValidConstantReference(CSSParserTokenRange, const CSSParserContext&);
 static bool isValidDashedFunction(CSSParserTokenRange, const CSSParserContext&);
 static bool isValidAttrReference(CSSParserTokenRange, const CSSParserContext&);
+static bool isValidRandomItemReference(CSSParserTokenRange, const CSSParserContext&);
 
 struct ClassifyBlockResult {
     bool hasSubstitutionFunctions { false };
@@ -135,6 +136,12 @@ static std::optional<ClassifyBlockResult> classifyBlock(CSSParserTokenRange rang
             }
             if (token.functionId() == CSSValueAttr && parserContext.cssAttrSubstitutionFunctionEnabled) {
                 if (!isValidAttrReference(block, parserContext))
+                    return { };
+                result.hasSubstitutionFunctions = true;
+                continue;
+            }
+            if (token.functionId() == CSSValueRandomItem && parserContext.cssRandomItemFunctionEnabled) {
+                if (!isValidRandomItemReference(block, parserContext))
                     return { };
                 result.hasSubstitutionFunctions = true;
                 continue;
@@ -219,24 +226,29 @@ bool isValidConstantReference(CSSParserTokenRange range, const CSSParserContext&
     return !!classifyBlock(range, parserContext);
 }
 
+// Validates a single comma-separated argument that is a <declaration-value> subject to the
+// comma-containing-production rules: a {}-wrapped block groups internal commas, but may not be
+// mixed with other values, and a bare {} is not a valid value.
+// https://drafts.csswg.org/css-values-5/#component-function-commas
+// `allowEmpty` distinguishes <declaration-value># (dashed functions) from <declaration-value>?#
+// (random-item() items, where an item may be empty).
+static bool isValidDeclarationValueArgument(CSSParserTokenRange argumentRange, const CSSParserContext& parserContext, bool allowEmpty)
+{
+    if (argumentRange.atEnd())
+        return allowEmpty;
+
+    auto result = classifyBlock(argumentRange, parserContext);
+    return result && !result->hasTopLevelBraceBlockMixedWithOtherValues && !result->hasEmptyTopLevelBraceBlock;
+}
+
 bool isValidDashedFunction(CSSParserTokenRange range, const CSSParserContext& parserContext)
 {
     // <dashed-function> --*( <declaration-value>#? )
     range.consumeWhitespace();
 
-    auto validateArgument = [&](auto argumentRange) {
-        if (argumentRange.atEnd())
-            return false;
-
-        // https://drafts.csswg.org/css-values-5/#component-function-commas
-        // Empty brace blocks are just empty values.
-        auto result = classifyBlock(argumentRange, parserContext);
-        return result && !result->hasTopLevelBraceBlockMixedWithOtherValues && !result->hasEmptyTopLevelBraceBlock;
-    };
-
     unsigned index = 0;
     while (auto argumentRange = CSSPropertyParserHelpers::consumeArgument(range, index)) {
-        if (!validateArgument(*argumentRange))
+        if (!isValidDeclarationValueArgument(*argumentRange, parserContext, /* allowEmpty */ false))
             return false;
         ++index;
     }
@@ -271,6 +283,48 @@ bool isValidAttrReference(CSSParserTokenRange range, const CSSParserContext& par
         return true;
 
     return !!classifyBlock(range, parserContext);
+}
+
+// https://drafts.csswg.org/css-values-5/#funcdef-random-item
+// <random-item-args> = random-item( <declaration-value>, [ <declaration-value>? ]# )
+// Validate using the argument grammar. Parsing the first argument as <random-key> and
+// selecting an item happen at substitution time.
+bool isValidRandomItemReference(CSSParserTokenRange range, const CSSParserContext& parserContext)
+{
+    range.consumeWhitespace();
+
+    // The first argument is the required <random-key>. Split at the first literal comma;
+    // commas inside blocks (e.g. {a, b}) are not separators.
+    auto keyStart = range;
+    while (!range.atEnd() && range.peek().type() != CommaToken)
+        range.consumeComponentValue();
+    auto keyRange = keyStart.rangeUntil(range);
+
+    // The <random-key> argument must be non-empty.
+    if (keyRange.atEnd())
+        return false;
+
+    if (!classifyBlock(keyRange, parserContext))
+        return false;
+
+    // A comma must separate the key from the list of items.
+    if (!CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range))
+        return false;
+
+    // [ <declaration-value>? ]# : a comma-separated list of one or more items, each of which
+    // may be empty. Items follow the same comma-containing-production rules as dashed-function
+    // arguments, except an empty item is allowed here.
+    do {
+        auto itemStart = range;
+        while (!range.atEnd() && range.peek().type() != CommaToken)
+            range.consumeComponentValue();
+        auto itemRange = itemStart.rangeUntil(range);
+
+        if (!isValidDeclarationValueArgument(itemRange, parserContext, /* allowEmpty */ true))
+            return false;
+    } while (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range));
+
+    return range.atEnd();
 }
 
 struct VariableType {


### PR DESCRIPTION
#### 5fa97e52fb27007b0f22df30391f614b9f179e78
<pre>
[css-values-5 random-item()] parse-time support for the argument grammar
<a href="https://bugs.webkit.org/show_bug.cgi?id=317675">https://bugs.webkit.org/show_bug.cgi?id=317675</a>
<a href="https://rdar.apple.com/180429446">rdar://180429446</a>

Reviewed by Antti Koivisto.

random-item() is an arbitrary substitution function, like var() and attr().
Per CSS Values 5 it is substituted at computed-value time, so at parse time
only its argument grammar needs to be validated:

    &lt;random-item-args&gt; = random-item( &lt;declaration-value&gt;, [ &lt;declaration-value&gt;? ]# )

Add parse-time support for that grammar behind a new feature flag,
CSSRandomItemFunctionEnabled (off by default). The substitution parser now
accepts a random-item() function whose first argument is a non-empty
&lt;declaration-value&gt;, followed by a comma-separated list of one or more
(possibly empty) item values. Items use {}-grouping for internal commas and
may not mix a brace block with other values, following the
component-function-commas rules, similar to isValidAttrReference.

The first argument is treated as an opaque &lt;declaration-value&gt; here, parsing
it as a &lt;random-key&gt; and selecting one of the items happen at computed-value
time and are handled in a follow-up. Forms such as random-item(foo, a, b)
are now accepted at parse time and only resolved (or made invalid) at computed-value time.

Spec: <a href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">https://drafts.csswg.org/css-values-5/#funcdef-random-item</a>

Test: imported/w3c/web-platform-tests/css/css-values/random-item-parsing.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-parsing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-parsing.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSubstitutionParser.cpp:
(WebCore::classifyBlock):
(WebCore::isValidRandomItemReference):

Canonical link: <a href="https://commits.webkit.org/315908@main">https://commits.webkit.org/315908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa87ab2b00e892acd5dd8809b41cb131b98c5207

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127954 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a5664ff-b3e1-453f-8579-c2d33cbebd18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132730 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f57b430-6181-4fee-a0e7-5fd2d0041874) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113231 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e50cbfb-4a90-490a-b94d-d90d39d5c9fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34496 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32853 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28300 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1571 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182201 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31497 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34990 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37025 "344 new passes 15 flakes 4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141171 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140995 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44511 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29537 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108922 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25978 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36261 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116392 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202921 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43021 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7637 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54379 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42440 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42667 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42556 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->