### PR TITLE
PathCG::strokeContains() is not thread safe

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-worker-unsafe-isPointInStroke-call-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-worker-unsafe-isPointInStroke-call-expected.txt
@@ -1,0 +1,1 @@
+PASS if this test does not crash.

--- a/LayoutTests/fast/canvas/offscreen-worker-unsafe-isPointInStroke-call.html
+++ b/LayoutTests/fast/canvas/offscreen-worker-unsafe-isPointInStroke-call.html
@@ -1,0 +1,51 @@
+<body>
+    <p>PASS if this test does not crash.</p>
+    <script>
+        window.testRunner?.waitUntilDone();
+        window.testRunner?.dumpAsText();
+
+        const tester = `self.onmessage = event => {
+            const ctx = event.data.getContext("2d");
+            for (let i = 0; i < 500; i++) {
+                ctx.setLineDash([5 + i % 20, 3 + i % 12]); // forces CG dash alloc/free
+                ctx.beginPath();
+                for (let j = 0; j < 25; j++) {
+                    let a = j / 25 * Math.PI * 2 + i * .1;
+                    let r = 30 + 20 * Math.sin(j * .7 + i * .3);
+                    let x = 64 + r * Math.cos(a);
+                    let y = 64 + r * Math.sin(a);
+                    if (!j)
+                        ctx.moveTo(x, y);
+                    else
+                        ctx.bezierCurveTo(
+                            x + 12 * Math.sin(i + j), y + 12 * Math.cos(i + j),
+                            x -  8 * Math.cos(i * j), y -  8 * Math.sin(i * j),
+                            x, y
+                        );
+                }
+                ctx.closePath();
+                ctx.isPointInStroke(64, 64);
+            }
+            self.postMessage({ type: 'done' }); // Send finished signal
+        };`;
+
+        const totalWorkers = 4;
+        let doneWorkers = 0;
+
+        for (let i = 0; i < totalWorkers; i++) {
+            const canvas = document.createElement("canvas");
+            canvas.width = 128;
+            canvas.height = 128;
+            const offscreen = canvas.transferControlToOffscreen();
+            const worker = new Worker(URL.createObjectURL(new Blob([tester])));
+            worker.postMessage(offscreen, [offscreen]);
+
+            worker.onmessage = event => {
+                if (event.data.type === 'done') {
+                    if (++doneWorkers == totalWorkers)
+                        window.testRunner?.notifyDone();
+                }
+            };
+        }
+    </script>
+</body>

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -606,6 +606,9 @@ bool PathCG::strokeContains(const FloatPoint& point, NOESCAPE const Function<voi
 {
     ASSERT(strokeStyleApplier);
 
+    static Lock scratchContextLock;
+    Locker locker { scratchContextLock };
+
     CGContextRef context = scratchContext();
 
     CGContextSaveGState(context);
@@ -641,6 +644,9 @@ FloatRect PathCG::boundingRect() const
 
 FloatRect PathCG::strokeBoundingRect(NOESCAPE const Function<void(GraphicsContext&)>& strokeStyleApplier) const
 {
+    static Lock scratchContextLock;
+    Locker locker { scratchContextLock };
+
     CGContextRef context = scratchContext();
 
     CGContextSaveGState(context);


### PR DESCRIPTION
#### 95f9f59bb141325d7468be23bb9e570ad751d71a
<pre>
PathCG::strokeContains() is not thread safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=313935">https://bugs.webkit.org/show_bug.cgi?id=313935</a>
<a href="https://rdar.apple.com/176138322">rdar://176138322</a>

Reviewed by Darin Adler.

PathCG::strokeContains() is not thread-safe because it accesses a global
CGContextRef managed by NeverDestroyed in scratchContext(). If multiple offscreen
canvases call CanvasRenderingContext2D:isPointInStroke() on worker threads, they
are going to call PathCG::strokeContains(). This means the same CGContextRef will
be used by these workers. This lake of global variable synchronization can lead
to all sort of security and correctness bugs depending on what was set in the
context when it is referenced.

The fix is to protect scratchContext() by a locker. This will allow only one caller
to have access to the underlying CGContextRef.

Test: fast/canvas/offscreen-worker-unsafe-isPointInStroke-call.html

* LayoutTests/fast/canvas/offscreen-worker-unsafe-isPointInStroke-call-expected.txt: Added.
* LayoutTests/fast/canvas/offscreen-worker-unsafe-isPointInStroke-call.html: Added.
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::PathCG::strokeContains const):
(WebCore::PathCG::strokeBoundingRect const):

Originally-landed-as: 305413.891@safari-7624-branch (232dada9ad29). <a href="https://rdar.apple.com/180437343">rdar://180437343</a>
Canonical link: <a href="https://commits.webkit.org/316037@main">https://commits.webkit.org/316037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/967027229ac308d25245d4ed6324fb3772aac725

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127522 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132343 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93245 "2 flakes 10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34262 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32484 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27867 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181768 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140792 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43388 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140623 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38116 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44077 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29127 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108372 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35887 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115842 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42588 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7226 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41980 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->