### PR TITLE
[WebGPU] Reject duplicate binding entries in Device::createBindGroup

### DIFF
--- a/LayoutTests/fast/webgpu/bind-group-duplicate-binding-expected.txt
+++ b/LayoutTests/fast/webgpu/bind-group-duplicate-binding-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: GPUDevice.createBindGroup: Binding 0 is duplicated in the bind group descriptor
+

--- a/LayoutTests/fast/webgpu/bind-group-duplicate-binding.html
+++ b/LayoutTests/fast/webgpu/bind-group-duplicate-binding.html
@@ -1,0 +1,53 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<script>
+globalThis.testRunner?.waitUntilDone();
+globalThis.testRunner?.dumpAsText();
+const log = console.debug;
+
+onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+
+    let large = device.createBuffer({ size: 1024, usage: GPUBufferUsage.STORAGE });
+    let small = device.createBuffer({ size: 256,  usage: GPUBufferUsage.STORAGE });
+
+    let bgl = device.createBindGroupLayout({ entries: [
+        { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: true } },
+        { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: true } },
+        { binding: 2, visibility: 0,                       sampler: { } },
+    ]});
+
+    let bg = device.createBindGroup({ layout: bgl, entries: [
+        { binding: 0, resource: { buffer: large, size: 256 } },
+        { binding: 0, resource: { buffer: large, size: 256 } },
+        { binding: 1, resource: { buffer: small } },
+    ]});
+
+    let module = device.createShaderModule({ code:
+        '@group(0) @binding(1) var<storage,read_write> b1: array<u32,64>;\n' +
+        '@compute @workgroup_size(1) fn main(){ b1[0] = 1u; }'
+    });
+
+    let pipeline = device.createComputePipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [bgl] }),
+        compute: { module }
+    });
+
+    let commandEncoder = device.createCommandEncoder();
+    let computePassEncoder = commandEncoder.beginComputePass({});
+    computePassEncoder.setPipeline(pipeline);
+    computePassEncoder.setBindGroup(0, bg, new Uint32Array([0, 512]));
+    computePassEncoder.dispatchWorkgroups(1);
+    computePassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+
+    let error = await device.popErrorScope();
+    if (error)
+        log(error.message);
+    else
+        log('no validation error');
+    globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1114,6 +1114,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
     auto& bindGroupLayoutEntries = bindGroupLayout->entries();
     BindGroup::DynamicBuffersContainer dynamicBuffers;
     BindGroup::SamplersContainer samplersSet;
+    HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> usedBindingSlots;
 
     for (const WGPUBindGroupEntry& entry : descriptor.entriesSpan()) {
         WGPUExternalTexture wgpuExternalTexture = entry.externalTexture;
@@ -1129,6 +1130,11 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
         bool bindingContainedInStage = false;
         bool appendedBufferToDynamicBuffers = false;
         auto bindingIndex = entry.binding;
+        if (usedBindingSlots.contains(bindingIndex)) {
+            VALIDATION_ERROR([NSString stringWithFormat:@"Binding %u is duplicated in the bind group descriptor", bindingIndex]);
+            return BindGroup::createInvalid(*this);
+        }
+        usedBindingSlots.add(bindingIndex);
         for (ShaderStage stage : stagesPlusUndefined) {
             auto index = bindGroupLayout->argumentBufferIndexForEntryIndex(bindingIndex, stage);
             if (index == NSNotFound)


### PR DESCRIPTION
#### 57ae1268754271fe3e80a72f98e2a7749bb2fde8
<pre>
[WebGPU] Reject duplicate binding entries in Device::createBindGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=314684">https://bugs.webkit.org/show_bug.cgi?id=314684</a>
<a href="https://rdar.apple.com/176482460">rdar://176482460</a>

Reviewed by Mike Wyrzykowski.

Device::createBindGroup checked that descriptor.entryCount matched the
layout&apos;s entry count, but not that each entry.binding was unique.
Duplicate entries caused dynamicBuffers and m_dynamicOffsetsIndices to
be built with extra records, so dynamic-offset validation in setBindGroup
no longer corresponded to the offsets applied at dispatch.

Track seen binding indices with a HashSet at the top of the per-entry
loop and reject duplicates with a validation error, mirroring the
existing check in Device::createBindGroupLayout.

* LayoutTests/fast/webgpu/bind-group-duplicate-binding-expected.txt: Added.
* LayoutTests/fast/webgpu/bind-group-duplicate-binding.html: Added.
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):

Originally-landed-as: 305413.903@safari-7624-branch (b49e6e956529). <a href="https://rdar.apple.com/180428744">rdar://180428744</a>
Canonical link: <a href="https://commits.webkit.org/316038@main">https://commits.webkit.org/316038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52ac87f4c1cbd32cb18c1a6842065524d4371210

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127543 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132358 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93256 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112860 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32498 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27888 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181789 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140808 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140639 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38117 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44098 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29223 "Found 1 new test failure: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108393 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35906 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115863 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42609 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7323 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->