### PR TITLE
[CoreIPC] [NP] CoreIPCNSURLRequest bodyParts Forwarded to CFNetwork Leads to Arbitrary File Exfiltration

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -272,25 +272,12 @@ CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
         m_data.headerFields = WTF::move(vector);
     }
 
-    SET_NSURLREQUESTDATA(body, NSData, CoreIPCData);
-
-    RetainPtr<NSArray> bodyParts = dict.get()[@"bodyParts"];
-    if ([bodyParts isKindOfClass:[NSArray class]]) {
-        Vector<CoreIPCNSURLRequestData::BodyParts> vector;
-        vector.reserveInitialCapacity(bodyParts.get().count);
-        for (id element in bodyParts.get()) {
-            if ([element isKindOfClass:[NSString class]]) {
-                CoreIPCString tooAdd(element);
-                vector.append(WTF::move(tooAdd));
-            }
-            if ([element isKindOfClass:[NSData class]]) {
-                CoreIPCData tooAdd(element);
-                vector.append(WTF::move(tooAdd));
-            }
-        }
-        vector.shrinkToFit();
-        m_data.bodyParts = WTF::move(vector);
-    }
+    // Security: body and bodyParts are intentionally not extracted. The HTTP
+    // body is carried separately via WebCore::FormData. The legitimate sender
+    // already clears the body before encoding (setHTTPBody:nil /
+    // setHTTPBodyStream:nil). In CFNetwork, NSString entries in bodyParts are
+    // interpreted as POSIX file paths, so forwarding them would let a
+    // compromised WebContent process exfiltrate NetworkProcess-readable files.
 
     SET_NSURLREQUESTDATA_PRIMITIVE(startTimeoutTime, NSNumber, double);
     SET_NSURLREQUESTDATA_PRIMITIVE(requiresShortConnectionTimeout, NSNumber, bool);
@@ -446,20 +433,22 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
         [dict setObject:headerFields.get() forKey:@"headerFields"];
     }
 
-    SET_DICT_FROM_OPTIONAL_MEMBER(body);
+    // Security: body is intentionally not forwarded to
+    // _initWithWebKitPropertyListData:. The HTTP body is carried separately
+    // via WebCore::FormData and validated through that path. A compromised
+    // WebContent process could use this field to inject arbitrary data.
+    ASSERT(!m_data.body);
 
-    if (m_data.bodyParts) {
-        auto array = adoptNS([[NSMutableArray alloc] initWithCapacity:(*m_data.bodyParts).size()]);
-        for (auto& value : *m_data.bodyParts) {
-            WTF::switchOn(value,
-                [&] (const auto& d) {
-                    if (auto obj = d.toID())
-                        [array addObject:obj.get()];
-                }
-            );
-        }
-        [dict setObject:array.get() forKey:@"bodyParts"];
-    }
+    // Security: bodyParts is intentionally not forwarded to
+    // _initWithWebKitPropertyListData:. In CFNetwork, NSString entries in
+    // bodyParts are interpreted as POSIX file paths and opened via
+    // CFReadStreamCreateWithFile inside NetworkProcess. A compromised
+    // WebContent process could exfiltrate any NetworkProcess-readable file
+    // by supplying arbitrary file paths in bodyParts. The legitimate sender
+    // already clears the HTTP body before encoding (setHTTPBody:nil /
+    // setHTTPBodyStream:nil), so bodyParts is always empty in legitimate IPC.
+    // The HTTP body is carried separately via WebCore::FormData.
+    ASSERT(!m_data.bodyParts);
 
     SET_DICT_FROM_PRIMITIVE(startTimeoutTime, NSInteger, Double);
     SET_DICT_FROM_PRIMITIVE(requiresShortConnectionTimeout, NSInteger, Bool);


### PR DESCRIPTION
#### a38f039d8f8a22dd138a45c0f8d33b9dc8528c9d
<pre>
[CoreIPC] [NP] CoreIPCNSURLRequest bodyParts Forwarded to CFNetwork Leads to Arbitrary File Exfiltration
<a href="https://bugs.webkit.org/show_bug.cgi?id=312553">https://bugs.webkit.org/show_bug.cgi?id=312553</a>
<a href="https://rdar.apple.com/174708131">rdar://174708131</a>

Reviewed by Brady Eidson.

In the macOS 15+ / iOS 18+ secure-coding path (HAVE_WK_SECURE_CODING_NSURLREQUEST),
CoreIPCNSURLRequest forwards fields from the decoded IPC message into
-[NSURLRequest _initWithWebKitPropertyListData:] inside NetworkProcess. CFNetwork
interprets NSString entries in bodyParts as POSIX file paths
(CFURLCreateWithFileSystemPath -&gt; CFReadStreamCreateWithFile), so a compromised
WebContent process could exfiltrate any NetworkProcess-readable file by injecting
arbitrary paths into bodyParts.

The legitimate encoder in ResourceRequestCocoa.mm already clears the HTTP body
before serialization (setHTTPBody:nil / setHTTPBodyStream:nil at lines 127-128),
so body and bodyParts are normally empty in the serialized NSURLRequest. However,
that strip is encoder-side only and a compromised WebContent process can populate
these fields directly on the wire. The HTTP body is carried separately via
WebCore::FormData which has its own validation.

Stop extracting body and bodyParts on the encoder side; stop forwarding them on
the receiver side in toID(); add assertions that they remain empty.

* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::CoreIPCNSURLRequest):
(WebKit::CoreIPCNSURLRequest::toID const):

Originally-landed-as: 305413.696@safari-7624-branch (0df93a7f1b13). <a href="https://rdar.apple.com/180428381">rdar://180428381</a>
Canonical link: <a href="https://commits.webkit.org/316056@main">https://commits.webkit.org/316056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c5415619120625ad6177445aa35bed322317a73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127551 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132365 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93262 "1 flakes 11 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172798 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35037 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32506 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181797 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140815 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43417 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140646 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38132 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44106 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29236 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108401 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35913 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115871 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42617 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7336 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->