### PR TITLE
[Navigation API] Extract prepareNavigateEvent helper from innerDispatchNavigateEvent

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1285,24 +1285,12 @@ std::optional<Navigation::DispatchResult> Navigation::handleSameDocumentNavigati
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
-Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationType, Ref<NavigationDestination>&& destination, const String& downloadRequestFilename, FormState* formState, SerializedScriptValue* classicHistoryAPIState, Element* sourceElement)
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
+// Returns std::nullopt when rate-limited (caller returns DispatchResult::Aborted).
+std::optional<Navigation::PreparedNavigateEvent> Navigation::prepareNavigateEvent(NavigationNavigationType navigationType, NavigationDestination& destination, const String& downloadRequestFilename, FormState* formState, SerializedScriptValue* classicHistoryAPIState, Element* sourceElement)
 {
-    if (hasEntriesAndEventsDisabled()) {
-        ASSERT(m_methodTrackers.isEmpty());
-        return DispatchResult::Completed;
-    }
-
-    bool wasBeingDispatched = m_ongoingNavigateEvent && m_ongoingNavigateEvent->isBeingDispatched();
-
-    abortOngoingNavigationIfNeeded();
-
-    // Prevent recursion on synchronous history navigation steps issued
-    // from the navigate event handler.
-    if (wasBeingDispatched && classicHistoryAPIState)
-        return DispatchResult::Completed;
-
     RefPtr apiMethodTracker = navigationType == NavigationNavigationType::Traverse
-        ? m_methodTrackers.promoteUpcomingTraverseToOngoing(destination->key())
+        ? m_methodTrackers.promoteUpcomingTraverseToOngoing(destination.key())
         : m_methodTrackers.promoteUpcomingNonTraverseToOngoing();
 
     // Enforce rate limiting to prevent excessive navigation requests.
@@ -1317,19 +1305,19 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
         if (apiMethodTracker)
             rejectFinishedPromise(apiMethodTracker.get(), Exception { ExceptionCode::QuotaExceededError, "Navigation rate limit exceeded"_s }, JSC::JSValue { });
 
-        return DispatchResult::Aborted;
+        return std::nullopt;
     }
 
-    RefPtr document = window()->document();
+    Ref document = *window()->document();
 
     // FIXME: this should not be needed, we should pass it into FrameLoader.
     if (apiMethodTracker && apiMethodTracker->serializedState())
-        destination->setStateObject(protect(apiMethodTracker->serializedState()));
-    bool isSameDocument = destination->sameDocument();
+        destination.setStateObject(protect(apiMethodTracker->serializedState()));
+    bool isSameDocument = destination.sameDocument();
     bool isTraversal = navigationType == NavigationNavigationType::Traverse;
-    bool canIntercept = documentCanHaveURLRewritten(*document, destination->url()) && (!isTraversal || isSameDocument);
+    bool canIntercept = documentCanHaveURLRewritten(document.get(), destination.url()) && (!isTraversal || isSameDocument);
     bool canBeCanceled = !isTraversal || (document->isTopDocument() && isSameDocument); // FIXME: and user involvement is not browser-ui or navigation's relevant global object has transient activation.
-    bool hashChange = !classicHistoryAPIState && equalIgnoringFragmentIdentifier(document->url(), destination->url()) && !equalRespectingNullity(document->url().fragmentIdentifier(),  destination->url().fragmentIdentifier());
+    bool hashChange = !classicHistoryAPIState && equalIgnoringFragmentIdentifier(document->url(), destination.url()) && !equalRespectingNullity(document->url().fragmentIdentifier(),  destination.url().fragmentIdentifier());
     auto info = apiMethodTracker ? apiMethodTracker->info().getValue() : JSC::jsUndefined();
     auto world = apiMethodTracker ? apiMethodTracker->info().world() : nullptr;
 
@@ -1350,14 +1338,14 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
             updatedSourceElement = form.ptr();
     }
 
-    RefPtr abortController = AbortController::create(*scriptExecutionContext);
+    Ref abortController = AbortController::create(*scriptExecutionContext);
 
     auto init = NavigateEvent::Init {
         { false, canBeCanceled, false },
         navigationType,
-        destination,
+        Ref { destination },
         canIntercept,
-        UserGestureIndicator::processingUserGesture(document.get()),
+        UserGestureIndicator::processingUserGesture(document.ptr()),
         hashChange,
         Ref { abortController->signal() },
         formData,
@@ -1371,7 +1359,41 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     if (apiMethodTracker)
         apiMethodTracker->info().clear();
 
-    Ref event = NavigateEvent::create(WTF::move(world), eventNames().navigateEvent, WTF::move(init), abortController.get());
+    Ref event = NavigateEvent::create(WTF::move(world), eventNames().navigateEvent, WTF::move(init), abortController.ptr());
+
+    return PreparedNavigateEvent {
+        WTF::move(event),
+        WTF::move(abortController),
+        WTF::move(apiMethodTracker),
+        WTF::move(document),
+    };
+}
+
+Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationType, Ref<NavigationDestination>&& destination, const String& downloadRequestFilename, FormState* formState, SerializedScriptValue* classicHistoryAPIState, Element* sourceElement)
+{
+    if (hasEntriesAndEventsDisabled()) {
+        ASSERT(m_methodTrackers.isEmpty());
+        return DispatchResult::Completed;
+    }
+
+    bool wasBeingDispatched = m_ongoingNavigateEvent && m_ongoingNavigateEvent->isBeingDispatched();
+
+    abortOngoingNavigationIfNeeded();
+
+    // Prevent recursion on synchronous history navigation steps issued
+    // from the navigate event handler.
+    if (wasBeingDispatched && classicHistoryAPIState)
+        return DispatchResult::Completed;
+
+    auto prepared = prepareNavigateEvent(navigationType, destination.get(), downloadRequestFilename, formState, classicHistoryAPIState, sourceElement);
+    if (!prepared)
+        return DispatchResult::Aborted;
+
+    Ref event = prepared->event;
+    Ref abortController = prepared->abortController;
+    RefPtr apiMethodTracker = prepared->apiMethodTracker;
+    Ref document = prepared->document;
+
     m_ongoingNavigateEvent = event.ptr();
     m_focusChangedDuringOngoingNavigation = FocusDidChange::No;
     m_suppressNormalScrollRestorationDuringOngoingNavigation = false;
@@ -1397,10 +1419,10 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
     // Step 32:
     if (event->wasIntercepted())
-        setupInterceptionState(event.get(), navigationType, destination.get(), *document, classicHistoryAPIState);
+        setupInterceptionState(event.get(), navigationType, destination.get(), document.get(), classicHistoryAPIState);
 
     if (endResultIsSameDocument) {
-        if (auto result = handleSameDocumentNavigation(event.get(), navigationType, apiMethodTracker.get(), *abortController, *document))
+        if (auto result = handleSameDocumentNavigation(event.get(), navigationType, apiMethodTracker.get(), abortController.get(), document.get()))
             return *result;
     } else if (apiMethodTracker) {
         // For cross-document navigations, don't cleanup the tracker immediately.

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -42,6 +42,7 @@
 
 namespace WebCore {
 
+class Document;
 class DocumentLoader;
 class FormState;
 class HistoryItem;
@@ -269,6 +270,13 @@ private:
     bool hasEntriesAndEventsDisabled() const;
     Result performTraversal(JSC::JSGlobalObject&, const String& key, Navigation::Options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
     ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
+    struct PreparedNavigateEvent {
+        Ref<NavigateEvent> event;
+        Ref<AbortController> abortController;
+        RefPtr<NavigationAPIMethodTracker> apiMethodTracker;
+        Ref<Document> document;
+    };
+    std::optional<PreparedNavigateEvent> prepareNavigateEvent(NavigationNavigationType, NavigationDestination&, const String& downloadRequestFilename, FormState*, SerializedScriptValue* classicHistoryAPIState, Element* sourceElement);
     DispatchResult innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename, FormState* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr, Element* sourceElement = nullptr);
     void setupInterceptionState(NavigateEvent&, NavigationNavigationType, NavigationDestination&, Document&, SerializedScriptValue* classicHistoryAPIState);
     std::optional<DispatchResult> handleSameDocumentNavigation(NavigateEvent&, NavigationNavigationType, NavigationAPIMethodTracker*, AbortController&, Document&);


### PR DESCRIPTION
#### 53b960a6a02d20453479a8c8716f7e54b4d3d59a
<pre>
[Navigation API] Extract prepareNavigateEvent helper from innerDispatchNavigateEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=311969">https://bugs.webkit.org/show_bug.cgi?id=311969</a>
<a href="https://rdar.apple.com/174513572">rdar://174513572</a>

Reviewed by NOBODY (OOPS!).

Pure structural refactor. Move the event-construction prelude
(method-tracker promotion, rate-limit check, NavigateEvent::Init flag
computation, AbortController and NavigateEvent construction) out of
innerDispatchNavigateEvent into a new private helper
prepareNavigateEvent that returns PreparedNavigateEvent, or
std::nullopt when rate-limited. After extraction
innerDispatchNavigateEvent retains pre-event guards, m_ongoingNavigateEvent
state assignment, dispatchEvent, and post-dispatch routing only.

The helper is defined above innerDispatchNavigateEvent so that the
main dispatch flow reads top-down with the helper already in scope,
mirroring the order of setupInterceptionState and
handleSameDocumentNavigation.

No observable behavior change. WPT navigation-api (428/428), layout
LayoutTests/navigation-api + http/{tests,wpt}/navigation-api (15/15),
and TestWebKitAPI.NavigationAPI all produce identical results to
origin/main; the one TestWebKitAPI.NavigationAPI timeout
(ClearWrappersWithNavigateEventListener) is pre-existing and reproduces
on origin/main without this change.

* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::prepareNavigateEvent):
(WebCore::Navigation::innerDispatchNavigateEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53b960a6a02d20453479a8c8716f7e54b4d3d59a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179199 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127552 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/168d34e5-1408-4ba4-98f2-a676239843da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132366 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93261 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2b58d1f-19a2-47a2-8ff7-2326efc6e197) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112868 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93754859-e529-450b-bc9e-c33ca95e9b41) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34547 "Found 10 new test failures: imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/report-only-frame.sub.html imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-cross-origin-same-document-navigation.window.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-with-x-frame-options.sub.html imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053.html imported/w3c/web-platform-tests/css/selectors/user-valid.html imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative.html?type=text imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative.html?type=textarea imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html?rest imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer.html?rest (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32507 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27897 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181798 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140819 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43418 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140650 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44107 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29156 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108402 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35915 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115872 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42618 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7256 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42265 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->