### PR TITLE
[WebKit Process Model | All] Wrong-container end() comparison in WebFrameProxy::nextSibling/previousSibling

### DIFF
--- a/LayoutTests/http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash-expected.txt
@@ -1,0 +1,4 @@
+This test passes if the UI process does not crash.
+
+PASS
+

--- a/LayoutTests/http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash.html
+++ b/LayoutTests/http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true SiteIsolationEnabled=true ] -->
+<html>
+<body>
+<p>This test passes if the UI process does not crash.</p>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+const log = (s) => { document.getElementById("log").textContent += s + "\n"; };
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function waitIPC(w) {
+    for (let i = 0; i < 200; i++) {
+        try { if (w.IPC && w.IPC.frameID) return; } catch (e) { }
+        await sleep(10);
+    }
+}
+
+async function main() {
+    if (!window.IPC) {
+        log("PASS");
+        return;
+    }
+
+    // Cross-site iframe so this page has remote frames under site isolation.
+    const remoteFrame = document.createElement('iframe');
+    remoteFrame.src = 'http://localhost:8000/site-isolation/resources/green-background.html';
+    document.body.appendChild(remoteFrame);
+    await new Promise(r => { remoteFrame.onload = r; setTimeout(r, 2000); });
+
+    // Same-origin popups B, C, D.
+    const B = window.open('about:blank');
+    const C = window.open('about:blank');
+    const D = window.open('about:blank');
+    await sleep(100);
+    await waitIPC(B); await waitIPC(C); await waitIPC(D);
+
+    // Nested iframes C1 -> C2 inside popup B.
+    B.document.body.innerHTML = '<iframe id=c1 src="about:blank"></iframe>';
+    const c1 = B.document.getElementById('c1').contentWindow;
+    await sleep(50); await waitIPC(c1);
+    c1.document.body.innerHTML = '<iframe id=c2 src="about:blank"></iframe>';
+    const c2 = c1.document.getElementById('c2').contentWindow;
+    await sleep(50); await waitIPC(c2);
+
+    function sendFocusedFrameChanged(targetPageProxyID, frameID) {
+        IPC.sendMessage('UI', targetPageProxyID, IPC.messages.WebPageProxy_FocusedFrameChanged.name, [
+            { type: 'bool', value: 1 },
+            { type: 'FrameID', value: frameID },
+        ]);
+    }
+    // A compromised web process could point each page's focused frame at frames belonging to popup B.
+    sendFocusedFrameChanged(IPC.webPageProxyID, c2.IPC.frameID);
+    sendFocusedFrameChanged(C.IPC.webPageProxyID, c1.IPC.frameID);
+    sendFocusedFrameChanged(D.IPC.webPageProxyID, B.IPC.frameID);
+    await sleep(100);
+
+    // Closing B clears C1's child frame set without clearing C2's parent pointer.
+    IPC.sendMessage('UI', B.IPC.webPageProxyID, IPC.messages.WebPageProxy_ClosePage.name, []);
+    await sleep(300);
+
+    // findString traverses from A's focused frame (C2); nextSibling() must not read past the parent's end().
+    await testRunner.findString('zzzNoMatch', []);
+    await sleep(200);
+
+    // Replace body content so dump output is consistent across configurations.
+    document.body.innerHTML = '<p>This test passes if the UI process does not crash.</p><pre id="log"></pre>';
+    log("PASS");
+}
+main().finally(() => window.testRunner?.notifyDone());
+setTimeout(() => window.testRunner?.notifyDone(), 30000);
+</script>
+</body>
+</html>

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -582,12 +582,14 @@ inline bool ListHashSet<T, U>::isEmpty() const
 template<typename T, typename U>
 inline T& ListHashSet<T, U>::first() LIFETIME_BOUND
 {
+    RELEASE_ASSERT(!isEmpty());
     return *begin();
 }
 
 template<typename T, typename U>
 inline const T& ListHashSet<T, U>::first() const LIFETIME_BOUND
 {
+    RELEASE_ASSERT(!isEmpty());
     return *begin();
 }
 
@@ -611,6 +613,7 @@ inline T ListHashSet<T, U>::takeFirst()
 template<typename T, typename U>
 inline T& ListHashSet<T, U>::last() LIFETIME_BOUND
 {
+    RELEASE_ASSERT(!isEmpty());
     auto last = --end();
     return *last;
 }
@@ -618,6 +621,7 @@ inline T& ListHashSet<T, U>::last() LIFETIME_BOUND
 template<typename T, typename U>
 inline const T& ListHashSet<T, U>::last() const LIFETIME_BOUND
 {
+    RELEASE_ASSERT(!isEmpty());
     auto last = --end();
     return *last;
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -205,8 +205,10 @@ WebProcessProxy& WebFrameProxy::provisionalLoadProcess()
 
 void WebFrameProxy::webProcessWillShutDown()
 {
-    for (auto& childFrame : std::exchange(m_childFrames, { }))
+    for (Ref childFrame : std::exchange(m_childFrames, { })) {
+        childFrame->m_parentFrame = nullptr;
         childFrame->webProcessWillShutDown();
+    }
 
     if (RefPtr page = m_page.get())
         page->inspectorController().willDestroyFrame(*this);
@@ -724,7 +726,8 @@ void WebFrameProxy::setProcess(FrameProcess& process)
 
 void WebFrameProxy::removeChildFrames()
 {
-    m_childFrames.clear();
+    for (Ref childFrame : std::exchange(m_childFrames, { }))
+        childFrame->m_parentFrame = nullptr;
 }
 
 Vector<Ref<WebFrameProxy>> WebFrameProxy::takeChildFrames()
@@ -929,7 +932,7 @@ WebFrameProxy* WebFrameProxy::lastChild() const
 
 WebFrameProxy* WebFrameProxy::nextSibling() const
 {
-    if (!m_parentFrame)
+    if (!m_parentFrame || m_parentFrame->m_childFrames.isEmpty())
         return nullptr;
 
     if (m_parentFrame->m_childFrames.last().ptr() == this)
@@ -945,7 +948,7 @@ WebFrameProxy* WebFrameProxy::nextSibling() const
 
 WebFrameProxy* WebFrameProxy::previousSibling() const
 {
-    if (!m_parentFrame)
+    if (!m_parentFrame || m_parentFrame->m_childFrames.isEmpty())
         return nullptr;
 
     if (m_parentFrame->m_childFrames.first().ptr() == this)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13190,6 +13190,8 @@ void WebPageProxy::focusedElementChanged(IPC::Connection& connection, const std:
 void WebPageProxy::focusedFrameChanged(IPC::Connection& connection, std::optional<FrameIdentifier>&& frameID)
 {
     RefPtr frame = frameID ? WebFrameProxy::webFrame(*frameID) : nullptr;
+    if (frame)
+        MESSAGE_CHECK_BASE(frame->page() == this, connection);
     m_focusedFrame = WTF::move(frame);
     broadcastFocusedFrameToOtherProcesses(connection, WTF::move(frameID));
 }


### PR DESCRIPTION
#### 15c722b934e53ef7e5da1dcf30715b7b6a797a93
<pre>
[WebKit Process Model | All] Wrong-container end() comparison in WebFrameProxy::nextSibling/previousSibling
<a href="https://bugs.webkit.org/show_bug.cgi?id=315348">https://bugs.webkit.org/show_bug.cgi?id=315348</a>
<a href="https://rdar.apple.com/176891673">rdar://176891673</a>

Reviewed by Ryosuke Niwa.

WebFrameProxy::nextSibling() and previousSibling() obtain an iterator from
m_parentFrame-&gt;m_childFrames.find(this) but compare it against this frame&apos;s own
m_childFrames.end(). ListHashSet const_iterator equality compares only m_position,
so the not-found guard is structurally always false in Release. They also call
last()/first() on the parent&apos;s m_childFrames without checking isEmpty(), which
dereferences the sentinel of an empty list.

A child can have a non-null m_parentFrame whose m_childFrames no longer contains
it because webProcessWillShutDown() and removeChildFrames() drop the parent&apos;s
child set without nulling each child&apos;s m_parentFrame. A compromised WebContent
process can keep such a frame alive across pages because focusedFrameChanged()
does not verify that the looked-up frame belongs to this page before storing it
in m_focusedFrame. Under Site Isolation, FindStringCallbackAggregator&apos;s destructor
then traverses from focusedOrMainFrame() through nextSibling() on the orphaned
child, advances past the parent&apos;s sentinel, and returns &amp;parent.m_parentFrame&apos;s
WeakPtr impl typed as WebFrameProxy*, leading to an EXC_ARM_PAC_FAIL in CFRetain
in the UI process.

Fix all four sites: compare against the parent&apos;s end(), early-return when the
parent&apos;s child set is empty, null each child&apos;s m_parentFrame when emptying
m_childFrames in webProcessWillShutDown() and removeChildFrames(), and
MESSAGE_CHECK in focusedFrameChanged() that the frame belongs to this page.
Also do hardening in ListHashSet so that calling first() / last() on an
empty set crashes safely.

Test: http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash.html

* LayoutTests/http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/find-string-with-cross-page-focused-frame-crash.html: Added.
* Source/WTF/wtf/ListHashSet.h:
(WTF::U&gt;::first):
(WTF::U&gt;::first const):
(WTF::U&gt;::last):
(WTF::U&gt;::last const):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::webProcessWillShutDown):
(WebKit::WebFrameProxy::removeChildFrames):
(WebKit::WebFrameProxy::nextSibling const):
(WebKit::WebFrameProxy::previousSibling const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::focusedFrameChanged):

Originally-landed-as: 305413.957@safari-7624-branch (7b5d09d5675a). <a href="https://rdar.apple.com/180428790">rdar://180428790</a>
Canonical link: <a href="https://commits.webkit.org/316041@main">https://commits.webkit.org/316041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf03bc890cb7523046cab21e67b047071961d028

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43772 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37164 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127562 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132381 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93272 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112883 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32518 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27907 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1204 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181808 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31105 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140838 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38118 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44117 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108412 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35925 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115882 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202529 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42628 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7267 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54283 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->