### PR TITLE
[libpas] Split pas_deallocate into inline-only and casual variants

### DIFF
--- a/Source/bmalloc/libpas/Documentation.md
+++ b/Source/bmalloc/libpas/Documentation.md
@@ -1295,8 +1295,8 @@ deallocation is just:
     }
 
 If you look at `pas_deallocate`, you'll see cleverness that ensures that the slow path call is a tail call,
-similarly to how allocators work. However, for deallocation, I haven't had the need to make the slow call
-explicit in the client side (the way that `bmalloc_try_allocate_inline` has to explicitly call the slow path).
+similarly to how allocators work. As with allocation, this is explicitly exposed to the client (i.e. both
+`bmalloc_try_allocate_inline` and `bmalloc_deallocate_inline` must explicitly call the slow path).
 
 This concludes the discussion of libpas design.
 

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
@@ -55,6 +55,11 @@ PAS_NEVER_INLINE void* bmalloc_try_allocate_auxiliary_with_alignment_casual(
     return (void*)bmalloc_try_allocate_auxiliary_impl_casual_case(heap_ref, size, alignment, allocation_mode).begin;
 }
 
+PAS_NEVER_INLINE void bmalloc_deallocate_casual(void* ptr)
+{
+    pas_deallocate_casual_case(ptr, BMALLOC_HEAP_CONFIG);
+}
+
 PAS_NEVER_INLINE void* bmalloc_allocate_auxiliary_with_alignment_casual(
     pas_primitive_heap_ref* heap_ref, size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -372,9 +372,13 @@ bmalloc_reallocate_inline(void* old_ptr, size_t new_size,
         free_mode).begin;
 }
 
+PAS_API void bmalloc_deallocate_casual(void* ptr);
+
 static PAS_ALWAYS_INLINE void bmalloc_deallocate_inline(void* ptr)
 {
-    pas_deallocate(ptr, BMALLOC_HEAP_CONFIG);
+    if (PAS_LIKELY(pas_try_deallocate_inline_only(ptr, BMALLOC_HEAP_CONFIG, pas_deallocate_mode)))
+        return;
+    bmalloc_deallocate_casual(ptr);
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -140,31 +140,84 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate_not_small_exclusive_segregated(
     return pas_try_deallocate_slow(begin, config.config_ptr, deallocation_mode);
 }
 
-static PAS_ALWAYS_INLINE bool pas_try_deallocate_impl(pas_thread_local_cache* thread_local_cache,
-                                                      void* ptr,
-                                                      pas_heap_config config,
-                                                      pas_deallocation_mode deallocation_mode)
+/* The deallocation fast path is split into an inline-only entry and a casual (slow)
+   case, mirroring how allocation works. The inline-only path handles only the
+   single most common case: we have a TLC, and the object lives in a small-exclusive-
+   segregated fast megapage. Anything else returns false so the client can tail-call
+   into the casual case. This keeps the inline path frame-free and lets clients that
+   need to dispatch across multiple heap configs do that in their own casual function
+   without bloating the inline body. */
+static PAS_ALWAYS_INLINE bool pas_try_deallocate_inline_only(void* ptr,
+                                                             pas_heap_config config,
+                                                             pas_deallocation_mode deallocation_mode)
 {
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
+
+    pas_thread_local_cache* thread_local_cache;
+    uintptr_t begin;
+    pas_fast_megapage_kind megapage_kind;
+
+    (void)deallocation_mode;
+
+    begin = (uintptr_t)ptr;
+    PAS_PROFILE(TRY_DEALLOCATE, &config, begin);
+
+    if (verbose)
+        pas_log("try_deallocate_inline_only for %p\n", (void*)begin);
+
+    thread_local_cache = pas_thread_local_cache_try_get();
+    if (PAS_UNLIKELY(!thread_local_cache)) {
+        if (verbose)
+            pas_log("Bailing to casual: no TLC.\n");
+        return false;
+    }
+
+    megapage_kind = config.fast_megapage_kind_func(begin);
+    if (PAS_UNLIKELY(megapage_kind != pas_small_exclusive_segregated_fast_megapage_kind)) {
+        if (verbose)
+            pas_log("Bailing to casual: megapage_kind = %d.\n", (int)megapage_kind);
+        return false;
+    }
+
+    pas_segregated_page_log_or_deallocate(
+        begin, thread_local_cache, config.small_segregated_config);
+    return true;
+}
+
+static PAS_ALWAYS_INLINE bool pas_try_deallocate_casual_case(void* ptr,
+                                                             pas_heap_config config,
+                                                             pas_deallocation_mode deallocation_mode)
+{
+    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
+
+    pas_thread_local_cache* thread_local_cache;
     uintptr_t begin;
     pas_fast_megapage_kind megapage_kind;
 
     begin = (uintptr_t)ptr;
-    
-    megapage_kind = config.fast_megapage_kind_func(begin);
-    if (PAS_LIKELY(megapage_kind == pas_small_exclusive_segregated_fast_megapage_kind)) {
-        pas_segregated_page_log_or_deallocate(
-            begin, thread_local_cache, config.small_segregated_config);
-        return true;
-    }
 
+    if (verbose)
+        pas_log("try_deallocate_casual_case for %p\n", (void*)begin);
+
+    thread_local_cache = pas_thread_local_cache_try_get();
+    if (PAS_UNLIKELY(!thread_local_cache))
+        return pas_try_deallocate_slow_no_cache((void*)begin, config.config_ptr, deallocation_mode);
+
+    megapage_kind = config.fast_megapage_kind_func(begin);
     return config.specialized_try_deallocate_not_small_exclusive_segregated(
         thread_local_cache, begin, deallocation_mode, megapage_kind);
 }
 
+static PAS_ALWAYS_INLINE void pas_deallocate_casual_case(void* ptr,
+                                                         pas_heap_config config)
+{
+    pas_try_deallocate_casual_case(ptr, config, pas_deallocate_mode);
+}
+
 /* This returns true if the object was successfully deallocated.
-   
+
    This returns false if the object pointer definitely does not into any heap for this config.
-   
+
    This may crash or return false if the object pointer points into a heap of this config, but not
    to a valid object start address. Specifically, this currently will crash if it's an invalid
    object pointer with an address inside pages managed by segregated or bitfit, but returns false
@@ -176,29 +229,9 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate(void* ptr,
                                                  pas_heap_config config,
                                                  pas_deallocation_mode deallocation_mode)
 {
-    static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
-
-    pas_thread_local_cache* thread_local_cache;
-    uintptr_t begin;
-
-    begin = (uintptr_t)ptr;
-    PAS_PROFILE(TRY_DEALLOCATE, &config, begin);
-    ptr = (void*)begin;
-
-    if (verbose)
-        pas_log("try_deallocate for %p\n", ptr);
-    
-    thread_local_cache = pas_thread_local_cache_try_get();
-    if (PAS_UNLIKELY(!thread_local_cache)) {
-        if (verbose)
-            pas_log("Going slow because no TLC.\n");
-        return pas_try_deallocate_slow_no_cache(ptr, config.config_ptr, deallocation_mode);
-    }
-
-    if (verbose)
-        pas_log("Going fast because have TLC = %p\n", thread_local_cache);
-    
-    return pas_try_deallocate_impl(thread_local_cache, ptr, config, deallocation_mode);
+    if (PAS_LIKELY(pas_try_deallocate_inline_only(ptr, config, deallocation_mode)))
+        return true;
+    return pas_try_deallocate_casual_case(ptr, config, deallocation_mode);
 }
 
 static PAS_ALWAYS_INLINE void pas_deallocate(void* ptr,


### PR DESCRIPTION
#### dbed4f5203d9dab0131c4687d6b87a87a932d5c8
<pre>
[libpas] Split pas_deallocate into inline-only and casual variants
<a href="https://bugs.webkit.org/show_bug.cgi?id=317687">https://bugs.webkit.org/show_bug.cgi?id=317687</a>
<a href="https://rdar.apple.com/problem/180447990">rdar://problem/180447990</a>

Reviewed by Yusuke Suzuki.

Consumers of libpas, e.g. bmalloc, must explicitly call the
inline-only allocation fast-path if they want to be able to allocate
with minimal latency. If that fails, then they are expected to call into
the slow path. This is more complicated than if libpas presented a
single try_allocate function, but that complexity is paid for by the
additional flexibility, as evidenced by pathways like the Gigacage and
other auxiliary heaps, as the fast-path of the main heap can be
preserved while still allowing callers to allocate from other heaps.

This patch applies the same approach to the deallocation pathway.
This has not previously been necessary, but is important for the ongoing
refactor of our MTE implementation, and for the Sequestered Heap
thereafter. In particular, we want to be able to preserve the fastest
fast-path on the deallocation side (i.e. the TLC-present
small-segregated free-to-scavenger) while still allowing the caller to
e.g. try freeing objects from multiple different candidate heaps.
This is not necessary for auxiliary heaps because they share megapage
tables and can thus participate in the same pas_deallocate lookup chain,
but distinct pas_heaps do not.

I intend to build on this patch with another one which will incorporate
the tagged-bmalloc-heap into our normal allocation paths. As with the
Gigacage today, the bmalloc layer will dispatch to either the normal
bmalloc_heap or the tagged_bmalloc_heap; on the deallocation side,
bmalloc&apos;s free will first try calling pas_deallocate_inline_only with
the untagged pas_heap_config, then if that fails fall back to the MTE
one, and finally to the casual case.

* Source/bmalloc/libpas/src/libpas/bmalloc_heap.c:
(bmalloc_deallocate_casual):
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
(bmalloc_deallocate_inline):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
(pas_try_deallocate_inline_only):
(pas_try_deallocate_casual_case):
(pas_deallocate_casual_case):
(pas_try_deallocate):
(pas_try_deallocate_impl): Deleted.

Canonical link: <a href="https://commits.webkit.org/315745@main">https://commits.webkit.org/315745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1845c836f1a9fa2e3139a3bf79575e6dcfb99c12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43775 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37167 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127565 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9b52811-21a7-43d3-881b-dea689d3bf58) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132376 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f6c9cdd-44b6-45dc-8c99-f8a9fb1273cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172812 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112878 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ffee5dde-9d9c-4450-9b97-5c52144452ff) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32520 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27910 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1207 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181811 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31108 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36686 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140831 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 21 flakes 1 failures; Uploaded test results; layout-tests; Running analyze-layout-tests-results") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43431 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37895 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44120 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108415 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35928 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202532 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42631 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7270 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54284 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42023 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42166 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->