### PR TITLE
use-after-free in CloseWatcher::destroy(): abort-signal algorithm calls destroy() via WeakPtr while CloseWatcherManager holds the last Ref

### DIFF
--- a/LayoutTests/fast/dom/CloseWatcher-watcher-crash-expected.txt
+++ b/LayoutTests/fast/dom/CloseWatcher-watcher-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/dom/CloseWatcher-watcher-crash.html
+++ b/LayoutTests/fast/dom/CloseWatcher-watcher-crash.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<body>
+This test passes if it does not crash.
+<script>
+globalThis.testRunner?.waitUntilDone();
+globalThis.testRunner?.dumpAsText();
+
+function gc() {
+    if (globalThis.GCController) GCController.collect();
+    else if (globalThis.$vm) $vm.gc();
+    else for (let i = 0; i < 10000; i++) new ArrayBuffer(0x1000);
+}
+
+const ac = new AbortController();
+
+// Create the CloseWatcher in a nested call frame so its wrapper
+// pointer doesn't linger on the conservative-scanned stack.
+(function () {
+    new CloseWatcher({ signal: ac.signal }); // no listeners, result discarded
+})();
+
+// Churn stack and force full GC so JSCloseWatcher is finalized and
+// the C++ CloseWatcher's refcount drops to 1 (held only by CloseWatcherManager).
+for (let i = 0; i < 100; i++) new Uint8Array(0x100);
+gc(); gc(); gc();
+
+// Trigger: AbortSignal::runAbortSteps -> lambda(weakWatcher) -> destroy()
+// -> manager->remove(*this) deletes `this` -> m_active=false (UAF write)
+// -> RefPtr signal = m_signal (UAF read).
+ac.abort();
+
+globalThis.testRunner?.notifyDone();
+</script>
+</body>

--- a/Source/WebCore/html/closewatcher/CloseWatcher.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.cpp
@@ -67,8 +67,8 @@ ExceptionOr<Ref<CloseWatcher>> CloseWatcher::create(ScriptExecutionContext& cont
         } else {
             watcher->m_signal = signal;
             watcher->m_signalAlgorithm = signal->addAlgorithm([weakWatcher = WeakPtr { watcher.get() }](JSC::JSValue) mutable {
-                if (weakWatcher)
-                    weakWatcher->destroy();
+                if (RefPtr watcher = weakWatcher.get())
+                    watcher->destroy();
             });
         }
     }


### PR DESCRIPTION
#### ae9baa4b0135d0c8e4c549793240905223f69d3e
<pre>
use-after-free in CloseWatcher::destroy(): abort-signal algorithm calls destroy() via WeakPtr while CloseWatcherManager holds the last Ref
<a href="https://bugs.webkit.org/show_bug.cgi?id=313626">https://bugs.webkit.org/show_bug.cgi?id=313626</a>
<a href="https://rdar.apple.com/175672431">rdar://175672431</a>

Reviewed by Ryosuke Niwa.

Protect the watcher before calling destroy() on it.

Test: fast/dom/CloseWatcher-watcher-crash.html

* LayoutTests/fast/dom/CloseWatcher-watcher-crash-expected.txt: Added.
* LayoutTests/fast/dom/CloseWatcher-watcher-crash.html: Added.
* Source/WebCore/html/closewatcher/CloseWatcher.cpp:
(WebCore::CloseWatcher::create):

Originally-landed-as: 305413.770@safari-7624-branch (a2cb3a724645). <a href="https://rdar.apple.com/180428565">rdar://180428565</a>
Canonical link: <a href="https://commits.webkit.org/316040@main">https://commits.webkit.org/316040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5036043a5fe48f41bf5340326812f6a4e0f2d702

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132380 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93270 "10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112882 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34549 "Found 9 new test failures: imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/report-only-frame.sub.html imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-cross-origin-same-document-navigation.window.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-with-x-frame-options.sub.html imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053.html imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative.html?type=text imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative.html?type=textarea imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html?rest imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer.html?rest (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32525 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27914 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181815 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140830 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140661 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38120 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44124 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108419 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35932 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115889 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42635 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7274 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42027 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->