### PR TITLE
Enable explicit module builds on cmake

### DIFF
--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -107,10 +107,10 @@ if (SWIFT_REQUIRED AND NOT (PORT STREQUAL GTK OR PORT STREQUAL WPE))
         ${PAL_DIR}/pal/crypto/CryptoKitShim.swift
     )
 
-    if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        # iOS Swift compiles transitively load UIKit→UIKitCore→WebKit_Private,
-        # whose PCM build needs our project -Xcc flags. Explicit modules let
-        # libSwiftScan pre-build PCMs with the right context.
+    if (APPLE)
+        # Swift compiles transitively load system frameworks whose PCM builds
+        # need our project -Xcc flags. Explicit modules let libSwiftScan
+        # pre-build PCMs with the right context.
         set(PAL_SWIFT_EXPLICIT_MODULE_BUILD TRUE)
     endif ()
 

--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -251,10 +251,10 @@ if (SWIFT_REQUIRED)
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-access-control>"
     )
 
-    if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
-        # iOS Swift compiles transitively load UIKit→UIKitCore→WebKit_Private,
-        # whose PCM build needs our project -Xcc flags. Explicit modules let
-        # libSwiftScan pre-build PCMs with the right context.
+    if (APPLE)
+        # Swift compiles transitively load system frameworks whose PCM builds
+        # need our project -Xcc flags. Explicit modules let libSwiftScan
+        # pre-build PCMs with the right context.
         set(WebGPU_SWIFT_EXPLICIT_MODULE_BUILD TRUE)
     endif ()
 

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -75,6 +75,11 @@ set(NetworkProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 # once ENABLE_BACK_FORWARD_LIST_SWIFT pulls in C++ interop.
 set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WEBKIT_DIR}/Modules/Internal")
 
+# Mac Swift compilation uses explicit module builds so libSwiftScan pre-builds
+# all PCMs (including WebKit_Internal C++ interop) with the project -Xcc flags,
+# avoiding duplicated per-process module compilation. Same rationale as iOS.
+set(WebKit_SWIFT_EXPLICIT_MODULE_BUILD TRUE)
+
 # Xcode does not set SWIFT_TREAT_WARNINGS_AS_ERRORS; override CMake's -warnings-as-errors.
 # Must go in WebKit_COMPILE_OPTIONS (applied after -warnings-as-errors in _WEBKIT_TARGET_SETUP).
 list(APPEND WebKit_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:Swift>:-no-warnings-as-errors>")

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1131,12 +1131,13 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # found". -disable-sandbox skips the inner sandbox; the macros are
         # WebKit's own, so the isolation it provides isn't load-bearing here.
         list(APPEND _swift_options "-disable-sandbox")
-        # Implicit module builds share work via -module-cache-path; explicit
-        # builds were tried but strip project -Xcc -include/-I from per-module
-        # PCM compiles, which breaks the C++ interop modules' prefix header.
-        # Targets that need explicit modules (e.g. iOS Swift targets that
-        # transitively load UIKit→UIKitCore→WebKit_Private) can opt in via
+        # Explicit module builds (EMB) pre-build all Clang PCMs once via
+        # libSwiftScan, so each swift-frontend process reuses them rather than
+        # rebuilding from scratch. This is faster when many Swift source files
+        # import the same C++ interop modules. Targets opt in by setting
         # ${_target}_SWIFT_EXPLICIT_MODULE_BUILD before the macro call.
+        # All Apple targets (PAL/WebGPU/WebKit on iOS and Mac) use EMB;
+        # non-Apple builds rely on -module-cache-path for implicit sharing.
         if (${_target}_SWIFT_EXPLICIT_MODULE_BUILD)
             list(APPEND _swift_options "-explicit-module-build")
             # Force experimental clang attributes ON to match cached SwiftShims


### PR DESCRIPTION
#### 429cef317f138696a883109d283d5dff09969ba6
<pre>
Enable explicit module builds on cmake
<a href="https://bugs.webkit.org/show_bug.cgi?id=317688">https://bugs.webkit.org/show_bug.cgi?id=317688</a>
<a href="https://rdar.apple.com/180449579">rdar://180449579</a>

Reviewed by Mike Wyrzykowski.

This aims to enable Explicit Module Builds in Swift. This should allow multiple
swift-frontend commands to avoid duplicating effort when importing C/C++
modules.

Canonical link: <a href="https://commits.webkit.org/315808@main">https://commits.webkit.org/315808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1aa5499d27b04b9a8fc52ca67c3ca57dfd65d2a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127571 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f06be6a3-86dc-4809-8607-e2692bb18797) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132382 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93271 "2 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbedd055-d6cc-4707-baf8-5e5c4783672d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172818 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35672 "Build is in progress. Recent messages:") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112884 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa532d60-d0cc-43fe-9e42-ba9019d8aef1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32528 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27916 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1212 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181817 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31114 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140832 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43437 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140663 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37943 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44126 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29175 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108421 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35933 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115891 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202538 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42637 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7275 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54285 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42029 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42284 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->