### PR TITLE
Fixup model warnings in Swift code

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -28,7 +28,6 @@ import WebKit
 import RealityKit
 import USDKit
 import DirectResource
-import ShaderGraph
 #endif
 
 @objc

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -286,7 +286,7 @@ internal func debugPrintShaderGraph(_ graph: ShaderGraph?, prefix: String = "", 
     // Print edges
     logInfo("\(nextIndent)Edges (\(graph.edges.count)):")
     for (index, edge) in graph.edges.enumerated() {
-        logInfo("\(nextIndent)  [\(index)] \(edge.outputNode):\(edge.outputPort ?? "") -> \(edge.inputNode):\(edge.inputPort ?? "")")
+        logInfo("\(nextIndent)  [\(index)] \(edge.outputNode):\(edge.outputPort ?? "") -> \(edge.inputNode):\(edge.inputPort)")
     }
 }
 
@@ -490,8 +490,8 @@ internal func compareShaderGraphs(
         differences.append("Edge count differs: \(graph1.edges.count) vs \(graph2.edges.count)")
     } else {
         // Create comparable edge descriptions
-        let edges1Set = Set(graph1.edges.map { "\($0.outputNode):\($0.outputPort ?? "") -> \($0.inputNode):\($0.inputPort ?? "")" })
-        let edges2Set = Set(graph2.edges.map { "\($0.outputNode):\($0.outputPort ?? "") -> \($0.inputNode):\($0.inputPort ?? "")" })
+        let edges1Set = Set(graph1.edges.map { "\($0.outputNode):\($0.outputPort ?? "") -> \($0.inputNode):\($0.inputPort)" })
+        let edges2Set = Set(graph2.edges.map { "\($0.outputNode):\($0.outputPort ?? "") -> \($0.inputNode):\($0.inputPort)" })
 
         let onlyIn1 = edges1Set.subtracting(edges2Set)
         let onlyIn2 = edges2Set.subtracting(edges1Set)

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel+Deformation.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel+Deformation.swift
@@ -27,12 +27,9 @@ import WebKit
 import simd
 
 #if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreDeformation, _version: 23.0.2) && canImport(USDKit, _version: 106.0.2) && arch(arm64)
-import RealityCoreTextureProcessing
 import USDKit
 import DirectResource
 import RealityKit
-import ShaderGraph
-import RealityCoreDeformation
 
 // Safe wrapper of unsafe functions
 extension MTLBuffer {

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -30,8 +30,6 @@ import simd
 import USDKit
 import DirectResource
 import RealityKit
-import ShaderGraph
-import RealityCoreDeformation
 import UniformTypeIdentifiers
 
 extension MTLCaptureDescriptor {


### PR DESCRIPTION
#### d393e73a54d9112f4ca85bd95d4c1f8f9f23f6af
<pre>
Fixup model warnings in Swift code
<a href="https://bugs.webkit.org/show_bug.cgi?id=317692">https://bugs.webkit.org/show_bug.cgi?id=317692</a>
<a href="https://rdar.apple.com/180451184">rdar://180451184</a>

Reviewed by Richard Robinson.

Cleanup some warnings.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
* Source/WebKit/GPUProcess/graphics/Model/USDModel+Deformation.swift:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/315717@main">https://commits.webkit.org/315717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec30d0beb513086c0494ce052cb54446b1c106fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179232 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47db2b6c-8cd4-412d-b642-ee35d810cdec) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43425 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab6ec6fc-80e3-4ecc-98d8-3565ed42b8ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172832 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112895 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb4eb401-33a7-408b-a8b1-ec21e3575e85) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27930 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181831 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/140844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43451 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140675 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37871 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44140 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108435 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35940 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42651 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42298 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42186 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->