### PR TITLE
WebResourceLoader::WillSendRequest reply may lead to cross-origin cookie access

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1460,10 +1460,19 @@ void NetworkResourceLoader::continueWillSendRedirectedRequest(ResourceRequest&& 
 
     // We send the request body separately because the ResourceRequest body normally does not get encoded when sent over IPC, as an optimization.
     // However, we really need the body here because a redirect cross-site may cause a process-swap and the request to start again in a new WebContent process.
-    sendWithAsyncReply(Messages::WebResourceLoader::WillSendRequest(redirectRequest, IPC::FormDataReference { redirectRequest.httpBody() }, sanitizeResponseIfPossible(WTF::move(redirectResponse), ResourceResponse::SanitizationType::Redirection)), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (ResourceRequest&& newRequest, bool isAllowedToAskUserForCredentials) mutable {
+    sendWithAsyncReply(Messages::WebResourceLoader::WillSendRequest(redirectRequest, IPC::FormDataReference { redirectRequest.httpBody() }, sanitizeResponseIfPossible(WTF::move(redirectResponse), ResourceResponse::SanitizationType::Redirection)), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler), firstPartyForCookiesFromRedirectRequest = redirectRequest.firstPartyForCookies()] (ResourceRequest&& newRequest, bool isAllowedToAskUserForCredentials) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler({ });
+
+        if (newRequest.firstPartyForCookies() != firstPartyForCookiesFromRedirectRequest) {
+            Ref connection = protectedThis->m_connection;
+            auto allowCookieAccess = connection->networkProcess().allowsFirstPartyForCookies(
+                connection->webProcessIdentifier(), newRequest.firstPartyForCookies());
+            MESSAGE_CHECK_COMPLETION_BASE(allowCookieAccess == NetworkProcess::AllowCookieAccess::Allow,
+                connection->connection(), completionHandler({ }));
+        }
+
         protectedThis->continueWillSendRequest(WTF::move(newRequest), isAllowedToAskUserForCredentials, WTF::move(completionHandler));
     });
 }


### PR DESCRIPTION
#### 64315b6f7b375021083fe772cf91baca65617cb1
<pre>
WebResourceLoader::WillSendRequest reply may lead to cross-origin cookie access
<a href="https://bugs.webkit.org/show_bug.cgi?id=313866">https://bugs.webkit.org/show_bug.cgi?id=313866</a>
<a href="https://rdar.apple.com/174663032">rdar://174663032</a>

Reviewed by Per Arne Vollan.

Consider this sequence of events:
1. A compromised web process schedules a load with its own origin used for
   firstPartyForCookies.
2. NetworkConnectionToWebProcess::scheduleResourceLoad() is called and the
   message check passes.
3. The request goes through and the server responds with 302 (redirect).
4. NetworkResourceLoader::continueWillSendRedirectedRequest() calls
   WebResourceLoader::WillSendRequest() which gives the web process the chance
   to alter the request that will be sent to perform the redirect.
5. The compromised web process alters the request so that firstPartyForCookies
   is now a different origin.
6. NetworkResourceLoader::continueWillSendRequest() receives this altered
   request and passes it off to CFNetwork.
7. The result of this request is that the compromised web process receives
   the cookies of this different origin.

There are multiple callsites of continueWillSendRequest(), but only one place
which allows the web process to alter the request before it&apos;s given to
continueWillSendRequest(). So we fix this by adding a message check right
before that callsite that will double check that the origin contained in this
potentially modified request from the web process is in this web process&apos;s
allowed list. If not, the web process will be killed so that it doesn&apos;t recieve
the cross-origin cookies.

We also only do this message check if the web process actually changes the
origin. This is because there are cases where the origin is not yet in the
allowlist but not because the web process modified it (like in:
imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect
where there is a cross-site redirect as part of a prefetch, so the cross-site
origin is supplied by the server but hasn&apos;t made it into the allow list since
the navigation to it is not complete).

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::continueWillSendRedirectedRequest):

Originally-landed-as: 305413.834@safari-7624-branch (9fd9439df22f). <a href="https://rdar.apple.com/180437365">rdar://180437365</a>
Canonical link: <a href="https://commits.webkit.org/316046@main">https://commits.webkit.org/316046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d45e42d23fd08ae903fa597f639f220ab6e4ca07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127590 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132396 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93283 "1 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112898 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34551 "Found 9 new test failures: imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/report-only-frame.sub.html imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-cross-origin-same-document-navigation.window.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-frame-ancestors-with-x-frame-options.sub.html imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053.html imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative.html?type=text imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative.html?type=textarea imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html?rest imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer.html?rest (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32537 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181836 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140848 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43456 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38123 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44145 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29181 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108440 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35945 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115910 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42656 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7281 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42048 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->