### PR TITLE
Stack buffer overflow in WebKit libwebrtc VideoCodecInitializer via remote SDP simulcast layers leads to WebContent memory corruption

### DIFF
--- a/LayoutTests/webrtc/addTrack-simulcast-expected.txt
+++ b/LayoutTests/webrtc/addTrack-simulcast-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Trim simulcast encodings when using receive encodings for send encodings
+

--- a/LayoutTests/webrtc/addTrack-simulcast.html
+++ b/LayoutTests/webrtc/addTrack-simulcast.html
@@ -1,0 +1,67 @@
+<!doctype html><!-- webkit-test-runner [ WebRTCRemoteVideoFrameEnabled=true ] -->
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing basic video exchange from offerer to receiver</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+<canvas id="canvas" width="640" height="480"></canvas>
+<script>
+function buildMaliciousOffer(nLayers) {
+  const rids = [];
+  for (let i = 0; i < nLayers; i++) rids.push('r' + i);
+  const ridLines = rids.map(r => `a=rid:${r} recv`).join('\r\n');
+  const simLayers = rids.map((r, i) => (i === nLayers - 1 ? r : '~' + r)).join(';');
+  return [
+    'v=0',
+    'o=- 1 2 IN IP4 127.0.0.1',
+    's=-',
+    't=0 0',
+    'a=group:BUNDLE 0',
+    'a=extmap-allow-mixed',
+    'a=msid-semantic: WMS',
+    'm=video 9 UDP/TLS/RTP/SAVPF 96',
+    'c=IN IP4 0.0.0.0',
+    'a=rtcp:9 IN IP4 0.0.0.0',
+    'a=ice-ufrag:aaaa',
+    'a=ice-pwd:bbbbbbbbbbbbbbbbbbbbbb',
+    'a=ice-options:trickle',
+    'a=fingerprint:sha-256 00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF',
+    'a=setup:actpass',
+    'a=mid:0',
+    'a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid',
+    'a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id',
+    'a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id',
+    'a=sendrecv',
+    'a=rtcp-mux',
+    'a=rtcp-rsize',
+    'a=rtpmap:96 VP8/90000',
+    'a=rtcp-fb:96 nack',
+    'a=rtcp-fb:96 nack pli',
+    'a=rtcp-fb:96 ccm fir',
+    ridLines,
+    `a=simulcast:recv ${simLayers}`,
+    ''
+  ].join('\r\n');
+}
+
+promise_test(async t => {
+    const pc = new RTCPeerConnection();
+    const malOffer = buildMaliciousOffer(4);
+    await pc.setRemoteDescription({ type: 'offer', sdp: malOffer });
+
+    const context = canvas.getContext('2d');
+    context.fillStyle = `green`;
+    setInterval(() => {
+        context.fillRect(0, 0, canvas.width, canvas.height);
+    }, 30);
+    const localStream = canvas.captureStream(30);
+    pc.addTrack(localStream.getVideoTracks()[0], localStream);
+
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+}, "Trim simulcast encodings when using receive encodings for send encodings");
+</script>
+</body>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/video_codec_initializer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/video_codec_initializer.cc
@@ -99,8 +99,11 @@ VideoCodec VideoCodecInitializer::SetupCodec(
   video_codec.timing_frame_thresholds = {
       .delay_ms = kDefaultTimingFramesDelayMs,
       .outlier_ratio_percent = kDefaultOutlierFrameSizePercent};
+#if WEBRTC_WEBKIT_BUILD
+  RTC_CHECK_LE(streams.size(), kMaxSimulcastStreams);
+#else
   RTC_DCHECK_LE(streams.size(), kMaxSimulcastStreams);
-
+#endif
   int max_framerate = 0;
 
   std::optional<ScalabilityMode> scalability_mode;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/sdp_offer_answer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/sdp_offer_answer.cc
@@ -841,6 +841,9 @@ std::vector<RtpEncodingParameters> GetSendEncodingsFromRemoteDescription(
 
   // This is a remote description, the parameters we are after should appear
   // as receive streams.
+#if WEBRTC_WEBKIT_BUILD
+  size_t parametersCounter = 0;
+#endif
   for (const auto& alternatives : simulcast.receive_layers()) {
     if (result.size() >= kMaxSimulcastStreams) {
       RTC_LOG(LS_WARNING)
@@ -864,6 +867,10 @@ std::vector<RtpEncodingParameters> GetSendEncodingsFromRemoteDescription(
       parameters.codec = rid_desc->codecs[0].ToCodecParameters();
     }
     result.push_back(parameters);
+#if WEBRTC_WEBKIT_BUILD
+    if (++parametersCounter >= kMaxSimulcastStreams)
+      break;
+#endif
   }
 
   return result;

--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeOutgoingVideoSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeOutgoingVideoSourceCocoa.cpp
@@ -67,8 +67,6 @@ RealtimeOutgoingVideoSourceCocoa::~RealtimeOutgoingVideoSourceCocoa() = default;
 
 void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetadata)
 {
-    ASSERT(!m_isApplyingRotation);
-
 #if !RELEASE_LOG_DISABLED
     if (!(++m_numberOfFrames % 60))
         ALWAYS_LOG(LOGIDENTIFIER, "frame ", m_numberOfFrames);


### PR DESCRIPTION
#### e8a476cd12df5fb1ea1f682f1c2381397c44ccef
<pre>
Stack buffer overflow in WebKit libwebrtc VideoCodecInitializer via remote SDP simulcast layers leads to WebContent memory corruption
<a href="https://rdar.apple.com/175624943">rdar://175624943</a>

Reviewed by Eric Carlson.

When computing send encodings from remote SDP, we trim them according the max simulcast encodings, like done for addTransceiver.
We also change the debug check VideoCodecInitializer::SetupCodec in a release check as a further mitigation.

Test: webrtc/addTrack-simulcast.html

* LayoutTests/webrtc/addTrack-simulcast-expected.txt: Added.
* LayoutTests/webrtc/addTrack-simulcast.html: Added.
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/video_codec_initializer.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/sdp_offer_answer.cc:

Originally-landed-as: 305413.820@safari-7624-branch (0d8fd1ca4be9). <a href="https://rdar.apple.com/181073924">rdar://181073924</a>
Canonical link: <a href="https://commits.webkit.org/316431@main">https://commits.webkit.org/316431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13846c75d4366fe51c707dfed2971d7183bdc551

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133912 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114385 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35979 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30229 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33968 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184147 "") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38453 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/184147 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154046 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/184147 "") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38516 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46434 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111117 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/26149 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37639 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44952 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8905 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->