### PR TITLE
Use-after-free in AutoFillButtonElement::defaultEventHandler

### DIFF
--- a/LayoutTests/fast/forms/auto-fill-button/auto-fill-button-click-then-type-change-crash-expected.txt
+++ b/LayoutTests/fast/forms/auto-fill-button/auto-fill-button-click-then-type-change-crash-expected.txt
@@ -1,0 +1,4 @@
+This test passes if WebKit does not hit debug assertions or crash under ASAN.
+
+
+PASS

--- a/LayoutTests/fast/forms/auto-fill-button/auto-fill-button-click-then-type-change-crash.html
+++ b/LayoutTests/fast/forms/auto-fill-button/auto-fill-button-click-then-type-change-crash.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<body>
+<div id="result"><input type="password"></div>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+onload = async () => {
+    if (!window.testRunner || !window.eventSender) {
+        result.innerHTML = '<p>FAIL - This test requires testRunner and eventSender.</p>';
+        return;
+    }
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const input = document.querySelector('input');
+    internals.setAutofillButtonType(input, 'Credentials');
+
+    const autoFillButton = Array.from(internals.shadowRoot(input).querySelectorAll('div')).find((div) => {
+        return internals.userAgentPart(div) == '-webkit-credentials-auto-fill-button';
+    });
+
+    input.addEventListener('click', () => {
+        input.type = 'button';
+        if (window.GCController)
+            GCController.collect();
+    }, { once:true });
+
+    await UIHelper.activateElement(autoFillButton);
+
+    result.innerHTML = '<p>This test passes if WebKit does not hit debug assertions or crash under ASAN.</p><br>PASS';
+
+    testRunner.notifyDone();
+};
+</script>

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -51,8 +51,8 @@ public:
     }
 
     // PopupMenuClient ref-counting (disambiguating from InputType)
-    void ref() const final { BaseTextInputType::ref(); }
-    void deref() const final { BaseTextInputType::deref(); }
+    void ref() const final { InputType::ref(); }
+    void deref() const final { InputType::deref(); }
 
     // PopupMenuClient methods
     void valueChanged(unsigned listIndex, bool fireEvents = true) override;

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -425,6 +425,8 @@ void TextFieldInputType::removeShadowSubtree()
         innerSpinButton->removeSpinButtonOwner();
     m_innerSpinButton = nullptr;
     m_capsLockIndicator = nullptr;
+    if (RefPtr autoFillButton = m_autoFillButton.get())
+        autoFillButton->removeOwner();
     m_autoFillButton = nullptr;
     m_dataListDropdownIndicator = nullptr;
     m_container = nullptr;

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -54,6 +54,9 @@ class TextFieldInputType : public InputType, protected SpinButtonOwner, protecte
 public:
     bool valueMissing(StringView) const final;
 
+    void ref() const override { InputType::ref(); }
+    void deref() const override { InputType::deref(); }
+
 protected:
     explicit TextFieldInputType(Type, HTMLInputElement&);
     virtual ~TextFieldInputType();
@@ -151,7 +154,7 @@ private:
     RefPtr<HTMLElement> m_placeholder;
     RefPtr<SpinButtonElement> m_innerSpinButton;
     RefPtr<HTMLElement> m_capsLockIndicator;
-    RefPtr<HTMLElement> m_autoFillButton;
+    RefPtr<AutoFillButtonElement> m_autoFillButton;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/AutoFillButtonElement.cpp
+++ b/Source/WebCore/html/shadow/AutoFillButtonElement.cpp
@@ -57,7 +57,8 @@ void AutoFillButtonElement::defaultEventHandler(Event& event)
     }
 
     if (isAnyClick(*mouseEvent)) {
-        m_owner.autoFillButtonElementWasClicked();
+        if (RefPtr owner = m_owner.get())
+            owner->autoFillButtonElementWasClicked();
         event.setDefaultHandled();
     }
 

--- a/Source/WebCore/html/shadow/AutoFillButtonElement.h
+++ b/Source/WebCore/html/shadow/AutoFillButtonElement.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "HTMLDivElement.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class AutoFillButtonElement final : public HTMLDivElement {
     WTF_MAKE_TZONE_ALLOCATED(AutoFillButtonElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AutoFillButtonElement);
 public:
-    class AutoFillButtonOwner {
+    class AutoFillButtonOwner : public AbstractRefCountedAndCanMakeWeakPtr<AutoFillButtonOwner> {
     public:
         virtual ~AutoFillButtonOwner() = default;
         virtual void autoFillButtonElementWasClicked() = 0;
@@ -43,12 +44,14 @@ public:
 
     static Ref<AutoFillButtonElement> create(Document&, AutoFillButtonOwner&);
 
+    void removeOwner() { m_owner = nullptr; }
+
 private:
     explicit AutoFillButtonElement(Document&, AutoFillButtonOwner&);
 
     void defaultEventHandler(Event&) final;
 
-    AutoFillButtonOwner& m_owner;
+    WeakPtr<AutoFillButtonOwner> m_owner;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### fac72c776640f70077dd6f4b021916213c10709a
<pre>
Use-after-free in AutoFillButtonElement::defaultEventHandler
<a href="https://bugs.webkit.org/show_bug.cgi?id=313700">https://bugs.webkit.org/show_bug.cgi?id=313700</a>

Reviewed by Aditya Keerthi.

AutoFillButtonElement held its AutoFillButtonOwner as a raw C++ reference. When a click listener on the host
input element flips input.type in the middle of a click event dispatch, HTMLInputElement::updateType()
destroys the old TextFieldInputType (the only owner), but the button is kept alive by EventPath.
callDefaultEventHandlersInBubblingOrder then makes the virtual call m_owner.autoFillButtonElementWasClicked()
through freed memory.

Fix mirrors the existing SpinButtonElement pattern: AutoFillButtonOwner now derives from
AbstractRefCountedAndCanMakeWeakPtr, the back-reference is a WeakPtr that is null-checked (and RefPtr-protected)
in defaultEventHandler, TextFieldInputType forwards ref()/deref() to InputType and clears the back-reference
in removeShadowSubtree() via a new removeAutoFillButtonOwner().

Test: fast/forms/auto-fill-button/auto-fill-button-click-then-type-change-crash.html

* LayoutTests/fast/forms/auto-fill-button/auto-fill-button-click-then-type-change-crash-expected.txt: Added.
* LayoutTests/fast/forms/auto-fill-button/auto-fill-button-click-then-type-change-crash.html: Added.
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::removeShadowSubtree):
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/html/shadow/AutoFillButtonElement.cpp:
(WebCore::AutoFillButtonElement::defaultEventHandler):
* Source/WebCore/html/shadow/AutoFillButtonElement.h:

Originally-landed-as: 305413.807@safari-7624-branch (354642cc1251). <a href="https://rdar.apple.com/180428678">rdar://180428678</a>
Canonical link: <a href="https://commits.webkit.org/316086@main">https://commits.webkit.org/316086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d301009cf63b3bf9b9b7575aab6584eb9daf4a6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133247 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113734 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35089 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33402 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28893 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182799 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141705 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141515 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38158 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45105 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109810 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36784 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116996 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43616 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8172 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43262 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->