### PR TITLE
[resize-observer] m_target could be null in ResizeObservation::computeObservedSizes

### DIFF
--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -76,15 +76,16 @@ auto ResizeObservation::computeObservedSizes() const -> std::optional<BoxSizes>
         }
     }
 
-    CheckedPtr box = m_target->renderBox();
-    if (box) {
-        if (box->isSkippedContent())
-            return std::nullopt;
-        return { {
-            Style::adjustLayoutSizeForAbsoluteZoom(box->contentBoxSize(), *box),
-            Style::adjustLayoutSizeForAbsoluteZoom(box->contentBoxLogicalSize(), *box),
-            Style::adjustLayoutSizeForAbsoluteZoom(box->borderBoxLogicalSize(), *box)
-        } };
+    if (RefPtr target = m_target) {
+        if (CheckedPtr box = target->renderBox()) {
+            if (box->isSkippedContent())
+                return std::nullopt;
+            return { {
+                Style::adjustLayoutSizeForAbsoluteZoom(box->contentBoxSize(), *box),
+                Style::adjustLayoutSizeForAbsoluteZoom(box->contentBoxLogicalSize(), *box),
+                Style::adjustLayoutSizeForAbsoluteZoom(box->borderBoxLogicalSize(), *box)
+            } };
+        }
     }
 
     return BoxSizes { };
@@ -92,11 +93,8 @@ auto ResizeObservation::computeObservedSizes() const -> std::optional<BoxSizes>
 
 LayoutPoint ResizeObservation::computeTargetLocation() const
 {
-    if (!m_target)
-        return { };
-
-    if (!m_target->isSVGElement()) {
-        if (CheckedPtr box = m_target->renderBox())
+    if (RefPtr target = m_target; target && !target->isSVGElement()) {
+        if (CheckedPtr box = target->renderBox())
             return LayoutPoint(box->paddingLeft(), box->paddingTop());
     }
 


### PR DESCRIPTION
#### a4228a6eb4ff8259274d9555f076885035670f67
<pre>
[resize-observer] m_target could be null in ResizeObservation::computeObservedSizes
<a href="https://rdar.apple.com/179427046">rdar://179427046</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317698">https://bugs.webkit.org/show_bug.cgi?id=317698</a>

Reviewed by Simon Fraser.

Crash reports indicate that when ResizeObservation::computeObservedSizes is called,
it&apos;s possible for m_target to be nullptr, indicating the Element was destroyed
before the method is called. So far I&apos;ve not been able to reproduce this nor
figure out a plausible explanation, so this patch speculatively fixes it by
adding a null check, plus turning the WeakPtr into RefPtr before using it.

* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::computeObservedSizes const):
(WebCore::ResizeObservation::computeTargetLocation const):

Canonical link: <a href="https://commits.webkit.org/315929@main">https://commits.webkit.org/315929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc9a763094fd6be738263432d1b7b702c7a8f2ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127782 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef819056-9b4c-4c53-bf07-66a8a29c3bea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132561 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93408 "1 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8da2c08c-dcf8-4823-bd9d-f40074ea216b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113063 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c269d0b-243c-4efa-b060-ebadc15e14c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34353 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32702 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28128 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182029 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34818 "Found 146 new failures in css/typedom/transform/CSSTransformValue.cpp, dfg/DFGBasicBlock.cpp, runtime/IndexingType.cpp, bytecompiler/BytecodeGenerator.cpp, dfg/DFGSpeculativeJIT.cpp, layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp, PipelineLayout.mm, jit/JITDisassembler.cpp, platform/SharedStringHash.cpp, b3/B3StackmapSpecial.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141013 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43649 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140842 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38030 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108687 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36111 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116219 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Running scan-build") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42849 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7477 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42241 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42495 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42384 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->