### PR TITLE
Stop rewriting prefixed CSS values in import-w3c-tests

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_converter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_converter.py
@@ -46,8 +46,8 @@ def convert_for_webkit(new_path, filename, reference_support_info, reference_fil
 
     converter = _W3CTestConverter(new_path, filename, reference_support_info, reference_file_renames, host, webkit_test_runner_options)
     if filename.endswith('.css'):
-        result = converter.add_webkit_prefix_to_unprefixed_properties_and_values(contents)
-        if not result[0] and not result[1]:
+        result = converter.add_webkit_prefix_to_unprefixed_properties(contents)
+        if not result[0]:
             return None
         return result
     elif filename.endswith(('.html', '.htm', '.xhtml', '.xht', '.xml', '.svg')):
@@ -68,7 +68,6 @@ class _W3CTestConverter(HTMLParser):
 
         self.converted_data = []
         self.converted_properties = []
-        self.converted_property_values = []
         self.in_style_tag = False
         self.style_data = []
         self.filename = filename
@@ -80,20 +79,15 @@ class _W3CTestConverter(HTMLParser):
 
         # These settings might vary between WebKit and Blink
         css_property_file = self.path_from_webkit_root('Source', 'WebCore', 'css', 'CSSProperties.json')
-        css_property_value_file = self.path_from_webkit_root('Source', 'WebCore', 'css', 'CSSValueKeywords.in')
 
         self.prefixed_properties = self.read_webkit_prefixed_css_property_list(css_property_file)
         prop_regex = r'([\s{]|^)(' + "|".join(prop.replace('-webkit-', '') for prop in self.prefixed_properties) + r')(\s+:|:)'
         self.prop_re = re.compile(prop_regex)
 
-        self.prefixed_property_values = self.legacy_read_webkit_prefixed_css_property_list(css_property_value_file)
-        prop_value_regex = r'(:\s*|^\s*)(' + "|".join(value.replace('-webkit-', '') for value in self.prefixed_property_values) + r')(\s*;|\s*}|\s*$)'
-        self.prop_value_re = re.compile(prop_value_regex)
-
     def output(self):
         if not self._modified:
             return None
-        return (self.converted_properties, self.converted_property_values, ''.join(self.converted_data))
+        return (self.converted_properties, ''.join(self.converted_data))
 
     def path_from_webkit_root(self, *comps):
         return self._filesystem.abspath(self._filesystem.join(self._webkit_root, *comps))
@@ -124,52 +118,22 @@ class _W3CTestConverter(HTMLParser):
         # Ignore any prefixed properties for which an unprefixed version is supported
         return [prop for prop in prefixed_properties if prop not in unprefixed_properties]
 
-    def legacy_read_webkit_prefixed_css_property_list(self, file_name):
-        contents = self._filesystem.read_text_file(file_name)
-        prefixed_properties = []
-        unprefixed_properties = set()
+    def add_webkit_prefix_to_unprefixed_properties(self, text):
+        """ Searches |text| for instances of properties requiring the -webkit- prefix and adds the prefix to them.
 
-        for line in contents.splitlines():
-            if re.match('^(#|//)', line) or len(line.strip()) == 0:
-                # skip comments and preprocessor directives and empty lines.
-                continue
-            # Property name is always first on the line.
-            property_name = line.split(' ', 1)[0]
-            # Find properties starting with the -webkit- prefix.
-            match = re.match(r'-webkit-([\w|-]*)', property_name)
-            if match:
-                prefixed_properties.append(match.group(1))
-            else:
-                unprefixed_properties.add(property_name.strip())
-
-        # Ignore any prefixed properties for which an unprefixed version is supported
-        return [prop for prop in prefixed_properties if prop not in unprefixed_properties]
-
-    def add_webkit_prefix_to_unprefixed_properties_and_values(self, text):
-        """ Searches |text| for instances of properties and values requiring the -webkit- prefix and adds the prefix to them.
-
-        Returns the list of converted properties, values and the modified text."""
-
-        converted_properties = self.add_webkit_prefix_following_regex(text, self.prop_re)
-        converted_property_values = self.add_webkit_prefix_following_regex(converted_properties[1], self.prop_value_re)
-
-        # FIXME: Handle the JS versions of these properties and values and GetComputedStyle, too.
-        return (converted_properties[0], converted_property_values[0], converted_property_values[1])
-
-    def add_webkit_prefix_following_regex(self, text, regex):
+        Returns the list of converted properties and the modified text."""
         converted_list = set()
-        text_chunks = []
-        cur_pos = 0
-        for m in regex.finditer(text):
-            text_chunks.extend([text[cur_pos:m.start()], m.group(1), '-webkit-', m.group(2), m.group(3)])
+
+        def replace(m):
             converted_list.add(m.group(2))
-            cur_pos = m.end()
-        text_chunks.append(text[cur_pos:])
+            return f'{m.group(1)}-webkit-{m.group(2)}{m.group(3)}'
+
+        new_text = self.prop_re.sub(replace, text)
 
         for item in converted_list:
             _log.info('  converting %s', item)
 
-        return (converted_list, ''.join(text_chunks))
+        return (converted_list, new_text)
 
     def convert_reference_relpaths(self, text):
         """ Searches |text| for instances of files in reference_support_info and updates the relative path to be correct for the new ref file location"""
@@ -185,18 +149,15 @@ class _W3CTestConverter(HTMLParser):
         return converted
 
     def convert_style_data(self, data):
-        converted = self.add_webkit_prefix_to_unprefixed_properties_and_values(data)
+        converted = self.add_webkit_prefix_to_unprefixed_properties(data)
         if converted[0]:
             self._modified = True
-            self.converted_properties.extend(list(converted[0]))
-        if converted[1]:
-            self._modified = True
-            self.converted_property_values.extend(list(converted[1]))
+            self.converted_properties.extend(converted[0])
 
         if self.reference_support_info is None or self.reference_support_info == {}:
-            return converted[2]
+            return converted[1]
 
-        return self.convert_reference_relpaths(converted[2])
+        return self.convert_reference_relpaths(converted[1])
 
     def convert_attributes_if_needed(self, tag, attrs):
         converted = self.get_starttag_text()

--- a/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
@@ -59,8 +59,6 @@ class W3CTestConverterTest(unittest.TestCase):
         converter = _W3CTestConverter(DUMMY_PATH, DUMMY_FILENAME, None)
         prop_list = converter.prefixed_properties
         self.assertTrue(prop_list, 'No prefixed properties found')
-        property_values_list = converter.prefixed_property_values
-        self.assertTrue(property_values_list, 'No prefixed property values found')
 
     def test_convert_for_webkit_nothing_to_convert(self):
         """ Tests convert_for_webkit() using a basic test that has nothing to convert """
@@ -118,28 +116,27 @@ CONTENT OF TEST
 <script src="/resources/testharness.js"></script>
 <style type="text/css">
 
-#block1 { @test0@: @propvalue0@; }
+#block1 { @test0@: placeholder; }
 
 </style>
 </head>
 <body>
-<div id="elem1" style="@test1@: @propvalue1@;"></div>
+<div id="elem1" style="@test1@: placeholder;"></div>
 </body>
 </html>
 """
         fake_dir_path = self.fake_dir_path('harnessandprops')
         converter = _W3CTestConverter(fake_dir_path, DUMMY_FILENAME, None)
-        test_content = self.generate_test_content_properties_and_values(converter.prefixed_properties, converter.prefixed_property_values, 1, test_html)
+        test_content = self.generate_test_content(converter.prefixed_properties, 1, 'test', test_html)
 
         with OutputCapture():
-            converter.feed(test_content[2])
+            converter.feed(test_content[1])
             converter.close()
             converted = converter.output()
 
         self.verify_conversion_happened(converted)
-        self.verify_test_harness_paths(converted[2], 1, 1)
+        self.verify_test_harness_paths(converted[1], 1, 1)
         self.verify_prefixed_properties(converted, test_content[0])
-        self.verify_prefixed_property_values(converted, test_content[1])
 
     def test_convert_for_webkit_harness_and_properties(self):
         """ Tests convert_for_webkit() using a basic JS test that uses testharness.js and testharness.css and has 4 prefixed properties: 3 in a style block + 1 inline style """
@@ -150,14 +147,14 @@ CONTENT OF TEST
 <script src="/resources/testharness.js"></script>
 <style type="text/css">
 
-#block1 { @test0@: @propvalue0@; }
-#block2 { @test1@: @propvalue1@; }
-#block3 { @test2@: @propvalue2@; }
+#block1 { @test0@: placeholder; }
+#block2 { @test1@: placeholder; }
+#block3 { @test2@: placeholder; }
 
 </style>
 </head>
 <body>
-<div id="elem1" style="@test3@: @propvalue3@;"></div>
+<div id="elem1" style="@test3@: placeholder;"></div>
 </body>
 </html>
 """
@@ -165,15 +162,14 @@ CONTENT OF TEST
         converter = _W3CTestConverter(fake_dir_path, DUMMY_FILENAME, None)
 
         with OutputCapture():
-            test_content = self.generate_test_content_properties_and_values(converter.prefixed_properties, converter.prefixed_property_values, 2, test_html)
-            converter.feed(test_content[2])
+            test_content = self.generate_test_content(converter.prefixed_properties, 2, 'test', test_html)
+            converter.feed(test_content[1])
             converter.close()
             converted = converter.output()
 
         self.verify_conversion_happened(converted)
-        self.verify_test_harness_paths(converted[2], 1, 1)
+        self.verify_test_harness_paths(converted[1], 1, 1)
         self.verify_prefixed_properties(converted, test_content[0])
-        self.verify_prefixed_property_values(converted, test_content[1])
 
     def test_convert_test_harness_paths(self):
         """ Tests convert_testharness_paths() with a test that uses all three testharness files """
@@ -210,66 +206,65 @@ CONTENT OF TEST
 }
 
 .block2 {
-    @test0@: @propvalue0@;
+    @test0@: placeholder;
 }
 
-.block3{@test1@: @propvalue1@;}
+.block3{@test1@: placeholder;}
 
-.block4 { @test2@:@propvalue2@; }
+.block4 { @test2@:placeholder; }
 
-.block5{ @test3@ :@propvalue3@; }
+.block5{ @test3@ :placeholder; }
 
-#block6 {    @test4@   :   @propvalue4@   ;  }
+#block6 {    @test4@   :   placeholder   ;  }
 
 #block7
 {
-    @test5@: @propvalue5@;
+    @test5@: placeholder;
 }
 
-#block8 { @test6@: @propvalue6@ }
+#block8 { @test6@: placeholder }
 
 #block9:pseudo
 {
 
-    @test7@: @propvalue7@;
+    @test7@: placeholder;
     @test8@:  propvalue propvalue propvalue;;
     propname:
-@propvalue8@;
+placeholder;
 }
 
 ]]></style>
 </head>
 <body>
-    <div id="elem1" style="@test9@: @propvalue9@;"></div>
-    <div id="elem2" style="propname: propvalue; @test10@ : @propvalue10@; propname:propvalue;"></div>
-    <div id="elem2" style="@test11@: @propvalue11@; @test12@ : @propvalue12@; @test13@   :   @propvalue13@   ;"></div>
-    <div id="elem3" style="@test14@:@propvalue14@"></div>
+    <div id="elem1" style="@test9@: placeholder;"></div>
+    <div id="elem2" style="propname: propvalue; @test10@ : placeholder; propname:propvalue;"></div>
+    <div id="elem2" style="@test11@: placeholder; @test12@ : placeholder; @test13@   :   placeholder   ;"></div>
+    <div id="elem3" style="@test14@:placeholder"></div>
 </body>
 <style type="text/css"><![CDATA[
 
-.block10{ @test15@: @propvalue15@; }
-.block11{ @test16@: @propvalue16@; }
-.block12{ @test17@: @propvalue17@; }
+.block10{ @test15@: placeholder; }
+.block11{ @test16@: placeholder; }
+.block12{ @test17@: placeholder; }
 #block13:pseudo
 {
-    @test18@: @propvalue18@;
-    @test19@: @propvalue19@;
+    @test18@: placeholder;
+    @test19@: placeholder;
 }
 
 ]]></style>
 </html>
 """
         converter = _W3CTestConverter(DUMMY_PATH, DUMMY_FILENAME, None)
-        test_content = self.generate_test_content_properties_and_values(converter.prefixed_properties, converter.prefixed_property_values, 17, test_html)
+        test_content = self.generate_test_content(converter.prefixed_properties, 17, 'test', test_html)
 
         with OutputCapture():
-            converter.feed(test_content[2])
+            converter.feed(test_content[1])
             converter.close()
             converted = converter.output()
 
         self.verify_conversion_happened(converted)
         self.verify_prefixed_properties(converted, test_content[0])
-        self.verify_prefixed_property_values(converted, test_content[1])
 
     def test_convert_attributes_if_needed(self):
         """ Tests convert_attributes_if_needed() using a reference file that has some relative src paths """
@@ -347,14 +342,14 @@ CONTENT OF TEST
         for path in test_reference_support_info['files']:
             expected_path = re.sub(test_reference_support_info['reference_relpath'], '', path, 1)
             expected_url = 'background-image:url(' + expected_path + ');'
-            self.assertTrue(expected_url in converted[2], 'relative path ' + path + ' was not converted correcty')
+            self.assertTrue(expected_url in converted[1], 'relative path ' + path + ' was not converted correcty')
 
 
     def verify_conversion_happened(self, converted):
         self.assertTrue(converted, "conversion didn't happen")
 
     def verify_no_conversion_happened(self, converted, original):
-        self.assertEqual(converted[2], original, 'test should not have been converted')
+        self.assertEqual(converted[1], original, 'test should not have been converted')
 
     def verify_test_harness_paths(self, converted, num_src_paths, num_href_paths):
         if isinstance(converted, str) or isinstance(converted, unicode):
@@ -367,12 +362,7 @@ CONTENT OF TEST
     def verify_prefixed_properties(self, converted, test_properties):
         self.assertEqual(len(set(converted[0])), len(set(test_properties)), 'Incorrect number of properties converted')
         for test_prop in test_properties:
-            self.assertTrue((test_prop in converted[2]), 'Property ' + test_prop + ' not found in converted doc')
-
-    def verify_prefixed_property_values(self, converted, test_property_values):
-        self.assertEqual(len(set(converted[1])), len(set(test_property_values)), 'Incorrect number of property values converted ' + str(len(set(converted[1]))) + ' vs ' + str(len(set(test_property_values))))
-        for test_value in test_property_values:
-            self.assertTrue((test_value in converted[2]), 'Property value ' + test_value + ' not found in converted doc')
+            self.assertTrue((test_prop in converted[1]), 'Property ' + test_prop + ' not found in converted doc')
 
     def verify_reference_relative_paths(self, converted, reference_support_info):
         idx = 0
@@ -381,14 +371,8 @@ CONTENT OF TEST
             element = reference_support_info['elements'][idx]
             element_src = 'href' if element == 'link' else 'src'
             expected_tag = '<' + element + ' ' + element_src + '=\"' + expected_path + '\">'
-            self.assertTrue(expected_tag in converted[2], 'relative path ' + path + ' was not converted correcty')
+            self.assertTrue(expected_tag in converted[1], 'relative path ' + path + ' was not converted correcty')
             idx += 1
-
-    def generate_test_content_properties_and_values(self, full_property_list, fully_property_values_list, num_test_properties_and_values, html):
-        """Inserts properties requiring a -webkit- prefix into the content, replacing \'@testXX@\' with a property and \'@propvalueXX@\' with a value."""
-        test_content_properties = self.generate_test_content(full_property_list, num_test_properties_and_values, 'test', html)
-        test_content_property_values = self.generate_test_content(fully_property_values_list, num_test_properties_and_values, 'propvalue', test_content_properties[1])
-        return (test_content_properties[0], test_content_property_values[0], test_content_property_values[1])
 
     def generate_test_content(self, full_list, num_test, suffix, html):
         assert num_test <= len(full_list), "can't generate more tests than we have input data for"

--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -572,7 +572,6 @@ class TestImporter(object):
         total_imported_jstests = 0
         total_imported_crashtests = 0
         total_prefixed_properties = {}
-        total_prefixed_property_values = {}
 
         failed_conversion_files = []
 
@@ -587,7 +586,6 @@ class TestImporter(object):
             total_imported_crashtests += dir_to_copy['crashtests']
 
             prefixed_properties = []
-            prefixed_property_values = []
 
             if not dir_to_copy['copy_list']:
                 continue
@@ -678,13 +676,7 @@ class TestImporter(object):
 
                         prefixed_properties.extend(set(converted_file[0]) - set(prefixed_properties))
 
-                        for prefixed_value in converted_file[1]:
-                            total_prefixed_property_values.setdefault(prefixed_value, 0)
-                            total_prefixed_property_values[prefixed_value] += 1
-
-                        prefixed_property_values.extend(set(converted_file[1]) - set(prefixed_property_values))
-
-                        self.filesystem.write_binary_file(new_filepath, converted_file[2])
+                        self.filesystem.write_binary_file(new_filepath, converted_file[1])
                 elif orig_filepath.endswith('__init__.py') and not self.filesystem.getsize(orig_filepath):
                     # Some bots dislike empty __init__.py.
                     self.write_init_py(new_filepath)
@@ -698,7 +690,7 @@ class TestImporter(object):
                 copied_files.append(new_filepath.replace(self._webkit_root, ''))
 
             self.remove_deleted_files(new_path, copied_files)
-            self.write_import_log(new_path, copied_files, prefixed_properties, prefixed_property_values)
+            self.write_import_log(new_path, copied_files, prefixed_properties)
 
         _log.info('Import complete')
         _log.info('IMPORTED %d TOTAL TESTS', total_imported_tests)
@@ -713,11 +705,6 @@ class TestImporter(object):
 
         for prefixed_property in sorted(total_prefixed_properties, key=lambda p: total_prefixed_properties[p]):
             _log.info('  %s: %s', prefixed_property, total_prefixed_properties[prefixed_property])
-        _log.info('')
-        _log.info('Property values needing prefixes (by count):')
-
-        for prefixed_value in sorted(total_prefixed_property_values, key=lambda p: total_prefixed_property_values[p]):
-            _log.info('  %s: %s', prefixed_value, total_prefixed_property_values[prefixed_value])
 
         if self.upstream_revision:
             _log.info('\n--------- Please include the following in your commit message: ---------\n')
@@ -813,7 +800,7 @@ class TestImporter(object):
                 continue
             self.filesystem.remove(deleted_file)
 
-    def write_import_log(self, import_directory, file_list, prop_list, property_values_list):
+    def write_import_log(self, import_directory, file_list, prop_list):
         """ Writes a w3c-import.log file in each directory with imported files. """
 
         import_log = []
@@ -828,12 +815,6 @@ class TestImporter(object):
         if prop_list:
             for prop in prop_list:
                 import_log.append(prop + '\n')
-        else:
-            import_log.append('None\n')
-        import_log.append('Property values requiring vendor prefixes:\n')
-        if property_values_list:
-            for value in property_values_list:
-                import_log.append(value + '\n')
         else:
             import_log.append('None\n')
         import_log.append('------------------------------------------------------------------------\n')

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -159,7 +159,6 @@ class TestImporterTest(unittest.TestCase):
             f'{FAKE_WPT_DIR}/css/t/test.html': MINIMAL_TESTHARNESS,
             f'{FAKE_WPT_DIR}/t/test.html': MINIMAL_TESTHARNESS,
             '/mock-checkout/Source/WebCore/css/CSSProperties.json': '',
-            '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
@@ -579,7 +578,6 @@ class TestImporterTest(unittest.TestCase):
             f'{FAKE_WPT_DIR}/t/test.any.js': 'test(() => {}, "empty")',
             '/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.any.html': '<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ dummy ] -->',
             '/mock-checkout/Source/WebCore/css/CSSProperties.json': '',
-            '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
@@ -760,7 +758,6 @@ class TestImporterTest(unittest.TestCase):
         FAKE_FILES = {
             f'{FAKE_WPT_DIR}/t/test.html': TEST_HTML,
             '/mock-checkout/Source/WebCore/css/CSSProperties.json': '{"properties":{}}',
-            '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
@@ -776,7 +773,6 @@ class TestImporterTest(unittest.TestCase):
             f'{FAKE_WPT_DIR}/t/test.html': MINIMAL_TESTHARNESS,
             f'{FAKE_WPT_DIR}/t/resource.html': RESOURCE_HTML,
             '/mock-checkout/Source/WebCore/css/CSSProperties.json': '{"properties":{}}',
-            '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
         }
         FAKE_FILES.update(FAKE_RESOURCES)
 
@@ -795,7 +791,6 @@ class TestImporterTest(unittest.TestCase):
 }''',
             f'{FAKE_WPT_DIR}/encoding/raw-test.html': TEST_HTML,
             '/mock-checkout/Source/WebCore/css/CSSProperties.json': '{"properties":{}}',
-            '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
             '/mock-checkout/LayoutTests/imported/w3c/resources/resource-files.json': '{"directories": [], "files": []}',
             f'{FAKE_WPT_DIR}/wpt': '',
             f'{FAKE_WPT_DIR}/resources/testharness.js': '',


### PR DESCRIPTION
#### a833e5a15129d88cd09d13688eb6b2827cd59d8d
<pre>
Stop rewriting prefixed CSS values in import-w3c-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=317693">https://bugs.webkit.org/show_bug.cgi?id=317693</a>
<a href="https://rdar.apple.com/180451366">rdar://180451366</a>

Reviewed by Tim Nguyen.

The few CSS value keywords that survive the
&quot;prefixed-with-no-unprefixed-form&quot; filter never occur unprefixed in
WPT sources and the value-rewriting never changes anything.

Thus, we simply remove the code to do this rewriting, on the
assumption it&apos;ll never again be relevant, and we want to eliminate
rewriting on import anyway.

* Tools/Scripts/webkitpy/w3c/test_converter.py:
(convert_for_webkit):
(_W3CTestConverter.__init__):
(_W3CTestConverter.output):
(_W3CTestConverter.add_webkit_prefix_to_unprefixed_properties):
(_W3CTestConverter.add_webkit_prefix_to_unprefixed_properties.replace):
(_W3CTestConverter.convert_style_data):
(_W3CTestConverter.legacy_read_webkit_prefixed_css_property_list): Deleted.
(_W3CTestConverter.add_webkit_prefix_to_unprefixed_properties_and_values): Deleted.
(_W3CTestConverter.add_webkit_prefix_following_regex): Deleted.
* Tools/Scripts/webkitpy/w3c/test_converter_unittest.py:
(W3CTestConverterTest.test_read_prefixed_property_list):
(verify_no_conversion_happened):
(verify_prefixed_properties):
(verify_reference_relative_paths):
(verify_prefixed_property_values): Deleted.
(generate_test_content_properties_and_values): Deleted.
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.import_tests):
(TestImporter.write_import_log):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:

Canonical link: <a href="https://commits.webkit.org/315798@main">https://commits.webkit.org/315798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1604fb6f05d490139c1d4be91d7e4b0b7a9fb7be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127611 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1f5a199-67ab-4961-8924-0b319fec24a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132411 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93297 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Skipped layout-tests; 10 failures; Uploaded test results; 1 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b42487b0-c266-4acd-a65d-68a234ebce62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172858 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112913 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/834888aa-914e-4cb7-9ade-b363bf8acfc7) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169220 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32558 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27956 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181857 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31154 "Build is in progress. Recent messages:") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140866 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43477 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140697 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29210 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108461 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25932 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35964 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42677 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7310 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42069 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->