### PR TITLE
[cocoa] multiple-cookies partitioned cookies test is a constant failure

### DIFF
--- a/LayoutTests/http/tests/cookies/multiple-cookies-iframes.https-expected.txt
+++ b/LayoutTests/http/tests/cookies/multiple-cookies-iframes.https-expected.txt
@@ -49,11 +49,17 @@ PASS Has DOM cookie "test2.10" with value foobar.
 
 Tests 3: Set multiple partitioned cookies.
 PASS cookie is 'test3=foobar'.
-PASS Do not have DOM cookie "test3.1".
+PASS Do not have DOM cookie "test3".
 PASS cookie is 'test3=foobar; test3=foobar'.
 PASS Has DOM cookie "test3" with value foobar.
 PASS cookie is 'test3=foobar; test3=foobar'.
 PASS Has DOM cookie "test3" with value foobar.
+PASS cookie is 'test3=foobar; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar.
+PASS cookie is 'test3=foobar2; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar2.
+PASS cookie is 'test3=foobar2; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar2.
 
 Tests 4: Set partitioned cookie with multiple partitioned attributes, unspecified samesite.
 PASS cookie is 'test4=foobar'.
@@ -377,11 +383,17 @@ FAIL Should have DOM cookie "test2.10". But do not.
 
 Tests 3: Set multiple partitioned cookies.
 PASS cookie is 'test3=foobar'.
-PASS Do not have DOM cookie "test3.1".
+PASS Do not have DOM cookie "test3".
 PASS cookie is 'test3=foobar; test3=foobar'.
 PASS Has DOM cookie "test3" with value foobar.
 PASS cookie is 'test3=foobar; test3=foobar'.
 PASS Has DOM cookie "test3" with value foobar.
+PASS cookie is 'test3=foobar; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar.
+PASS cookie is 'test3=foobar2; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar2.
+PASS cookie is 'test3=foobar2; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar2.
 
 Tests 4: Set partitioned cookie with multiple partitioned attributes, unspecified samesite.
 PASS cookie is 'test4=foobar'.

--- a/LayoutTests/http/tests/cookies/multiple-cookies.https-expected.txt
+++ b/LayoutTests/http/tests/cookies/multiple-cookies.https-expected.txt
@@ -36,11 +36,17 @@ PASS Has DOM cookie "test2.10" with value foobar.
 
 Tests 3: Set multiple partitioned cookies.
 PASS cookie is 'test3=foobar'.
-PASS Do not have DOM cookie "test3.1".
+PASS Do not have DOM cookie "test3".
 PASS cookie is 'test3=foobar; test3=foobar'.
 PASS Has DOM cookie "test3" with value foobar.
 PASS cookie is 'test3=foobar; test3=foobar'.
 PASS Has DOM cookie "test3" with value foobar.
+PASS cookie is 'test3=foobar; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar.
+PASS cookie is 'test3=foobar2; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar2.
+PASS cookie is 'test3=foobar2; test3=foobar2'.
+PASS Has DOM cookie "test3" with value foobar2.
 
 Tests 4: Set partitioned cookie with multiple partitioned attributes, unspecified samesite.
 PASS cookie is 'test4=foobar'.

--- a/LayoutTests/http/tests/cookies/multiple-cookies.https.html
+++ b/LayoutTests/http/tests/cookies/multiple-cookies.https.html
@@ -35,14 +35,15 @@ clearCookiesFromSubTests();
 debug("Tests 2: Set multiple cookies, mixing unpartitioned and partitioned.");
 cookiesShouldBe("test2.1=foobar; Secure;", "test2.1=foobar");
 cookiesShouldBe("test2.2=foobar; HttpOnly;", "test2.1=foobar; test2.2=foobar");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("test2.3=foobar; Partitioned;", "test2.1=foobar; test2.2=foobar");
 cookiesShouldBe("test2.4=foobar; Secure; Partitioned;", "test2.1=foobar; test2.2=foobar; test2.4=foobar");
 cookiesShouldBe("test2.5=foobar; asdfasfasd", "test2.1=foobar; test2.2=foobar; test2.4=foobar; test2.5=foobar");
 cookiesShouldBe("test2.6=foobar; Secure; Path=/", "test2.1=foobar; test2.2=foobar; test2.4=foobar; test2.5=foobar; test2.6=foobar");
 cookiesShouldBe("test2.7=foobar; HttpOnly; Path=/;", "test2.1=foobar; test2.2=foobar; test2.4=foobar; test2.5=foobar; test2.6=foobar; test2.7=foobar");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("test2.8=foobar; Partitioned; Path=/;", "test2.1=foobar; test2.2=foobar; test2.4=foobar; test2.5=foobar; test2.6=foobar; test2.7=foobar");
+// Requires SameSite=None
 cookiesShouldBe("test2.9=foobar; Secure; Partitioned; Path=/;", "test2.1=foobar; test2.2=foobar; test2.4=foobar; test2.5=foobar; test2.6=foobar; test2.7=foobar; test2.9=foobar");
 cookiesShouldBe("test2.10=foobar; asdfasfasd; Path=/", "test2.1=foobar; test2.2=foobar; test2.4=foobar; test2.5=foobar; test2.6=foobar; test2.7=foobar; test2.9=foobar; test2.10=foobar");
 shouldNotHaveDOMCookie("test2.1");
@@ -60,11 +61,18 @@ clearCookiesFromSubTests();
 
 debug("Tests 3: Set multiple partitioned cookies.");
 cookiesShouldBe("test3=foobar; Partitioned; Secure;", "test3=foobar");
-shouldNotHaveDOMCookie("test3.1");
+shouldNotHaveDOMCookie("test3");
 cookiesShouldBe("test3=foobar; Partitioned; Secure; Path=/", "test3=foobar; test3=foobar");
 shouldHaveDOMCookieWithValue("test3", "foobar");
 cookiesShouldBe("test3=foobar; Partitioned; Secure;", "test3=foobar; test3=foobar");
 shouldHaveDOMCookieWithValue("test3", "foobar");
+
+cookiesShouldBe("test3=foobar2; Partitioned; Secure; SameSite=None", "test3=foobar; test3=foobar2");
+shouldHaveDOMCookieWithValue("test3", "foobar");
+cookiesShouldBe("test3=foobar2; Partitioned; Secure; Path=/; SameSite=None", "test3=foobar2; test3=foobar2");
+shouldHaveDOMCookieWithValue("test3", "foobar2");
+cookiesShouldBe("test3=foobar2; Partitioned; Secure; SameSite=None", "test3=foobar2; test3=foobar2");
+shouldHaveDOMCookieWithValue("test3", "foobar2");
 
 clearCookiesFromSubTests();
 
@@ -79,7 +87,7 @@ cookiesShouldBe("test5=foobar; SameSite=None; Partitioned; Secure; Partitioned;"
 clearCookiesFromSubTests();
 
 debug("Tests 6: Set partitioned cookie with multiple partitioned attributes, explicit samesite={lax,strict}.");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("test6.1=foobar; SameSite=Lax; Partitioned; Secure; Partitioned;", "");
 cookiesShouldBe("test6.2=foobar; SameSite=Strict; Partitioned; Secure; Partitioned;", "");
 
@@ -117,20 +125,20 @@ shouldHaveDOMCookieWithValue("_Secure-test9.6", "foobar");
 clearCookiesFromSubTests();
 
 debug("Tests 10: Set multiple cookies, mixing unpartitioned and partitioned; different samesite, multiple Partitioned attributes.");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("test10.1=foobar; SameSite=Strict; Partitioned; Secure; Partitioned;", "");
 cookiesShouldBe("test10.2=foobar; Secure;", "test10.2=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("test10.3=foobar; SameSite=Lax; Partitioned; Secure; Partitioned;", "test10.2=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("test10.4=foobar; SameSite=Strict; Partitioned; Secure; Partitioned;", "test10.2=foobar");
 cookiesShouldBe("test10.5=foobar; SameSite=None; Partitioned; Secure; Partitioned;", "test10.2=foobar; test10.5=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("test10.6=foobar; Path=/; SameSite=Strict; Partitioned; Secure; Partitioned;", "test10.2=foobar; test10.5=foobar");
 cookiesShouldBe("test10.7=foobar; Path=/; Secure;", "test10.2=foobar; test10.5=foobar; test10.7=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("test10.8=foobar; Path=/; SameSite=Lax; Partitioned; Secure; Partitioned;", "test10.2=foobar; test10.5=foobar; test10.7=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("test10.9=foobar; Path=/; SameSite=Strict; Partitioned; Secure; Partitioned;", "test10.2=foobar; test10.5=foobar; test10.7=foobar; test10.9=foobar");
 cookiesShouldBe("test10.10=foobar; Path=/; SameSite=None; Partitioned; Secure; Partitioned;", "test10.2=foobar; test10.5=foobar; test10.7=foobar; test10.9=foobar; test10.10=foobar");
 
@@ -148,41 +156,41 @@ shouldHaveDOMCookieWithValue("test10.10", "foobar");
 clearCookiesFromSubTests();
 
 debug("Tests 11: Set partitioned and unpartitioned cookies with multiple partitioned attributes; mixed in with meaningful __Secure prefix, later Secure attribute.");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Secure-test11.1=foobar; SameSite=Strict; Partitioned; Partitioned;", "");
 // Requires Secure attribute
 cookiesShouldBe("__Secure-test11.2=foobar;", "");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Secure-test11.3=foobar; SameSite=Lax; Partitioned; Partitioned;", "");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Secure-test11.4=foobar; SameSite=Strict; Partitioned; Partitioned;", "");
 cookiesShouldBe("__Secure-test11.5=foobar; SameSite=None; Partitioned; Partitioned;", "");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test11.6=foobar; SameSite=Strict; Partitioned; Secure; Partitioned;", "");
 cookiesShouldBe("__Secure-test11.7=foobar; Secure", "__Secure-test11.7=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test11.8=foobar; SameSite=Lax; Partitioned; Secure; Partitioned;", "__Secure-test11.7=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test11.9=foobar; SameSite=Strict; Partitioned; Secure; Partitioned;", "__Secure-test11.7=foobar");
 cookiesShouldBe("__Secure-test11.10=foobar; SameSite=None; Partitioned; Secure; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar");
 cookiesShouldBe("__Secure-test11.10=foobar; SameSite=None; Secure;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.10=foobar");
 cookiesShouldBe("__Secure-test11.11=foobar; SameSite=None; Secure; HttpOnly", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar");
 cookiesShouldBe("__Secure-test11.12=foobar; SameSite=None; Partitioned; Secure; Partitioned; HttpOnly", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Secure-test11.13=foobar; SameSite=Strict; Path=/; Partitioned; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar");
 // Requires Secure attribute
 cookiesShouldBe("__Secure-test11.14=foobar; Path=/;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Secure-test11.15=foobar; SameSite=Lax; Path=/; Partitioned; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Secure-test11.16=foobar; SameSite=Strict; Path=/; Partitioned; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar");
 cookiesShouldBe("__Secure-test11.17=foobar; SameSite=None; Partitioned; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test11.18=foobar; SameSite=Strict; Path=/; Partitioned; Secure; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar");
 cookiesShouldBe("__Secure-test11.19=foobar; Secure; Path=/", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar; __Secure-test11.19=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test11.20=foobar; SameSite=Lax; Path=/; Partitioned; Secure; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar; __Secure-test11.19=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test11.21=foobar; SameSite=Strict; Path=/; Partitioned; Secure; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar; __Secure-test11.19=foobar");
 cookiesShouldBe("__Secure-test11.22=foobar; SameSite=None; Path=/; Partitioned; Secure; Partitioned;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar; __Secure-test11.19=foobar; __Secure-test11.22=foobar");
 cookiesShouldBe("__Secure-test11.23=foobar; SameSite=None; Path=/; Secure;", "__Secure-test11.7=foobar; __Secure-test11.10=foobar; __Secure-test11.11=foobar; __Secure-test11.12=foobar; __Secure-test11.19=foobar; __Secure-test11.22=foobar; __Secure-test11.23=foobar");
@@ -217,33 +225,33 @@ shouldHaveDOMCookieWithValue("__Secure-test11.23", "foobar");
 clearCookiesFromSubTests();
 
 debug("Tests 12: Set partitioned and unpartitioned cookies with multiple partitioned attributes; mixed in with meaningful __Secure prefix, early Secure attribute.");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test12.1=foobar; SameSite=Strict; Partitioned; Path=/; Secure; Partitioned;", "");
 cookiesShouldBe("__Secure-test12.2=foobar; Path=/; Secure;", "__Secure-test12.2=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test12.3=foobar; SameSite=Lax; Partitioned; Path=/; Secure; Partitioned;", "__Secure-test12.2=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test12.4=foobar; Partitioned; SameSite=Strict; Path=/; Secure; Partitioned;", "__Secure-test12.2=foobar");
-cookiesShouldBe("__Secure-test12.5=foobar; SameSite=None; Partitioned; Path=/; Secure; Partitioned;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar");
-cookiesShouldBe("__Secure-test12.6=foobar; Path=/; Secure; Partitioned;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar");
+cookiesShouldBe("__Secure-test12.5=foobar; SameSite=None; Partitioned; Path=/; Secure; Partitioned; SameSite=None", "__Secure-test12.2=foobar; __Secure-test12.5=foobar");
+cookiesShouldBe("__Secure-test12.6=foobar; Path=/; Secure; Partitioned; SameSite=None", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar");
 // Requires Secure attribute
 cookiesShouldBe("__Secure-test12.7=foobar; Partitioned; Path=/;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar");
 cookiesShouldBe("__Secure-test12.8=foobar; Partitioned; Path=/; Secure; Path=/", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar");
 cookiesShouldBe("__Secure-test12.9=foobar; SameSite=None; Path=/; Secure; HttpOnly", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar");
 cookiesShouldBe("__Secure-test12.10=foobar; SameSite=None; Partitioned; Path=/; Secure; Partitioned; HttpOnly", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar");
 cookiesShouldBe("__Secure-test12.10=foobar; Path=/; Secure; Partitioned; HttpOnly", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test12.11=foobar; SameSite=Strict; Partitioned; Secure; Partitioned;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar");
 cookiesShouldBe("__Secure-test12.12=foobar; Secure;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test12.13=foobar; SameSite=Lax; Partitioned; Secure; Partitioned;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Secure-test12.14=foobar; Partitioned; SameSite=Strict; Secure; Partitioned;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar");
 cookiesShouldBe("__Secure-test12.15=foobar; SameSite=None; Partitioned; Secure; Partitioned;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar; __Secure-test12.15=foobar");
 cookiesShouldBe("__Secure-test12.16=foobar; Secure; Partitioned;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar; __Secure-test12.15=foobar; __Secure-test12.16=foobar");
 // Requires Secure attribute
 cookiesShouldBe("__Secure-test12.17=foobar; Partitioned;", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar; __Secure-test12.15=foobar; __Secure-test12.16=foobar");
-cookiesShouldBe("__Secure-test12.18=foobar; Partitioned; Secure; Path=/", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar; __Secure-test12.15=foobar; __Secure-test12.16=foobar; __Secure-test12.18=foobar");
+cookiesShouldBe("__Secure-test12.18=foobar; Partitioned; Secure; SameSite=None; Path=/", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar; __Secure-test12.15=foobar; __Secure-test12.16=foobar; __Secure-test12.18=foobar");
 cookiesShouldBe("__Secure-test12.19=foobar; SameSite=None; Secure; HttpOnly", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar; __Secure-test12.15=foobar; __Secure-test12.16=foobar; __Secure-test12.18=foobar; __Secure-test12.19=foobar");
 cookiesShouldBe("__Secure-test12.20=foobar; SameSite=None; Partitioned; Secure; Partitioned; HttpOnly", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar; __Secure-test12.15=foobar; __Secure-test12.16=foobar; __Secure-test12.18=foobar; __Secure-test12.19=foobar; __Secure-test12.20=foobar");
 cookiesShouldBe("__Secure-test12.20=foobar; Secure; Partitioned; HttpOnly", "__Secure-test12.2=foobar; __Secure-test12.5=foobar; __Secure-test12.6=foobar; __Secure-test12.8=foobar; __Secure-test12.9=foobar; __Secure-test12.10=foobar; __Secure-test12.10=foobar; __Secure-test12.12=foobar; __Secure-test12.15=foobar; __Secure-test12.16=foobar; __Secure-test12.18=foobar; __Secure-test12.19=foobar; __Secure-test12.20=foobar");
@@ -271,24 +279,24 @@ shouldHaveDOMCookieWithValue("__Secure-test12.18", "foobar");
 clearCookiesFromSubTests();
 
 debug("Tests 13: Set partitioned and unpartitioned __Host- cookies with multiple partitioned attributes.");
-// Requires Secure; SameSite=None / Default; Path
+// Requires Secure; SameSite=None; Path
 cookiesShouldBe("__Host-test13.1=foobar; SameSite=Strict; Partitioned; Partitioned;", "");
 // Requires Secure attribute; Path
 cookiesShouldBe("__Host-test13.2=foobar;", "");
-// Requires Secure; SameSite=None / Default; Path
+// Requires Secure; SameSite=None; Path
 cookiesShouldBe("__Host-test13.3=foobar; SameSite=Lax; Partitioned; Partitioned;", "");
-// Requires Secure; SameSite=None / Default; Path
+// Requires Secure; SameSite=None; Path
 cookiesShouldBe("__Host-test13.4=foobar; SameSite=None; Partitioned; Partitioned;", "");
 // Requires Path
 cookiesShouldBe("__Host-test13.5=foobar; Partitioned;", "");
 cookiesShouldBe("__Host-test13.6=foobar; Partitioned; Secure; Path=/", "__Host-test13.6=foobar");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Host-test13.7=foobar; SameSite=Strict; Partitioned; Path=/; Partitioned;", "__Host-test13.6=foobar");
 // Requires Secure attribute
 cookiesShouldBe("__Host-test13.8=foobar; Path=/", "__Host-test13.6=foobar");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Host-test13.9=foobar; SameSite=Lax; Partitioned; Partitioned;", "__Host-test13.6=foobar");
-// Requires Secure; SameSite=None / Default
+// Requires Secure; SameSite=None
 cookiesShouldBe("__Host-test13.10=foobar; SameSite=Strict; Partitioned; Partitioned;", "__Host-test13.6=foobar");
 // Requires Secure attribute
 cookiesShouldBe("__Host-test13.11=foobar; SameSite=None; Partitioned; Partitioned;", "__Host-test13.6=foobar");
@@ -315,13 +323,13 @@ shouldHaveDOMCookieWithValue("__Host-test13.14", "foobar");
 clearCookiesFromSubTests();
 
 debug("Tests 14: Set partitioned and unpartitioned __Host- cookies with multiple partitioned attributes; different order, Path after Secure.");
-// Requires SameSite=None / Default; Path
+// Requires SameSite=None; Path
 cookiesShouldBe("__Host-test14.1=foobar; SameSite=Strict; Partitioned; Secure; Partitioned;", "");
 // Requires Path
 cookiesShouldBe("__Host-test14.2=foobar; Secure;", "");
-// Requires SameSite=None / Default; Path
+// Requires SameSite=None; Path
 cookiesShouldBe("__Host-test14.3=foobar; SameSite=Lax; Partitioned; Secure; Partitioned;", "");
-// Requires SameSite=None / Default; Path
+// Requires SameSite=None; Path
 cookiesShouldBe("__Host-test14.4=foobar; SameSite=Strict; Partitioned; Secure; Partitioned;", "");
 // Requires Path
 cookiesShouldBe("__Host-test14.5=foobar; SameSite=None; Partitioned; Secure; Partitioned;", "");
@@ -329,12 +337,12 @@ cookiesShouldBe("__Host-test14.5=foobar; SameSite=None; Partitioned; Secure; Par
 cookiesShouldBe("__Host-test14.6=foobar; Secure; Partitioned;", "");
 // Requires Secure; Path
 cookiesShouldBe("__Host-test14.7=foobar; Partitioned;", "");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Host-test14.8=foobar; SameSite=Strict; Partitioned; Secure; Path=/; Partitioned;", "");
 cookiesShouldBe("__Host-test14.9=foobar; Secure; Path=/", "__Host-test14.9");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 cookiesShouldBe("__Host-test14.10=foobar; SameSite=Lax; Partitioned; Secure; Path=/; Partitioned;", "__Host-test14.9");
-// Requires SameSite=None / Default;
+// Requires SameSite=None
 cookiesShouldBe("__Host-test14.11=foobar; SameSite=Strict; Path=/; Partitioned; Secure; Path=/; Partitioned;", "__Host-test14.9");
 cookiesShouldBe("__Host-test14.12=foobar; SameSite=None; Partitioned; Path=/; Secure; Path=/; Partitioned;", "__Host-test14.9; __Host-test14.12");
 cookiesShouldBe("__Host-test14.13=foobar; Secure; Path=/; Partitioned; Path=/;", "__Host-test14.9; __Host-test14.12; __Host-test14.13");
@@ -361,7 +369,7 @@ clearCookiesFromSubTests();
 
 debug("Tests 15: Set partitioned and unpartitioned __Host- cookies with multiple partitioned attributes; different order, Path after Secure; from JavaScript.");
 
-// Requires SameSite=None / Default; Path
+// Requires SameSite=None; Path
 setDOMCookie("__Host-test15.1", "foobar", { "SameSite": "Strict", "Partitioned": undefined, "Secure": undefined, " Partitioned": undefined });
 testCookies("");
 shouldNotHaveDOMCookie("__Host-test15.1");
@@ -371,12 +379,12 @@ setDOMCookie("__Host-test15.2", "foobar", { "Secure": undefined });
 testCookies("");
 shouldNotHaveDOMCookie("__Host-test15.2");
 
-// Requires SameSite=None / Default; Path
+// Requires SameSite=None; Path
 setDOMCookie("__Host-test15.3", "foobar", { "SameSite": "Lax", "Partitioned": undefined, "Secure": undefined, " Partitioned": undefined });
 testCookies("");
 shouldNotHaveDOMCookie("__Host-test15.3");
 
-// Requires SameSite=None / Default; Path
+// Requires SameSite=None; Path
 setDOMCookie("__Host-test15.4", "foobar", { "SameSite": "Strict", "Partitioned": undefined, "Secure": undefined, " Partitioned": undefined });
 testCookies("");
 shouldNotHaveDOMCookie("__Host-test15.4");
@@ -386,17 +394,17 @@ setDOMCookie("__Host-test15.5", "foobar", { "SameSite": "None", "Partitioned": u
 testCookies("");
 shouldNotHaveDOMCookie("__Host-test15.5");
 
-// Requires Path
+// Requires SameSite=None; Path
 setDOMCookie("__Host-test15.6", "foobar", { "Secure": undefined, "Partitioned": undefined });
 testCookies("");
 shouldNotHaveDOMCookie("__Host-test15.6");
 
-// Requires Secure; Path
+// Requires SameSite=None; Secure; Path
 setDOMCookie("__Host-test15.7", "foobar", { "Partitioned": undefined });
 testCookies("");
 shouldNotHaveDOMCookie("__Host-test15.7");
 
-// Requires SameSite=None / Default;
+// Requires SameSite=None;
 setDOMCookie("__Host-test15.8", "foobar", { "SameSite": "Strict", "Partitioned": undefined, "Secure": undefined, "Path": "/", " Partitioned": undefined });
 testCookies("");
 shouldNotHaveDOMCookie("__Host-test15.8");
@@ -405,12 +413,12 @@ setDOMCookie("__Host-test15.9", "foobar", { "Secure": undefined, "Path": "/" });
 testCookies("__Host-test15.9");
 shouldHaveDOMCookieWithValue("__Host-test15.9", "foobar");
 
-// Requires SameSite=None / Default
+// Requires SameSite=None
 setDOMCookie("__Host-test15.10", "foobar", { "SameSite": "Lax", "Partitioned": undefined, "Secure": undefined, "Path": "/", " Partitioned": undefined });
 testCookies("__Host-test15.9");
 shouldNotHaveDOMCookie("__Host-test15.10");
 
-// Requires SameSite=None / Default
+// Requires SameSite=None
 setDOMCookie("__Host-test15.11", "foobar", { "SameSite": "Strict", "Partitioned": undefined, "Secure": undefined, "Path": "/", " Path": "/", " Partitioned": undefined });
 testCookies("__Host-test15.9");
 shouldNotHaveDOMCookie("__Host-test15.11");
@@ -419,11 +427,12 @@ setDOMCookie("__Host-test15.12", "foobar", { "SameSite": "None", "Partitioned": 
 testCookies("__Host-test15.9; __Host-test15.12");
 shouldHaveDOMCookieWithValue("__Host-test15.12", "foobar");
 
+// Requires SameSite=None
 setDOMCookie("__Host-test15.13", "foobar", { "Partitioned": undefined, "Secure": undefined, "Path": "/", " Path": "/", " Partitioned": undefined });
 testCookies("__Host-test15.9; __Host-test15.12; __Host-test15.13");
 shouldHaveDOMCookieWithValue("__Host-test15.13", "foobar");
 
-// Requires Secure
+// Requires SameSite=None; Secure
 setDOMCookie("__Host-test15.14", "foobar", { "Partitioned": undefined, "Path": "/" });
 testCookies("__Host-test15.9; __Host-test15.12; __Host-test15.13");
 shouldNotHaveDOMCookie("__Host-test15.14");
@@ -436,7 +445,7 @@ shouldNotHaveDOMCookie("__Host-test15.15");
 clearCookiesFromSubTests();
 
 debug("Tests 16: Set partitioned and unpartitioned cookies with multiple partitioned attributes; different order, Path after Secure; from JavaScript.");
-// Requires SameSite=None / Default
+// Requires SameSite=None
 setDOMCookie("test16.1", "foobar", { "SameSite": "Strict", "Partitioned": undefined, "Secure": undefined, " Partitioned": undefined });
 testCookies("");
 shouldNotHaveDOMCookie("test16.1");
@@ -445,12 +454,12 @@ setDOMCookie("test16.2", "foobar", { "Secure": undefined });
 testCookies("test16.2");
 shouldHaveDOMCookieWithValue("test16.2", "foobar");
 
-// Requires SameSite=None / Default
+// Requires SameSite=None
 setDOMCookie("test16.3", "foobar", { "SameSite": "Lax", "Partitioned": undefined, "Secure": undefined, " Partitioned": undefined });
 testCookies("test16.2");
 shouldNotHaveDOMCookie("test16.3");
 
-// Requires SameSite=None / Default
+// Requires SameSite=None
 setDOMCookie("test16.4", "foobar", { "SameSite": "Strict", "Partitioned": undefined, "Secure": undefined, " Partitioned": undefined });
 testCookies("test16.2");
 shouldNotHaveDOMCookie("test16.4");
@@ -459,16 +468,16 @@ setDOMCookie("test16.5", "foobar", { "SameSite": "None", "Partitioned": undefine
 testCookies("test16.2; test16.5");
 shouldHaveDOMCookieWithValue("test16.5", "foobar");
 
-setDOMCookie("test16.6", "foobar", { "Secure": undefined, "Partitioned": undefined });
+setDOMCookie("test16.6", "foobar", { "SameSite": "None", "Secure": undefined, "Partitioned": undefined });
 testCookies("test16.2; test16.5; test16.6");
 shouldHaveDOMCookieWithValue("test16.6", "foobar");
 
-// Requires Secure
+// Requires SameSite=None; Secure
 setDOMCookie("test16.7", "foobar", { "Partitioned": undefined });
 testCookies("test16.2; test16.5; test16.6");
 shouldNotHaveDOMCookie("test16.7");
 
-// Requires SameSite=None / Default
+// Requires SameSite=None
 setDOMCookie("test16.8", "foobar", { "SameSite": "Strict", "Partitioned": undefined, "Secure": undefined, "Path": "/", " Partitioned": undefined });
 testCookies("test16.2; test16.5; test16.6");
 shouldNotHaveDOMCookie("test16.8");
@@ -477,12 +486,12 @@ setDOMCookie("test16.9", "foobar", { "Secure": undefined, "Path": "/" });
 testCookies("test16.2; test16.5; test16.6; test16.9");
 shouldHaveDOMCookieWithValue("test16.9", "foobar");
 
-// Requires SameSite=None / Default
+// Requires SameSite=None
 setDOMCookie("test16.10", "foobar", { "SameSite": "Lax", "Partitioned": undefined, "Secure": undefined, "Path": "/", " Partitioned": undefined });
 testCookies("test16.2; test16.5; test16.6; test16.9");
 shouldNotHaveDOMCookie("test16.10");
 
-// Requires SameSite=None / Default
+// Requires SameSite=None
 setDOMCookie("test16.11", "foobar", { "SameSite": "Strict", "Partitioned": undefined, "Secure": undefined, "Path": "/", " Path": "/", " Partitioned": undefined });
 testCookies("test16.2; test16.5; test16.6; test16.9");
 shouldNotHaveDOMCookie("test16.11");
@@ -491,17 +500,18 @@ setDOMCookie("test16.12", "foobar", { "SameSite": "None", "Partitioned": undefin
 testCookies("test16.2; test16.5; test16.6; test16.9; test16.12");
 shouldHaveDOMCookieWithValue("test16.12", "foobar");
 
+// Requires SameSite=None
 setDOMCookie("test16.13", "foobar", { "Partitioned": undefined, "Secure": undefined, "Path": "/", " Path": "/", " Partitioned": undefined });
 testCookies("test16.2; test16.5; test16.6; test16.9; test16.12; test16.13");
 shouldHaveDOMCookieWithValue("test16.13", "foobar");
 
-// Requires Secure
+// Requires SameSite=None; Secure
 setDOMCookie("test16.14", "foobar", { "Partitioned": undefined, "Path": "/" });
 testCookies("test16.2; test16.5; test16.6; test16.9; test16.12; test16.13");
 shouldNotHaveDOMCookie("test16.14");
 
 // Can't set HttpOnly
-setDOMCookie("test16.15", "foobar", { "HttpOnly": undefined, "Secure": undefined, "Path": "/", "Partitioned": undefined, "Path": "/" });
+setDOMCookie("test16.15", "foobar", { "SameSite": "None", "HttpOnly": undefined, "Secure": undefined, "Path": "/", "Partitioned": undefined, "Path": "/" });
 testCookies("test16.2; test16.5; test16.6; test16.9; test16.12; test16.13");
 shouldNotHaveDOMCookie("test16.15");
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -358,6 +358,9 @@ void WebsiteDataStore::registerProcess(WebProcessProxy& process)
 {
     ASSERT(process.pageCount() || process.provisionalPageCount() || process.remotePageCount());
     m_processes.add(process);
+#if ENABLE(OPT_IN_PARTITIONED_COOKIES)
+    m_cachedIsOptInCookiePartitioningEnabled = std::nullopt;
+#endif
 }
 
 void WebsiteDataStore::unregisterProcess(WebProcessProxy& process)


### PR DESCRIPTION
#### 588319957d0f360b5269bd35febab95bf871e6f7
<pre>
[cocoa] multiple-cookies partitioned cookies test is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=317703">https://bugs.webkit.org/show_bug.cgi?id=317703</a>
<a href="https://rdar.apple.com/180007937">rdar://180007937</a>

Reviewed by Alex Christensen.

This patch fixes two issues.

1) A recent change in the Cooca cookie implementation now requires that `SameSite=None`
is explicitly specified along with the `Partitioned` cookie attribute. This
patch updates the test and expectations to reflect this change.

2) A recent change within WebKit broke how the preference controlling opt-in
cookie partitioning is propagated to the web content processes. There is a race
condition within which a newly launched web content process may not receive an
updated value when the setting is enabled.

The setting propagation mechanism probably needs to be redesigned, but as a
workaround this patch invalidates the cached preference value whenever we
register a new web process with a datastore.

* LayoutTests/http/tests/cookies/multiple-cookies-iframes.https-expected.txt:
* LayoutTests/http/tests/cookies/multiple-cookies.https-expected.txt:
* LayoutTests/http/tests/cookies/multiple-cookies.https.html:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::registerProcess):

Canonical link: <a href="https://commits.webkit.org/317328@main">https://commits.webkit.org/317328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d845651ba93bd9e94179c40ea5810bbbcb71031

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131416 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b475582-2908-4a13-a431-b05b9ad9026f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134951 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95238 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef27a6e4-2437-439e-8398-1adf943cf31c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115428 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37019 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35376 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31606 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185547 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143829 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143685 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39065 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47827 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31846 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112994 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38623 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119693 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46333 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10184 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45966 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->