### PR TITLE
Fix failures in css/css-values/tree-counting/calc-sibling-function-in-shadow-dom.html WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-in-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-in-shadow-dom-expected.txt
@@ -4,6 +4,6 @@ In host tree (4)
 In host tree (5)
 
 PASS Host children have sibling-index() and sibling-count() based on the DOM tree order
-FAIL Shadow children have sibling-index() and sibling-count() based on the DOM tree order assert_equals: sibling-index() expected "5" but got "1"
-FAIL Direct shadow root children have correct sibling-index() and sibling-count() assert_equals: sibling-index() for direct shadow root child expected "2" but got "1"
+PASS Shadow children have sibling-index() and sibling-count() based on the DOM tree order
+PASS Direct shadow root children have correct sibling-index() and sibling-count()
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -344,13 +344,17 @@ unsigned BuilderState::siblingCount()
     if (m_currentProperty && m_currentProperty->styleScopeOrdinal <= ScopeOrdinal::ContainingHost)
         return 0;
 
-    auto* parent = element()->parentElement();
-    if (!parent)
+    // parentNode() rather than parentElement() to support direct children of shadow roots.
+    auto* parentNode = element()->parentNode();
+    if (!parentNode || is<Document>(*parentNode))
         return 1;
 
     m_style.setUsesTreeCountingFunctions();
-    parent->setChildrenAffectedByBackwardPositionalRules();
-    parent->setChildrenAffectedByForwardPositionalRules();
+
+    if (auto* parentElement = dynamicDowncast<Element>(*parentNode)) {
+        parentElement->setChildrenAffectedByBackwardPositionalRules();
+        parentElement->setChildrenAffectedByForwardPositionalRules();
+    }
 
     unsigned count = 1;
     for (const auto* sibling = ElementTraversal::previousSibling(*element()); sibling; sibling = ElementTraversal::previousSibling(*sibling))
@@ -371,13 +375,17 @@ unsigned BuilderState::siblingIndex()
     if (m_currentProperty && m_currentProperty->styleScopeOrdinal <= ScopeOrdinal::ContainingHost)
         return 0;
 
-    auto* parent = element()->parentElement();
-    if (!parent)
+    // parentNode() rather than parentElement() to support direct children of shadow roots.
+    auto* parentNode = element()->parentNode();
+    if (!parentNode || is<Document>(*parentNode))
         return 1;
 
     m_style.setUsesTreeCountingFunctions();
-    parent->setChildrenAffectedByBackwardPositionalRules();
-    parent->setChildrenAffectedByForwardPositionalRules();
+
+    if (auto* parentElement = dynamicDowncast<Element>(*parentNode)) {
+        parentElement->setChildrenAffectedByBackwardPositionalRules();
+        parentElement->setChildrenAffectedByForwardPositionalRules();
+    }
 
     unsigned count = 1;
     for (const auto* sibling = ElementTraversal::previousSibling(*element()); sibling; sibling = ElementTraversal::previousSibling(*sibling))


### PR DESCRIPTION
#### 35a13a3e5368f7a7af54a4802f8ccc9b3c791c64
<pre>
Fix failures in css/css-values/tree-counting/calc-sibling-function-in-shadow-dom.html WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=317715">https://bugs.webkit.org/show_bug.cgi?id=317715</a>
<a href="https://rdar.apple.com/180469161">rdar://180469161</a>

Reviewed by NOBODY (OOPS!).

Allow counting children of shadow roots by getting the parent node instead of the parent element.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/calc-sibling-function-in-shadow-dom-expected.txt:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::siblingCount):
(WebCore::Style::BuilderState::siblingIndex):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35a13a3e5368f7a7af54a4802f8ccc9b3c791c64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127638 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/193e6715-3852-4b6c-9e60-9359680b024f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132676 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93311 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1edc1b1-60ee-4648-a3d8-0e5f8df4f45f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113177 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39bec7b9-c708-4799-a21d-eccd7b7638ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34560 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32581 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27983 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144713 "Found 1 new API test failure: TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181884 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140890 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43504 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140721 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44193 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29238 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108498 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35988 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115958 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42704 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7338 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42096 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42351 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42239 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->