### PR TITLE
[JSC] Weakening ByteCodeParser::refineStatically based on some additional information

### DIFF
--- a/JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js
+++ b/JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js
@@ -1,5 +1,6 @@
 //@ skip if not $jitTests
 //@ $skipModes << :lockdown
+//@ $skipModes << :no_cjit_validate_phases
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.h
@@ -104,7 +104,9 @@ public:
     bool canOptimize() const { return !m_variants.isEmpty(); }
 
     bool NODELETE isClosureCall() const; // Returns true if any callee is a closure call.
-    
+
+    void makeClosureCall();
+
     unsigned maxArgumentCountIncludingThisForVarargs() const { return m_maxArgumentCountIncludingThisForVarargs; }
     
     bool finalize(VM&);
@@ -116,8 +118,7 @@ public:
     void dump(PrintStream&) const;
     
 private:
-    void makeClosureCall();
-    
+
 #if ENABLE(JIT)
     static CallLinkStatus computeFromCallLinkInfo(
         const ConcurrentJSLocker&, CallLinkInfo&);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1485,8 +1485,23 @@ ByteCodeParser::Terminality ByteCodeParser::handleCall(const JSInstruction* pc, 
 
 void ByteCodeParser::refineStatically(CallLinkStatus& callLinkStatus, Node* callTarget)
 {
-    if (callTarget->isCellConstant())
-        callLinkStatus.setProvenConstantCallee(CallVariant(callTarget->asCell()));
+    if (m_graph.m_plan.isUnlinked())
+        return;
+
+    if (callLinkStatus.canOptimize()) {
+        if (callTarget->isCellConstant()) {
+            callLinkStatus.setProvenConstantCallee(CallVariant(callTarget->asCell()));
+            return;
+        }
+
+        // We know statically that callTarget came from NewFunction / NewGeneratorFunction /
+        // NewAsyncFunction / NewAsyncGeneratorFunction — so its executable is a constant. But
+        // we must still wait for the CallIC to actually populate, with exactly one observed
+        // variant, before promoting to a closure-call inline. Speculating ahead of the IC
+        // costs more than it saves.
+        if (callTarget->isFunctionAllocation() && callLinkStatus.size() == 1)
+            callLinkStatus.makeClosureCall();
+    }
 }
 
 ByteCodeParser::Terminality ByteCodeParser::handleCall(


### PR DESCRIPTION
#### 07cae57442c99f84453f39bbca2fcbdc90849ea8
<pre>
[JSC] Weakening ByteCodeParser::refineStatically based on some additional information
<a href="https://bugs.webkit.org/show_bug.cgi?id=317716">https://bugs.webkit.org/show_bug.cgi?id=317716</a>
<a href="https://rdar.apple.com/180470182">rdar://180470182</a>

Reviewed by Yijia Huang.

We are observing that this checks are too strong.

1. If callLinkStatus.canOptimize() is false, let&apos;s not do anything.
   Leave it unknown so that inlining etc. will just ignore that.
   We should handle unused callsite as it deserves.
2. From the inlining etc., if we already know that this callsite is
   taking function expression from the same code, this is very likely a
   closure call. Let&apos;s mark it as closure call and avoid using constant
   call even if CallIC says so, because it is possible that we are
   tiering up too early now.

* JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js:
* Source/JavaScriptCore/bytecode/CallLinkStatus.h:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::refineStatically):

Canonical link: <a href="https://commits.webkit.org/315803@main">https://commits.webkit.org/315803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad0482c616e27fcd8b6453dc4186dc51822b3a73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37285 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179315 "Hash ad0482c6 for PR 67748 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127666 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95342c50-3233-4f10-9ece-1d06b1950369) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43506 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/179315 "Hash ad0482c6 for PR 67748 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93326 "2 flakes 10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9319b206-1da6-4da6-bd45-a490d8341047) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172913 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152894 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/179315 "Hash ad0482c6 for PR 67748 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3e9b017-101c-4a7e-92e3-cde0be6415de) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28011 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1310 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181912 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31209 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140918 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43532 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140749 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44221 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108548 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25937 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36015 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115986 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202633 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42732 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7374 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54306 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42124 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42379 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42267 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->