### PR TITLE
Make `EditingRange::clampedFirstLineRange` defined out-of-line and move into a `.cpp` file

### DIFF
--- a/Source/WebKit/Platform/EditingRangeClamping.cpp
+++ b/Source/WebKit/Platform/EditingRangeClamping.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "EditingRange.h"
+
+#include <algorithm>
+#include <wtf/SaturatingArithmetic.h>
+
+namespace WebKit {
+
+EditingRange EditingRange::clampedFirstLineRange(EditingRange firstLineRange, const EditingRange& requestedRange)
+{
+    auto requestedEnd = saturatingSum<uint64_t>(requestedRange.location, requestedRange.length);
+    auto location = std::clamp(firstLineRange.location, requestedRange.location, requestedEnd);
+    auto firstLineEnd = saturatingSum<uint64_t>(location, firstLineRange.length);
+    return EditingRange(location, std::min(firstLineEnd, requestedEnd) - location);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/Platform/Sources.txt
+++ b/Source/WebKit/Platform/Sources.txt
@@ -23,3 +23,5 @@ Platform/IPC/StreamConnectionWorkQueue.cpp
 Platform/IPC/SharedFileHandle.cpp
 Platform/IPC/StreamServerConnection.cpp
 Platform/IPC/TransferString.cpp
+
+Platform/EditingRangeClamping.cpp

--- a/Source/WebKit/Shared/EditingRange.h
+++ b/Source/WebKit/Shared/EditingRange.h
@@ -26,11 +26,9 @@
 #pragma once
 
 #include <WebCore/CharacterRange.h>
-#include <algorithm>
 #include <optional>
 #include <wtf/NotFound.h>
 #include <wtf/RefPtr.h>
-#include <wtf/SaturatingArithmetic.h>
 
 namespace WebCore {
 class LocalFrame;
@@ -75,13 +73,7 @@ struct EditingRange {
     // Returns `firstLineRange` clamped to lie within `requestedRange`. Uses saturating arithmetic
     // so the result always satisfies isValid() (i.e. location + length never overflows), regardless
     // of the inputs. This is sent back to the UIProcess as the "actual range".
-    static EditingRange clampedFirstLineRange(EditingRange firstLineRange, const EditingRange& requestedRange)
-    {
-        auto requestedEnd = saturatingSum<uint64_t>(requestedRange.location, requestedRange.length);
-        auto location = std::clamp(firstLineRange.location, requestedRange.location, requestedEnd);
-        auto firstLineEnd = saturatingSum<uint64_t>(location, firstLineRange.length);
-        return EditingRange(location, std::min(firstLineEnd, requestedEnd) - location);
-    }
+    static EditingRange clampedFirstLineRange(EditingRange firstLineRange, const EditingRange& requestedRange);
 
 #if defined(__OBJC__)
     EditingRange(NSRange range)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5232,6 +5232,7 @@
 		2D9CD5EB21FA503F0029ACFA /* TextCheckingControllerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = TextCheckingControllerProxy.messages.in; sourceTree = "<group>"; };
 		2D9CD5EC21FA503F0029ACFA /* TextCheckingControllerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextCheckingControllerProxy.mm; sourceTree = "<group>"; };
 		2D9CD5ED21FA503F0029ACFA /* TextCheckingControllerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextCheckingControllerProxy.h; sourceTree = "<group>"; };
+		221419632FEB73BA00C7E2ED /* EditingRangeClamping.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EditingRangeClamping.cpp; sourceTree = "<group>"; };
 		2D9CD5EE21FA75EE0029ACFA /* EditingRange.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EditingRange.cpp; sourceTree = "<group>"; };
 		2D9EA30C1A96CB59002D2807 /* WKPageInjectedBundleClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPageInjectedBundleClient.h; sourceTree = "<group>"; };
 		2D9EA30E1A96CBFF002D2807 /* WebPageInjectedBundleClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPageInjectedBundleClient.h; sourceTree = "<group>"; };
@@ -16525,6 +16526,7 @@
 				1A7E814E1152D2240003695B /* mac */,
 				CE1A0BCA1A48E6C60054EF74 /* spi */,
 				51B15A7D138439B200321AD8 /* unix */,
+				221419632FEB73BA00C7E2ED /* EditingRangeClamping.cpp */,
 				ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */,
 				ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */,
 				E3C788F02D035CED00D6C13D /* LogClient.cpp */,


### PR DESCRIPTION
#### d0b94cb5b4a4b6e623bd13d71d666de126d9897f
<pre>
Make `EditingRange::clampedFirstLineRange` defined out-of-line and move into a `.cpp` file
<a href="https://bugs.webkit.org/show_bug.cgi?id=317718">https://bugs.webkit.org/show_bug.cgi?id=317718</a>
<a href="https://rdar.apple.com/180472627">rdar://180472627</a>

Reviewed by Chris Dumez.

Initially, EditingRange::clampedFirstLineRange failed to link out-of-line when
used from the IPC API tests even when using WK_EXPORT. The reason is that TestIPC
links against libWebKitPlatform.a, not WebKit.framework. So, a symbol in the
framework dylib is unreachable from the test regardless of export macros. This
defines the symbol out-of-line in a new translation unit such that it builds into
libWebKitPlatform.a so the symbol resolves directly.

* Source/WebKit/Platform/EditingRangeClamping.cpp: Added.
(WebKit::EditingRange::clampedFirstLineRange):
* Source/WebKit/Platform/Sources.txt:
* Source/WebKit/Shared/EditingRange.h:
(WebKit::EditingRange::clampedFirstLineRange): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/315816@main">https://commits.webkit.org/315816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5119b67f5c6b3e1061f4045722a472d15a524215

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132639 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173112 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113141 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28211 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182112 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34901 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141092 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43733 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140917 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37949 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44422 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108793 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36187 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116302 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42932 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7554 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42324 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->