### PR TITLE
[threaded-animations] webanimations/threaded-animations/fill-mode-adjustment-additive.html may crash under ASan

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/timing-function-threading-check-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/timing-function-threading-check-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Resolving threaded-animation timing on the main and scrolling threads concurrently does not trip the RefCounted threading check.
+

--- a/LayoutTests/webanimations/threaded-animations/timing-function-threading-check.html
+++ b/LayoutTests/webanimations/threaded-animations/timing-function-threading-check.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<body>
+<style>
+#target { width: 100px; height: 100px; background-color: black; }
+</style>
+<div id="target"></div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+<script>
+
+promise_test(async t => {
+    const target = document.getElementById("target");
+    const duration = 1000 * 1000;
+    // Use a cubic-bezier easing so TimingFunction::transformProgress() does
+    // non-trivial work, widening the window during which both the main and
+    // scrolling threads hold a transient ref on the same TimingFunction.
+    const easing = "cubic-bezier(0.1, 0.7, 1.0, 0.1)";
+    const animations = [
+        target.animate({ translate: ["100px", "200px"] }, { duration, easing }),
+        target.animate({ translate: ["300px", "400px"] }, { duration, easing, composite: "add" }),
+        target.animate({ scale: [1, 2] }, { duration, easing }),
+        target.animate({ scale: [3, 4] }, { duration, easing, composite: "add" })
+    ];
+    await Promise.all(animations.map(animation => animationAcceleration(animation)));
+
+    // Repeatedly resolve the animation stack on the main thread while the
+    // scrolling thread is concurrently applying effects. Both paths call
+    // AnimationEffectTiming::resolve() which protects the effect's
+    // TimingFunction; this must not trip the RefCounted threading check.
+    for (let i = 0; i < 50; ++i)
+        await UIHelper.remoteAnimationStackForElement(target);
+}, "Resolving threaded-animation timing on the main and scrolling threads concurrently does not trip the RefCounted threading check.");
+
+</script>
+</body>

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -26,7 +26,7 @@
 
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -35,7 +35,7 @@ class TextStream;
 
 namespace WebCore {
 
-class TimingFunction : public RefCounted<TimingFunction> {
+class TimingFunction : public ThreadSafeRefCounted<TimingFunction> {
 public:
     virtual Ref<TimingFunction> clone() const = 0;
 


### PR DESCRIPTION
#### c541bf0a0086e9fd56e558450623062e7f085944
<pre>
[threaded-animations] webanimations/threaded-animations/fill-mode-adjustment-additive.html may crash under ASan
<a href="https://bugs.webkit.org/show_bug.cgi?id=317719">https://bugs.webkit.org/show_bug.cgi?id=317719</a>
<a href="https://rdar.apple.com/180122972">rdar://180122972</a>

Reviewed by Tim Nguyen.

Since accelerated effects may be accessed both via the main thread and the scrolling thread on macOS,
the `TimingFunction` class should use `ThreadSafeRefCounted` like all the other ref-counted types used
by `AcceleratedEffect` and `AcceleratedEffectValues`.

This fix was automatically suggested by an LLM during bug analysis, I validated its approach.

Test: webanimations/threaded-animations/timing-function-threading-check.html

* LayoutTests/webanimations/threaded-animations/timing-function-threading-check-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/timing-function-threading-check.html: Added.
* Source/WebCore/platform/animation/TimingFunction.h:

Canonical link: <a href="https://commits.webkit.org/315777@main">https://commits.webkit.org/315777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8265b4bfceb71efd449f6a12aae824508e15654d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127655 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73158725-448d-44e4-9d7b-5c75169255c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132458 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/857c3f33-c454-409e-8c77-660f62b874b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172902 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112960 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9182d31e-1594-433c-950b-ca334466b17f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28000 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181901 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140908 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140739 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44210 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108525 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25915 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36007 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115975 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42721 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7362 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42113 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42368 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->