### PR TITLE
REGRESSION(315516@main): [iOS] TestWebKitAPI.SiteIsolation tests are flaky timeout

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -1081,11 +1081,32 @@ void appendToBackForwardStateItems(Vector<WebKit::BackForwardListItemState>& ite
     items.append({ entry.copyMainFrameStateWithChildren(), entry.navigatedFrameID() });
 }
 
+void setFrameStateBackForwardItemIdentifier(WebKit::FrameState& frameState, const WebCore::BackForwardItemIdentifier& itemID)
+{
+    frameState.itemID = itemID;
+    for (auto& child : frameState.children)
+        setFrameStateBackForwardItemIdentifier(child, itemID);
+}
+
 Ref<WebKit::WebBackForwardListItem> createItemFromState(const WebKit::BackForwardListItemState& itemState, WebKit::WebPageProxyIdentifier pageIdentifier)
 {
     Ref stateCopy = itemState.frameState->copy();
     setBackForwardItemIdentifiers(stateCopy, WebCore::BackForwardItemIdentifier::generate());
     return WebKit::WebBackForwardListItem::create(WTF::move(stateCopy), pageIdentifier, itemState.navigatedFrameID);
+}
+
+Vector<Ref<WebKit::WebBackForwardListItem>> createItemsFromState(const WebKit::BackForwardListState& state, WebKit::WebPageProxyIdentifier pageIdentifier)
+{
+    Vector<Ref<WebKit::WebBackForwardListItem>> items;
+    items.reserveInitialCapacity(state.items.size());
+    for (auto& itemState : state.items)
+        items.append(createItemFromState(itemState, pageIdentifier));
+    return items;
+}
+
+WebKit::WebBackForwardListItem* itemAtIndexInBackForwardListItemVector(const Vector<Ref<WebKit::WebBackForwardListItem>>& items, size_t index)
+{
+    return items[index].ptr();
 }
 
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -709,9 +709,12 @@ final class WebBackForwardList {
 
         // FIXME: Enable restoring resourceDirectoryURL.
         entries.removeAll()
-        entries.reserveCapacity(backForwardListState.items.size())
-        for itemState in CxxVectorIterator(vec: backForwardListState.items) {
-            entries.append(createItemFromState(itemState, page.identifier()).ptr())
+        let restoredItems = createItemsFromState(backForwardListState, page.identifier())
+        let count = restoredItems.size()
+        entries.reserveCapacity(count)
+        for i in 0..<count {
+            // swift-format-ignore: NeverForceUnwrap
+            entries.append(itemAtIndexInBackForwardListItemVector(restoredItems, i)!)
         }
 
         currentIndex = Optional(fromCxx: backForwardListState.currentIndex).map({ val in Int(val) })
@@ -933,10 +936,7 @@ final class WebBackForwardList {
     }
 
     func setBackForwardItemIdentifier(frameState: WebKit.FrameState, itemID: WebCore.BackForwardItemIdentifier) {
-        frameState.itemID = WebCore.MarkableBackForwardItemIdentifier(itemID)
-        for child in CxxVectorIterator(vec: frameState.children) {
-            setBackForwardItemIdentifier(frameState: child.ptr(), itemID: itemID)
-        }
+        setFrameStateBackForwardItemIdentifier(frameState, itemID)
     }
 
     func completeFrameStateForNavigation(navigatedFrameState: WebKit.FrameState) -> WebKit.FrameState {
@@ -956,7 +956,8 @@ final class WebBackForwardList {
         if mainFrameItem.childItemForFrameID(navigatedFrameID) == nil {
             return navigatedFrameState
         }
-        let frameState = currentItem.copyMainFrameStateWithChildren().ptr()
+        let frameStateRef = currentItem.copyMainFrameStateWithChildren()
+        let frameState = frameStateRef.ptr()
         setBackForwardItemIdentifier(frameState: frameState, itemID: navigatedFrameState.itemID.pointee)
         frameState.replaceChildFrameState(consuming: WebKit.RefFrameState(navigatedFrameState))
         return frameState

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -73,8 +73,12 @@ inline WebKit::FrameState* getFrameState(WebKit::WebBackForwardListFrameItem& it
     return &item.frameState();
 }
 
+void setFrameStateBackForwardItemIdentifier(WebKit::FrameState&, const WebCore::BackForwardItemIdentifier&);
+
 // Workarounds for rdar://171011011
 void appendToBackForwardStateItems(Vector<WebKit::BackForwardListItemState>& items, const WebKit::WebBackForwardListItem& entry);
 Ref<WebKit::WebBackForwardListItem> createItemFromState(const WebKit::BackForwardListItemState&, WebKit::WebPageProxyIdentifier pageIdentifier);
+Vector<Ref<WebKit::WebBackForwardListItem>> createItemsFromState(const WebKit::BackForwardListState&, WebKit::WebPageProxyIdentifier pageIdentifier);
+WebKit::WebBackForwardListItem* itemAtIndexInBackForwardListItemVector(const Vector<Ref<WebKit::WebBackForwardListItem>>& items, size_t index);
 
 #endif // ENABLE(BACK_FORWARD_LIST_SWIFT)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2761,12 +2761,12 @@ RefPtr<API::Navigation> WebPageProxy::goBack()
     return goToBackForwardItem(frameItemForLegacyTraversalRouting(*backItem, "goBack"_s), FrameLoadType::Back);
 }
 
-RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListItem& item)
+RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListItem& item, IsSessionRestoreNavigation isSessionRestore)
 {
-    return goToBackForwardItem(protect(item.mainFrameItem()), FrameLoadType::IndexedBackForward);
+    return goToBackForwardItem(protect(item.mainFrameItem()), FrameLoadType::IndexedBackForward, isSessionRestore);
 }
 
-RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFrameItem& frameItem, FrameLoadType frameLoadType)
+RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFrameItem& frameItem, FrameLoadType frameLoadType, IsSessionRestoreNavigation isSessionRestore)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "goToBackForwardItem:");
 
@@ -2855,12 +2855,12 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
         bool anySent = false;
         if (RefPtr currentItem = backForwardList().currentItem())
             anySent = dispatchPerFrameTraversals(protect(currentItem->mainFrameItem()), protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
-        else {
-            sendGoToBackForwardItemForFrame(protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
-            anySent = true;
+        if (!anySent) {
+            if (!backForwardList().currentItem() || isSessionRestore == IsSessionRestoreNavigation::Yes)
+                sendGoToBackForwardItemForFrame(protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
+            else
+                WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "goToBackForwardItem: walk dispatched no GoToBackForwardItem messages — back/forward action will be silently dropped");
         }
-        if (!anySent)
-            WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "goToBackForwardItem: walk dispatched no GoToBackForwardItem messages — back/forward action will be silently dropped");
     } else {
         process->markProcessAsRecentlyUsed();
         process->send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(frameItem), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, shouldRestoreFromBackForwardCache, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), webPageIDInProcess(process));
@@ -6376,7 +6376,7 @@ RefPtr<API::Navigation> WebPageProxy::restoreFromSessionState(SessionState sessi
 
         if (hasBackForwardList) {
             if (RefPtr item = backForwardList().currentItem())
-                return goToBackForwardItem(*item);
+                return goToBackForwardItem(*item, IsSessionRestoreNavigation::Yes);
         }
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1000,7 +1000,8 @@ public:
     RefPtr<API::Navigation> goForward();
     RefPtr<API::Navigation> goBack();
 
-    RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListItem&);
+    enum class IsSessionRestoreNavigation : bool { No, Yes };
+    RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListItem&, IsSessionRestoreNavigation = IsSessionRestoreNavigation::No);
     void tryRestoreScrollPosition();
     void didChangeBackForwardList(WebBackForwardListItem* addedItem, Vector<Ref<WebBackForwardListItem>>&& removed);
     void shouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier, bool inBackForwardCache, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
@@ -3020,7 +3021,7 @@ private:
     Ref<WebPageProxy> downloadOriginatingPage(const API::Navigation*);
     Ref<WebPageProxy> navigationOriginatingPage(const FrameInfoData&);
 
-    RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListFrameItem&, WebCore::FrameLoadType);
+    RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListFrameItem&, WebCore::FrameLoadType, IsSessionRestoreNavigation = IsSessionRestoreNavigation::No);
 
     bool dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);
     void sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);

--- a/TestExpectations/apitests
+++ b/TestExpectations/apitests
@@ -335,11 +335,6 @@ webkit.org/b/317214 [ mac ] TestWebKitAPI.NowPlayingTest.VideoElementWithMutedAu
 webkit.org/b/317214 [ mac ] TestWebKitAPI.NowPlayingTest.VideoElementWithoutAudio [ Crash ]
 webkit.org/b/317214 [ mac ] TestWebKitAPI.NowPlayingTest.VideoElementWithoutAudioPlayWithUserGesture [ Crash ]
 
-webkit.org/b/317676 TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward [ Skip ]
-webkit.org/b/317676 TestWebKitAPI.SiteIsolation.NavigateIframeCrossOriginBackForwardAfterSessionRestoreToNewWebView [ Skip ]
-webkit.org/b/317676 TestWebKitAPI.SiteIsolation.NavigateIframeSameOriginBackForwardAfterSessionRestoreToNewWebView [ Skip ]
-webkit.org/b/317676 TestWebKitAPI.SiteIsolation.RestoreSessionFromAnotherWebView [ Skip ]
-
 webkit.org/b/317783 [ ios ] TestWebKitAPI.SiteIsolation.FindStringSelectionSameOriginFrameBeforeWrap [ Skip ]
 
 webkit.org/b/317800 [ ios ] TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackAfterTerminateProcess [ Skip ]


### PR DESCRIPTION
#### 5b2c8a7befcd089b1ab0393948036625913aebb4
<pre>
REGRESSION(315516@main): [iOS] TestWebKitAPI.SiteIsolation tests are flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=317676">https://bugs.webkit.org/show_bug.cgi?id=317676</a>
<a href="https://rdar.apple.com/180432846">rdar://180432846</a>

Reviewed by Basuke Suzuki.

Fix two issues exposed or caused by 315516@main, which led Site Isolation tests to fail on macOS Golden Gate:

1. Iterating WTF::Vectors of Ref&lt;T&gt;-bearing elements from Swift via CxxVectorIterator hits <a href="https://rdar.apple.com/173815363">rdar://173815363</a>: Swift
mishandles destruction of Ref&lt;T&gt; elements during iteration, producing assertions like &quot;ASSERTION FAILED: m_ptr&quot; in
Ref&lt;FrameState&gt;::get(). Two such loops in WebBackForwardList.swift were affected:
- setBackForwardItemIdentifier(frameState:itemID:) iterating frameState.children (a Vector&lt;Ref&lt;FrameState&gt;&gt;)
- restoreFromState(backForwardListState:) iterating backForwardListState.items (a Vector&lt;BackForwardListItemState&gt;,
whose elements transitively hold a Ref&lt;FrameState&gt;)
To fix it, move both iterations into C++ helpers, mirroring the existing workaround pattern set by 310371@main for
setBackForwardItemIdentifiers.

2. After session restore with andNavigate:YES, restoreFromSessionState calls goToBackForwardItem(currentItem). Under
useUIProcessForBackForwardItemLoading, the per-frame walk introduced by 315516@main compares currentItem.mainFrameItem()
to item.mainFrameItem() — the same object — finds no per-frame itemSequenceNumber / documentSequenceNumber diff,
dispatches no GoToBackForwardItem message, and only logs an error. The WebProcess never loads anything and the session
restore tests time out.
To fix it, Add an IsSessionRestoreNavigation parameter to goToBackForwardItem and pass Yes from restoreFromSessionState.
When the walk dispatches no message, force a single GoToBackForwardItem on the target&apos;s main frame if there is no
current item OR the call is from session restore. Otherwise (e.g. a redundant go(to: currentlyLoadedItem) call, or
Back-forward list corruption that produced identical sequence numbers across distinct items) the walk&apos;s verdict is
trustworthy: log the existing error and drop. The fallback uses sendGoToBackForwardItemForFrame to stay within the
per-frame dispatch model and re-resolve the destination process for the target frame.

There is a drive-by fix to keep frameStateRef bound across completeFrameStateForNavigation so ARC keeps the underlying
FrameState alive across the subsequent calls; relying on the temporary Ref&apos;s lifetime would require Swift to auto-retain
the Foreign Reference Type returned from .ptr(), which isn&apos;t guaranteed.

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(setFrameStateBackForwardItemIdentifier):
(createItemsFromState):
(itemAtIndexInBackForwardListItemVector):
* Source/WebKit/UIProcess/WebBackForwardList.swift:
(MakeAPIArray.restoreFromState(_:)):
(MakeAPIArray.setBackForwardItemIdentifier(_:itemID:)):
(MakeAPIArray.completeFrameStateForNavigation(_:)):
* Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::restoreFromSessionState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* TestExpectations/apitests:

Canonical link: <a href="https://commits.webkit.org/315817@main">https://commits.webkit.org/315817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6076c69b3fc0352bb8b39453cc49d362fdeb381

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170084 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; check-webkit-style") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44007 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Running checkout-pull-request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127796 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/831936e3-f057-46c8-8740-5282f5a28c68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132573 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73490b2a-2b38-47ab-aaad-51e76a19d3ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173043 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113075 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bfaaf360-39eb-4a8f-b7db-bc8ea4ffa3ee) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169405 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28142 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182043 "Built successfully") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34832 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 28351 issues; Found 139 new failures in platform/graphics/IntRect.cpp, bytecode/ExpressionInfo.cpp, dfg/DFGBasicBlock.cpp, wasm/WasmIPIntGenerator.cpp, rendering/RenderFlexibleBox.h, html/FormController.cpp, dfg/DFGByteCodeParser.cpp, html/canvas/WebGLTransformFeedback.cpp, editing/cocoa/WebContentReaderCocoa.mm, rendering/cocoa/RenderThemeCocoa.mm ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141023 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43663 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140852 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37948 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44352 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29399 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108703 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Compiled WebKit") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36120 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116233 "Found 92 new failures in plugins/DOMPluginArray.cpp, rendering/NinePieceImagePainter.cpp, css/SelectorFilter.cpp, layout/formattingContexts/inline/InlineFormattingContext.cpp, css/typedom/transform/CSSTransformValue.cpp, loader/TextResourceDecoder.cpp, dom/TreeScope.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm, dom/ImageOverlay.cpp, dfg/DFGFixupPhase.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42863 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7498 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42255 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42509 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->