### PR TITLE
[OpenXR] Remove the dependency with OpenGLES

### DIFF
--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -313,6 +313,7 @@ UIProcess/gtk/WebPreferencesGtk.cpp
 UIProcess/soup/WebProcessPoolSoup.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
+UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.cpp
 UIProcess/XR/openxr/OpenXRHitTestManager.cpp
 UIProcess/XR/openxr/OpenXRInput.cpp
 UIProcess/XR/openxr/OpenXRInputSource.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -296,6 +296,7 @@ UIProcess/wpe/WebPreferencesWPE.cpp
 UIProcess/wpe/WebContextMenuProxyWPE.cpp
 
 UIProcess/XR/openxr/OpenXRExtensions.cpp
+UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.cpp
 UIProcess/XR/openxr/OpenXRHitTestManager.cpp
 UIProcess/XR/openxr/OpenXRInput.cpp
 UIProcess/XR/openxr/OpenXRInputSource.cpp

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBinding.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBinding.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+
+#include "OpenXRUtils.h"
+#include <memory>
+#include <optional>
+#include <wtf/Vector.h>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+namespace WebKit {
+
+class OpenXRSwapchain;
+
+// Encapsulates the graphics library specific parts of the OpenXR backend behind an API-agnostic interface.
+// Initialization is split because the constraints differ per API: EGL creates its display before
+// xrCreateInstance, whereas a Vulkan binding must create its instance/device only after the OpenXR
+// instance and system exist. So requiredInstanceExtensions()/initializeDisplay() run before/around
+// instance creation and initializeForSession() once the instance and system are known.
+class OpenXRGraphicsBinding {
+public:
+    enum class TextureType {
+        Texture2D,
+        Cubemap,
+    };
+
+    virtual ~OpenXRGraphicsBinding() = default;
+
+    virtual Vector<ASCIILiteral> requiredInstanceExtensions() const = 0;
+    virtual bool initializeDisplay(bool isForTesting) = 0;
+    virtual bool initializeForSession(XrInstance, XrSystemId) = 0;
+
+    // XrGraphicsBinding* to chain into XrSessionCreateInfo::next.
+    virtual const void* sessionGraphicsBinding() const = 0;
+
+    virtual int64_t selectColorFormat(const Vector<int64_t>& supportedFormats, bool alpha) const = 0;
+    virtual Vector<uint64_t> enumerateSwapchainImages(XrSwapchain) const = 0;
+
+    virtual std::optional<PlatformXR::FrameData::ExternalTexture> exportTexture(uint64_t image, const OpenXRSwapchain&, TextureType, uint32_t width, uint32_t height) = 0;
+
+    virtual void commitFrame(uint64_t keyImage, const OpenXRSwapchain&, TextureType, const Vector<uint64_t>& images) = 0;
+    virtual void waitFrameFence(WTF::UnixFileDescriptor&&) = 0;
+
+    virtual void releaseSessionGraphics() = 0;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.cpp
@@ -1,0 +1,633 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "OpenXRGraphicsBindingOpenGLES.h"
+
+#if ENABLE(WEBXR) && USE(OPENXR) && defined(XR_USE_GRAPHICS_API_OPENGL_ES)
+
+#include "OpenXRExtensions.h"
+#include "OpenXRSwapchain.h"
+#if USE(LIBEPOXY)
+#define __GBM__ 1
+#include <epoxy/egl.h>
+#else
+#include <EGL/egl.h>
+#endif
+#include <WebCore/FourCC.h>
+#include <WebCore/GLContext.h>
+#include <WebCore/GLDisplay.h>
+#include <WebCore/GLFence.h>
+#include <wtf/RunLoop.h>
+#include <wtf/SafeStrerror.h>
+#include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+#if OS(ANDROID)
+#include <android/hardware_buffer.h>
+#endif
+
+#if USE(GBM)
+#include "DRMMainDevice.h"
+#include <WebCore/DMABufBuffer.h>
+#include <WebCore/DRMDevice.h>
+#include <WebCore/GBMDevice.h>
+#include <WebCore/GBMVersioning.h>
+#include <drm_fourcc.h>
+#endif
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRGraphicsBindingOpenGLES);
+
+std::unique_ptr<OpenXRGraphicsBindingOpenGLES> OpenXRGraphicsBindingOpenGLES::create()
+{
+    return std::unique_ptr<OpenXRGraphicsBindingOpenGLES>(new OpenXRGraphicsBindingOpenGLES());
+}
+
+OpenXRGraphicsBindingOpenGLES::OpenXRGraphicsBindingOpenGLES() = default;
+
+OpenXRGraphicsBindingOpenGLES::~OpenXRGraphicsBindingOpenGLES()
+{
+    ASSERT(!m_glContext);
+}
+
+Vector<ASCIILiteral> OpenXRGraphicsBindingOpenGLES::requiredInstanceExtensions() const
+{
+    Vector<ASCIILiteral> extensions;
+#if defined(XR_USE_PLATFORM_EGL)
+    if (OpenXRExtensions::singleton().isExtensionSupported(XR_MNDX_EGL_ENABLE_EXTENSION_NAME ""_span))
+        extensions.append(XR_MNDX_EGL_ENABLE_EXTENSION_NAME ""_s);
+#endif
+    extensions.append(XR_KHR_OPENGL_ES_ENABLE_EXTENSION_NAME ""_s);
+    return extensions;
+}
+
+bool OpenXRGraphicsBindingOpenGLES::initializeDisplay(bool isForTesting)
+{
+    ASSERT(RunLoop::isMain());
+    ASSERT(!m_glDisplay);
+
+    const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
+    auto tryCreateDisplay = [&](EGLenum platform, void *native) -> RefPtr<WebCore::GLDisplay> {
+        if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
+            return WebCore::GLDisplay::create(eglGetPlatformDisplayEXT(platform, native, nullptr));
+        if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
+            return WebCore::GLDisplay::create(eglGetPlatformDisplay(platform, native, nullptr));
+        return nullptr;
+    };
+
+    RefPtr<WebCore::GLDisplay> glDisplay;
+
+#if OS(ANDROID)
+    if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_android")) {
+        glDisplay = tryCreateDisplay(EGL_PLATFORM_ANDROID_KHR, EGL_DEFAULT_DISPLAY);
+        if (!glDisplay)
+            glDisplay = WebCore::GLDisplay::create(eglGetDisplay(EGL_DEFAULT_DISPLAY));
+        if (glDisplay && !(glDisplay->extensions().ANDROID_get_native_client_buffer && glDisplay->extensions().ANDROID_image_native_buffer))
+            glDisplay = nullptr;
+    }
+#endif // OS(ANDROID)
+
+    if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_MESA_platform_surfaceless")) {
+        glDisplay = tryCreateDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY);
+        if (glDisplay && !isForTesting && !glDisplay->extensions().MESA_image_dma_buf_export)
+            glDisplay = nullptr;
+    }
+
+#if USE(GBM)
+    if (!glDisplay && WebCore::GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_gbm")) {
+        const auto& mainDevice = drmMainDevice();
+        if (!mainDevice.isNull()) {
+            m_gbmDevice = WebCore::GBMDevice::create(!mainDevice.renderNode.isNull() ? mainDevice.renderNode : mainDevice.primaryNode);
+            if (m_gbmDevice)
+                glDisplay = tryCreateDisplay(EGL_PLATFORM_GBM_KHR, m_gbmDevice->device());
+        }
+    }
+#endif
+
+    m_glDisplay = WTF::move(glDisplay);
+    return !!m_glDisplay;
+}
+
+bool OpenXRGraphicsBindingOpenGLES::initializeForSession(XrInstance instance, XrSystemId systemId)
+{
+    ASSERT(!RunLoop::isMain());
+    ASSERT(m_glDisplay);
+
+#if !OS(ANDROID)
+    if (!OpenXRExtensions::singleton().isExtensionSupported(XR_MNDX_EGL_ENABLE_EXTENSION_NAME ""_span)) {
+        LOG(XR, "OpenXR MNDX_EGL_ENABLE extension is not supported.");
+        return false;
+    }
+#endif
+
+    auto requirements = createOpenXRStruct<XrGraphicsRequirementsOpenGLESKHR, XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_ES_KHR>();
+    CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrGetOpenGLESGraphicsRequirementsKHR(instance, systemId, &requirements));
+
+    if (!m_glContext) {
+#if USE(GBM)
+        const WebCore::GLContext::Target target = m_gbmDevice ? WebCore::GLContext::Target::Default : WebCore::GLContext::Target::Surfaceless;
+#else
+        static const WebCore::GLContext::Target target = WebCore::GLContext::Target::Surfaceless;
+#endif
+        m_glContext = WebCore::GLContext::create(*m_glDisplay, target);
+        if (!m_glContext) {
+            LOG(XR, "Failed to create the GL context for OpenXR.");
+            return false;
+        }
+        if (!m_glContext->makeContextCurrent()) {
+            LOG(XR, "Failed to make the GL context current.");
+            return false;
+        }
+    }
+
+#if OS(ANDROID)
+    m_graphicsBinding = createOpenXRStruct<XrGraphicsBindingOpenGLESAndroidKHR, XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR>();
+#else
+    m_graphicsBinding = createOpenXRStruct<XrGraphicsBindingEGLMNDX, XR_TYPE_GRAPHICS_BINDING_EGL_MNDX>();
+    m_graphicsBinding.getProcAddress = OpenXRExtensions::singleton().methods().getProcAddressFunc;
+#endif
+    m_graphicsBinding.display = m_glDisplay->eglDisplay();
+    m_graphicsBinding.context = m_glContext->platformContext();
+    m_graphicsBinding.config = m_glContext->config();
+
+    return true;
+}
+
+const void* OpenXRGraphicsBindingOpenGLES::sessionGraphicsBinding() const
+{
+    return &m_graphicsBinding;
+}
+
+int64_t OpenXRGraphicsBindingOpenGLES::selectColorFormat(const Vector<int64_t>& supportedFormats, bool) const
+{
+    // Even if alpha is false we always ask for the RGBA8 format, as the DRM_FORMAT_RGB8 is not supported by ANGLE.
+    // In this case we ignore the alpha channel by using DRM_FORMAT_XRGB8888 when exporting the texture.
+    int64_t preferredFormat = GL_RGBA8;
+    return supportedFormats.contains(preferredFormat) ? preferredFormat : supportedFormats.first();
+}
+
+Vector<uint64_t> OpenXRGraphicsBindingOpenGLES::enumerateSwapchainImages(XrSwapchain swapchain) const
+{
+    uint32_t imageCount;
+    CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, 0, &imageCount, nullptr));
+    if (!imageCount) {
+        LOG(XR, "xrEnumerateSwapchainImages(): no images\n");
+        return { };
+    }
+
+    Vector<XrSwapchainImageOpenGLESKHR> imageBuffers(FillWith { }, imageCount, [] {
+        return createOpenXRStruct<XrSwapchainImageOpenGLESKHR, XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_ES_KHR>();
+    }());
+
+    Vector<XrSwapchainImageBaseHeader*> imageHeaders = imageBuffers.map([](auto& image) {
+        return (XrSwapchainImageBaseHeader*) &image;
+    });
+
+    // Get images from an XrSwapchain
+    CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, imageCount, &imageCount, imageHeaders[0]));
+
+    return imageBuffers.map([](auto& image) -> uint64_t {
+        return image.image;
+    });
+}
+
+void OpenXRGraphicsBindingOpenGLES::waitFrameFence(WTF::UnixFileDescriptor&& fenceFD)
+{
+    ASSERT(m_glDisplay);
+    if (auto fence = WebCore::GLFence::importFD(*m_glDisplay, WTF::move(fenceFD)))
+        fence->serverWait();
+}
+
+void OpenXRGraphicsBindingOpenGLES::releaseSessionGraphics()
+{
+    // Deleting the GL objects below requires the context that owns them to be current. The context may be null if the session graphics
+    // were never initialized, in which case there is nothing to delete.
+    ASSERT(!m_glContext || WebCore::GLContext::current() == m_glContext.get());
+
+#if USE(GBM) || OS(ANDROID)
+    if (m_fbosForBlitting[0])
+        glDeleteFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
+    m_fbosForBlitting = { 0, 0 };
+    for (auto texture : m_exportedTexturesMap.values())
+        glDeleteTextures(1, &texture);
+    m_exportedTexturesMap.clear();
+#endif
+
+#if defined(XR_KHR_composition_layer_cube)
+    for (auto texture : m_sideBySideTextures.values())
+        glDeleteTextures(1, &texture);
+    m_sideBySideTextures.clear();
+    if (m_reconstructionFBOs[0])
+        glDeleteFramebuffers(m_reconstructionFBOs.size(), m_reconstructionFBOs.data());
+    m_reconstructionFBOs = { 0, 0 };
+#endif
+
+    m_glContext = nullptr;
+}
+
+#if OS(ANDROID)
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingOpenGLES::exportOpenXRTextureAndroid(const OpenXRSwapchain& swapchain, PlatformGLObject openxrTexture, uint32_t width, uint32_t height)
+{
+    static constexpr auto kHardwareBufferUsage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER | AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+
+    RefPtr<AHardwareBuffer> hardwareBuffer;
+    {
+        RELEASE_ASSERT(width > 0);
+        RELEASE_ASSERT(height > 0);
+
+        AHardwareBuffer_Desc bufferDesc = { };
+        bufferDesc.width = width;
+        bufferDesc.height = height;
+        bufferDesc.usage = kHardwareBufferUsage;
+        bufferDesc.layers = 1;
+
+        switch (swapchain.format()) {
+        case GL_RGBA8:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+            break;
+        case GL_RGB8:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
+            if (!AHardwareBuffer_isSupported(&bufferDesc))
+                bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM;
+            break;
+        case GL_RGB565:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM;
+            break;
+        case GL_RGBA16F:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT;
+            break;
+        case GL_RGB10_A2:
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM;
+            break;
+        }
+
+        if (!bufferDesc.format || !AHardwareBuffer_isSupported(&bufferDesc)) {
+            RELEASE_LOG_INFO(XR, "AHardwareBuffer format %#" PRIX32 " not supported, using"
+                " RGBA8888 fallback that may result in slow blits", bufferDesc.format);
+            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+        }
+
+        AHardwareBuffer* buffer { nullptr };
+        if (auto error = AHardwareBuffer_allocate(&bufferDesc, &buffer)) {
+            if (error < 0)
+                RELEASE_LOG_ERROR(XR, "Failed to allocate AHardwareBuffer for OpenXR texture: %s", safeStrerror(-error).data());
+            else
+                RELEASE_LOG_ERROR(XR, "Failed to allocate AHardwareBuffer for OpenXR texture: %" PRIi32, error);
+            return { };
+        }
+        hardwareBuffer = adoptRef(buffer);
+    }
+
+    static PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC s_eglGetNativeClientBufferANDROID { nullptr };
+    if (!s_eglGetNativeClientBufferANDROID) [[unlikely]] {
+        s_eglGetNativeClientBufferANDROID = reinterpret_cast<PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC>(eglGetProcAddress("eglGetNativeClientBufferANDROID"));
+        RELEASE_ASSERT(s_eglGetNativeClientBufferANDROID);
+    }
+
+    static const Vector<EGLAttrib> attributes = { EGL_IMAGE_PRESERVED, EGL_TRUE, EGL_NONE };
+    auto clientBuffer = s_eglGetNativeClientBufferANDROID(hardwareBuffer.get());
+    auto image = m_glDisplay->createImage(EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuffer, attributes);
+    if (image == EGL_NO_IMAGE_KHR) {
+        RELEASE_LOG(XR, "Failed to create EGL image for OpenXR texture (%#06x)", eglGetError());
+        return { };
+    }
+
+    GLint boundTexture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
+    PlatformGLObject exportedTexture;
+    glGenTextures(1, &exportedTexture);
+    glBindTexture(GL_TEXTURE_2D, exportedTexture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    glBindTexture(GL_TEXTURE_2D, boundTexture);
+
+    m_glDisplay->destroyImage(image);
+
+    m_exportedTexturesMap.add(openxrTexture, exportedTexture);
+
+    return hardwareBuffer;
+}
+#else
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingOpenGLES::exportOpenXRTextureDMABuf(const OpenXRSwapchain& swapchain, PlatformGLObject openxrTexture)
+{
+    UNUSED_PARAM(swapchain);
+
+    // Texture must be bound to be exported.
+    glBindTexture(GL_TEXTURE_2D, openxrTexture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+    auto image = m_glDisplay->createImage(m_glContext->platformContext(), EGL_GL_TEXTURE_2D, (EGLClientBuffer)(uint64_t)openxrTexture, { });
+
+    auto releaseImageOnError = makeScopeExit([&] {
+        if (image)
+            m_glDisplay->destroyImage(image);
+    });
+
+    if (!image) {
+        RELEASE_LOG(XR, "Failed to create EGL image from OpenXR texture");
+        return std::nullopt;
+    }
+
+    int fourcc, planeCount;
+    uint64_t modifier;
+    if (!eglExportDMABUFImageQueryMESA(m_glDisplay->eglDisplay(), image, &fourcc, &planeCount, &modifier)) {
+        RELEASE_LOG(XR, "eglExportDMABUFImageQueryMESA failed");
+        return std::nullopt;
+    }
+
+    Vector<int> fdsOut(planeCount);
+    Vector<int> stridesOut(planeCount);
+    Vector<int> offsetsOut(planeCount);
+    if (!eglExportDMABUFImageMESA(m_glDisplay->eglDisplay(), image, fdsOut.mutableSpan().data(), stridesOut.mutableSpan().data(), offsetsOut.mutableSpan().data())) {
+        RELEASE_LOG(XR, "eglExportDMABUFImageMESA failed");
+        return std::nullopt;
+    }
+
+    m_glDisplay->destroyImage(image);
+
+    releaseImageOnError.release();
+
+    Vector<WTF::UnixFileDescriptor> fds = fdsOut.map([](int fd) {
+        return WTF::UnixFileDescriptor(fd, WTF::UnixFileDescriptor::Adopt);
+    });
+    Vector<uint32_t> strides = stridesOut.map([](int stride) {
+        return static_cast<uint32_t>(stride);
+    });
+    Vector<uint32_t> offsets = offsetsOut.map([](int offset) {
+        return static_cast<uint32_t>(offset);
+    });
+
+    return PlatformXR::FrameData::ExternalTexture {
+        .fds = WTF::move(fds),
+        .strides = WTF::move(strides),
+        .offsets = WTF::move(offsets),
+        .fourcc = static_cast<uint32_t>(fourcc),
+        .modifier = modifier,
+    };
+}
+#endif // !OS(ANDROID)
+
+#if USE(GBM)
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingOpenGLES::exportOpenXRTextureGBM(const OpenXRSwapchain& swapchain, PlatformGLObject openxrTexture, uint32_t width, uint32_t height)
+{
+    static constexpr std::array<WebCore::FourCC, 3> preferredAlphaDRMFormats = { DRM_FORMAT_ARGB8888, DRM_FORMAT_RGBA8888, DRM_FORMAT_ABGR8888 };
+    static constexpr std::array<WebCore::FourCC, 3> preferredNoAlphaDRMFormats = { DRM_FORMAT_XRGB8888, DRM_FORMAT_RGBX8888, DRM_FORMAT_BGRX8888 };
+    const auto& preferredDRMFormats = swapchain.hasAlpha() == OpenXRSwapchain::HasAlpha::Yes ? preferredAlphaDRMFormats : preferredNoAlphaDRMFormats;
+    WebCore::GLDisplay::BufferFormat format;
+    const auto& supportedFormats = m_glDisplay->bufferFormats();
+    for (const auto& preferredFormat : preferredDRMFormats) {
+        auto matchIndex = supportedFormats.findIf([preferredFormat](const auto& supportedFormat) {
+            return supportedFormat.fourcc == preferredFormat;
+        });
+        if (matchIndex != notFound) {
+            format = supportedFormats[matchIndex];
+            break;
+        }
+    }
+
+    if (!format.fourcc.value) {
+        RELEASE_LOG(XR, "OpenXR texture format not supported");
+        return std::nullopt;
+    }
+
+    auto* buffer = gbm_bo_create_with_modifiers2(m_gbmDevice->device(), width, height, format.fourcc.value, format.modifiers.span().data(), format.modifiers.size(), GBM_BO_USE_RENDERING);
+    if (!buffer)
+        buffer = gbm_bo_create(m_gbmDevice->device(), width, height, format.fourcc.value, GBM_BO_USE_RENDERING);
+    if (!buffer) {
+        RELEASE_LOG(XR, "Failed to allocate GBM buffer for OpenXR texture");
+        return std::nullopt;
+    }
+
+    auto dmaBufAttributes = WebCore::DMABufBufferAttributes::fromGBMBufferObject(buffer);
+    if (!dmaBufAttributes) {
+        gbm_bo_destroy(buffer);
+        RELEASE_LOG(XR, "Failed to extract DMA-buf attributes from GBM buffer for OpenXR texture");
+        return std::nullopt;
+    }
+
+    auto image = WebCore::DMABufBuffer::createEGLImage(*m_glDisplay, *dmaBufAttributes);
+    gbm_bo_destroy(buffer);
+    if (!image) {
+        RELEASE_LOG(XR, "Failed to create EGL image from OpenXR texture");
+        return std::nullopt;
+    }
+
+    GLint boundTexture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
+    PlatformGLObject exportedTexture;
+    glGenTextures(1, &exportedTexture);
+    glBindTexture(GL_TEXTURE_2D, exportedTexture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    glBindTexture(GL_TEXTURE_2D, boundTexture);
+
+    m_glDisplay->destroyImage(image);
+
+    m_exportedTexturesMap.add(openxrTexture, exportedTexture);
+
+    return PlatformXR::FrameData::ExternalTexture {
+        .fds = WTF::move(dmaBufAttributes->fds),
+        .strides = WTF::move(dmaBufAttributes->strides),
+        .offsets = WTF::move(dmaBufAttributes->offsets),
+        .fourcc = dmaBufAttributes->fourcc.value,
+        .modifier = dmaBufAttributes->modifier
+    };
+}
+#endif // USE(GBM)
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingOpenGLES::exportTexture(uint64_t image, const OpenXRSwapchain& swapchain, TextureType type, uint32_t width, uint32_t height)
+{
+    ASSERT(m_glContext);
+    ASSERT(m_glDisplay);
+
+    switch (type) {
+    case TextureType::Texture2D:
+        return exportTexture2D(static_cast<PlatformGLObject>(image), swapchain, width, height);
+    case TextureType::Cubemap:
+#if defined(XR_KHR_composition_layer_cube)
+        return exportCubeBuffer(image, swapchain, width, height);
+#else
+        break;
+#endif
+    }
+    return std::nullopt;
+}
+
+void OpenXRGraphicsBindingOpenGLES::commitFrame(uint64_t keyImage, const OpenXRSwapchain& swapchain, TextureType type, const Vector<uint64_t>& images)
+{
+    switch (type) {
+    case TextureType::Texture2D:
+        blitTextureIfNeeded(swapchain);
+        break;
+    case TextureType::Cubemap:
+#if defined(XR_KHR_composition_layer_cube)
+        reconstructCubeFaces(keyImage, images, static_cast<uint32_t>(swapchain.width()));
+#endif
+        break;
+    }
+#if !defined(XR_KHR_composition_layer_cube)
+    UNUSED_PARAM(keyImage);
+    UNUSED_PARAM(images);
+#endif
+}
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingOpenGLES::exportTexture2D(PlatformGLObject openxrTexture, const OpenXRSwapchain& swapchain, [[maybe_unused]] uint32_t width, [[maybe_unused]] uint32_t height)
+{
+#if OS(ANDROID)
+    return exportOpenXRTextureAndroid(swapchain, openxrTexture, width, height);
+#else
+    if (m_glDisplay->extensions().MESA_image_dma_buf_export)
+        return exportOpenXRTextureDMABuf(swapchain, openxrTexture);
+#endif
+
+#if USE(GBM)
+    if (m_gbmDevice)
+        return exportOpenXRTextureGBM(swapchain, openxrTexture, width, height);
+#endif
+
+    RELEASE_LOG(XR, "Failed to export OpenXR texture");
+    return std::nullopt;
+}
+
+void OpenXRGraphicsBindingOpenGLES::blitTextureIfNeeded(const OpenXRSwapchain& swapchain)
+{
+#if OS(ANDROID) || USE(GBM)
+#if !OS(ANDROID)
+    // Only the GBM path renders into a separate exported buffer that has to be blitted back; the
+    // MESA dma-buf path exports the swapchain image directly, so there is nothing to blit.
+    if (!m_gbmDevice)
+        return;
+#endif
+    if (!m_fbosForBlitting[0])
+        glGenFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
+
+    auto openxrTexture = static_cast<PlatformGLObject>(swapchain.acquiredTexture());
+    ASSERT(openxrTexture);
+
+    auto exportedTexture = m_exportedTexturesMap.get(openxrTexture);
+    ASSERT(exportedTexture);
+
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbosForBlitting[0]);
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, exportedTexture, 0);
+
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fbosForBlitting[1]);
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, openxrTexture, 0);
+
+    auto width = swapchain.width();
+    auto height = swapchain.height();
+    glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+#else
+    UNUSED_PARAM(swapchain);
+#endif
+}
+
+#if defined(XR_KHR_composition_layer_cube)
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRGraphicsBindingOpenGLES::exportCubeBuffer(uint64_t keyImage, const OpenXRSwapchain& swapchain, uint32_t width, uint32_t height)
+{
+    ASSERT(m_glContext);
+    ASSERT(m_glDisplay);
+
+    auto key = static_cast<PlatformGLObject>(keyImage);
+    PlatformGLObject sideBySideTexture = 0;
+#if OS(ANDROID)
+    auto externalTexture = exportOpenXRTextureAndroid(swapchain, key, width, height);
+    if (!externalTexture)
+        return std::nullopt;
+    sideBySideTexture = m_exportedTexturesMap.take(key);
+#else
+    GLint boundTexture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
+    glGenTextures(1, &sideBySideTexture);
+    glBindTexture(GL_TEXTURE_2D, sideBySideTexture);
+    glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, static_cast<GLsizei>(width), static_cast<GLsizei>(height));
+    glBindTexture(GL_TEXTURE_2D, boundTexture);
+
+    std::optional<PlatformXR::FrameData::ExternalTexture> externalTexture;
+    if (m_glDisplay->extensions().MESA_image_dma_buf_export)
+        externalTexture = exportOpenXRTextureDMABuf(swapchain, sideBySideTexture);
+#if USE(GBM)
+    else if (m_gbmDevice)
+        externalTexture = exportOpenXRTextureGBM(swapchain, sideBySideTexture, width, height);
+#endif
+    if (!externalTexture) {
+        glDeleteTextures(1, &sideBySideTexture);
+        return std::nullopt;
+    }
+#endif
+    if (!sideBySideTexture)
+        return std::nullopt;
+
+    m_sideBySideTextures.set(key, sideBySideTexture);
+    return externalTexture;
+}
+
+void OpenXRGraphicsBindingOpenGLES::reconstructCubeFaces(uint64_t keyImage, const Vector<uint64_t>& cubeImages, uint32_t faceSize)
+{
+    // A cube swapchain always has the 6 cube-map faces.
+    static constexpr uint32_t faceCount = 6;
+
+    auto sideBySideTexture = m_sideBySideTextures.get(static_cast<PlatformGLObject>(keyImage));
+    if (!sideBySideTexture)
+        return;
+
+    if (!m_reconstructionFBOs[0])
+        glGenFramebuffers(m_reconstructionFBOs.size(), m_reconstructionFBOs.data());
+
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_reconstructionFBOs[0]);
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, sideBySideTexture, 0);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_reconstructionFBOs[1]);
+
+    // Side-by-side region (cube * faceCount + face) maps to GL_TEXTURE_CUBE_MAP_POSITIVE_X + face.
+    for (uint32_t cube = 0; cube < cubeImages.size(); ++cube) {
+        auto cubeTexture = static_cast<PlatformGLObject>(cubeImages[cube]);
+        if (!cubeTexture)
+            continue;
+        for (uint32_t face = 0; face < faceCount; ++face) {
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, cubeTexture, 0);
+            int srcX = static_cast<int>(cube * faceCount + face) * static_cast<int>(faceSize);
+            glBlitFramebuffer(srcX, 0, srcX + static_cast<int>(faceSize), static_cast<int>(faceSize), 0, 0, static_cast<int>(faceSize), static_cast<int>(faceSize), GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        }
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+#endif // XR_KHR_composition_layer_cube
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR) && defined(XR_USE_GRAPHICS_API_OPENGL_ES)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(OPENXR) && defined(XR_USE_GRAPHICS_API_OPENGL_ES)
+
+#include "OpenXRGraphicsBinding.h"
+
+typedef void* EGLDisplay;
+typedef void* EGLContext;
+typedef void* EGLConfig;
+typedef unsigned EGLenum;
+#if defined(XR_USE_PLATFORM_EGL)
+typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
+#endif
+
+// The JNI types need to be defined before including openxr_platform.h
+#if OS(ANDROID)
+#include <jni.h>
+#endif
+
+#include <WebCore/GraphicsTypesGL.h>
+#include <array>
+#include <openxr/openxr_platform.h>
+#include <wtf/HashMap.h>
+#include <wtf/RefPtr.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+class GLContext;
+class GLDisplay;
+#if USE(GBM)
+class GBMDevice;
+#endif
+}
+
+namespace WebKit {
+
+class OpenXRSwapchain;
+
+class OpenXRGraphicsBindingOpenGLES final : public OpenXRGraphicsBinding {
+    WTF_MAKE_TZONE_ALLOCATED(OpenXRGraphicsBindingOpenGLES);
+public:
+    static std::unique_ptr<OpenXRGraphicsBindingOpenGLES> create();
+
+    ~OpenXRGraphicsBindingOpenGLES();
+
+    Vector<ASCIILiteral> requiredInstanceExtensions() const final;
+    bool initializeDisplay(bool isForTesting) final;
+    bool initializeForSession(XrInstance, XrSystemId) final;
+    const void* sessionGraphicsBinding() const final;
+    int64_t selectColorFormat(const Vector<int64_t>& supportedFormats, bool alpha) const final;
+    Vector<uint64_t> enumerateSwapchainImages(XrSwapchain) const final;
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportTexture(uint64_t image, const OpenXRSwapchain&, TextureType, uint32_t width, uint32_t height) final;
+    void commitFrame(uint64_t keyImage, const OpenXRSwapchain&, TextureType, const Vector<uint64_t>& images) final;
+    void waitFrameFence(WTF::UnixFileDescriptor&&) final;
+    void releaseSessionGraphics() final;
+
+private:
+    OpenXRGraphicsBindingOpenGLES();
+
+#if OS(ANDROID)
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureAndroid(const OpenXRSwapchain&, PlatformGLObject, uint32_t width, uint32_t height);
+#else
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureDMABuf(const OpenXRSwapchain&, PlatformGLObject);
+#endif
+#if USE(GBM)
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureGBM(const OpenXRSwapchain&, PlatformGLObject, uint32_t width, uint32_t height);
+#endif
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportTexture2D(PlatformGLObject, const OpenXRSwapchain&, uint32_t width, uint32_t height);
+    void blitTextureIfNeeded(const OpenXRSwapchain&);
+
+#if defined(XR_KHR_composition_layer_cube)
+    std::optional<PlatformXR::FrameData::ExternalTexture> exportCubeBuffer(uint64_t keyImage, const OpenXRSwapchain&, uint32_t width, uint32_t height);
+    void reconstructCubeFaces(uint64_t keyImage, const Vector<uint64_t>& cubeImages, uint32_t faceSize);
+#endif
+
+    RefPtr<WebCore::GLDisplay> m_glDisplay;
+    std::unique_ptr<WebCore::GLContext> m_glContext;
+#if USE(GBM)
+    RefPtr<WebCore::GBMDevice> m_gbmDevice;
+#endif
+#if OS(ANDROID)
+    XrGraphicsBindingOpenGLESAndroidKHR m_graphicsBinding;
+#else
+    XrGraphicsBindingEGLMNDX m_graphicsBinding;
+#endif
+#if USE(GBM) || OS(ANDROID)
+    // Exported texture per swapchain image (exported once, then reused). Shared across the session's
+    // swapchains, which assumes images live until session end (layers are add-only); if per-layer
+    // removal is added, evict here or a recycled GL name would alias a stale texture.
+    HashMap<PlatformGLObject, PlatformGLObject> m_exportedTexturesMap;
+    std::array<PlatformGLObject, 2> m_fbosForBlitting { 0, 0 };
+#endif
+#if defined(XR_KHR_composition_layer_cube)
+    HashMap<PlatformGLObject, PlatformGLObject> m_sideBySideTextures;
+    std::array<PlatformGLObject, 2> m_reconstructionFBOs { 0, 0 };
+#endif
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WEBXR) && USE(OPENXR) && defined(XR_USE_GRAPHICS_API_OPENGL_ES)

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -28,32 +28,11 @@
 #if ENABLE(WEBXR) && USE(OPENXR)
 
 #include "OpenXRLayer.h"
-#include <openxr/openxr.h>
-#if USE(LIBEPOXY)
-#define __GBM__ 1
-#include <epoxy/egl.h>
-#else
-#include <EGL/egl.h>
-#endif
 
-#include <WebCore/FourCC.h>
-#include <WebCore/GLContext.h>
-#include <WebCore/GLDisplay.h>
-#include <wtf/SafeStrerror.h>
+#include "OpenXRGraphicsBinding.h"
+#include <openxr/openxr.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/unix/UnixFileDescriptor.h>
-
-#if OS(ANDROID)
-#include <android/hardware_buffer.h>
-#endif
-
-#if USE(GBM)
-#include <WebCore/DMABufBuffer.h>
-#include <WebCore/GBMDevice.h>
-#include <WebCore/GBMVersioning.h>
-#include <drm_fourcc.h>
-#endif
 
 namespace WebKit {
 
@@ -73,284 +52,7 @@ OpenXRLayer::OpenXRLayer(UniqueRef<OpenXRSwapchain>&& swapchain)
 {
 }
 
-OpenXRLayer::~OpenXRLayer()
-{
-    ASSERT(WebCore::GLContext::current());
-#if USE(GBM)
-    if (m_fbosForBlitting[0])
-        glDeleteFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
-    for (auto texture : m_exportedTexturesMap.values())
-        glDeleteTextures(1, &texture);
-#endif
-}
-
-#if OS(ANDROID)
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureAndroid(WebCore::GLDisplay& display, PlatformGLObject openxrTexture, uint32_t width, uint32_t height)
-{
-    static constexpr auto kHardwareBufferUsage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER | AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
-
-    RefPtr<AHardwareBuffer> hardwareBuffer;
-    {
-        RELEASE_ASSERT(width > 0);
-        RELEASE_ASSERT(height > 0);
-
-        AHardwareBuffer_Desc bufferDesc = { };
-        bufferDesc.width = width;
-        bufferDesc.height = height;
-        bufferDesc.usage = kHardwareBufferUsage;
-        bufferDesc.layers = 1;
-
-        switch (m_swapchain->format()) {
-        case GL_RGBA8:
-            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
-            break;
-        case GL_RGB8:
-            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM;
-            if (!AHardwareBuffer_isSupported(&bufferDesc))
-                bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM;
-            break;
-        case GL_RGB565:
-            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM;
-            break;
-        case GL_RGBA16F:
-            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT;
-            break;
-        case GL_RGB10_A2:
-            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM;
-            break;
-        }
-
-        if (!bufferDesc.format || !AHardwareBuffer_isSupported(&bufferDesc)) {
-            RELEASE_LOG_INFO(XR, "AHardwareBuffer format %#" PRIX32 " not supported, using"
-                " RGBA8888 fallback that may result in slow blits", bufferDesc.format);
-            bufferDesc.format = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
-        }
-
-        AHardwareBuffer* buffer { nullptr };
-        if (auto error = AHardwareBuffer_allocate(&bufferDesc, &buffer)) {
-            if (error < 0)
-                RELEASE_LOG_ERROR(XR, "Failed to allocate AHardwareBuffer for OpenXR texture: %s", safeStrerror(-error).data());
-            else
-                RELEASE_LOG_ERROR(XR, "Failed to allocate AHardwareBuffer for OpenXR texture: %" PRIi32, error);
-            return { };
-        }
-        hardwareBuffer = adoptRef(buffer);
-    }
-
-    static PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC s_eglGetNativeClientBufferANDROID { nullptr };
-    if (!s_eglGetNativeClientBufferANDROID) [[unlikely]] {
-        s_eglGetNativeClientBufferANDROID = reinterpret_cast<PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC>(eglGetProcAddress("eglGetNativeClientBufferANDROID"));
-        RELEASE_ASSERT(s_eglGetNativeClientBufferANDROID);
-    }
-
-    static const Vector<EGLAttrib> attributes = { EGL_IMAGE_PRESERVED, EGL_TRUE, EGL_NONE };
-    auto clientBuffer = s_eglGetNativeClientBufferANDROID(hardwareBuffer.get());
-    auto image = display.createImage(EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuffer, attributes);
-    if (image == EGL_NO_IMAGE_KHR) {
-        RELEASE_LOG(XR, "Failed to create EGL image for OpenXR texture (%#06x)", eglGetError());
-        return { };
-    }
-
-    GLint boundTexture = 0;
-    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
-    PlatformGLObject exportedTexture;
-    glGenTextures(1, &exportedTexture);
-    glBindTexture(GL_TEXTURE_2D, exportedTexture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
-    glBindTexture(GL_TEXTURE_2D, boundTexture);
-
-    display.destroyImage(image);
-
-    m_exportedTexturesMap.add(openxrTexture, exportedTexture);
-
-    return hardwareBuffer;
-}
-#else
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureDMABuf(WebCore::GLDisplay& display, WebCore::GLContext& context, PlatformGLObject openxrTexture)
-{
-    // Texture must be bound to be exported.
-    glBindTexture(GL_TEXTURE_2D, openxrTexture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-
-    auto image = display.createImage(context.platformContext(), EGL_GL_TEXTURE_2D, (EGLClientBuffer)(uint64_t)openxrTexture, { });
-
-    auto releaseImageOnError = makeScopeExit([&] {
-        if (image)
-            display.destroyImage(image);
-    });
-
-    if (!image) {
-        RELEASE_LOG(XR, "Failed to create EGL image from OpenXR texture");
-        return std::nullopt;
-    }
-
-    int fourcc, planeCount;
-    uint64_t modifier;
-    if (!eglExportDMABUFImageQueryMESA(display.eglDisplay(), image, &fourcc, &planeCount, &modifier)) {
-        RELEASE_LOG(XR, "eglExportDMABUFImageQueryMESA failed");
-        return std::nullopt;
-    }
-
-    Vector<int> fdsOut(planeCount);
-    Vector<int> stridesOut(planeCount);
-    Vector<int> offsetsOut(planeCount);
-    if (!eglExportDMABUFImageMESA(display.eglDisplay(), image, fdsOut.mutableSpan().data(), stridesOut.mutableSpan().data(), offsetsOut.mutableSpan().data())) {
-        RELEASE_LOG(XR, "eglExportDMABUFImageMESA failed");
-        return std::nullopt;
-    }
-
-    display.destroyImage(image);
-
-    releaseImageOnError.release();
-
-    Vector<UnixFileDescriptor> fds = fdsOut.map([](int fd) {
-        return UnixFileDescriptor(fd, UnixFileDescriptor::Adopt);
-    });
-    Vector<uint32_t> strides = stridesOut.map([](int stride) {
-        return static_cast<uint32_t>(stride);
-    });
-    Vector<uint32_t> offsets = offsetsOut.map([](int offset) {
-        return static_cast<uint32_t>(offset);
-    });
-
-    return PlatformXR::FrameData::ExternalTexture {
-        .fds = WTF::move(fds),
-        .strides = WTF::move(strides),
-        .offsets = WTF::move(offsets),
-        .fourcc = static_cast<uint32_t>(fourcc),
-        .modifier = modifier,
-    };
-}
-#endif // !OS(ANDROID)
-
-#if USE(GBM)
-void OpenXRLayer::setGBMDevice(RefPtr<WebCore::GBMDevice> gbmDevice)
-{
-    m_gbmDevice = gbmDevice;
-}
-
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTextureGBM(WebCore::GLDisplay& display, PlatformGLObject openxrTexture, uint32_t width, uint32_t height)
-{
-    static constexpr std::array<WebCore::FourCC, 3> preferredAlphaDRMFormats = { DRM_FORMAT_ARGB8888, DRM_FORMAT_RGBA8888, DRM_FORMAT_ABGR8888 };
-    static constexpr std::array<WebCore::FourCC, 3> preferredNoAlphaDRMFormats = { DRM_FORMAT_XRGB8888, DRM_FORMAT_RGBX8888, DRM_FORMAT_BGRX8888 };
-    const auto& preferredDRMFormats = m_swapchain->hasAlpha() == OpenXRSwapchain::HasAlpha::Yes ? preferredAlphaDRMFormats : preferredNoAlphaDRMFormats;
-    WebCore::GLDisplay::BufferFormat format;
-    const auto& supportedFormats = display.bufferFormats();
-    for (const auto& preferredFormat : preferredDRMFormats) {
-        auto matchIndex = supportedFormats.findIf([preferredFormat](const auto& supportedFormat) {
-            return supportedFormat.fourcc == preferredFormat;
-        });
-        if (matchIndex != notFound) {
-            format = supportedFormats[matchIndex];
-            break;
-        }
-    }
-
-    if (!format.fourcc.value) {
-        RELEASE_LOG(XR, "OpenXR texture format not supported");
-        return std::nullopt;
-    }
-
-    auto* buffer = gbm_bo_create_with_modifiers2(m_gbmDevice->device(), width, height, format.fourcc.value, format.modifiers.span().data(), format.modifiers.size(), GBM_BO_USE_RENDERING);
-    if (!buffer)
-        buffer = gbm_bo_create(m_gbmDevice->device(), width, height, format.fourcc.value, GBM_BO_USE_RENDERING);
-    if (!buffer) {
-        RELEASE_LOG(XR, "Failed to allocate GBM buffer for OpenXR texture");
-        return std::nullopt;
-    }
-
-    auto dmaBufAttributes = WebCore::DMABufBufferAttributes::fromGBMBufferObject(buffer);
-    if (!dmaBufAttributes) {
-        gbm_bo_destroy(buffer);
-        RELEASE_LOG(XR, "Failed to extract DMA-buf attributes from GBM buffer for OpenXR texture");
-        return std::nullopt;
-    }
-
-    auto image = WebCore::DMABufBuffer::createEGLImage(display, *dmaBufAttributes);
-    gbm_bo_destroy(buffer);
-    if (!image) {
-        RELEASE_LOG(XR, "Failed to create EGL image from OpenXR texture");
-        return std::nullopt;
-    }
-
-    GLint boundTexture = 0;
-    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
-    PlatformGLObject exportedTexture;
-    glGenTextures(1, &exportedTexture);
-    glBindTexture(GL_TEXTURE_2D, exportedTexture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
-    glBindTexture(GL_TEXTURE_2D, boundTexture);
-
-    display.destroyImage(image);
-
-    m_exportedTexturesMap.add(openxrTexture, exportedTexture);
-
-    return PlatformXR::FrameData::ExternalTexture {
-        .fds = WTF::move(dmaBufAttributes->fds),
-        .strides = WTF::move(dmaBufAttributes->strides),
-        .offsets = WTF::move(dmaBufAttributes->offsets),
-        .fourcc = dmaBufAttributes->fourcc.value,
-        .modifier = dmaBufAttributes->modifier
-    };
-}
-#endif // USE(GBM)
-
-#if USE(GBM) || OS(ANDROID)
-void OpenXRLayer::blitTexture() const
-{
-    auto openxrTexture = m_swapchain->acquiredTexture();
-    ASSERT(openxrTexture);
-
-    auto exportedTexture = m_exportedTexturesMap.get(openxrTexture);
-    ASSERT(exportedTexture);
-
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbosForBlitting[0]);
-    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, exportedTexture, 0);
-
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fbosForBlitting[1]);
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, openxrTexture, 0);
-
-    auto width = m_swapchain->width();
-    auto height = m_swapchain->height();
-    glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-}
-#endif // USE(GBM) || OS(ANDROID)
-
-std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTexture(PlatformGLObject openxrTexture, uint32_t width, uint32_t height)
-{
-    auto* glContext = WebCore::GLContext::current();
-    ASSERT(glContext);
-
-    auto display = glContext->display();
-    ASSERT(display);
-
-#if OS(ANDROID)
-    return exportOpenXRTextureAndroid(*display, openxrTexture, width, height);
-#else
-    if (display->extensions().MESA_image_dma_buf_export)
-        return exportOpenXRTextureDMABuf(*display, *glContext, openxrTexture);
-#endif
-
-#if USE(GBM)
-    if (m_gbmDevice)
-        return exportOpenXRTextureGBM(*display, openxrTexture, width, height);
-#endif
-
-    RELEASE_LOG(XR, "Failed to export OpenXR texture");
-    return std::nullopt;
-}
+OpenXRLayer::~OpenXRLayer() = default;
 
 // OpenXRLayerProjection
 
@@ -365,7 +67,7 @@ OpenXRLayerProjection::OpenXRLayerProjection(UniqueRef<OpenXRSwapchain>&& swapch
 {
 }
 
-std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFrame()
+std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFrame(OpenXRGraphicsBinding& graphicsBinding)
 {
     auto texture = m_swapchain->acquireImage();
     if (!texture)
@@ -386,7 +88,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFram
         return layerData;
     m_nextReusableTextureIndex++;
 
-    auto externalTexture = exportOpenXRTexture(*texture, m_swapchain->width(), m_swapchain->height());
+    auto externalTexture = graphicsBinding.exportTexture(*texture, m_swapchain, OpenXRGraphicsBinding::TextureType::Texture2D, m_swapchain->width(), m_swapchain->height());
     if (!externalTexture)
         return std::nullopt;
 
@@ -404,17 +106,11 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFram
     return layerData;
 }
 
-Vector<XrCompositionLayerBaseHeader*> OpenXRLayerProjection::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
+Vector<XrCompositionLayerBaseHeader*> OpenXRLayerProjection::endFrame(OpenXRGraphicsBinding& graphicsBinding, const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
     ASSERT(m_swapchain->acquiredTexture());
 
-#if OS(ANDROID) || USE(GBM)
-    if (needsBlitTexture()) {
-        if (!m_fbosForBlitting[0])
-            glGenFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
-        blitTexture();
-    }
-#endif
+    graphicsBinding.commitFrame(m_swapchain->acquiredTexture(), m_swapchain, OpenXRGraphicsBinding::TextureType::Texture2D, { m_swapchain->acquiredTexture() });
     auto viewCount = frameViews.size();
     m_projectionViews.fill(createOpenXRStruct<XrCompositionLayerProjectionView, XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW>(), viewCount);
     for (uint32_t i = 0; i < viewCount; ++i) {
@@ -472,7 +168,7 @@ OpenXRQuadLayer::OpenXRQuadLayer(UniqueRef<OpenXRSwapchain>&& swapchain, Platfor
     }
 }
 
-std::optional<PlatformXR::FrameData::LayerData> OpenXRQuadLayer::startFrame()
+std::optional<PlatformXR::FrameData::LayerData> OpenXRQuadLayer::startFrame(OpenXRGraphicsBinding& graphicsBinding)
 {
     auto texture = m_swapchain->acquireImage();
     if (!texture)
@@ -493,7 +189,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRQuadLayer::startFrame()
         return layerData;
     m_nextReusableTextureIndex++;
 
-    auto externalTexture = exportOpenXRTexture(*texture, m_swapchain->width(), m_swapchain->height());
+    auto externalTexture = graphicsBinding.exportTexture(*texture, m_swapchain, OpenXRGraphicsBinding::TextureType::Texture2D, m_swapchain->width(), m_swapchain->height());
     if (!externalTexture)
         return std::nullopt;
 
@@ -508,17 +204,11 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRQuadLayer::startFrame()
     return layerData;
 }
 
-Vector<XrCompositionLayerBaseHeader*> OpenXRQuadLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
+Vector<XrCompositionLayerBaseHeader*> OpenXRQuadLayer::endFrame(OpenXRGraphicsBinding& graphicsBinding, const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
     ASSERT(m_swapchain->acquiredTexture());
 
-#if OS(ANDROID) || USE(GBM)
-    if (needsBlitTexture()) {
-        if (!m_fbosForBlitting[0])
-            glGenFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
-        blitTexture();
-    }
-#endif
+    graphicsBinding.commitFrame(m_swapchain->acquiredTexture(), m_swapchain, OpenXRGraphicsBinding::TextureType::Texture2D, { m_swapchain->acquiredTexture() });
 
     auto eyeVisibility = [](bool isLeftEye, bool isMonoPresentation) {
         if (isMonoPresentation)
@@ -603,7 +293,7 @@ OpenXREquirectLayer::OpenXREquirectLayer(UniqueRef<OpenXRSwapchain>&& swapchain,
     }
 }
 
-std::optional<PlatformXR::FrameData::LayerData> OpenXREquirectLayer::startFrame()
+std::optional<PlatformXR::FrameData::LayerData> OpenXREquirectLayer::startFrame(OpenXRGraphicsBinding& graphicsBinding)
 {
     auto texture = m_swapchain->acquireImage();
     if (!texture)
@@ -624,7 +314,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXREquirectLayer::startFrame(
         return layerData;
     m_nextReusableTextureIndex++;
 
-    auto externalTexture = exportOpenXRTexture(*texture, m_swapchain->width(), m_swapchain->height());
+    auto externalTexture = graphicsBinding.exportTexture(*texture, m_swapchain, OpenXRGraphicsBinding::TextureType::Texture2D, m_swapchain->width(), m_swapchain->height());
     if (!externalTexture)
         return std::nullopt;
 
@@ -639,17 +329,11 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXREquirectLayer::startFrame(
     return layerData;
 }
 
-Vector<XrCompositionLayerBaseHeader*> OpenXREquirectLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
+Vector<XrCompositionLayerBaseHeader*> OpenXREquirectLayer::endFrame(OpenXRGraphicsBinding& graphicsBinding, const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
     ASSERT(m_swapchain->acquiredTexture());
 
-#if OS(ANDROID) || USE(GBM)
-    if (needsBlitTexture()) {
-        if (!m_fbosForBlitting[0])
-            glGenFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
-        blitTexture();
-    }
-#endif
+    graphicsBinding.commitFrame(m_swapchain->acquiredTexture(), m_swapchain, OpenXRGraphicsBinding::TextureType::Texture2D, { m_swapchain->acquiredTexture() });
 
     auto eyeVisibility = [](bool isLeftEye, bool isMonoPresentation) {
         if (isMonoPresentation)
@@ -736,7 +420,7 @@ OpenXRCylinderLayer::OpenXRCylinderLayer(UniqueRef<OpenXRSwapchain>&& swapchain,
     }
 }
 
-std::optional<PlatformXR::FrameData::LayerData> OpenXRCylinderLayer::startFrame()
+std::optional<PlatformXR::FrameData::LayerData> OpenXRCylinderLayer::startFrame(OpenXRGraphicsBinding& graphicsBinding)
 {
     auto texture = m_swapchain->acquireImage();
     if (!texture)
@@ -757,7 +441,7 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRCylinderLayer::startFrame(
         return layerData;
     m_nextReusableTextureIndex++;
 
-    auto externalTexture = exportOpenXRTexture(*texture, m_swapchain->width(), m_swapchain->height());
+    auto externalTexture = graphicsBinding.exportTexture(*texture, m_swapchain, OpenXRGraphicsBinding::TextureType::Texture2D, m_swapchain->width(), m_swapchain->height());
     if (!externalTexture)
         return std::nullopt;
 
@@ -772,17 +456,11 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRCylinderLayer::startFrame(
     return layerData;
 }
 
-Vector<XrCompositionLayerBaseHeader*> OpenXRCylinderLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
+Vector<XrCompositionLayerBaseHeader*> OpenXRCylinderLayer::endFrame(OpenXRGraphicsBinding& graphicsBinding, const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)
 {
     ASSERT(m_swapchain->acquiredTexture());
 
-#if OS(ANDROID) || USE(GBM)
-    if (needsBlitTexture()) {
-        if (!m_fbosForBlitting[0])
-            glGenFramebuffers(m_fbosForBlitting.size(), m_fbosForBlitting.data());
-        blitTexture();
-    }
-#endif
+    graphicsBinding.commitFrame(m_swapchain->acquiredTexture(), m_swapchain, OpenXRGraphicsBinding::TextureType::Texture2D, { m_swapchain->acquiredTexture() });
 
     auto eyeVisibility = [](bool isLeftEye, bool isMonoPresentation) {
         if (isMonoPresentation)
@@ -860,16 +538,7 @@ OpenXRCubeLayer::OpenXRCubeLayer(UniqueRef<OpenXRSwapchain>&& swapchain, std::un
     }
 }
 
-OpenXRCubeLayer::~OpenXRCubeLayer()
-{
-    ASSERT(WebCore::GLContext::current());
-    for (auto texture : m_sideBySideTextures.values())
-        glDeleteTextures(1, &texture);
-    if (m_reconstructionFBOs[0])
-        glDeleteFramebuffers(m_reconstructionFBOs.size(), m_reconstructionFBOs.data());
-}
-
-std::optional<PlatformXR::FrameData::LayerData> OpenXRCubeLayer::startFrame()
+std::optional<PlatformXR::FrameData::LayerData> OpenXRCubeLayer::startFrame(OpenXRGraphicsBinding& graphicsBinding)
 {
     auto texture = m_swapchain->acquireImage();
     if (!texture)
@@ -901,32 +570,14 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRCubeLayer::startFrame()
     }
     m_nextReusableTextureIndex++;
 
-    // The WebProcess renders the cube faces into a side-by-side 2D buffer (cubeCount*faceCount faces laid
-    // out horizontally, each face square). This layer reconstructs those into the cubemap swapchain(s).
-    int faceSize = m_swapchain->width();
-    int sideBySideWidth = static_cast<int>(faceCount * cubeCount()) * faceSize;
-    uint32_t width = static_cast<uint32_t>(sideBySideWidth);
-    uint32_t height = static_cast<uint32_t>(faceSize);
+    // The cube faces are laid out side by side (cubeCount * faceCount squares) in a single 2D buffer.
+    uint32_t faceSize = m_swapchain->width();
+    uint32_t sideBySideWidth = faceCount * cubeCount() * faceSize;
 
-    std::optional<PlatformXR::FrameData::ExternalTexture> externalTexture;
-    PlatformGLObject sideBySideTexture = 0;
-#if OS(ANDROID)
-    externalTexture = exportOpenXRTexture(*texture, width, height);
-    if (externalTexture)
-        sideBySideTexture = m_exportedTexturesMap.take(*texture);
-#else
-    GLint boundTexture = 0;
-    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
-    glGenTextures(1, &sideBySideTexture);
-    glBindTexture(GL_TEXTURE_2D, sideBySideTexture);
-    glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, sideBySideWidth, faceSize);
-    glBindTexture(GL_TEXTURE_2D, boundTexture);
-    externalTexture = exportOpenXRTexture(sideBySideTexture, width, height);
-#endif
-    if (!externalTexture || !sideBySideTexture)
+    auto externalTexture = graphicsBinding.exportTexture(*texture, m_swapchain, OpenXRGraphicsBinding::TextureType::Cubemap, sideBySideWidth, faceSize);
+    if (!externalTexture)
         return std::nullopt;
 
-    m_sideBySideTextures.set(*texture, sideBySideTexture);
     layerData.textureData->colorTexture = WTF::move(externalTexture.value());
     layerData.layerSetup = {
         .physicalSize = { { { static_cast<uint16_t>(sideBySideWidth), static_cast<uint16_t>(faceSize) } } },
@@ -938,43 +589,15 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRCubeLayer::startFrame()
     return layerData;
 }
 
-void OpenXRCubeLayer::reconstructCubeFaces()
-{
-    auto sideBySideTexture = m_sideBySideTextures.get(m_swapchain->acquiredTexture());
-    if (!sideBySideTexture)
-        return;
-
-    if (!m_reconstructionFBOs[0])
-        glGenFramebuffers(m_reconstructionFBOs.size(), m_reconstructionFBOs.data());
-
-    int faceSize = m_swapchain->width();
-
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_reconstructionFBOs[0]);
-    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, sideBySideTexture, 0);
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_reconstructionFBOs[1]);
-
-    // Region (cube*faceCount + face) maps to GL_TEXTURE_CUBE_MAP_POSITIVE_X + face of that cube's swapchain;
-    // same ordering as the WebProcess blit.
-    // FIXME: face winding/orientation may need adjustment once validated against a runtime.
-    for (uint32_t cube = 0; cube < cubeCount(); ++cube) {
-        auto cubeTexture = swapchainForCube(cube).acquiredTexture();
-        if (!cubeTexture)
-            continue;
-        for (uint32_t face = 0; face < faceCount; ++face) {
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, cubeTexture, 0);
-            int srcX = static_cast<int>(cube * faceCount + face) * faceSize;
-            glBlitFramebuffer(srcX, 0, srcX + faceSize, faceSize, 0, 0, faceSize, faceSize, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-        }
-    }
-
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-}
-
-Vector<XrCompositionLayerBaseHeader*> OpenXRCubeLayer::endFrame(const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>&)
+Vector<XrCompositionLayerBaseHeader*> OpenXRCubeLayer::endFrame(OpenXRGraphicsBinding& graphicsBinding, const PlatformXR::DeviceLayer& layer, XrSpace space, const Vector<XrView>&)
 {
     ASSERT(m_swapchain->acquiredTexture());
 
-    reconstructCubeFaces();
+    Vector<uint64_t> cubeImages;
+    cubeImages.reserveCapacity(cubeCount());
+    for (uint32_t cube = 0; cube < cubeCount(); ++cube)
+        cubeImages.append(swapchainForCube(cube).acquiredTexture());
+    graphicsBinding.commitFrame(m_swapchain->acquiredTexture(), m_swapchain, OpenXRGraphicsBinding::TextureType::Cubemap, cubeImages);
 
     auto flags = layer.blendTextureSourceAlpha ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
     XrQuaternionf orientation { 0, 0, 0, 1 };

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -36,13 +36,9 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 
-namespace WebCore {
-class GBMDevice;
-class GLContext;
-class GLDisplay;
-}
-
 namespace WebKit {
+
+class OpenXRGraphicsBinding;
 
 class OpenXRLayer {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRLayer);
@@ -50,43 +46,18 @@ class OpenXRLayer {
 public:
     virtual ~OpenXRLayer();
 
-    virtual std::optional<PlatformXR::FrameData::LayerData> startFrame() = 0;
-    virtual Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) = 0;
-
-#if USE(GBM)
-    void setGBMDevice(RefPtr<WebCore::GBMDevice>);
-#endif
+    virtual std::optional<PlatformXR::FrameData::LayerData> startFrame(OpenXRGraphicsBinding&) = 0;
+    virtual Vector<XrCompositionLayerBaseHeader*> endFrame(OpenXRGraphicsBinding&, const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) = 0;
 
 protected:
     OpenXRLayer(UniqueRef<OpenXRSwapchain>&&);
-#if OS(ANDROID)
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureAndroid(WebCore::GLDisplay&, PlatformGLObject, uint32_t width, uint32_t height);
-    void blitTexture() const;
-    inline bool needsBlitTexture() const { return true; }
-#else
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureDMABuf(WebCore::GLDisplay&, WebCore::GLContext&, PlatformGLObject);
-#endif
-#if USE(GBM)
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTextureGBM(WebCore::GLDisplay&, PlatformGLObject, uint32_t width, uint32_t height);
-    void blitTexture() const;
-    inline bool needsBlitTexture() const { return m_gbmDevice; }
-#endif
-    std::optional<PlatformXR::FrameData::ExternalTexture> exportOpenXRTexture(PlatformGLObject, uint32_t width, uint32_t height);
 
     UniqueRef<OpenXRSwapchain> m_swapchain;
 
     uint64_t m_renderingFrameIndex { 0 };
     using ReusableTextureIndex = uint64_t;
-    HashMap<PlatformGLObject, ReusableTextureIndex> m_exportedTextures;
+    HashMap<uint64_t, ReusableTextureIndex> m_exportedTextures;
     ReusableTextureIndex m_nextReusableTextureIndex { 0 };
-
-#if USE(GBM) || OS(ANDROID)
-    HashMap<PlatformGLObject, PlatformGLObject> m_exportedTexturesMap;
-    std::array<PlatformGLObject, 2> m_fbosForBlitting { 0, 0 };
-#endif
-#if USE(GBM)
-    RefPtr<WebCore::GBMDevice> m_gbmDevice;
-#endif
 };
 
 class OpenXRLayerProjection final: public OpenXRLayer  {
@@ -97,8 +68,8 @@ public:
 private:
     explicit OpenXRLayerProjection(UniqueRef<OpenXRSwapchain>&&);
 
-    std::optional<PlatformXR::FrameData::LayerData> startFrame() override;
-    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
+    std::optional<PlatformXR::FrameData::LayerData> startFrame(OpenXRGraphicsBinding&) override;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(OpenXRGraphicsBinding&, const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
 
     XrCompositionLayerProjection m_layerProjection;
     Vector<XrCompositionLayerProjectionView> m_projectionViews;
@@ -110,8 +81,8 @@ class OpenXRCompositionLayer : public OpenXRLayer {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRCompositionLayer);
     WTF_MAKE_NONCOPYABLE(OpenXRCompositionLayer);
 public:
-    std::optional<PlatformXR::FrameData::LayerData> startFrame() = 0;
-    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) = 0;
+    std::optional<PlatformXR::FrameData::LayerData> startFrame(OpenXRGraphicsBinding&) override = 0;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(OpenXRGraphicsBinding&, const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override = 0;
 
 protected:
     OpenXRCompositionLayer(UniqueRef<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
@@ -125,8 +96,8 @@ class OpenXRQuadLayer final : public OpenXRCompositionLayer {
 public:
     static std::unique_ptr<OpenXRQuadLayer> create(std::unique_ptr<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
 
-    std::optional<PlatformXR::FrameData::LayerData> startFrame() override;
-    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
+    std::optional<PlatformXR::FrameData::LayerData> startFrame(OpenXRGraphicsBinding&) override;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(OpenXRGraphicsBinding&, const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
 
 private:
     explicit OpenXRQuadLayer(UniqueRef<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
@@ -141,8 +112,8 @@ class OpenXREquirectLayer final : public OpenXRCompositionLayer {
 public:
     static std::unique_ptr<OpenXREquirectLayer> create(std::unique_ptr<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
 
-    std::optional<PlatformXR::FrameData::LayerData> startFrame() override;
-    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
+    std::optional<PlatformXR::FrameData::LayerData> startFrame(OpenXRGraphicsBinding&) override;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(OpenXRGraphicsBinding&, const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
 
 private:
     explicit OpenXREquirectLayer(UniqueRef<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
@@ -158,8 +129,8 @@ class OpenXRCylinderLayer final : public OpenXRCompositionLayer {
 public:
     static std::unique_ptr<OpenXRCylinderLayer> create(std::unique_ptr<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
 
-    std::optional<PlatformXR::FrameData::LayerData> startFrame() override;
-    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
+    std::optional<PlatformXR::FrameData::LayerData> startFrame(OpenXRGraphicsBinding&) override;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(OpenXRGraphicsBinding&, const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
 
 private:
     explicit OpenXRCylinderLayer(UniqueRef<OpenXRSwapchain>&&, PlatformXR::LayerLayout);
@@ -177,15 +148,13 @@ class OpenXRCubeLayer final : public OpenXRCompositionLayer {
     WTF_MAKE_NONCOPYABLE(OpenXRCubeLayer);
 public:
     static std::unique_ptr<OpenXRCubeLayer> create(std::unique_ptr<OpenXRSwapchain>&&, std::unique_ptr<OpenXRSwapchain>&& rightSwapchain, PlatformXR::LayerLayout);
-    ~OpenXRCubeLayer();
 
-    std::optional<PlatformXR::FrameData::LayerData> startFrame() override;
-    Vector<XrCompositionLayerBaseHeader*> endFrame(const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
+    std::optional<PlatformXR::FrameData::LayerData> startFrame(OpenXRGraphicsBinding&) override;
+    Vector<XrCompositionLayerBaseHeader*> endFrame(OpenXRGraphicsBinding&, const PlatformXR::DeviceLayer&, XrSpace, const Vector<XrView>&) override;
 
 private:
     OpenXRCubeLayer(UniqueRef<OpenXRSwapchain>&&, std::unique_ptr<OpenXRSwapchain>&& rightSwapchain, PlatformXR::LayerLayout);
 
-    void reconstructCubeFaces();
     uint32_t cubeCount() const { return m_layout == PlatformXR::LayerLayout::Mono ? 1 : 2; }
     OpenXRSwapchain& swapchainForCube(uint32_t cube) { return cube && m_rightSwapchain ? *m_rightSwapchain : m_swapchain.get(); }
 
@@ -193,10 +162,6 @@ private:
 
     Vector<XrCompositionLayerCubeKHR> m_layers;
     std::unique_ptr<OpenXRSwapchain> m_rightSwapchain;
-    // One side-by-side buffer per swapchain image (keyed by the image), so the WebProcess and the
-    // reconstruction don't read/write the same buffer concurrently. Mirrors the per-image reuse of other layers.
-    HashMap<PlatformGLObject, PlatformGLObject> m_sideBySideTextures;
-    std::array<PlatformGLObject, 2> m_reconstructionFBOs { 0, 0 };
 };
 #endif
 

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp
@@ -28,13 +28,14 @@
 #if ENABLE(WEBXR) && USE(OPENXR)
 #include "OpenXRSwapchain.h"
 
+#include "OpenXRGraphicsBinding.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRSwapchain);
 
-std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrSession session, const XrSwapchainCreateInfo& info, HasAlpha hasAlpha)
+std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrSession session, const XrSwapchainCreateInfo& info, HasAlpha hasAlpha, const OpenXRGraphicsBinding& graphicsBinding)
 {
     ASSERT(session != XR_NULL_HANDLE);
     // faceCount is 1 for regular swapchains and 6 for cube (cubemap) swapchains.
@@ -47,31 +48,19 @@ std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrSession session, cons
         return nullptr;
     }
 
-    uint32_t imageCount;
-    CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, 0, &imageCount, nullptr));
-    if (!imageCount) {
-        LOG(XR, "xrEnumerateSwapchainImages(): no images\n");
+    auto imageHandles = graphicsBinding.enumerateSwapchainImages(swapchain);
+    if (imageHandles.isEmpty()) {
+        xrDestroySwapchain(swapchain);
         return nullptr;
     }
 
-    Vector<XrSwapchainImageOpenGLESKHR> imageBuffers(FillWith { }, imageCount, [] {
-        return createOpenXRStruct<XrSwapchainImageOpenGLESKHR, XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_ES_KHR>();
-    }());
-
-    Vector<XrSwapchainImageBaseHeader*> imageHeaders = imageBuffers.map([](auto& image) {
-        return (XrSwapchainImageBaseHeader*) &image;
-    });
-
-    // Get images from an XrSwapchain
-    CHECK_XRCMD(xrEnumerateSwapchainImages(swapchain, imageCount, &imageCount, imageHeaders[0]));
-
-    return std::unique_ptr<OpenXRSwapchain>(new OpenXRSwapchain(swapchain, info, WTF::move(imageBuffers), hasAlpha));
+    return std::unique_ptr<OpenXRSwapchain>(new OpenXRSwapchain(swapchain, info, WTF::move(imageHandles), hasAlpha));
 }
 
-OpenXRSwapchain::OpenXRSwapchain(XrSwapchain swapchain, const XrSwapchainCreateInfo& info, Vector<XrSwapchainImageOpenGLESKHR>&& imageBuffers, HasAlpha hasAlpha)
+OpenXRSwapchain::OpenXRSwapchain(XrSwapchain swapchain, const XrSwapchainCreateInfo& info, Vector<uint64_t>&& imageHandles, HasAlpha hasAlpha)
     : m_swapchain(swapchain)
     , m_createInfo(info)
-    , m_imageBuffers(WTF::move(imageBuffers))
+    , m_imageHandles(WTF::move(imageHandles))
     , m_hasAlpha(hasAlpha)
 {
 }
@@ -84,20 +73,20 @@ OpenXRSwapchain::~OpenXRSwapchain()
         xrDestroySwapchain(m_swapchain);
 }
 
-std::optional<PlatformGLObject> OpenXRSwapchain::acquireImage()
+std::optional<uint64_t> OpenXRSwapchain::acquireImage()
 {
     RELEASE_ASSERT_WITH_MESSAGE(!m_acquiredTexture , "Expected no acquired images. ReleaseImage not called?");
 
     auto acquireInfo = createOpenXRStruct<XrSwapchainImageAcquireInfo, XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO>();
     uint32_t swapchainImageIndex = 0;
     CHECK_XRCMD(xrAcquireSwapchainImage(m_swapchain, &acquireInfo, &swapchainImageIndex));
-    ASSERT(swapchainImageIndex < m_imageBuffers.size());
+    ASSERT(swapchainImageIndex < m_imageHandles.size());
 
     auto waitInfo = createOpenXRStruct<XrSwapchainImageWaitInfo, XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO>();
     waitInfo.timeout = XR_INFINITE_DURATION;
     CHECK_XRCMD(xrWaitSwapchainImage(m_swapchain, &waitInfo));
 
-    m_acquiredTexture = m_imageBuffers[swapchainImageIndex].image;
+    m_acquiredTexture = m_imageHandles[swapchainImageIndex];
 
     return m_acquiredTexture;
 }

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h
@@ -28,56 +28,42 @@
 #if ENABLE(WEBXR) && USE(OPENXR)
 
 #include "OpenXRUtils.h"
-#include <WebCore/GraphicsTypesGL.h>
 #include <WebCore/IntSize.h>
-
-typedef void* EGLDisplay;
-typedef void* EGLContext;
-typedef void* EGLConfig;
-typedef unsigned EGLenum;
-
-#if defined(XR_USE_PLATFORM_EGL)
-typedef void (*(*PFNEGLGETPROCADDRESSPROC)(const char *))(void);
-#endif
-
-// The JNI types need to be defined before including openxr_platform.h
-#if OS(ANDROID)
-#include <jni.h>
-#endif
-
-#include <openxr/openxr_platform.h>
+#include <openxr/openxr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 
+class OpenXRGraphicsBinding;
+
 class OpenXRSwapchain {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRSwapchain);
     WTF_MAKE_NONCOPYABLE(OpenXRSwapchain);
 public:
     enum class HasAlpha { No, Yes };
-    static std::unique_ptr<OpenXRSwapchain> create(XrSession, const XrSwapchainCreateInfo&, HasAlpha);
+    static std::unique_ptr<OpenXRSwapchain> create(XrSession, const XrSwapchainCreateInfo&, HasAlpha, const OpenXRGraphicsBinding&);
     ~OpenXRSwapchain();
 
-    std::optional<PlatformGLObject> acquireImage();
+    std::optional<uint64_t> acquireImage();
     void releaseImage();
     XrSwapchain swapchain() const { return m_swapchain; }
     int32_t width() const { return m_createInfo.width; }
     int32_t height() const { return m_createInfo.height; }
     WebCore::IntSize size() const { return WebCore::IntSize(width(), height()); }
     int64_t format() const { return m_createInfo.format; }
-    PlatformGLObject acquiredTexture() const { return m_acquiredTexture; }
+    uint64_t acquiredTexture() const { return m_acquiredTexture; }
     HasAlpha hasAlpha() const { return m_hasAlpha; }
-    size_t imageCount() const { return m_imageBuffers.size(); }
+    size_t imageCount() const { return m_imageHandles.size(); }
 
 private:
-    OpenXRSwapchain(XrSwapchain, const XrSwapchainCreateInfo&, Vector<XrSwapchainImageOpenGLESKHR>&&, HasAlpha);
+    OpenXRSwapchain(XrSwapchain, const XrSwapchainCreateInfo&, Vector<uint64_t>&&, HasAlpha);
 
     XrSwapchain m_swapchain;
     XrSwapchainCreateInfo m_createInfo;
-    Vector<XrSwapchainImageOpenGLESKHR> m_imageBuffers;
-    PlatformGLObject m_acquiredTexture { 0 };
+    Vector<uint64_t> m_imageHandles;
+    uint64_t m_acquiredTexture { 0 };
     HasAlpha m_hasAlpha;
 };
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -30,6 +30,10 @@
 
 #include "APIUIClient.h"
 #include "OpenXRExtensions.h"
+#include "OpenXRGraphicsBinding.h"
+#if defined(XR_USE_GRAPHICS_API_OPENGL_ES)
+#include "OpenXRGraphicsBindingOpenGLES.h"
+#endif
 #include "OpenXRHitTestManager.h"
 #include "OpenXRInput.h"
 #include "OpenXRInputSource.h"
@@ -37,23 +41,8 @@
 #include "OpenXRUtils.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
-#if USE(LIBEPOXY)
-#define __GBM__ 1
-#include <epoxy/egl.h>
-#else
-#include <EGL/egl.h>
-#endif
-#include <WebCore/GLContext.h>
-#include <WebCore/GLDisplay.h>
-#include <WebCore/GLFence.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WorkQueue.h>
-
-#if USE(GBM)
-#include "DRMMainDevice.h"
-#include <WebCore/DRMDevice.h>
-#include <WebCore/GBMDevice.h>
-#endif
 
 #if OS(ANDROID)
 #include <dlfcn.h>
@@ -196,10 +185,7 @@ bool OpenXRCoordinator::collectSwapchainFormatsIfNeeded()
 
 std::unique_ptr<OpenXRSwapchain> OpenXRCoordinator::createSwapchain(uint32_t width, uint32_t height, bool alpha, uint32_t faceCount) const
 {
-    // Even if alpha is false we always ask for the RGBA8 format, as the DRM_FORMAT_RGB8 is not supported by ANGLE.
-    // In this case we ignore the alpha channel by using DRM_FORMAT_XRGB8888 when exporting the texture.
-    auto preferredFormat = GL_RGBA8;
-    auto format = m_supportedSwapchainFormats.contains(preferredFormat) ? preferredFormat : m_supportedSwapchainFormats.first();
+    auto format = m_graphicsBinding->selectColorFormat(m_supportedSwapchainFormats, alpha);
     auto sampleCount = m_viewConfigurationViews.isEmpty() ? 1 : m_viewConfigurationViews.first().recommendedSwapchainSampleCount;
 
     auto info = createOpenXRStruct<XrSwapchainCreateInfo, XR_TYPE_SWAPCHAIN_CREATE_INFO>();
@@ -212,7 +198,7 @@ std::unique_ptr<OpenXRSwapchain> OpenXRCoordinator::createSwapchain(uint32_t wid
     info.sampleCount = sampleCount;
     info.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
 
-    return OpenXRSwapchain::create(m_session, info, alpha ? OpenXRSwapchain::HasAlpha::Yes : OpenXRSwapchain::HasAlpha::No);
+    return OpenXRSwapchain::create(m_session, info, alpha ? OpenXRSwapchain::HasAlpha::Yes : OpenXRSwapchain::HasAlpha::No, *m_graphicsBinding);
 }
 
 void OpenXRCoordinator::createLayerProjection(uint32_t width, uint32_t height, bool alpha, CompletionHandler<void(std::optional<PlatformXR::LayerInfo>)>&& reply)
@@ -241,10 +227,6 @@ void OpenXRCoordinator::createLayerProjection(uint32_t width, uint32_t height, b
 
                 auto imageCount = swapchain->imageCount();
                 if (auto layer = OpenXRLayerProjection::create(WTF::move(swapchain))) {
-#if USE(GBM)
-                    if (m_gbmDevice)
-                        layer->setGBMDevice(m_gbmDevice);
-#endif
                     auto layerHandle = m_nextLayerHandle++;
                     m_layers.add(layerHandle, WTF::move(layer));
                     PlatformXR::LayerInfo layerInfo { layerHandle, imageCount };
@@ -345,10 +327,6 @@ void OpenXRCoordinator::createCompositionLayer(PlatformXR::CompositionLayerType 
                     return;
                 }
 
-#if USE(GBM)
-                if (m_gbmDevice)
-                    layer->setGBMDevice(m_gbmDevice);
-#endif
                 auto layerHandle = m_nextLayerHandle++;
                 m_layers.add(layerHandle, WTF::move(layer));
                 PlatformXR::LayerInfo layerInfo { layerHandle, imageCount };
@@ -675,13 +653,8 @@ void OpenXRCoordinator::createInstance()
 #endif
 
     Vector<char *> extensions;
-#if defined(XR_USE_PLATFORM_EGL)
-    if (OpenXRExtensions::singleton().isExtensionSupported(XR_MNDX_EGL_ENABLE_EXTENSION_NAME ""_span))
-        extensions.append(const_cast<char*>(XR_MNDX_EGL_ENABLE_EXTENSION_NAME));
-#endif
-#if defined(XR_USE_GRAPHICS_API_OPENGL_ES)
-    extensions.append(const_cast<char*>(XR_KHR_OPENGL_ES_ENABLE_EXTENSION_NAME));
-#endif
+    for (auto graphicsExtension : m_graphicsBinding->requiredInstanceExtensions())
+        extensions.append(const_cast<char*>(graphicsExtension.characters()));
 #if defined(XR_EXT_hand_interaction)
     if (OpenXRExtensions::singleton().isExtensionSupported(XR_EXT_HAND_INTERACTION_EXTENSION_NAME ""_span))
         extensions.append(const_cast<char*>(XR_EXT_HAND_INTERACTION_EXTENSION_NAME));
@@ -732,52 +705,6 @@ void OpenXRCoordinator::createInstance()
     CHECK_XRCMD(xrCreateInstance(&createInfo, &m_instance));
 }
 
-RefPtr<WebCore::GLDisplay> OpenXRCoordinator::createGLDisplay(bool isForTesting) const
-{
-    ASSERT(RunLoop::isMain());
-    ASSERT(!m_glDisplay);
-
-    const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
-    auto tryCreateDisplay = [&](EGLenum platform, void *native) -> RefPtr<WebCore::GLDisplay> {
-        if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
-            return WebCore::GLDisplay::create(eglGetPlatformDisplayEXT(platform, native, nullptr));
-        if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
-            return WebCore::GLDisplay::create(eglGetPlatformDisplay(platform, native, nullptr));
-        return nullptr;
-    };
-
-    RefPtr<WebCore::GLDisplay> glDisplay;
-
-#if OS(ANDROID)
-    if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_android")) {
-        glDisplay = tryCreateDisplay(EGL_PLATFORM_ANDROID_KHR, EGL_DEFAULT_DISPLAY);
-        if (!glDisplay)
-            glDisplay = WebCore::GLDisplay::create(eglGetDisplay(EGL_DEFAULT_DISPLAY));
-        if (glDisplay && !(glDisplay->extensions().ANDROID_get_native_client_buffer && glDisplay->extensions().ANDROID_image_native_buffer))
-            glDisplay = nullptr;
-    }
-#endif // OS(ANDROID)
-
-    if (WebCore::GLContext::isExtensionSupported(extensions, "EGL_MESA_platform_surfaceless")) {
-        glDisplay = tryCreateDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY);
-        if (glDisplay && !isForTesting && !glDisplay->extensions().MESA_image_dma_buf_export)
-            glDisplay = nullptr;
-    }
-
-#if USE(GBM)
-    if (!glDisplay && WebCore::GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_gbm")) {
-        const auto& mainDevice = drmMainDevice();
-        if (!mainDevice.isNull()) {
-            m_gbmDevice = WebCore::GBMDevice::create(!mainDevice.renderNode.isNull() ? mainDevice.renderNode : mainDevice.primaryNode);
-            if (m_gbmDevice)
-                glDisplay = tryCreateDisplay(EGL_PLATFORM_GBM_KHR, m_gbmDevice->device());
-        }
-    }
-#endif
-
-    return glDisplay;
-}
-
 void OpenXRCoordinator::collectViewConfigurations()
 {
     ASSERT(RunLoop::isMain());
@@ -825,15 +752,22 @@ void OpenXRCoordinator::initializeDevice(bool isForTesting)
     if (m_instance != XR_NULL_HANDLE)
         return;
 
-    auto display = createGLDisplay(isForTesting);
-    if (!display) {
+    std::unique_ptr<OpenXRGraphicsBinding> graphicsBinding;
+#if defined(XR_USE_GRAPHICS_API_OPENGL_ES)
+    graphicsBinding = OpenXRGraphicsBindingOpenGLES::create();
+#endif
+    if (!graphicsBinding || !graphicsBinding->initializeDisplay(isForTesting)) {
         LOG(XR, "Failed to create a display for OpenXR.");
         return;
     }
+    m_graphicsBinding = WTF::move(graphicsBinding);
 
     createInstance();
     if (m_instance == XR_NULL_HANDLE) {
         LOG(XR, "Failed to create OpenXR instance.");
+        // The display is only kept once the instance has been created successfully, so that a
+        // later retry recreates the whole graphics binding from scratch.
+        m_graphicsBinding = nullptr;
         return;
     }
 
@@ -850,8 +784,6 @@ void OpenXRCoordinator::initializeDevice(bool isForTesting)
 
     collectViewConfigurations();
     initializeBlendModes();
-
-    m_glDisplay = WTF::move(display);
 }
 
 void OpenXRCoordinator::initializeBlendModes()
@@ -882,43 +814,6 @@ void OpenXRCoordinator::initializeBlendModes()
     m_vrBlendMode = supportsOpaqueBlendMode ? XR_ENVIRONMENT_BLEND_MODE_OPAQUE : m_arBlendMode;
 }
 
-void OpenXRCoordinator::tryInitializeGraphicsBinding()
-{
-#if !OS(ANDROID)
-    if (!OpenXRExtensions::singleton().isExtensionSupported(XR_MNDX_EGL_ENABLE_EXTENSION_NAME ""_span)) {
-        LOG(XR, "OpenXR MNDX_EGL_ENABLE extension is not supported.");
-        return;
-    }
-#endif
-
-    if (!m_glContext) {
-#if USE(GBM)
-        const WebCore::GLContext::Target target = m_gbmDevice ? WebCore::GLContext::Target::Default : WebCore::GLContext::Target::Surfaceless;
-#else
-        static const WebCore::GLContext::Target target = WebCore::GLContext::Target::Surfaceless;
-#endif
-        m_glContext = WebCore::GLContext::create(*m_glDisplay, target);
-        if (!m_glContext) {
-            LOG(XR, "Failed to create the GL context for OpenXR.");
-            return;
-        }
-        if (!m_glContext->makeContextCurrent()) {
-            LOG(XR, "Failed to make the GL context current.");
-            return;
-        }
-    }
-
-#if OS(ANDROID)
-    m_graphicsBinding = createOpenXRStruct<XrGraphicsBindingOpenGLESAndroidKHR, XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR>();
-#else
-    m_graphicsBinding = createOpenXRStruct<XrGraphicsBindingEGLMNDX, XR_TYPE_GRAPHICS_BINDING_EGL_MNDX>();
-    m_graphicsBinding.getProcAddress = OpenXRExtensions::singleton().methods().getProcAddressFunc;
-#endif
-    m_graphicsBinding.display = m_glDisplay->eglDisplay();
-    m_graphicsBinding.context = m_glContext->platformContext();
-    m_graphicsBinding.config = m_glContext->config();
-}
-
 void OpenXRCoordinator::createSessionIfNeeded()
 {
     ASSERT(!RunLoop::isMain());
@@ -927,19 +822,17 @@ void OpenXRCoordinator::createSessionIfNeeded()
     if (m_session != XR_NULL_HANDLE)
         return;
 
-#if defined(XR_USE_GRAPHICS_API_OPENGL_ES)
-    auto requirements = createOpenXRStruct<XrGraphicsRequirementsOpenGLESKHR, XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_ES_KHR>();
-    CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrGetOpenGLESGraphicsRequirementsKHR(m_instance, m_systemId, &requirements));
-#endif
-
-    tryInitializeGraphicsBinding();
+    if (!m_graphicsBinding->initializeForSession(m_instance, m_systemId)) {
+        LOG(XR, "Failed to initialize the graphics binding for the OpenXR session.");
+        return;
+    }
 
     m_views.resize(m_viewConfigurationViews.size());
 
     // Create the session.
     auto sessionCreateInfo = createOpenXRStruct<XrSessionCreateInfo, XR_TYPE_SESSION_CREATE_INFO>();
     sessionCreateInfo.systemId = m_systemId;
-    sessionCreateInfo.next = &m_graphicsBinding;
+    sessionCreateInfo.next = m_graphicsBinding->sessionGraphicsBinding();
     CHECK_XRCMD(xrCreateSession(m_instance, &sessionCreateInfo, &m_session));
 }
 
@@ -974,7 +867,8 @@ void OpenXRCoordinator::cleanupSessionAndAssociatedResources()
         m_session = XR_NULL_HANDLE;
     }
 
-    m_glContext.reset();
+    if (m_graphicsBinding)
+        m_graphicsBinding->releaseSessionGraphics();
 }
 
 void OpenXRCoordinator::cleanupInstanceAndAssociatedResources()
@@ -982,8 +876,7 @@ void OpenXRCoordinator::cleanupInstanceAndAssociatedResources()
     m_viewConfigurationViews.clear();
     m_systemId = XR_NULL_SYSTEM_ID;
 
-    ASSERT(!m_glContext);
-    m_glDisplay = nullptr;
+    m_graphicsBinding = nullptr;
 
     if (m_instance == XR_NULL_HANDLE)
         return;
@@ -1160,7 +1053,7 @@ PlatformXR::FrameData OpenXRCoordinator::populateFrameData(Box<RenderState> rend
     for (auto& layer : m_layers) {
         if (!renderState->activeLayerHandles.contains(layer.key))
             continue;
-        auto layerData = layer.value->startFrame();
+        auto layerData = layer.value->startFrame(*m_graphicsBinding);
         if (layerData) {
             auto layerDataRef = makeUniqueRef<PlatformXR::FrameData::LayerData>(WTF::move(*layerData));
             frameData.layers.add(layer.key, WTF::move(layerDataRef));
@@ -1323,12 +1216,10 @@ void OpenXRCoordinator::endFrame(Box<RenderState> renderState, Vector<PlatformXR
             continue;
         }
 
-        if (layer.fenceFD) {
-            if (auto fence = WebCore::GLFence::importFD(*m_glDisplay, WTF::move(layer.fenceFD)))
-                fence->serverWait();
-        }
+        if (layer.fenceFD)
+            m_graphicsBinding->waitFrameFence(WTF::move(layer.fenceFD));
 
-        auto headers = it->value->endFrame(layer, m_localSpace, m_views);
+        auto headers = it->value->endFrame(*m_graphicsBinding, layer, m_localSpace, m_views);
         frameEndLayers.appendVector(WTF::move(headers));
     }
 

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -36,17 +36,12 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
 
-namespace WebCore {
-class GBMDevice;
-class GLContext;
-class GLDisplay;
-}
-
 namespace WebKit {
 
 #if ENABLE(WEBXR_HIT_TEST)
 class OpenXRHitTestManager;
 #endif
+class OpenXRGraphicsBinding;
 class OpenXRInput;
 class OpenXRLayer;
 class OpenXRSwapchain;
@@ -82,7 +77,6 @@ public:
 
 private:
     void createInstance();
-    RefPtr<WebCore::GLDisplay> createGLDisplay(bool isForTesting) const;
     void initializeDevice(bool isForTesting);
     void initializeSystem();
     void initializeBlendModes();
@@ -101,7 +95,6 @@ private:
 
     void createSessionIfNeeded();
     void handleSessionStateChange();
-    void tryInitializeGraphicsBinding();
     void cleanupAllResources();
     void cleanupInstanceAndAssociatedResources();
     void cleanupSessionAndAssociatedResources();
@@ -129,10 +122,7 @@ private:
     XrEnvironmentBlendMode m_vrBlendMode;
     XrEnvironmentBlendMode m_arBlendMode;
     PlatformXR::SessionMode m_sessionMode;
-    RefPtr<WebCore::GLDisplay> m_glDisplay;
-#if USE(GBM)
-    mutable RefPtr<WebCore::GBMDevice> m_gbmDevice;
-#endif
+    std::unique_ptr<OpenXRGraphicsBinding> m_graphicsBinding;
     std::unique_ptr<OpenXRInput> m_input;
 
     XrSession m_session { XR_NULL_HANDLE };
@@ -141,12 +131,6 @@ private:
     Vector<XrView> m_views;
     HashMap<PlatformXR::LayerHandle, std::unique_ptr<OpenXRLayer>> m_layers;
     Vector<int64_t> m_supportedSwapchainFormats;
-#if OS(ANDROID)
-    XrGraphicsBindingOpenGLESAndroidKHR m_graphicsBinding;
-#else
-    XrGraphicsBindingEGLMNDX m_graphicsBinding;
-#endif
-    std::unique_ptr<WebCore::GLContext> m_glContext;
     XrSpace m_viewerSpace { XR_NULL_HANDLE };
     XrSpace m_localSpace { XR_NULL_HANDLE };
     XrSpace m_floorSpace { XR_NULL_HANDLE };


### PR DESCRIPTION
#### d92d5a69f22d9b42cda91e6ae19674765616fee9
<pre>
[OpenXR] Remove the dependency with OpenGLES
<a href="https://bugs.webkit.org/show_bug.cgi?id=317729">https://bugs.webkit.org/show_bug.cgi?id=317729</a>

Reviewed by Dan Glastonbury.

The OpenXR backend was hardwired to OpenGLES/EGL: EGL display/context
creation, the XrGraphicsBinding struct, the graphics requirements check, the
required instance extensions and the render fence wait were all spread across
OpenXRCoordinator. OpenXR itself is graphics library agnostic so we
should try to keep that independence to eventually support other
graphics libraries (e.g. Vulkan) for WebXR.

Added an abstract OpenXRGraphicsBinding with a single concrete implementation,
OpenXRGraphicsBindingOpenGLES, that reproduces the current behavior. The
lifecycle is split into three phases so that it can also fit APIs whose device
creation requires the OpenXR instance/system (unlike EGL):

- requiredInstanceExtensions(): before xrCreateInstance (main thread).
- initializeDisplay(): creates the platform display (main thread).
- initializeForSession(): creates the context/device and fill the XrGraphicsBinding
  once the instance and system are known (render thread).

The OpenXRCoordinator now holds a unique_ptr&lt;OpenXRGraphicsBinding&gt; in place
of the GLDisplay/GLContext/GBMDevice/XrGraphicsBinding members, delegating the
instance extension list, display/context setup, session graphics binding, the
endFrame fence wait and the two-phase teardown to it. No behavior change.

Swapchains logic is also moved to the new OpenXRGraphicsBinding, in particular:

- the preferred color format selection that used to be hardcoded in createSwapchain()
- enumerateSwapchainImages()

OpenXRSwapchain no longer depends on the OpenGLES image struct, it now stores the
opaque uint64_t handles returned by the binding and delegates enumeration to it
at creation time.

The last step was to move the texture sharing code also to the new
graphics binding object:

- exportTexture(): the GL texture -&gt; EGLImage -&gt; DMABuf/AHardwareBuffer export
  (includes Android, DMABuf and GBM paths).
- needsBlit()/blit(): used in those cases in which the texture sharing
  mechanism uses its own resources (like Android and GBM paths).
- other specific paths (like setDevice in GBM code path) were also
  moved.

We&apos;re using this change to merge needsBlit() with blitTexture() in a new
blitTextureIfNeeded() because they were exclusively used in pairs, there
were not other usages of needsBlit().

This is mostly about moving code, so there shouldn&apos;t be any behavioral
change and the original code should be nearly identical to the one in
the new abstract class (modulo trivial refactorings like the needsBlit).

* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBinding.h: Added.
* Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.cpp: Added.
(WebKit::OpenXRGraphicsBindingOpenGLES::create):
(WebKit::OpenXRGraphicsBindingOpenGLES::~OpenXRGraphicsBindingOpenGLES):
(WebKit::OpenXRGraphicsBindingOpenGLES::requiredInstanceExtensions const):
(WebKit::OpenXRGraphicsBindingOpenGLES::initializeDisplay):
(WebKit::OpenXRGraphicsBindingOpenGLES::initializeForSession):
(WebKit::OpenXRGraphicsBindingOpenGLES::sessionGraphicsBinding const):
(WebKit::OpenXRGraphicsBindingOpenGLES::selectColorFormat const):
(WebKit::OpenXRGraphicsBindingOpenGLES::enumerateSwapchainImages const):
(WebKit::OpenXRGraphicsBindingOpenGLES::waitFrameFence):
(WebKit::OpenXRGraphicsBindingOpenGLES::releaseSessionGraphics):
(WebKit::OpenXRGraphicsBindingOpenGLES::exportOpenXRTextureAndroid):
(WebKit::OpenXRGraphicsBindingOpenGLES::exportOpenXRTextureDMABuf):
(WebKit::OpenXRGraphicsBindingOpenGLES::exportOpenXRTextureGBM):
(WebKit::OpenXRGraphicsBindingOpenGLES::exportTexture):
(WebKit::OpenXRGraphicsBindingOpenGLES::commitFrame):
(WebKit::OpenXRGraphicsBindingOpenGLES::exportTexture2D):
(WebKit::OpenXRGraphicsBindingOpenGLES::blitTextureIfNeeded):
(WebKit::OpenXRGraphicsBindingOpenGLES::exportCubeBuffer):
(WebKit::OpenXRGraphicsBindingOpenGLES::reconstructCubeFaces):
* Source/WebKit/UIProcess/XR/openxr/OpenXRGraphicsBindingOpenGLES.h: Added.
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
(WebKit::OpenXRLayerProjection::startFrame):
(WebKit::OpenXRQuadLayer::startFrame):
(WebKit::OpenXREquirectLayer::startFrame):
(WebKit::OpenXRCylinderLayer::startFrame):
(WebKit::OpenXRCubeLayer::startFrame):
(WebKit::OpenXRLayer::~OpenXRLayer): Deleted.
(WebKit::OpenXRLayer::exportOpenXRTextureAndroid): Deleted.
(WebKit::OpenXRLayer::exportOpenXRTextureDMABuf): Deleted.
(WebKit::OpenXRLayer::setGBMDevice): Deleted.
(WebKit::OpenXRLayer::exportOpenXRTextureGBM): Deleted.
(WebKit::OpenXRLayer::blitTexture const): Deleted.
(WebKit::OpenXRLayer::exportOpenXRTexture): Deleted.
(WebKit::OpenXRCubeLayer::~OpenXRCubeLayer): Deleted.
(WebKit::OpenXRCubeLayer::reconstructCubeFaces): Deleted.
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h:
(WebKit::OpenXRLayer::needsBlitTexture const): Deleted.
* Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.cpp:
(WebKit::OpenXRSwapchain::create):
(WebKit::OpenXRSwapchain::OpenXRSwapchain):
(WebKit::OpenXRSwapchain::acquireImage):
* Source/WebKit/UIProcess/XR/openxr/OpenXRSwapchain.h:
(WebKit::OpenXRSwapchain::acquiredTexture const):
(WebKit::OpenXRSwapchain::imageCount const):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::createSwapchain const):
(WebKit::OpenXRCoordinator::createLayerProjection):
(WebKit::OpenXRCoordinator::createCompositionLayer):
(WebKit::OpenXRCoordinator::createInstance):
(WebKit::OpenXRCoordinator::initializeDevice):
(WebKit::OpenXRCoordinator::createSessionIfNeeded):
(WebKit::OpenXRCoordinator::cleanupSessionAndAssociatedResources):
(WebKit::OpenXRCoordinator::cleanupInstanceAndAssociatedResources):
(WebKit::OpenXRCoordinator::populateFrameData):
(WebKit::OpenXRCoordinator::endFrame):
(WebKit::OpenXRCoordinator::createGLDisplay const): Deleted.
(WebKit::OpenXRCoordinator::tryInitializeGraphicsBinding): Deleted.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/316023@main">https://commits.webkit.org/316023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1819b76a7fb7a369f58b99002881765c6b74a518

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128475 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133181 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173721 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113678 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33335 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28820 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182725 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35520 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141642 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44343 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38096 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45032 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109719 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36726 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116921 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43543 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8112 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42947 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->