### PR TITLE
[JSC] Support cross-realm Array fast path in `forEachInIterable`

### DIFF
--- a/JSTests/microbenchmarks/set-constructor-cross-realm-array.js
+++ b/JSTests/microbenchmarks/set-constructor-cross-realm-array.js
@@ -1,0 +1,14 @@
+var other = createGlobalObject();
+
+function test(array)
+{
+    return new Set(array);
+}
+noInline(test);
+
+var array = new other.Array(50);
+for (var j = 0; j < 50; ++j)
+    array[j] = j;
+
+for (var i = 0; i < 1e4; ++i)
+    test(array);

--- a/JSTests/stress/for-each-in-iterable-cross-realm-array-fast-path.js
+++ b/JSTests/stress/for-each-in-iterable-cross-realm-array-fast-path.js
@@ -1,0 +1,63 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error((msg ? msg + ": " : "") + `expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(func) {
+    let threw = false;
+    try {
+        func();
+    } catch {
+        threw = true;
+    }
+    shouldBe(threw, true, "should have thrown");
+}
+
+// forEachInIterable can take a fast path for cross-realm JSArrays whose own
+// realm's array iterator protocol is pristine. When the callback throws,
+// IteratorClose must look up `return` on the iterator that the spec would have
+// created, i.e. one inheriting from the *array's own realm's*
+// %ArrayIteratorPrototype%, not the caller realm's.
+{
+    const other = createGlobalObject();
+    const otherArray = other.Array.of(1, 2, 3);
+
+    let callerRealmReturnCount = 0;
+    const ArrayIteratorPrototype = Object.getPrototypeOf([].values());
+    ArrayIteratorPrototype.return = function () {
+        callerRealmReturnCount++;
+        return { value: undefined, done: true };
+    };
+
+    // new WeakSet(otherArray): primitive entries cause the adder callback to
+    // throw a TypeError, which triggers IteratorClose on the (materialized)
+    // array iterator. Per spec that iterator inherits from the other realm's
+    // %ArrayIteratorPrototype%, which has no `return`, so nothing should run.
+    shouldThrow(() => new WeakSet(otherArray));
+    shouldBe(callerRealmReturnCount, 0, "Array: caller realm %ArrayIteratorPrototype%.return must not be called");
+
+    delete ArrayIteratorPrototype.return;
+}
+
+// Also confirm that the fast path is observably equivalent for the non-throwing case.
+{
+    const other = createGlobalObject();
+    const otherArray = other.Array.of(1, 2, 3, 3, 2, 1);
+
+    let callCount = 0;
+    const ArrayIteratorPrototype = Object.getPrototypeOf([].values());
+    const originalNext = ArrayIteratorPrototype.next;
+    ArrayIteratorPrototype.next = function () {
+        callCount++;
+        return originalNext.call(this);
+    };
+
+    const set = new Set(otherArray);
+    shouldBe(set.size, 3, "Set size");
+    // The other realm's %ArrayIteratorPrototype%.next is unmodified, so the
+    // fast path (or even the generic path against the other realm's iterator)
+    // must never call the caller realm's overridden next.
+    shouldBe(callCount, 0, "Array: caller realm %ArrayIteratorPrototype%.next must not be called");
+
+    ArrayIteratorPrototype.next = originalNext;
+}

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -560,26 +560,15 @@ IterationMode getIterationMode(VM&, JSGlobalObject* globalObject, JSValue iterab
     return IterationMode::Generic;
 }
 
-IterationMode getIterationMode(VM&, JSGlobalObject* globalObject, JSValue iterable)
+IterationMode getIterationMode(JSValue iterable)
 {
     if (!isJSArray(iterable))
         return IterationMode::Generic;
 
     JSArray* array = uncheckedDowncast<JSArray>(iterable);
-    Structure* structure = array->structure();
-    // FIXME: We want to support broader JSArrays as long as array[@@iterator] is not defined.
-    if (!globalObject->isOriginalArrayStructure(structure))
+    if (!array->isIteratorProtocolFastAndNonObservable())
         return IterationMode::Generic;
 
-    if (!globalObject->arrayIteratorProtocolWatchpointSet().isStillValid())
-        return IterationMode::Generic;
-
-    // Now, Array has original Array Structures and arrayIteratorProtocolWatchpointSet is not fired.
-    // This means,
-    // 1. Array.prototype is [[Prototype]].
-    // 2. array[@@iterator] is not overridden.
-    // 3. Array.prototype[@@iterator] is an expected one.
-    // So, we can say this will create an expected ArrayIterator.
     return IterationMode::FastArray;
 }
 

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -89,7 +89,7 @@ enum class IterableValidationResult : uint8_t {
 JS_EXPORT_PRIVATE IterableValidationResult validateIterable(VM&, JSValue iterable, JSValue symbolIterator);
 JS_EXPORT_PRIVATE ASCIILiteral getIteratorErrorMessage(IterableValidationResult, JSValue iterable);
 
-JS_EXPORT_PRIVATE IterationMode NODELETE getIterationMode(VM&, JSGlobalObject*, JSValue iterable);
+JS_EXPORT_PRIVATE IterationMode getIterationMode(JSValue iterable);
 JS_EXPORT_PRIVATE IterationMode getIterationMode(VM&, JSGlobalObject*, JSValue iterable, JSValue symbolIterator);
 
 
@@ -197,7 +197,7 @@ static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSVal
     UNUSED_PARAM(iterable);
 
     auto& vm = getVM(globalObject);
-    ASSERT(getIterationMode(vm, globalObject, iterable) == IterationMode::FastArray);
+    ASSERT(getIterationMode(iterable) == IterationMode::FastArray);
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -207,7 +207,7 @@ static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSVal
         callback(vm, globalObject, nextValue);
         if (scope.exception()) [[unlikely]] {
             scope.release();
-            JSArrayIterator* iterator = JSArrayIterator::create(vm, globalObject->arrayIteratorStructure(), array, IterationKind::Values);
+            JSArrayIterator* iterator = JSArrayIterator::create(vm, array->realm()->arrayIteratorStructure(), array, IterationKind::Values);
             iterator->internalField(JSArrayIterator::Field::Index).setWithoutWriteBarrier(jsNumber(index + 1));
             iteratorClose(globalObject, iterator);
             return;
@@ -261,7 +261,7 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE 
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (getIterationMode(vm, globalObject, iterable) == IterationMode::FastArray) {
+    if (getIterationMode(iterable) == IterationMode::FastArray) {
         auto* array = uncheckedDowncast<JSArray>(iterable);
         forEachInFastArray(globalObject, iterable, array, callback);
         RETURN_IF_EXCEPTION(scope, void());


### PR DESCRIPTION
#### 7be57c077eda4ed04a6f77b547f01ffe214891d8
<pre>
[JSC] Support cross-realm Array fast path in `forEachInIterable`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317731">https://bugs.webkit.org/show_bug.cgi?id=317731</a>

Reviewed by Keith Miller.

The 2-argument getIterationMode (used only by forEachInIterable) gated FastArray
on the caller realm&apos;s isOriginalArrayStructure, so cross-realm arrays always
fell back to the generic iterator path. Switch to
JSArray::isIteratorProtocolFastAndNonObservable(), which checks the array&apos;s own
realm just like the existing JSMap/JSSet fast paths.

There is no observable behavior change: the predicate guarantees the array&apos;s own
realm&apos;s iterator protocol is pristine, so the inlined index loop is equivalent to
what GetIterator + IteratorStep would do, and the materialized iterator for
IteratorClose now uses array-&gt;realm()-&gt;arrayIteratorStructure(), matching what
the spec&apos;s GetIterator would have produced.

                                       Baseline                  Patched
set-constructor-cross-realm-array  18.0169+-0.1186     ^      6.0958+-0.0508    ^ definitely 2.9556x faster

Tests: JSTests/microbenchmarks/set-constructor-cross-realm-array.js
       JSTests/stress/for-each-in-iterable-cross-realm-array-fast-path.js

* JSTests/microbenchmarks/set-constructor-cross-realm-array.js: Added.
(test):
* JSTests/stress/for-each-in-iterable-cross-realm-array-fast-path.js: Added.
(shouldBe):
(shouldBe.ArrayIteratorPrototype.return):
(ArrayIteratorPrototype.next):
* Source/JavaScriptCore/runtime/IteratorOperations.cpp:
(JSC::getIterationMode):
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInFastArray):
(JSC::forEachInIterable):
* Source/JavaScriptCore/runtime/JSArray.h:

Canonical link: <a href="https://commits.webkit.org/317121@main">https://commits.webkit.org/317121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7aad29990c6ae59f0e037fb7319c708a7f008cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127855 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132628 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93468 "12 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113130 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169464 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Running checkout-pull-request; Passed webkitpy tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34405 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32764 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28201 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1477 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32459 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182102 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31398 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34891 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36932 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141081 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/169543 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152531 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/182102 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/37936 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44412 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108776 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26504 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116292 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202822 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42922 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Running checkout-pull-request") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7542 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54355 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->