### PR TITLE
[315691@main] With MediaContainment off, YouTube seeking never completes

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-complete-gpu.html
+++ b/LayoutTests/media/media-source/media-source-seek-complete-gpu.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MediaContainmentEnabled=false ] -->
+<html>
+<head>
+    <title>mock-media-source</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var samples;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    function runTest()
+    {
+        findMediaElement();
+
+        source = new MediaSource();
+        testExpected('source.readyState', 'closed');
+
+        waitForEventOn(source, 'sourceopen', sourceOpen);
+        var videoSource = document.createElement('source');
+        videoSource.type = 'video/mock; codecs=mock';
+        videoSource.src = URL.createObjectURL(source);
+        video.appendChild(videoSource);
+    }
+
+    function sourceOpen()
+    {
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        waitForEventOn(sourceBuffer, 'updateend', loadSamples, false, true);
+        initSegment = makeAInit(8, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+        run('sourceBuffer.appendBuffer(initSegment)');
+    }
+
+    function loadSamples()
+    {
+        samples = concatenateSamples([
+            makeASample(10, 10, 1, 1, 1, SAMPLE_FLAG.SYNC),
+        ]);
+        waitForEventOn(sourceBuffer, 'updateend', seek, false, true);
+        run('sourceBuffer.appendBuffer(samples)');
+    }
+
+    function seek()
+    {
+        waitForEventAndEnd('seeked', endTest);
+        run('source.duration = 11');
+        run('source.endOfStream()');
+        run('video.currentTime = 10');
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3629,6 +3629,7 @@ ipc/web-authenticator-get-assertion.html [ Skip ]
 
 # These tests require UseGPUProcessForMediaEnabled
 ipc/restrictedendpoints/allow-access-testOnlyIPC.html [ Skip ]
+media/media-source/media-source-seek-complete-gpu.html [ Skip ]
 
 ### FAILING TESTS
 

--- a/LayoutTests/platform/mac/media/media-source/media-source-seek-complete-gpu-expected.txt
+++ b/LayoutTests/platform/mac/media/media-source/media-source-seek-complete-gpu-expected.txt
@@ -1,0 +1,14 @@
+
+EXPECTED (source.readyState == 'closed') OK
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(samples))
+EVENT(updateend)
+RUN(source.duration = 11)
+RUN(source.endOfStream())
+RUN(video.currentTime = 10)
+EVENT(seeked)
+END OF TEST
+

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -38,6 +38,7 @@
 #include "MediaPlayer.h"
 #include "MediaPromiseTypes.h"
 #include "MediaSourceInit.h"
+#include "MediaSourcePrivate.h"
 #include "MediaSourcePrivateClient.h"
 #include "URLRegistry.h"
 #include <optional>
@@ -64,8 +65,6 @@ class TimeRanges;
 class VideoTrack;
 class VideoTrackPrivate;
 template<typename> class ExceptionOr;
-
-enum class MediaSourceReadyState { Closed, Open, Ended };
 
 class MediaSource
     : public RefCounted<MediaSource>

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -49,8 +49,14 @@ class SourceBufferPrivate;
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 class LegacyCDMSession;
 #endif
-enum class MediaSourceReadyState;
+
 struct MediaSourceConfiguration;
+
+enum class MediaSourceReadyState : uint8_t {
+    Closed,
+    Open,
+    Ended
+};
 
 enum class MediaSourcePrivateAddStatus : uint8_t {
     Ok,

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -158,6 +158,11 @@ void RemoteMediaSourceProxy::cancelPendingWaitForTarget()
         protectedPrivate->cancelPendingWaitForTarget();
 }
 
+void RemoteMediaSourceProxy::setReadyState(WebCore::MediaSourceReadyState readyState)
+{
+    if (RefPtr protectedPrivate = m_private)
+        protectedPrivate->setReadyState(readyState);
+}
 
 void RemoteMediaSourceProxy::setMediaPlayerReadyState(WebCore::MediaPlayerEnums::ReadyState readyState)
 {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -93,6 +93,7 @@ private:
     void markEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus);
     void unmarkEndOfStream();
     void cancelPendingWaitForTarget();
+    void setReadyState(WebCore::MediaSourceReadyState);
     void setMediaPlayerReadyState(WebCore::MediaPlayerEnums::ReadyState);
     void setTimeFudgeFactor(const MediaTime&);
     void NODELETE attached();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
@@ -34,6 +34,7 @@ messages -> RemoteMediaSourceProxy {
     AddSourceBuffer(WebCore::ContentType contentType, struct WebCore::MediaSourceConfiguration configuration) -> (enum:uint8_t WebCore::MediaSourcePrivateAddStatus status, std::optional<WebKit::RemoteSourceBufferIdentifier> remoteSourceBufferIdentifier) Synchronous
     DurationChanged(MediaTime duration)
     BufferedChanged(WebCore::PlatformTimeRanges buffered)
+    SetReadyState(enum:uint8_t WebCore::MediaSourceReadyState readyState)
     SetMediaPlayerReadyState(enum:uint8_t WebCore::MediaPlayerReadyState readyState)
     SetTimeFudgeFactor(MediaTime fudgeFactor)
     MarkEndOfStream(enum:uint8_t WebCore::MediaSourcePrivateEndOfStreamStatus status)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1342,6 +1342,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::MediaSettingsRange': ['<WebCore/MediaSettingsRange.h>'],
         'WebCore::MediaSourcePrivateAddStatus': ['<WebCore/MediaSourcePrivate.h>'],
         'WebCore::MediaSourcePrivateEndOfStreamStatus': ['<WebCore/MediaSourcePrivate.h>'],
+        'WebCore::MediaSourceReadyState': ['<WebCore/MediaSourcePrivate.h>'],
         'WebCore::MediaTimePromise::Result': ['<WebCore/MediaPromiseTypes.h>'],
         'WebCore::MessagePortChannelProvider::HasActivity': ['<WebCore/MessagePortChannelProvider.h>'],
         'WebCore::ModalContainerControlType': ['<WebCore/ModalContainerTypes.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
@@ -968,6 +968,13 @@ enum class WebCore::MediaSourcePrivateEndOfStreamStatus : uint8_t {
     DecodeError
 };
 
+header: <WebCore/MediaSourcePrivate.h>
+enum class WebCore::MediaSourceReadyState : uint8_t {
+    Closed,
+    Open,
+    Ended
+};
+
 header: <WebCore/SourceBufferPrivate.h>
 enum class WebCore::SourceBufferAppendMode : uint8_t {
     Segments,

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -217,6 +217,15 @@ void MediaSourcePrivateRemote::cancelPendingWaitForTarget()
     });
 }
 
+void MediaSourcePrivateRemote::setReadyState(MediaSourceReadyState readyState)
+{
+    MediaSourcePrivate::setReadyState(readyState);
+    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    if (!isGPURunning() || !gpuProcessConnection)
+        return;
+    gpuProcessConnection->connection().send(Messages::RemoteMediaSourceProxy::SetReadyState(readyState), m_identifier);
+}
+
 void MediaSourcePrivateRemote::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
     // Call from MediaSource's dispatcher.

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -66,6 +66,7 @@ public:
     void markEndOfStream(EndOfStreamStatus) final;
     void unmarkEndOfStream() final;
     void cancelPendingWaitForTarget() final;
+    void setReadyState(WebCore::MediaSourceReadyState) final;
     void setMediaPlayerReadyState(WebCore::MediaPlayer::ReadyState) final;
     void setPlayer(WebCore::MediaPlayerPrivateInterface*) final;
     void shutdown() final;


### PR DESCRIPTION
#### 4b6c349e5ea44901d3fab98f14cb1f6a901c512e
<pre>
[315691@main] With MediaContainment off, YouTube seeking never completes
<a href="https://bugs.webkit.org/show_bug.cgi?id=317728">https://bugs.webkit.org/show_bug.cgi?id=317728</a>
<a href="https://rdar.apple.com/180481278">rdar://180481278</a>

Reviewed by Youenn Fablet.

In 315691@main, we moved the checks for buffered ranges into the MediaSourcePrivate.
All those methods were gated on the readyState being everything but &quot;Closed&quot;.
However, when the MediaSourcePrivate lives in the GPU process, the readyState
was never set and kept its initial value: &quot;Closed&quot;. This issue didn&apos;t matter
before because nothing on the GPU process side relied on the readyState value.

We plumb the readyState update.

MediaSourcePrivateRemote &amp; Co should be removed ; it&apos;s becoming too hard
to maintain now that MediaContainment is the default and the GPU process
path is no longer properly tested.

Test: media/media-source/media-source-seek-complete-gpu.html

* LayoutTests/media/media-source/media-source-seek-complete-gpu.html: Added.
* LayoutTests/platform/mac/media/media-source/media-source-seek-complete-gpu-expected.txt: Added.
* Source/WebCore/Modules/mediasource/MediaSource.h: MediaSource.h isn&apos;t a global header and can&apos;t be used from WebKit.
so we move the readyState enum to MediaSourcePrivate.h.
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::setReadyState):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::setReadyState):
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/315739@main">https://commits.webkit.org/315739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd7879bef2067fb512c674f66ef58ce4301d058d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127675 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b670556b-ab10-46e3-b7f4-2992e37a7e4a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171829 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132476 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07ff5c4d-1a49-4fc2-88ce-8cf1a10eb53f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172922 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112978 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d669ae9-8c8c-4951-a6ee-a1554ee1e48f) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169284 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28021 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181921 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34629 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140927 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140758 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37890 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44230 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29287 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108562 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36025 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/115995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42741 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42133 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42388 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->