### PR TITLE
[JSC] Emit expression info before `[Symbol.iterator]` get and spread

### DIFF
--- a/JSTests/stress/catch-rest-parameter.js
+++ b/JSTests/stress/catch-rest-parameter.js
@@ -22,12 +22,13 @@ function shouldThrow(func, errorMessage) {
 }
 
 let expected = "TypeError: undefined is not an object (evaluating '[[]]')";
+let expectedInner = "TypeError: undefined is not an object (evaluating '[]')";
 
 // AsyncFunction
 (() => {
     async function f(...[[]]) { }
     let isExpected = false;
-    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    f().then(e => isExpected = false).catch(e => isExpected = e == expectedInner);
     drainMicrotasks();
     assert(isExpected);
 })();
@@ -43,7 +44,7 @@ let expected = "TypeError: undefined is not an object (evaluating '[[]]')";
 (() => {
     async function f(a, ...[[]]) { }
     let isExpected = false;
-    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    f().then(e => isExpected = false).catch(e => isExpected = e == expectedInner);
     drainMicrotasks();
     assert(isExpected);
 })();
@@ -66,7 +67,7 @@ let expected = "TypeError: undefined is not an object (evaluating '[[]]')";
 (() => {
     let f = async (...[[]]) => { };
     let isExpected = false;
-    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    f().then(e => isExpected = false).catch(e => isExpected = e == expectedInner);
     drainMicrotasks();
     assert(isExpected);
 })();
@@ -82,7 +83,7 @@ let expected = "TypeError: undefined is not an object (evaluating '[[]]')";
 (() => {
     let f = async (a, ...[[]]) => { };
     let isExpected = false;
-    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    f().then(e => isExpected = false).catch(e => isExpected = e == expectedInner);
     drainMicrotasks();
     assert(isExpected);
 })();
@@ -105,7 +106,7 @@ let expected = "TypeError: undefined is not an object (evaluating '[[]]')";
 (() => {
     class x { static async f(...[[]]) { } }
     let isExpected = false;
-    x.f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    x.f().then(e => isExpected = false).catch(e => isExpected = e == expectedInner);
     drainMicrotasks();
     assert(isExpected);
 })();
@@ -121,7 +122,7 @@ let expected = "TypeError: undefined is not an object (evaluating '[[]]')";
 (() => {
     class x { static async f(a, ...[[]]) { } }
     let isExpected = false;
-    x.f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    x.f().then(e => isExpected = false).catch(e => isExpected = e == expectedInner);
     drainMicrotasks();
     assert(isExpected);
 })();
@@ -143,8 +144,8 @@ let expected = "TypeError: undefined is not an object (evaluating '[[]]')";
 
 // AsyncGenerator
 shouldThrow(async function* f([[]]) { }, expected);
-shouldThrow(async function* f(...[[]]) { }, expected);
-shouldThrow(async function* f(a, ...[[]]) { }, expected);
+shouldThrow(async function* f(...[[]]) { }, expectedInner);
+shouldThrow(async function* f(a, ...[[]]) { }, expectedInner);
 (() => {
     var a = 1, b = 2, c = 3;
     async function* f(arg0, ...args) {
@@ -159,8 +160,8 @@ shouldThrow(async function* f(a, ...[[]]) { }, expected);
 
 // Generator
 shouldThrow(function* f([[]]) { }, expected);
-shouldThrow(function* f(...[[]]) { }, expected);
-shouldThrow(function* f(a, ...[[]]) { }, expected);
+shouldThrow(function* f(...[[]]) { }, expectedInner);
+shouldThrow(function* f(a, ...[[]]) { }, expectedInner);
 (() => {
     var a = 1, b = 2, c = 3;
     function* f(arg0, ...args) {
@@ -174,8 +175,8 @@ shouldThrow(function* f(a, ...[[]]) { }, expected);
 
 // Function
 shouldThrow(function f([[]]) { }, expected);
-shouldThrow(function f(...[[]]) { }, expected);
-shouldThrow(function f(a, ...[[]]) { }, expected);
+shouldThrow(function f(...[[]]) { }, expectedInner);
+shouldThrow(function f(a, ...[[]]) { }, expectedInner);
 (() => {
     var a = 1, b = 2, c = 3;
     function f(arg0, ...args) {

--- a/JSTests/stress/iterator-error-messages-consistent.js
+++ b/JSTests/stress/iterator-error-messages-consistent.js
@@ -32,8 +32,8 @@ function runTest(value, expectedError) {
     }
 }
 
-runTest(null, "TypeError: null is not an object (evaluating 'value')");
-runTest(undefined, "TypeError: undefined is not an object (evaluating 'value')");
+runTest(null, "TypeError: null is not an object (evaluating 'x of value')");
+runTest(undefined, "TypeError: undefined is not an object (evaluating 'x of value')");
 runTest(0, "TypeError: number is not iterable");
 runTest(42, "TypeError: number is not iterable");
 runTest(true, "TypeError: true is not iterable");
@@ -64,7 +64,7 @@ function testDestructuring(value, expectedError) {
 
 for (let i = 0; i < testLoopCount; i++) {
     testDestructuring(42, "TypeError: number is not iterable");
-    testDestructuring(null, "TypeError: null is not an object (evaluating 'value')");
+    testDestructuring(null, "TypeError: null is not an object (evaluating '[x]')");
 }
 
 function testSpread(value, expectedError) {

--- a/JSTests/stress/iterator-open-expression-info.js
+++ b/JSTests/stress/iterator-open-expression-info.js
@@ -1,0 +1,49 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected ${expected}, got ${actual}`);
+}
+
+function shouldNotInclude(string, substring) {
+    if (string.includes(substring))
+        throw new Error(`FAIL: ${JSON.stringify(string)} should not include ${JSON.stringify(substring)}`);
+}
+
+// When the subject of an iteration construct is a constant that does not itself
+// emit expression info (e.g. a null literal), the [Symbol.iterator] get_by_id /
+// op_spread should still be attributed to the iterating construct, not to the
+// previous statement.
+
+function check(prefix, body) {
+    let source = `(${prefix} () {
+"sentinelStatement";
+${body}
+})`;
+    let f = eval(source);
+    let error = null;
+    let onError = e => { error = e; };
+    try {
+        let result = f();
+        if (prefix === "function*")
+            result.next();
+        else if (prefix === "async function") {
+            result.catch(onError);
+            drainMicrotasks();
+        }
+    } catch (e) {
+        onError(e);
+    }
+    if (!error)
+        throw new Error(`FAIL: ${body} did not throw`);
+    shouldBe(error.line, 3);
+    shouldNotInclude(error.message, "sentinelStatement");
+}
+
+check("function", `for (const b of null) {}`);
+check("function", `for (const b of undefined) {}`);
+check("function", `const [a] = null;`);
+check("function", `var a = [...null];`);
+check("function", `var a = [1, ...null, 2];`);
+check("function", `Array(...[...null]);`);
+check("function", `new Array(...[...null]);`);
+check("function*", `yield* null;`);
+check("async function", `for await (const b of null) {}`);

--- a/LayoutTests/js/arguments-iterator-expected.txt
+++ b/LayoutTests/js/arguments-iterator-expected.txt
@@ -3,7 +3,7 @@ This test checks the behavior of Arguments object iteration.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS (function (arguments) { for (var argument of arguments) {}})() threw exception TypeError: undefined is not an object (evaluating 'arguments').
+PASS (function (arguments) { for (var argument of arguments) {}})() threw exception TypeError: undefined is not an object (evaluating 'argument of arguments').
 PASS actualArgumentsLength is iteratedArgumentsLength
 PASS arg === realArg is true
 PASS actualArgumentsLength is iteratedArgumentsLength

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -3489,10 +3489,12 @@ RegisterID* BytecodeGenerator::emitNewArrayWithSpread(RegisterID* dst, ElementNo
         unsigned i = 0;
         for (ElementNode* node = elements; node; node = node->next()) {
             if (node->value()->isSpreadExpression()) {
-                ExpressionNode* expression = static_cast<SpreadExpressionNode*>(node->value())->expression();
+                auto* spread = static_cast<SpreadExpressionNode*>(node->value());
+                ExpressionNode* expression = spread->expression();
                 RefPtr<RegisterID> tmp = newTemporary();
                 emitNode(tmp.get(), expression);
 
+                emitExpressionInfo(spread->divot(), spread->divotStart(), spread->divotEnd());
                 OpSpread::emit(this, argv[i].get(), tmp.get());
             } else {
                 ExpressionNode* expression = node->value();
@@ -3773,8 +3775,10 @@ RegisterID* BytecodeGenerator::emitCall(RegisterID* dst, RegisterID* func, Expec
             if (expression->isArrayLiteral()) {
                 auto* elements = static_cast<ArrayNode*>(expression)->elements();
                 if (elements && !elements->next() && elements->value()->isSpreadExpression()) {
-                    ExpressionNode* expression = static_cast<SpreadExpressionNode*>(elements->value())->expression();
+                    auto* spread = static_cast<SpreadExpressionNode*>(elements->value());
+                    ExpressionNode* expression = spread->expression();
                     RefPtr<RegisterID> argumentRegister = tempDestination(emitNode(callArguments.argumentRegister(0), expression));
+                    emitExpressionInfo(spread->divot(), spread->divotStart(), spread->divotEnd());
                     OpSpread::emit(this, argumentRegister.get(), argumentRegister.get());
 
                     return emitCallVarargs<typename VarArgsOp<CallOp>::type>(dst, func, callArguments.thisRegister(), argumentRegister.get(), newTemporary(), 0, divot, divotStart, divotEnd, debuggableCall);
@@ -3985,11 +3989,14 @@ RegisterID* BytecodeGenerator::emitConstructImpl(RegisterID* dst, RegisterID* fu
             if (expression->isArrayLiteral()) {
                 auto* elements = static_cast<ArrayNode*>(expression)->elements();
                 if (elements && !elements->next() && elements->value()->isSpreadExpression()) {
-                    ExpressionNode* expression = static_cast<SpreadExpressionNode*>(elements->value())->expression();
+                    auto* spread = static_cast<SpreadExpressionNode*>(elements->value());
+                    ExpressionNode* expression = spread->expression();
                     RefPtr<RegisterID> argumentRegister = tempDestination(emitNode(callArguments.argumentRegister(0), expression));
 
-                    if (!isDefaultDerivedConstructorCall)
+                    if (!isDefaultDerivedConstructorCall) {
+                        emitExpressionInfo(spread->divot(), spread->divotStart(), spread->divotEnd());
                         OpSpread::emit(this, argumentRegister.get(), argumentRegister.get());
+                    }
 
                     move(callArguments.thisRegister(), lazyThis);
                     return emitCallVarargs<typename VarArgsOp<ConstructOp>::type>(dst, func, callArguments.thisRegister(), argumentRegister.get(), newTemporary(), 0, divot, divotStart, divotEnd, DebuggableCall::No);
@@ -4972,6 +4979,7 @@ void BytecodeGenerator::emitEnumeration(ThrowableExpressionData* node, Expressio
     RefPtr<RegisterID> nextOrIndex = newTemporary();
     RefPtr<RegisterID> iterator = newTemporary();
     {
+        emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
         RefPtr<RegisterID> iteratorSymbol = emitGetById(newTemporary(), iterable.get(), propertyNames().iteratorSymbol);
         CallArguments args(*this, nullptr, 0);
         move(args.thisRegister(), iterable.get());
@@ -5400,6 +5408,7 @@ void BytecodeGenerator::emitIteratorNext(RegisterID* done, RegisterID* value, Re
 
 RegisterID* BytecodeGenerator::emitGetGenericIterator(RegisterID* argument, ThrowableExpressionData* node)
 {
+    emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
     RefPtr<RegisterID> iterator = emitGetById(newTemporary(), argument, propertyNames().iteratorSymbol);
     emitCallIterator(iterator.get(), argument, node);
 
@@ -5459,6 +5468,7 @@ void BytecodeGenerator::emitIteratorGenericClose(RegisterID* iterator, const Thr
 
 RegisterID* BytecodeGenerator::emitGetAsyncIterator(RegisterID* argument, ThrowableExpressionData* node)
 {
+    emitExpressionInfo(node->divot(), node->divotStart(), node->divotEnd());
     RefPtr<RegisterID> iterator = emitGetById(newTemporary(), argument, propertyNames().asyncIteratorSymbol);
     Ref<Label> asyncIteratorNotFound = newLabel();
     Ref<Label> asyncIteratorFound = newLabel();

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -6029,6 +6029,7 @@ void ArrayPatternNode::bindValue(BytecodeGenerator& generator, RegisterID* rhs) 
     RefPtr<RegisterID> iterator = generator.newTemporary();
     RefPtr<RegisterID> nextOrIndex = generator.newTemporary();
     {
+        generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
         RefPtr<RegisterID> iteratorSymbol = generator.emitGetById(generator.newTemporary(), iterable.get(), generator.propertyNames().iteratorSymbol);
         CallArguments args(generator, nullptr, 0);
         generator.move(args.thisRegister(), iterable.get());


### PR DESCRIPTION
#### 970dcc8db7e57aeade0101a0d9b0996e2ec4190c
<pre>
[JSC] Emit expression info before `[Symbol.iterator]` get and spread
<a href="https://bugs.webkit.org/show_bug.cgi?id=317733">https://bugs.webkit.org/show_bug.cgi?id=317733</a>

Reviewed by Yusuke Suzuki.

When the subject of for-of / for-await-of / array destructuring / yield* /
array spread is a constant or other node that does not itself emit expression
info (e.g. a null or undefined literal), the get_by_id for [Symbol.iterator]
(or the OpSpread) inherited the previous statement&apos;s expression range. The
resulting TypeError was attributed to the wrong line and the &quot;evaluating &apos;...&apos;&quot;
text quoted the previous statement.

    print(&quot;here&quot;);
    for (const b of null) {}
    // TypeError: null is not an object (evaluating &apos;print(&quot;here&quot;)&apos;)
    //     at test.js:1:6

Emit expression info from the enclosing ThrowableExpressionData before each of
these ops so the throw is attributed to the iterating construct itself,
matching what emitIteratorOpen / emitIteratorNext already do.

    // TypeError: null is not an object (evaluating &apos;b of null&apos;)
    //     at test.js:2:14

Test: JSTests/stress/iterator-open-expression-info.js

* JSTests/stress/catch-rest-parameter.js:
(async let):
(shouldThrow.async f):
(shouldThrow.f):
* JSTests/stress/iterator-error-messages-consistent.js:
* JSTests/stress/iterator-open-expression-info.js: Added.
(shouldBe):
(await):
* LayoutTests/js/arguments-iterator-expected.txt:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitNewArrayWithSpread):
(JSC::BytecodeGenerator::emitCall):
(JSC::BytecodeGenerator::emitConstructImpl):
(JSC::BytecodeGenerator::emitEnumeration):
(JSC::BytecodeGenerator::emitGetGenericIterator):
(JSC::BytecodeGenerator::emitGetAsyncIterator):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ArrayPatternNode::bindValue const):

Canonical link: <a href="https://commits.webkit.org/315867@main">https://commits.webkit.org/315867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78133ef70345b05c08c2ee2215c9b9439eb6b943

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37976 "Built successfully and passed tests") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->