### PR TITLE
unifi.ui.com: Security camera video playback not working in Safari, works in Chrome

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2053,6 +2053,9 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
         .contentType = WTF::move(contentType),
         .requiresRemotePlayback = !!m_remotePlaybackConfiguration,
         .supportsLimitedMatroska = limitedMatroskaSupportEnabled(),
+#if ENABLE(MEDIA_SOURCE)
+        .supportsProgressMonitoringOverride = protect(document())->quirks().needsSupportsProgressMonitoring() ? std::optional<bool> { true } : std::nullopt,
+#endif
     };
 
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2621,6 +2621,13 @@ bool Quirks::needsLimitedMatroskaSupport() const
 #endif
 }
 
+#if ENABLE(MEDIA_SOURCE)
+bool Quirks::needsSupportsProgressMonitoring() const
+{
+    return isDomain("ui.com"_s);
+}
+#endif
+
 // rdar://174779259.
 // Anthropic's claude.ai SPA, after a logout, leaves some identification cookies behind.
 // On the next /chat boot those non-auth cookies are enough to push the SPA into an

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -319,6 +319,9 @@ public:
     bool NODELETE needsFacebookStoriesCreationFormQuirk(const Element&, const Style::ComputedStyle&) const;
 
     bool needsLimitedMatroskaSupport() const;
+#if ENABLE(MEDIA_SOURCE)
+    bool needsSupportsProgressMonitoring() const;
+#endif
 
     bool needsCustomUserAgentData() const;
     bool needsNavigatorUserAgentDataQuirk() const;

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -180,6 +180,7 @@ struct MediaPlayerLoadOptions {
     ContentType contentType { };
     bool requiresRemotePlayback { false };
     bool supportsLimitedMatroska { false };
+    std::optional<bool> supportsProgressMonitoringOverride { };
     VideoRendererPreferences videoRendererPreferences { };
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -309,7 +309,7 @@ private:
     void updateStateFromReadyState();
     void mediaSourceHasRetrievedAllData() final;
 
-    bool supportsProgressMonitoring() const final { return false; }
+    bool supportsProgressMonitoring() const final;
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool supportsLinearMediaPlayer() const final { return true; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1566,6 +1566,13 @@ void MediaPlayerPrivateMediaSourceAVFObjC::screenReservedChanged(bool reserved)
 }
 #endif
 
+bool MediaPlayerPrivateMediaSourceAVFObjC::supportsProgressMonitoring() const
+{
+    assertIsMainThread();
+    return m_loadOptions.supportsProgressMonitoringOverride.value_or(false);
+}
+
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
@@ -254,6 +254,7 @@ header: <WebCore/MediaPlayer.h>
     WebCore::ContentType contentType;
     bool requiresRemotePlayback;
     bool supportsLimitedMatroska;
+    std::optional<bool> supportsProgressMonitoringOverride;
     OptionSet<WebCore::VideoRendererPreference> videoRendererPreferences;
 };
 


### PR DESCRIPTION
#### e59e5a3f448911f6f7eb31402640a5ec93d8358c
<pre>
unifi.ui.com: Security camera video playback not working in Safari, works in Chrome
<a href="https://bugs.webkit.org/show_bug.cgi?id=317742">https://bugs.webkit.org/show_bug.cgi?id=317742</a>
<a href="https://rdar.apple.com/180411019">rdar://180411019</a>

Reviewed by Eric Carlson.

Per spec, the `stalled`, `progress`, `suspend` events are controlled
by the  resource fetch algorithm (#1) when the mode is `remote`.
The Media Source Extension override the resource fetch algorithm and set the
mode as `local` (#2) in the resource fetch algorithm.
As such those media events can&apos;t be fired with MSE. MediaSource spec however
do mention that is is possible for an implementation to fire those events (#3)
in a 10 years old note stating:
&quot;An attached MediaSource does not use the remote mode steps in the resource
fetch algorithm, so the media element will not fire &quot;suspend&quot; events.
Though future versions of this specification will likely remove &quot;progress&quot;
and &quot;stalled&quot; events from a media element with an attached MediaSource,
user agents conforming to this version of the specification may still fire
these two events as these [HTML] references changed after implementations
of this specification stabilized.&quot;

Some media-source web-platform-tests do test that no stalled or progress
event are fired (which both Firefox and Chrome pass indicating that they
do not fire the `progress` event either).

A bug in the MediaPlayerPrivateRemote made it always fire the `progress`
event at regular interval as it never checked the MediaPlayerPrivate::supportsProgressMonitoring
and so Safari used to fire this event at regular interval when using MSE.
When MediaContainment was enabled, supportsProgressMonitoring override became
functional again and MediaPlayerPrivateMediaSourceAVFObjC::supportsProgressMonitoring
returned false.

Unifi.ui.com web player listen to the `progress` event to determine when
to call `play()`, as no progress event is fired with MSE, play() wasn&apos;t called
and so playback never started and only the first video frame was shown.

We add a quirk for ui.com that forces the `progress`, `suspend`, `stalled`
event to be fired. Note that `stalled` is fired often in this mode as
it is fired if nothing has been downloaded for 3s. With MSE it is not uncommon
to have the JS player only enqueue new content every 10s or so and media
is progressing properly.

1)<a href="https://html.spec.whatwg.org/multipage/media.html#concept-media-load-resource">https://html.spec.whatwg.org/multipage/media.html#concept-media-load-resource</a>
2)<a href="https://www.w3.org/TR/media-source-2/#mediasource-attach">https://www.w3.org/TR/media-source-2/#mediasource-attach</a>

Manually tested.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::supportsProgressMonitoring const):
* Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in:

Canonical link: <a href="https://commits.webkit.org/315774@main">https://commits.webkit.org/315774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/715b663662806c3ea581f6875e0a48f2d05019a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127685 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f2062fa-43e0-49ae-9dda-f3ef95527e4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132485 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce1cbb95-a16a-41a2-8238-4b50511d8d35) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172932 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112987 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b56a43b-4195-49b0-bb5c-7f5407b853a5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28031 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181932 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140937 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43551 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140771 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37909 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44240 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29296 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108572 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36035 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116005 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42751 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7396 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42143 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42398 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42286 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->