### PR TITLE
Work around GCC 14+ false -Wuninitialized in Variant

### DIFF
--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -1520,6 +1520,11 @@ namespace mpark {
               alt_at<I>(in_place_t{}, lib::forward<Args>(args)...);
       }
 
+// GCC 14 through 16 emit a bogus -Wuninitialized for index_ when these
+// accessors are inlined into HashTable bucket teardown (e.g.
+// HashMap<GenericHashKey<...>, ...>::remove()), even though index_ is set by
+// every base constructor. Clang and GCC <= 13 are unaffected.
+IGNORE_GCC_WARNINGS_BEGIN("uninitialized")
       inline constexpr bool valueless_by_exception() const noexcept {
         return index_ == static_cast<index_t<Ts...>>(-1);
       }
@@ -1527,6 +1532,7 @@ namespace mpark {
       inline constexpr std::size_t index() const noexcept {
         return valueless_by_exception() ? variant_npos : index_;
       }
+IGNORE_GCC_WARNINGS_END
 
       template <std::size_t I> inline constexpr alt_at<I> &get_alt() & noexcept {
         return *std::launder(reinterpret_cast<alt_at<I> *>(data_.storage_));


### PR DESCRIPTION
#### 73da1e5722c9c299034ea3d18d8ea8fa87e1f2b1
<pre>
Work around GCC 14+ false -Wuninitialized in Variant
<a href="https://bugs.webkit.org/show_bug.cgi?id=317745">https://bugs.webkit.org/show_bug.cgi?id=317745</a>

Reviewed by Nikolas Zimmermann.

GCC 14 through 16 report mpark variant&apos;s index_ as used uninitialized when
valueless_by_exception()/index() inline into
HashMap&lt;GenericHashKey&lt;...&gt;, ...&gt;::remove(), even though index_ is set by
every base constructor. This breaks --fatal-warnings builds (e.g. Ubuntu
26.04 / GCC 15). Suppress -Wuninitialized around the two accessors on GCC;
clang and GCC &lt;= 13 are unaffected.

* Source/WTF/wtf/Variant.h:

Canonical link: <a href="https://commits.webkit.org/315766@main">https://commits.webkit.org/315766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c1dad10c371e72c99cab223b0da1d1cb5d95e0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43891 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37317 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127681 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132486 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172928 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112988 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32623 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28027 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1342 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32324 "Passed tests") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31224 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140935 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43547 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140769 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44236 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108568 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25906 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36033 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116001 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202648 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42747 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7406 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54310 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->