### PR TITLE
[GTK][WPE] Skia Compositor: directly composited image is painted as a solid rectangle when partially offscreen

### DIFF
--- a/LayoutTests/compositing/patterns/direct-pattern-compositing-offscreen-expected.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing-offscreen-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <style>
+    .test {
+      position: absolute;
+      top: -100px;
+      left: -40px;
+      width: 200px;
+      height: 200px;
+      background: url(../resources/alpha-gradient.png) no-repeat;
+    }
+  </style>
+</head>
+<body>
+  <div class="test"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/patterns/direct-pattern-compositing-offscreen.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing-offscreen.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-4000" />
+  <style>
+    .test {
+      position: absolute;
+      top: -100px;
+      left: -40px;
+      width: 200px;
+      height: 200px;
+      background: url(../resources/alpha-gradient.png) no-repeat;
+      will-change: opacity;
+    }
+  </style>
+</head>
+<body>
+  <div class="test"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -564,7 +564,7 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 sk_sp<SkImage> tileImage = std::exchange(image, nullptr);
                 SkMatrix matrix;
                 matrix.setScale(m_contentsTiling.size.width() / tileImage->width(), m_contentsTiling.size.height() / tileImage->height());
-                matrix.postTranslate(-m_contentsTiling.phase.width(), -m_contentsTiling.phase.height());
+                matrix.postTranslate(m_contentsRect.x() - m_contentsTiling.phase.width(), m_contentsRect.y() - m_contentsTiling.phase.height());
                 SkPaint paint = setupPaint();
                 paint.setShader(tileImage->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), matrix));
                 canvas.drawRect(m_contentsRect, paint);


### PR DESCRIPTION
#### 14dfefc6795a38c665aaa22ec596ae1e887c3dd2
<pre>
[GTK][WPE] Skia Compositor: directly composited image is painted as a solid rectangle when partially offscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=317744">https://bugs.webkit.org/show_bug.cgi?id=317744</a>

Reviewed by Carlos Garcia Campos.

A directly composited image is drawn in SkiaCompositingLayer::paintContents()
with an SkShader whose local matrix was computed from the contents tile size
and phase only, ignoring the contents rect origin. When the layer is partially
clipped (for instance an element positioned partly offscreen) the contents rect
has a non-zero, negative origin, so the kRepeat shader sampled the wrong region
of the image and the layer was painted as an opaque rectangle instead of the
image&apos;s actual shape.

Anchor the pattern at the contents rect origin, matching both the non-tiled
drawImageRect() path below it and the TextureMapper implementation. It is a
no-op when the contents rect origin is zero.

Added a new layout test:
  - compositing/patterns/direct-pattern-compositing-offscreen.html

* LayoutTests/compositing/patterns/direct-pattern-compositing-offscreen-expected.html: Added.
* LayoutTests/compositing/patterns/direct-pattern-compositing-offscreen.html: Added.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintContents):

Canonical link: <a href="https://commits.webkit.org/315748@main">https://commits.webkit.org/315748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe4a2d2e52d5efeee6ac462110035b02e222be7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171836 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172929 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112984 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28028 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144646 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181929 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140933 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37897 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44237 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108569 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36032 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116002 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42748 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->