### PR TITLE
WebGL: GL limits are queried synchronously during context initialization

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -132,19 +132,19 @@ void WebGL2RenderingContext::initializeContextState()
     WebGLRenderingContextBase::initializeContextState();
 
     RefPtr context = m_context;
-    m_maxTransformFeedbackSeparateAttribs = context->getInteger(GraphicsContextGL::MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS);
+    m_maxTransformFeedbackSeparateAttribs = context->maxTransformFeedbackSeparateAttribs();
 
     m_defaultTransformFeedback = WebGLTransformFeedback::create(*this);
     m_boundTransformFeedback = m_defaultTransformFeedback;
     if (m_defaultTransformFeedback)
         context->bindTransformFeedback(GraphicsContextGL::TRANSFORM_FEEDBACK, m_defaultTransformFeedback->object());
 
-    m_boundIndexedUniformBuffers.resize(context->getInteger(GraphicsContextGL::MAX_UNIFORM_BUFFER_BINDINGS));
-    m_uniformBufferOffsetAlignment = context->getInteger(GraphicsContextGL::UNIFORM_BUFFER_OFFSET_ALIGNMENT);
+    m_boundIndexedUniformBuffers.resize(context->maxUniformBufferBindings());
+    m_uniformBufferOffsetAlignment = context->uniformBufferOffsetAlignment();
 
-    m_max3DTextureSize = context->getInteger(GraphicsContextGL::MAX_3D_TEXTURE_SIZE);
+    m_max3DTextureSize = context->max3DTextureSize();
     m_max3DTextureLevel = WebGLTexture::computeLevelCount(m_max3DTextureSize, m_max3DTextureSize);
-    m_maxArrayTextureLayers = context->getInteger(GraphicsContextGL::MAX_ARRAY_TEXTURE_LAYERS);
+    m_maxArrayTextureLayers = context->maxArrayTextureLayers();
 
     m_boundSamplers.resize(m_textureUnits.size());
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -558,21 +558,20 @@ void WebGLRenderingContextBase::initializeContextState()
     m_colorMask[0] = m_colorMask[1] = m_colorMask[2] = m_colorMask[3] = true;
 
     RefPtr context = m_context;
-    GCGLint numCombinedTextureImageUnits = context->getInteger(GraphicsContextGL::MAX_COMBINED_TEXTURE_IMAGE_UNITS);
+    GCGLint numCombinedTextureImageUnits = context->maxCombinedTextureImageUnits();
     m_textureUnits.clear();
     m_textureUnits.grow(numCombinedTextureImageUnits);
 
-    GCGLint numVertexAttribs = context->getInteger(GraphicsContextGL::MAX_VERTEX_ATTRIBS);
+    GCGLint numVertexAttribs = context->maxVertexAttribs();
     m_vertexAttribValue.clear();
     m_vertexAttribValue.grow(numVertexAttribs);
 
-    m_maxTextureSize = context->getInteger(GraphicsContextGL::MAX_TEXTURE_SIZE);
+    m_maxTextureSize = context->maxTextureSize();
     m_maxTextureLevel = WebGLTexture::computeLevelCount(m_maxTextureSize, m_maxTextureSize);
-    m_maxCubeMapTextureSize = context->getInteger(GraphicsContextGL::MAX_CUBE_MAP_TEXTURE_SIZE);
+    m_maxCubeMapTextureSize = context->maxCubeMapTextureSize();
     m_maxCubeMapTextureLevel = WebGLTexture::computeLevelCount(m_maxCubeMapTextureSize, m_maxCubeMapTextureSize);
-    m_maxRenderbufferSize = context->getInteger(GraphicsContextGL::MAX_RENDERBUFFER_SIZE);
-    m_maxViewportDims = { 0, 0 };
-    context->getIntegerv(GraphicsContextGL::MAX_VIEWPORT_DIMS, m_maxViewportDims);
+    m_maxRenderbufferSize = context->maxRenderbufferSize();
+    m_maxViewportDims = context->maxViewportDims();
     m_isDepthStencilSupported = context->enableExtension(GCGLExtension::OES_packed_depth_stencil) || context->enableExtension(GCGLExtension::ANGLE_depth_texture);
     auto glAttributes = m_context->contextAttributes();
     m_attributes.powerPreference = glAttributes.powerPreference;
@@ -587,7 +586,7 @@ void WebGLRenderingContextBase::initializeContextState()
     }
     // WebXR might use multisampling in WebGL2 context. Multisample extensions are also enabled in WebGL 1 case context
     // is antialiased.
-    m_maxSamples = (isWebGL2() || m_attributes.antialias) ? context->getInteger(GraphicsContextGL::MAX_SAMPLES) : 0;
+    m_maxSamples = (isWebGL2() || m_attributes.antialias) ? context->maxSamples() : 0;
 
     // These two values from EXT_draw_buffers are lazily queried.
     m_maxDrawBuffers = 0;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -38,6 +38,7 @@
 #include <WebCore/Image.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
+#include <array>
 #include <span>
 #include <wtf/EnumSet.h>
 #include <wtf/FunctionDispatcher.h>
@@ -1653,6 +1654,22 @@ public:
 
     GraphicsContextGLAttributes contextAttributes() const { return m_attrs; }
     void setContextAttributes(const GraphicsContextGLAttributes& attrs) { m_attrs = attrs; }
+
+    // Static GL implementation limits. These never change for the lifetime of
+    // the context, so the remote-context implementation caches them at context
+    // creation and returns them without an IPC round-trip.
+    virtual GCGLint maxCombinedTextureImageUnits() = 0;
+    virtual GCGLint maxVertexAttribs() = 0;
+    virtual GCGLint maxTextureSize() = 0;
+    virtual GCGLint maxCubeMapTextureSize() = 0;
+    virtual GCGLint maxRenderbufferSize() = 0;
+    virtual std::array<GCGLint, 2> maxViewportDims() = 0;
+    virtual GCGLint maxSamples() = 0;
+    virtual GCGLint maxTransformFeedbackSeparateAttribs() = 0;
+    virtual GCGLint maxUniformBufferBindings() = 0;
+    virtual GCGLint uniformBufferOffsetAlignment() = 0;
+    virtual GCGLint max3DTextureSize() = 0;
+    virtual GCGLint maxArrayTextureLayers() = 0;
 
     virtual std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint();
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -592,6 +592,68 @@ void GraphicsContextGLANGLE::getIntegeri_v(GCGLenum pname, GCGLuint index, std::
     GL_GetIntegeri_vRobustANGLE(pname, index, value.size(), nullptr, value.data());
 }
 
+GCGLint GraphicsContextGLANGLE::maxCombinedTextureImageUnits()
+{
+    return getInteger(GraphicsContextGL::MAX_COMBINED_TEXTURE_IMAGE_UNITS);
+}
+
+GCGLint GraphicsContextGLANGLE::maxVertexAttribs()
+{
+    return getInteger(GraphicsContextGL::MAX_VERTEX_ATTRIBS);
+}
+
+GCGLint GraphicsContextGLANGLE::maxTextureSize()
+{
+    return getInteger(GraphicsContextGL::MAX_TEXTURE_SIZE);
+}
+
+GCGLint GraphicsContextGLANGLE::maxCubeMapTextureSize()
+{
+    return getInteger(GraphicsContextGL::MAX_CUBE_MAP_TEXTURE_SIZE);
+}
+
+GCGLint GraphicsContextGLANGLE::maxRenderbufferSize()
+{
+    return getInteger(GraphicsContextGL::MAX_RENDERBUFFER_SIZE);
+}
+
+std::array<GCGLint, 2> GraphicsContextGLANGLE::maxViewportDims()
+{
+    std::array<GCGLint, 2> dims { 0, 0 };
+    getIntegerv(GraphicsContextGL::MAX_VIEWPORT_DIMS, dims);
+    return dims;
+}
+
+GCGLint GraphicsContextGLANGLE::maxSamples()
+{
+    return getInteger(GraphicsContextGL::MAX_SAMPLES);
+}
+
+GCGLint GraphicsContextGLANGLE::maxTransformFeedbackSeparateAttribs()
+{
+    return getInteger(GraphicsContextGL::MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS);
+}
+
+GCGLint GraphicsContextGLANGLE::maxUniformBufferBindings()
+{
+    return getInteger(GraphicsContextGL::MAX_UNIFORM_BUFFER_BINDINGS);
+}
+
+GCGLint GraphicsContextGLANGLE::uniformBufferOffsetAlignment()
+{
+    return getInteger(GraphicsContextGL::UNIFORM_BUFFER_OFFSET_ALIGNMENT);
+}
+
+GCGLint GraphicsContextGLANGLE::max3DTextureSize()
+{
+    return getInteger(GraphicsContextGL::MAX_3D_TEXTURE_SIZE);
+}
+
+GCGLint GraphicsContextGLANGLE::maxArrayTextureLayers()
+{
+    return getInteger(GraphicsContextGL::MAX_ARRAY_TEXTURE_LAYERS);
+}
+
 void GraphicsContextGLANGLE::getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType, std::span<GCGLint, 2> range, GCGLint* precision)
 {
     if (!makeContextCurrent())

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -115,6 +115,19 @@ public:
     void getIntegeri_v(GCGLenum pname, GCGLuint index, std::span<GCGLint, 4> value) final; // NOLINT
     GCGLint64 getInteger64(GCGLenum pname) final;
     GCGLint64 getInteger64i(GCGLenum pname, GCGLuint index) final;
+
+    GCGLint maxCombinedTextureImageUnits() final;
+    GCGLint maxVertexAttribs() final;
+    GCGLint maxTextureSize() final;
+    GCGLint maxCubeMapTextureSize() final;
+    GCGLint maxRenderbufferSize() final;
+    std::array<GCGLint, 2> maxViewportDims() final;
+    GCGLint maxSamples() final;
+    GCGLint maxTransformFeedbackSeparateAttribs() final;
+    GCGLint maxUniformBufferBindings() final;
+    GCGLint uniformBufferOffsetAlignment() final;
+    GCGLint max3DTextureSize() final;
+    GCGLint maxArrayTextureLayers() final;
     GCGLint getProgrami(PlatformGLObject program, GCGLenum pname) final;
     CString getProgramInfoLog(PlatformGLObject) final;
     GCGLint getRenderbufferParameteri(GCGLenum target, GCGLenum pname) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -128,6 +128,7 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
     m_connection->open(*this, m_workQueue);
     if (RefPtr context = m_context) {
         context->setClient(this);
+        auto contextAttributes = context->contextAttributes();
         auto knownActiveExtensions = context->knownActiveExtensions();
         auto requestableExtensions = context->requestableExtensions();
         auto [externalImageTarget, externalImageBindingQuery] = context->externalImageTextureBindingPoint();
@@ -137,7 +138,22 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
             .requestableExtensions = requestableExtensions.toRaw(),
             .externalImageTarget = externalImageTarget,
             .externalImageBindingQuery = externalImageBindingQuery,
+            .maxCombinedTextureImageUnits = context->maxCombinedTextureImageUnits(),
+            .maxVertexAttribs = context->maxVertexAttribs(),
+            .maxTextureSize = context->maxTextureSize(),
+            .maxCubeMapTextureSize = context->maxCubeMapTextureSize(),
+            .maxRenderbufferSize = context->maxRenderbufferSize(),
+            .maxViewportDims = context->maxViewportDims(),
         };
+        if (contextAttributes.isWebGL2 || contextAttributes.antialias)
+            initializationState.maxSamples = context->maxSamples();
+        if (contextAttributes.isWebGL2) {
+            initializationState.maxTransformFeedbackSeparateAttribs = context->maxTransformFeedbackSeparateAttribs();
+            initializationState.maxUniformBufferBindings = context->maxUniformBufferBindings();
+            initializationState.uniformBufferOffsetAlignment = context->uniformBufferOffsetAlignment();
+            initializationState.max3DTextureSize = context->max3DTextureSize();
+            initializationState.maxArrayTextureLayers = context->maxArrayTextureLayers();
+        }
         send(Messages::RemoteGraphicsContextGLProxy::WasCreated(workQueue().wakeUpSemaphore(), m_connection->clientWaitSemaphore(), { initializationState }));
         m_connection->startReceivingMessages(*this, Messages::RemoteGraphicsContextGL::messageReceiverName(), m_identifier.toUInt64());
     } else

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h
@@ -30,6 +30,7 @@
 #include <WebCore/GCGLExtension.h>
 #include <WebCore/GraphicsContextGLAttributes.h>
 #include <WebCore/GraphicsTypesGL.h>
+#include <array>
 #include <wtf/OptionSet.h>
 
 namespace WebKit {
@@ -40,6 +41,18 @@ struct RemoteGraphicsContextGLInitializationState {
     uint64_t requestableExtensions { 0 }; // EnumSet<WebCore::GCGLExtension> when EnumSet serialization works.
     GCGLenum externalImageTarget { 0 };
     GCGLenum externalImageBindingQuery { 0 };
+    GCGLint maxCombinedTextureImageUnits { 0 };
+    GCGLint maxVertexAttribs { 0 };
+    GCGLint maxTextureSize { 0 };
+    GCGLint maxCubeMapTextureSize { 0 };
+    GCGLint maxRenderbufferSize { 0 };
+    std::array<GCGLint, 2> maxViewportDims { { 0, 0 } };
+    GCGLint maxSamples { 0 };
+    GCGLint maxTransformFeedbackSeparateAttribs { 0 };
+    GCGLint maxUniformBufferBindings { 0 };
+    GCGLint uniformBufferOffsetAlignment { 0 };
+    GCGLint max3DTextureSize { 0 };
+    GCGLint maxArrayTextureLayers { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in
@@ -28,6 +28,18 @@ struct WebKit::RemoteGraphicsContextGLInitializationState {
     uint64_t requestableExtensions;
     GCGLenum externalImageTarget;
     GCGLenum externalImageBindingQuery;
+    GCGLint maxCombinedTextureImageUnits;
+    GCGLint maxVertexAttribs;
+    GCGLint maxTextureSize;
+    GCGLint maxCubeMapTextureSize;
+    GCGLint maxRenderbufferSize;
+    std::array<GCGLint, 2> maxViewportDims;
+    GCGLint maxSamples;
+    GCGLint maxTransformFeedbackSeparateAttribs;
+    GCGLint maxUniformBufferBindings;
+    GCGLint uniformBufferOffsetAlignment;
+    GCGLint max3DTextureSize;
+    GCGLint maxArrayTextureLayers;
 };
 
 enum class WebCore::TextDrawingMode : uint8_t {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -154,6 +154,18 @@ void RemoteGraphicsContextGLProxy::initialize(const RemoteGraphicsContextGLIniti
     m_requestableExtensions = EnumSet<GCGLExtension>::fromRaw(initializationState.requestableExtensions);
     m_externalImageTarget = initializationState.externalImageTarget;
     m_externalImageBindingQuery = initializationState.externalImageBindingQuery;
+    m_maxCombinedTextureImageUnits = initializationState.maxCombinedTextureImageUnits;
+    m_maxVertexAttribs = initializationState.maxVertexAttribs;
+    m_maxTextureSize = initializationState.maxTextureSize;
+    m_maxCubeMapTextureSize = initializationState.maxCubeMapTextureSize;
+    m_maxRenderbufferSize = initializationState.maxRenderbufferSize;
+    m_maxViewportDims = initializationState.maxViewportDims;
+    m_maxSamples = initializationState.maxSamples;
+    m_maxTransformFeedbackSeparateAttribs = initializationState.maxTransformFeedbackSeparateAttribs;
+    m_maxUniformBufferBindings = initializationState.maxUniformBufferBindings;
+    m_uniformBufferOffsetAlignment = initializationState.uniformBufferOffsetAlignment;
+    m_max3DTextureSize = initializationState.max3DTextureSize;
+    m_maxArrayTextureLayers = initializationState.maxArrayTextureLayers;
 }
 
 std::tuple<GCGLenum, GCGLenum> RemoteGraphicsContextGLProxy::externalImageTextureBindingPoint()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -79,6 +79,19 @@ public:
     bool supportsExtension(WebCore::GCGLExtension) final;
     bool enableExtension(WebCore::GCGLExtension) final;
 
+    GCGLint maxCombinedTextureImageUnits() final { return m_maxCombinedTextureImageUnits; }
+    GCGLint maxVertexAttribs() final { return m_maxVertexAttribs; }
+    GCGLint maxTextureSize() final { return m_maxTextureSize; }
+    GCGLint maxCubeMapTextureSize() final { return m_maxCubeMapTextureSize; }
+    GCGLint maxRenderbufferSize() final { return m_maxRenderbufferSize; }
+    std::array<GCGLint, 2> maxViewportDims() final { return m_maxViewportDims; }
+    GCGLint maxSamples() final { return m_maxSamples; }
+    GCGLint maxTransformFeedbackSeparateAttribs() final { return m_maxTransformFeedbackSeparateAttribs; }
+    GCGLint maxUniformBufferBindings() final { return m_maxUniformBufferBindings; }
+    GCGLint uniformBufferOffsetAlignment() final { return m_uniformBufferOffsetAlignment; }
+    GCGLint max3DTextureSize() final { return m_max3DTextureSize; }
+    GCGLint maxArrayTextureLayers() final { return m_maxArrayTextureLayers; }
+
     RefPtr<WebCore::NativeImage> copyNativeImageYFlipped(SurfaceBuffer) final;
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     RefPtr<WebCore::VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) final;
@@ -421,6 +434,18 @@ private:
 #endif
     GCGLenum m_externalImageTarget { 0 };
     GCGLenum m_externalImageBindingQuery { 0 };
+    GCGLint m_maxCombinedTextureImageUnits { 0 };
+    GCGLint m_maxVertexAttribs { 0 };
+    GCGLint m_maxTextureSize { 0 };
+    GCGLint m_maxCubeMapTextureSize { 0 };
+    GCGLint m_maxRenderbufferSize { 0 };
+    std::array<GCGLint, 2> m_maxViewportDims { 0, 0 };
+    GCGLint m_maxSamples { 0 };
+    GCGLint m_maxTransformFeedbackSeparateAttribs { 0 };
+    GCGLint m_maxUniformBufferBindings { 0 };
+    GCGLint m_uniformBufferOffsetAlignment { 0 };
+    GCGLint m_max3DTextureSize { 0 };
+    GCGLint m_maxArrayTextureLayers { 0 };
     uint32_t m_nextObjectName { 0 };
     WebCore::DestinationColorSpace m_drawingBufferColorSpace { WebCore::DestinationColorSpace::SRGB() };
     WeakPtr<RemoteRenderingBackendProxy> m_renderingBackend;


### PR DESCRIPTION
#### 3eb3120db40bf4ad49ce7f69a44220f959520d50
<pre>
WebGL: GL limits are queried synchronously during context initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=317746">https://bugs.webkit.org/show_bug.cgi?id=317746</a>
<a href="https://rdar.apple.com/180503395">rdar://180503395</a>

Reviewed by Dan Glastonbury.

Make all limits used in context creation be sent as initialization
parameters. This way the initialization does not run extra synchronous
queries to GPUP.

Works towards avoiding open-ended queries to GPUP.

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::initializeContextState):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::maxCombinedTextureImageUnits):
(WebCore::GraphicsContextGLANGLE::maxVertexAttribs):
(WebCore::GraphicsContextGLANGLE::maxTextureSize):
(WebCore::GraphicsContextGLANGLE::maxCubeMapTextureSize):
(WebCore::GraphicsContextGLANGLE::maxRenderbufferSize):
(WebCore::GraphicsContextGLANGLE::maxViewportDims):
(WebCore::GraphicsContextGLANGLE::maxSamples):
(WebCore::GraphicsContextGLANGLE::maxTransformFeedbackSeparateAttribs):
(WebCore::GraphicsContextGLANGLE::maxUniformBufferBindings):
(WebCore::GraphicsContextGLANGLE::uniformBufferOffsetAlignment):
(WebCore::GraphicsContextGLANGLE::max3DTextureSize):
(WebCore::GraphicsContextGLANGLE::maxArrayTextureLayers):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::initialize):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:

Canonical link: <a href="https://commits.webkit.org/315889@main">https://commits.webkit.org/315889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f17dd7a834deccbed4b35b43a152fdecd991cbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128106 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1fb27e2-81b1-4750-905d-141ebf683092) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5435610e-076b-40bc-8a8f-907f789ae4cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36043 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113365 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3be11b5f-6ce8-409e-8d72-9d4e517b67a8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28452 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182354 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43974 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37998 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44663 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109125 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36403 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/116545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43173 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7782 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42579 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42819 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->