### PR TITLE
Speech recognition microphone source should make sure to keep its audio session active while capturing

### DIFF
--- a/LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition-expected.txt
+++ b/LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Removing a media session while SpeechRecognition is capturing must not deactivate AudioSession
+

--- a/LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition.html
+++ b/LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../media/media-file.js"></script>
+</head>
+<body>
+<video id="video"></video>
+<script>
+function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+promise_test(async (test) => {
+    assert_true(!!window.internals, "Test requires window.internals");
+    internals.settings.setShouldDeactivateAudioSession(true);
+
+    const recognition = new webkitSpeechRecognition();
+    test.add_cleanup(() => recognition.stop());
+
+    await new Promise((resolve, reject) => {
+        recognition.onstart = resolve;
+        recognition.onerror = (e) => reject(`SpeechRecognition error: ${e.error}`);
+        recognition.start();
+        setTimeout(() => reject("timed out waiting for SpeechRecognition onstart"), 5000);
+    });
+
+    let counter = 0;
+    while (++counter < 50 && !internals.audioSessionActive())
+        await new Promise(resolve => setTimeout(resolve, 50));
+    assert_true(internals.audioSessionActive(), "AudioSession must be active once SpeechRecognition starts capturing");
+
+    const video = document.getElementById("video");
+    video.src = findMediaFile("video", "../../media/content/test");
+    await video.play();
+
+    assert_true(internals.audioSessionActive(), "AudioSession remains active while video and SpeechRecognition are both running");
+
+    video.src = "";
+    video.remove();
+
+    assert_true(internals.audioSessionActive(), "AudioSession must remain active after the video session is removed because SpeechRecognition is capturing");
+    await wait(0);
+    assert_true(internals.audioSessionActive(), "AudioSession must still remain active after the video session is removed because SpeechRecognition is capturing");
+    await wait(10);
+    assert_true(internals.audioSessionActive(), "AudioSession must really remain active after the video session is removed because SpeechRecognition is capturing");
+}, "Removing a media session while SpeechRecognition is capturing must not deactivate AudioSession");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webrtc/audioSessionInFrames.html
+++ b/LayoutTests/http/tests/webrtc/audioSessionInFrames.html
@@ -16,7 +16,6 @@ function with_iframe(url, allow) {
 promise_test(async () => {
     navigator.audioSession.type = "play-and-record";
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    stream.getTracks().forEach(t => t.stop());
 
     const frame1 = await with_iframe("http://localhost:8080/webrtc/resources/audioSessionFrame.html", "microphone:'none'");
     const result1 = await new Promise(resolve => window.onmessage = (event) => resolve(event.data));
@@ -31,6 +30,8 @@ promise_test(async () => {
 
     assert_equals(result2.type, "play-and-record");
     assert_equals(result2.state, "active");
+
+    stream.getTracks().forEach(t => t.stop());
 }, "Allow audioSession in iframes where microphone is allowed");
 </script>
 </body>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3854,6 +3854,7 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html [ WontFix ]
 # Missing WebSpeech implementation
 webkit.org/b/136224 fast/speechrecognition [ Skip ]
 http/tests/media/media-stream/speech-recognition-iframe-allow-attribute.html [ Skip ]
+fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition.html [ Skip ]
 
 # Depends on HTTP Live Streaming (non-supported in non-Apple ports).
 fast/url/data-url-mediatype.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -231,6 +231,8 @@ imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-before-x
 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html [ Skip ]
 webkit.org/b/235072 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-repeating.html [ Skip ]
 
+fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition.html [ Pass Failure ]
+
 webanimations/frame-rate [ Pass ]
 
 imported/w3c/web-platform-tests/fs/ [ Pass ]

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -268,7 +268,7 @@ void MediaStreamTrack::stopTrack(StopMode mode)
 
     if (isAudio() && isCaptureTrack())
         if (RefPtr manager = mediaSessionManager())
-            manager->audioCaptureSourceStateChanged();
+            manager->audioCaptureSourceStateChanged(MediaSessionManagerInterface::IsCaptureStarting::No);
 
     configureTrackRendering();
 }
@@ -559,7 +559,7 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
 
         if (isAudio() && isCaptureTrack())
             if (RefPtr manager = mediaSessionManager())
-                manager->audioCaptureSourceStateChanged();
+                manager->audioCaptureSourceStateChanged(muted ? MediaSessionManagerInterface::IsCaptureStarting::No : MediaSessionManagerInterface::IsCaptureStarting::Yes);
 
         dispatchEvent(Event::create(muted ? eventNames().muteEvent : eventNames().unmuteEvent, Event::CanBubble::No, Event::IsCancelable::No));
     };

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -41,6 +41,10 @@
 #include "SpeechRecognitionResultList.h"
 #include <wtf/TZoneMallocInlines.h>
 
+#if ENABLE(MEDIA_STREAM)
+#include "RealtimeMediaSource.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechRecognition);
@@ -112,6 +116,11 @@ void SpeechRecognition::stop()
 {
     abortRecognition();
 
+#if ENABLE(MEDIA_STREAM)
+    if (RefPtr captureSource = m_captureSource.get())
+        captureSource->stop();
+#endif
+
     if (!m_connection)
         return;
     m_connection->unregisterClient(*this);
@@ -127,6 +136,13 @@ void SpeechRecognition::didStart()
 
     queueTaskToDispatchEvent(*this, TaskSource::Speech, Event::create(eventNames().startEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
+
+#if ENABLE(MEDIA_STREAM)
+void SpeechRecognition::captureSourceCreated(RealtimeMediaSource& source)
+{
+    m_captureSource = source;
+}
+#endif
 
 void SpeechRecognition::didStartCapturingAudio()
 {

--- a/Source/WebCore/Modules/speech/SpeechRecognition.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.h
@@ -31,6 +31,7 @@
 #include "SpeechRecognitionConnection.h"
 #include "SpeechRecognitionConnectionClient.h"
 #include "SpeechRecognitionResult.h"
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
@@ -77,6 +78,9 @@ private:
     explicit SpeechRecognition(Document&);
 
     // SpeechRecognitionConnectionClient
+#if ENABLE(MEDIA_STREAM)
+    void captureSourceCreated(RealtimeMediaSource&) final;
+#endif
     void didStart() final;
     void didStartCapturingAudio() final;
     void didStartCapturingSound() final;
@@ -108,6 +112,9 @@ private:
     State m_state { State::Inactive };
     Vector<Ref<SpeechRecognitionResult>> m_finalResults;
     const RefPtr<SpeechRecognitionConnection> m_connection;
+#if ENABLE(MEDIA_STREAM)
+    ThreadSafeWeakPtr<RealtimeMediaSource> m_captureSource;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognitionConnection.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionConnection.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class RealtimeMediaSource;
 class SpeechRecognitionConnectionClient;
 class SpeechRecognitionUpdate;
 struct ClientOrigin;
@@ -43,6 +44,9 @@ public:
     virtual void stop(SpeechRecognitionConnectionClientIdentifier) = 0;
     virtual void abort(SpeechRecognitionConnectionClientIdentifier) = 0;
     virtual void didReceiveUpdate(SpeechRecognitionUpdate&&) = 0;
+#if ENABLE(MEDIA_STREAM)
+    virtual void dispatchCaptureSourceCreated(SpeechRecognitionConnectionClientIdentifier, RealtimeMediaSource&) { }
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h
@@ -34,12 +34,19 @@ namespace WebCore {
 struct SpeechRecognitionError;
 struct SpeechRecognitionResultData;
 
+#if ENABLE(MEDIA_STREAM)
+class RealtimeMediaSource;
+#endif
+
 class SpeechRecognitionConnectionClient : public Identified<SpeechRecognitionConnectionClientIdentifier>, public AbstractRefCountedAndCanMakeWeakPtr<SpeechRecognitionConnectionClient> {
 public:
     SpeechRecognitionConnectionClient() = default;
 
     virtual ~SpeechRecognitionConnectionClient() { }
 
+#if ENABLE(MEDIA_STREAM)
+    virtual void captureSourceCreated(RealtimeMediaSource&) { }
+#endif
     virtual void didStart() = 0;
     virtual void didStartCapturingAudio() = 0;
     virtual void didStartCapturingSound() = 0;

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -137,8 +137,8 @@ bool AudioSession::tryToSetActive(bool active)
 
     ALWAYS_LOG(LOGIDENTIFIER, "is active = ", active, ", previousIsActive = ", previousIsActive);
 
-    bool hasActiveChanged = previousIsActive != isActive();
-    m_active = active;
+    bool hasActiveChanged = previousIsActive != active;
+    setActive(active);
     if (m_isInterrupted && m_active) {
         callOnMainThread([hasActiveChanged] {
             if (singleton().m_isInterrupted && singleton().m_active)
@@ -150,6 +150,11 @@ bool AudioSession::tryToSetActive(bool active)
         activeStateChanged();
 
     return true;
+}
+
+void AudioSession::setActive(bool active)
+{
+    m_active = active;
 }
 
 static WeakHashSet<AudioSessionInterruptionObserver>& NODELETE audioSessionInterruptionObserversSingleton()

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -153,7 +153,7 @@ public:
     static void addInterruptionObserver(AudioSessionInterruptionObserver&);
     static void removeInterruptionObserver(AudioSessionInterruptionObserver&);
 
-    virtual bool isActive() const { return m_active; }
+    bool isActive() const { return m_active; }
 
     void setRoutingArbitrationClient(AudioSessionRoutingArbitrationClient& client) { m_routingArbitrationClient = client; }
 
@@ -177,6 +177,7 @@ protected:
     AudioSession();
 
     virtual bool tryToSetActiveInternal(bool);
+    void setActive(bool);
     void activeStateChanged();
 
     Logger& logger();

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -578,6 +578,19 @@ void MediaSessionManagerInterface::removeAudioCaptureSource(AudioCaptureSource& 
     scheduleUpdateSessionState();
 }
 
+void MediaSessionManagerInterface::audioCaptureSourceStateChanged(IsCaptureStarting isCaptureStarting)
+{
+    updateSessionState();
+#if USE(AUDIO_SESSION)
+    if (isCaptureStarting == IsCaptureStarting::Yes)
+        maybeActivateAudioSession();
+    else if (!activeAudioSessionRequired())
+        maybeDeactivateAudioSession();
+#else
+    UNUSED_PARAM(isCaptureStarting);
+#endif
+}
+
 int MediaSessionManagerInterface::countActiveAudioCaptureSources()
 {
     int count = 0;

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -138,7 +138,8 @@ public:
 
     virtual void addAudioCaptureSource(AudioCaptureSource&);
     virtual void removeAudioCaptureSource(AudioCaptureSource&);
-    virtual void audioCaptureSourceStateChanged() { updateSessionState(); }
+    enum class IsCaptureStarting : bool { No, Yes };
+    virtual void audioCaptureSourceStateChanged(IsCaptureStarting);
     virtual size_t audioCaptureSourceCount() const { return m_audioCaptureSources.computeSize(); }
 
     virtual void processDidReceiveRemoteControlCommand(PlatformMediaSessionRemoteControlCommandType, const PlatformMediaSessionRemoteCommandArgument&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -80,7 +80,6 @@ RemoteAudioSessionConfiguration RemoteAudioSessionProxy::configuration()
         session->preferredBufferSize(),
         session->outputLatency(),
         session->isMuted(),
-        m_active,
         m_sceneIdentifier,
         m_soundStageSize,
         session->categoryOverride(),

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -130,7 +130,10 @@ public:
 #if PLATFORM(IOS_FAMILY)
         m_providePresentingApplicationPIDFunction();
 #endif
+        // FIXME: We should ensure that WebProcess sets up the AudioSession properly before starting to capture microphone.
         Ref session = AudioSession::singleton();
+        RELEASE_LOG_ERROR_IF(!session->isActive() || session->category() != AudioSession::CategoryType::PlayAndRecord, WebRTC, "Audio session should be active (%d) and category should be play and record (%d)", session->isActive(), session->category() != AudioSession::CategoryType::PlayAndRecord);
+
         session->setCategory(AudioSession::CategoryType::PlayAndRecord, AudioSession::Mode::VideoChat, RouteSharingPolicy::Default);
         session->tryToSetActive(true);
     }

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -241,8 +241,6 @@ bool RemoteMediaSessionManagerProxy::tryToSetActiveInternal(bool active)
     auto [succeeded] = sendResult.takeReplyOr(false);
  */
     bool succeeded = true;
-    if (succeeded)
-        m_audioConfiguration.isActive = active;
     return succeeded;
 }
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
@@ -40,14 +40,15 @@
 
 namespace WebKit {
 
-Ref<WebCore::RealtimeMediaSource> SpeechRecognitionRemoteRealtimeMediaSource::create(SpeechRecognitionRemoteRealtimeMediaSourceManager& manager, const WebCore::CaptureDevice& captureDevice, WebCore::PageIdentifier pageIdentifier)
+Ref<WebCore::RealtimeMediaSource> SpeechRecognitionRemoteRealtimeMediaSource::create(SpeechRecognitionRemoteRealtimeMediaSourceManager& manager, const WebCore::CaptureDevice& captureDevice, WebCore::PageIdentifier pageIdentifier, WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier)
 {
-    return adoptRef(*new SpeechRecognitionRemoteRealtimeMediaSource(WebCore::RealtimeMediaSourceIdentifier::generate(), manager, captureDevice, pageIdentifier));
+    return adoptRef(*new SpeechRecognitionRemoteRealtimeMediaSource(WebCore::RealtimeMediaSourceIdentifier::generate(), manager, captureDevice, pageIdentifier, clientIdentifier));
 }
 
-SpeechRecognitionRemoteRealtimeMediaSource::SpeechRecognitionRemoteRealtimeMediaSource(WebCore::RealtimeMediaSourceIdentifier identifier, SpeechRecognitionRemoteRealtimeMediaSourceManager& manager, const WebCore::CaptureDevice& captureDevice, WebCore::PageIdentifier pageIdentifier)
+SpeechRecognitionRemoteRealtimeMediaSource::SpeechRecognitionRemoteRealtimeMediaSource(WebCore::RealtimeMediaSourceIdentifier identifier, SpeechRecognitionRemoteRealtimeMediaSourceManager& manager, const WebCore::CaptureDevice& captureDevice, WebCore::PageIdentifier pageIdentifier, WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier)
     : WebCore::RealtimeMediaSource(captureDevice, { }, pageIdentifier)
     , m_identifier(identifier)
+    , m_clientIdentifier(clientIdentifier)
     , m_manager(manager)
 {
     manager.addSource(*this, captureDevice);

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
+#include <WebCore/SpeechRecognitionConnectionClientIdentifier.h>
 #include <wtf/MediaTime.h>
 
 #if PLATFORM(COCOA)
@@ -48,11 +49,12 @@ class SpeechRecognitionRemoteRealtimeMediaSourceManager;
     
 class SpeechRecognitionRemoteRealtimeMediaSource : public WebCore::RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource, WTF::DestructionThread::MainRunLoop> {
 public:
-    static Ref<WebCore::RealtimeMediaSource> create(SpeechRecognitionRemoteRealtimeMediaSourceManager&, const WebCore::CaptureDevice&, WebCore::PageIdentifier);
+    static Ref<WebCore::RealtimeMediaSource> create(SpeechRecognitionRemoteRealtimeMediaSourceManager&, const WebCore::CaptureDevice&, WebCore::PageIdentifier, WebCore::SpeechRecognitionConnectionClientIdentifier);
     ~SpeechRecognitionRemoteRealtimeMediaSource();
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 
     WebCore::RealtimeMediaSourceIdentifier identifier() const { return m_identifier; }
+    WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier() const { return m_clientIdentifier; }
 
 #if PLATFORM(COCOA)
     void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
@@ -63,7 +65,7 @@ public:
     void remoteSourceStopped();
 
 private:
-    SpeechRecognitionRemoteRealtimeMediaSource(WebCore::RealtimeMediaSourceIdentifier, SpeechRecognitionRemoteRealtimeMediaSourceManager&, const WebCore::CaptureDevice&, WebCore::PageIdentifier);
+    SpeechRecognitionRemoteRealtimeMediaSource(WebCore::RealtimeMediaSourceIdentifier, SpeechRecognitionRemoteRealtimeMediaSourceManager&, const WebCore::CaptureDevice&, WebCore::PageIdentifier, WebCore::SpeechRecognitionConnectionClientIdentifier);
 
     // WebCore::RealtimeMediaSource
     void startProducingData() final;
@@ -72,6 +74,7 @@ private:
     const WebCore::RealtimeMediaSourceSettings& settings() LIFETIME_BOUND final { return m_settings; }
 
     WebCore::RealtimeMediaSourceIdentifier m_identifier;
+    WebCore::SpeechRecognitionConnectionClientIdentifier m_clientIdentifier;
     WeakPtr<SpeechRecognitionRemoteRealtimeMediaSourceManager> m_manager;
     WebCore::RealtimeMediaSourceCapabilities m_capabilities;
     WebCore::RealtimeMediaSourceSettings m_settings;

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -59,7 +59,7 @@ void SpeechRecognitionRemoteRealtimeMediaSourceManager::addSource(SpeechRecognit
     ASSERT(!m_sources.contains(identifier));
     m_sources.add(identifier, source);
 
-    send(Messages::SpeechRecognitionRealtimeMediaSourceManager::CreateSource(identifier, captureDevice, *source.pageIdentifier()));
+    send(Messages::SpeechRecognitionRealtimeMediaSourceManager::CreateSource(identifier, captureDevice, *source.pageIdentifier(), source.clientIdentifier()));
 }
 
 void SpeechRecognitionRemoteRealtimeMediaSourceManager::removeSource(SpeechRecognitionRemoteRealtimeMediaSource& source)

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
@@ -132,7 +132,7 @@ void SpeechRecognitionServer::handleRequest(Ref<WebCore::SpeechRecognitionReques
     }, WTF::move(request));
 
 #if ENABLE(MEDIA_STREAM)
-    auto sourceOrError = m_realtimeMediaSourceCreateFunction();
+    auto sourceOrError = m_realtimeMediaSourceCreateFunction(clientIdentifier);
     if (!sourceOrError) {
         sendUpdate(WebCore::SpeechRecognitionUpdate::createError(clientIdentifier, WebCore::SpeechRecognitionError { WebCore::SpeechRecognitionErrorType::AudioCapture, sourceOrError.error.errorMessage }));
         return;

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -57,7 +57,7 @@ using SpeechRecognitionCheckIfMockSpeechRecognitionEnabled = Function<bool()>;
 class SpeechRecognitionServer : public IPC::MessageReceiver, private IPC::MessageSender, public RefCounted<SpeechRecognitionServer> {
     WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionServer);
 public:
-    using RealtimeMediaSourceCreateFunction = Function<WebCore::CaptureSourceOrError()>;
+    using RealtimeMediaSourceCreateFunction = Function<WebCore::CaptureSourceOrError(WebCore::SpeechRecognitionConnectionClientIdentifier)>;
     static Ref<SpeechRecognitionServer> create(WebProcessProxy&, SpeechRecognitionServerIdentifier, SpeechRecognitionPermissionChecker&&, SpeechRecognitionCheckIfMockSpeechRecognitionEnabled&&
 #if ENABLE(MEDIA_STREAM)
         , RealtimeMediaSourceCreateFunction&&

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -17892,7 +17892,7 @@ void WebPageProxy::requestMediaKeySystemPermissionByDefaultAction(const WebCore:
 
 #if ENABLE(MEDIA_STREAM)
 
-WebCore::CaptureSourceOrError WebPageProxy::createRealtimeMediaSourceForSpeechRecognition()
+WebCore::CaptureSourceOrError WebPageProxy::createRealtimeMediaSourceForSpeechRecognition(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier)
 {
     auto captureDevice = SpeechRecognitionCaptureSource::findCaptureDevice();
     if (!captureDevice)
@@ -17900,10 +17900,10 @@ WebCore::CaptureSourceOrError WebPageProxy::createRealtimeMediaSourceForSpeechRe
 
     Ref speechRecognitionRemoteRealtimeMediaSourceManager = protect(legacyMainFrameProcess())->ensureSpeechRecognitionRemoteRealtimeMediaSourceManager();
     if (protect(preferences())->captureAudioInGPUProcessEnabled())
-        return CaptureSourceOrError { SpeechRecognitionRemoteRealtimeMediaSource::create(speechRecognitionRemoteRealtimeMediaSourceManager, *captureDevice, m_webPageID) };
+        return CaptureSourceOrError { SpeechRecognitionRemoteRealtimeMediaSource::create(speechRecognitionRemoteRealtimeMediaSourceManager, *captureDevice, m_webPageID, clientIdentifier) };
 
 #if PLATFORM(IOS_FAMILY)
-    return CaptureSourceOrError { SpeechRecognitionRemoteRealtimeMediaSource::create(speechRecognitionRemoteRealtimeMediaSourceManager, *captureDevice, m_webPageID) };
+    return CaptureSourceOrError { SpeechRecognitionRemoteRealtimeMediaSource::create(speechRecognitionRemoteRealtimeMediaSourceManager, *captureDevice, m_webPageID, clientIdentifier) };
 #else
     return SpeechRecognitionCaptureSource::createRealtimeMediaSource(*captureDevice, m_webPageID);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include "TextExtractionAssertionScope.h"
 #include <WebCore/UserGestureTokenIdentifier.h>
+#include <WebCore/SpeechRecognitionConnectionClientIdentifier.h>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
@@ -2555,7 +2556,7 @@ public:
 
 #if ENABLE(MEDIA_STREAM)
     UserMediaPermissionRequestManagerProxy* NODELETE userMediaPermissionRequestManagerIfExists();
-    WebCore::CaptureSourceOrError createRealtimeMediaSourceForSpeechRecognition();
+    WebCore::CaptureSourceOrError createRealtimeMediaSourceForSpeechRecognition(WebCore::SpeechRecognitionConnectionClientIdentifier);
     void clearUserMediaPermissionRequestHistory(WebCore::PermissionName);
     bool shouldListenToVoiceActivity() const { return m_shouldListenToVoiceActivity; }
     void voiceActivityDetected();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2648,8 +2648,8 @@ void WebProcessProxy::createSpeechRecognitionServer(SpeechRecognitionServerIdent
 
     m_speechRecognitionServerMap.ensure(identifier, [&]() {
 #if ENABLE(MEDIA_STREAM)
-        auto createRealtimeMediaSource = [weakPage = WeakPtr { targetPage }]() {
-            return weakPage ? weakPage->createRealtimeMediaSourceForSpeechRecognition() : CaptureSourceOrError { { "Page is invalid"_s, WebCore::MediaAccessDenialReason::InvalidAccess } };
+        auto createRealtimeMediaSource = [weakPage = WeakPtr { targetPage }](WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier) {
+            return weakPage ? weakPage->createRealtimeMediaSourceForSpeechRecognition(clientIdentifier) : CaptureSourceOrError { { "Page is invalid"_s, WebCore::MediaAccessDenialReason::InvalidAccess } };
         };
         Ref speechRecognitionServer = SpeechRecognitionServer::create(*this, identifier, WTF::move(permissionChecker), WTF::move(checkIfMockCaptureDevicesEnabled), WTF::move(createRealtimeMediaSource));
 #else

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -65,6 +65,7 @@ void RemoteAudioSession::gpuProcessConnectionDidClose(GPUProcessConnection& conn
 {
     ASSERT(m_gpuProcessConnection.get() == &connection);
     m_gpuProcessConnection = nullptr;
+    setActive(false);
     connection.messageReceiverMap().removeMessageReceiver(Messages::RemoteAudioSession::messageReceiverName());
 }
 
@@ -128,8 +129,6 @@ bool RemoteAudioSession::tryToSetActiveInternal(bool active)
 
     auto sendResult = protect(ensureConnection())->sendSync(Messages::RemoteAudioSessionProxy::TryToSetActive(active), { });
     auto [succeeded] = sendResult.takeReplyOr(false);
-    if (succeeded)
-        configuration().isActive = active;
     return succeeded;
 }
 
@@ -164,7 +163,6 @@ void RemoteAudioSession::configurationChanged(RemoteAudioSessionConfiguration&& 
     bool mutedStateChanged = !m_configuration || configuration.isMuted != (*m_configuration).isMuted;
     bool bufferSizeChanged = !m_configuration || configuration.bufferSize != (*m_configuration).bufferSize;
     bool sampleRateChanged = !m_configuration || configuration.sampleRate != (*m_configuration).sampleRate;
-    bool isActiveChanged = !m_configuration || configuration.isActive != (*m_configuration).isActive;
     bool routingContextUIDChanged = !m_configuration || configuration.routingContextUID != (*m_configuration).routingContextUID;
 
     m_configuration = WTF::move(configuration);
@@ -182,10 +180,8 @@ void RemoteAudioSession::configurationChanged(RemoteAudioSessionConfiguration&& 
         if (routingContextUIDChanged)
             observer.routingContextUIDDidChange(*this);
     });
-    if (isActiveChanged)
-        activeStateChanged();
 
-    if (!mutedStateChanged && !bufferSizeChanged && !sampleRateChanged && !isActiveChanged && !routingContextUIDChanged)
+    if (!mutedStateChanged && !bufferSizeChanged && !sampleRateChanged && !routingContextUIDChanged)
         return;
 
     RefPtr protectedProcess = m_webProcess.get();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -95,8 +95,6 @@ private:
 
     bool isMuted() const final { return configuration().isMuted; }
 
-    bool isActive() const final { return configuration().isActive; }
-
     void beginInterruptionForTesting() final;
     void endInterruptionForTesting() final;
     void clearInterruptionFlagForTesting() final { m_isInterruptedForTesting = false; }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h
@@ -40,7 +40,6 @@ struct RemoteAudioSessionConfiguration {
     uint64_t preferredBufferSize { 0 };
     uint64_t outputLatency { 0 };
     bool isMuted { false };
-    bool isActive { false };
     String sceneIdentifier;
     WebCore::AudioSessionSoundStageSize soundStageSize { WebCore::AudioSessionSoundStageSize::Automatic };
     WebCore::AudioSessionCategory categoryOverride { WebCore::AudioSession::CategoryType::None };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
@@ -31,7 +31,6 @@ struct WebKit::RemoteAudioSessionConfiguration {
     uint64_t preferredBufferSize;
     uint64_t outputLatency;
     bool isMuted;
-    bool isActive;
     String sceneIdentifier;
     WebCore::AudioSessionSoundStageSize soundStageSize;
     WebCore::AudioSessionCategory categoryOverride;

--- a/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
+++ b/Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp
@@ -70,7 +70,6 @@ RemoteMediaSessionManager::RemoteMediaSessionManager(WebPage& webPage)
         sharedSession->preferredBufferSize(),
         sharedSession->outputLatency(),
         sharedSession->isMuted(),
-        sharedSession->isActive(),
         sharedSession->sceneIdentifier(),
         sharedSession->soundStageSize(),
         sharedSession->categoryOverride(),

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -32,10 +32,14 @@
 #include "MessageSenderInlines.h"
 #include "SpeechRecognitionRealtimeMediaSourceManagerMessages.h"
 #include "SpeechRecognitionRemoteRealtimeMediaSourceManagerMessages.h"
+#include "WebPage.h"
 #include "WebProcess.h"
+#include <WebCore/MediaSessionManagerInterface.h>
+#include <WebCore/Page.h>
+#include <WebCore/PlatformMediaSessionTypes.h>
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/SpeechRecognitionCaptureSource.h>
-#include <wtf/CheckedRef.h>
+#include <WebCore/SpeechRecognitionConnection.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if PLATFORM(COCOA)
@@ -56,54 +60,104 @@ namespace WebKit {
 using namespace WebCore;
 
 class SpeechRecognitionRealtimeMediaSourceManager::Source final
-    : private RealtimeMediaSourceObserver
+    : public ThreadSafeRefCounted<SpeechRecognitionRealtimeMediaSourceManager::Source, WTF::DestructionThread::Main>
+    , public AudioCaptureSource
+    , private RealtimeMediaSourceObserver
     , private RealtimeMediaSource::AudioSampleObserver
     , public CanMakeCheckedPtr<SpeechRecognitionRealtimeMediaSourceManager::Source>
 {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(SpeechRecognitionRealtimeMediaSourceManager);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Source);
 public:
-    Source(RealtimeMediaSourceIdentifier identifier, Ref<RealtimeMediaSource>&& source, Ref<IPC::Connection>&& connection)
-        : m_identifier(identifier)
-        , m_source(WTF::move(source))
-        , m_connection(WTF::move(connection))
+    static Ref<Source> create(RealtimeMediaSourceIdentifier identifier, Ref<RealtimeMediaSource>&& source, Ref<IPC::Connection>&& connection, PageIdentifier pageIdentifier, SpeechRecognitionConnectionClientIdentifier clientIdentifier)
     {
-        m_source->addObserver(*this);
-        m_source->addAudioSampleObserver(*this);
+        return adoptRef(*new Source(identifier, WTF::move(source), WTF::move(connection), pageIdentifier, clientIdentifier));
     }
 
     ~Source()
     {
+        bool wasProducing = m_source->isProducingData();
+        if (wasProducing)
+            m_source->stop();
+
+        if (RefPtr manager = mediaSessionManager()) {
+            if (wasProducing)
+                manager->audioCaptureSourceStateChanged(MediaSessionManagerInterface::IsCaptureStarting::No);
+            manager->removeAudioCaptureSource(*this);
+        }
+
         m_source->removeAudioSampleObserver(*this);
         m_source->removeObserver(*this);
     }
 
     void start()
     {
+        if (m_source->isProducingData())
+            return;
         m_source->start();
+        if (RefPtr manager = mediaSessionManager())
+            manager->audioCaptureSourceStateChanged(MediaSessionManagerInterface::IsCaptureStarting::Yes);
     }
 
     void stop()
     {
+        if (!m_source->isProducingData())
+            return;
         m_source->stop();
+        if (RefPtr manager = mediaSessionManager())
+            manager->audioCaptureSourceStateChanged(MediaSessionManagerInterface::IsCaptureStarting::No);
     }
 
-    // CheckedPtr interface
-    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
 private:
+    Source(RealtimeMediaSourceIdentifier identifier, Ref<RealtimeMediaSource>&& source, Ref<IPC::Connection>&& connection, PageIdentifier pageIdentifier, SpeechRecognitionConnectionClientIdentifier clientIdentifier)
+        : m_identifier(identifier)
+        , m_source(WTF::move(source))
+        , m_connection(WTF::move(connection))
+        , m_pageIdentifier(pageIdentifier)
+        , m_clientIdentifier(clientIdentifier)
+    {
+        m_source->addObserver(*this);
+        m_source->addAudioSampleObserver(*this);
+
+        if (RefPtr manager = mediaSessionManager())
+            manager->addAudioCaptureSource(*this);
+
+        RefPtr webPage = WebProcess::singleton().webPage(m_pageIdentifier);
+        if (!webPage)
+            return;
+        if (RefPtr corePage = webPage->corePage())
+            protect(corePage->speechRecognitionConnection())->dispatchCaptureSourceCreated(m_clientIdentifier, m_source.get());
+    }
+
+    RefPtr<MediaSessionManagerInterface> mediaSessionManager() const
+    {
+        RefPtr webPage = WebProcess::singleton().webPage(m_pageIdentifier);
+        if (!webPage)
+            return nullptr;
+        RefPtr corePage = webPage->corePage();
+        if (!corePage)
+            return nullptr;
+        return corePage->mediaSessionManager();
+    }
 
     void sourceStopped() final
     {
-        if (m_source->captureDidFail()) {
+        if (m_source->captureDidFail())
             m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::RemoteCaptureFailed(m_identifier), 0);
-            return;
-        }
-        m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::RemoteSourceStopped(m_identifier), 0);
+        else
+            m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::RemoteSourceStopped(m_identifier), 0);
+
+        if (RefPtr manager = mediaSessionManager())
+            manager->audioCaptureSourceStateChanged(MediaSessionManagerInterface::IsCaptureStarting::No);
+    }
+
+    void sourceMutedChanged() final
+    {
+        if (RefPtr manager = mediaSessionManager())
+            manager->audioCaptureSourceStateChanged(m_source->muted() ? MediaSessionManagerInterface::IsCaptureStarting::No : MediaSessionManagerInterface::IsCaptureStarting::Yes);
     }
 
     void audioSamplesAvailable(const MediaTime& time, const PlatformAudioData& audioData, const AudioStreamDescription& description, size_t numberOfFrames) final
@@ -135,6 +189,7 @@ private:
     void audioUnitWillStart() final
     {
 #if USE(AUDIO_SESSION)
+        // FIXME: We should be able to remove this call.
         auto& audioSessionSingleton = AudioSession::singleton();
         auto bufferSize = audioSessionSingleton.sampleRate() / 50;
         if (audioSessionSingleton.preferredBufferSize() > bufferSize)
@@ -143,9 +198,22 @@ private:
 #endif
     }
 
+    // AudioCaptureSource
+    bool isCapturingAudio() const final { return m_source->isProducingData() && !m_source->muted(); }
+    bool wantsToCaptureAudio() const final { return m_source->isProducingData() && !m_source->muted(); }
+
+    // CheckedPtr interface
+    uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+
     RealtimeMediaSourceIdentifier m_identifier;
     const Ref<RealtimeMediaSource> m_source;
     const Ref<IPC::Connection> m_connection;
+    PageIdentifier m_pageIdentifier;
+    SpeechRecognitionConnectionClientIdentifier m_clientIdentifier;
 
 #if PLATFORM(COCOA)
     std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
@@ -181,7 +249,7 @@ void SpeechRecognitionRealtimeMediaSourceManager::deref() const
     m_process->deref();
 }
 
-void SpeechRecognitionRealtimeMediaSourceManager::createSource(RealtimeMediaSourceIdentifier identifier, const CaptureDevice& device, PageIdentifier pageIdentifier)
+void SpeechRecognitionRealtimeMediaSourceManager::createSource(RealtimeMediaSourceIdentifier identifier, const CaptureDevice& device, PageIdentifier pageIdentifier, SpeechRecognitionConnectionClientIdentifier clientIdentifier)
 {
     auto result = SpeechRecognitionCaptureSource::createRealtimeMediaSource(device, pageIdentifier);
     if (!result) {
@@ -191,7 +259,7 @@ void SpeechRecognitionRealtimeMediaSourceManager::createSource(RealtimeMediaSour
     }
 
     ASSERT(!m_sources.contains(identifier));
-    m_sources.add(identifier, makeUnique<Source>(identifier, result.source(), protect(connection())));
+    m_sources.add(identifier, Source::create(identifier, result.source(), protect(connection()), pageIdentifier, clientIdentifier));
 }
 
 void SpeechRecognitionRealtimeMediaSourceManager::deleteSource(RealtimeMediaSourceIdentifier identifier)
@@ -201,13 +269,13 @@ void SpeechRecognitionRealtimeMediaSourceManager::deleteSource(RealtimeMediaSour
 
 void SpeechRecognitionRealtimeMediaSourceManager::start(RealtimeMediaSourceIdentifier identifier)
 {
-    if (CheckedPtr source = m_sources.get(identifier))
+    if (RefPtr source = m_sources.get(identifier))
         source->start();
 }
 
 void SpeechRecognitionRealtimeMediaSourceManager::stop(RealtimeMediaSourceIdentifier identifier)
 {
-    if (CheckedPtr source = m_sources.get(identifier))
+    if (RefPtr source = m_sources.get(identifier))
         source->stop();
 }
 

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -32,6 +32,7 @@
 #include "SandboxExtension.h"
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
+#include <WebCore/SpeechRecognitionConnectionClientIdentifier.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -53,7 +54,7 @@ public:
 
 private:
     // Messages::SpeechRecognitionRealtimeMediaSourceManager
-    void createSource(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice&, WebCore::PageIdentifier);
+    void createSource(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice&, WebCore::PageIdentifier, WebCore::SpeechRecognitionConnectionClientIdentifier);
     void deleteSource(WebCore::RealtimeMediaSourceIdentifier);
     void start(WebCore::RealtimeMediaSourceIdentifier);
     void stop(WebCore::RealtimeMediaSourceIdentifier);
@@ -71,7 +72,7 @@ private:
 
     class Source;
     friend class Source;
-    HashMap<WebCore::RealtimeMediaSourceIdentifier, std::unique_ptr<Source>> m_sources;
+    HashMap<WebCore::RealtimeMediaSourceIdentifier, Ref<Source>> m_sources;
 
 #if ENABLE(SANDBOX_EXTENSIONS)
     RefPtr<SandboxExtension> m_machBootstrapExtension;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in
@@ -28,7 +28,7 @@
     DispatchedTo=WebContent
 ]
 messages -> SpeechRecognitionRealtimeMediaSourceManager {
-    CreateSource(WebCore::RealtimeMediaSourceIdentifier identifier, WebCore::CaptureDevice device, WebCore::PageIdentifier pageIdentifier)
+    CreateSource(WebCore::RealtimeMediaSourceIdentifier identifier, WebCore::CaptureDevice device, WebCore::PageIdentifier pageIdentifier, WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier)
     DeleteSource(WebCore::RealtimeMediaSourceIdentifier identifier)
     Start(WebCore::RealtimeMediaSourceIdentifier identifier);
     Stop(WebCore::RealtimeMediaSourceIdentifier identifier);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp
@@ -34,6 +34,7 @@
 #include "WebProcessProxyMessages.h"
 #include "WebSpeechRecognitionConnectionMessages.h"
 #include <WebCore/Frame.h>
+#include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/SpeechRecognitionConnectionClient.h>
 #include <WebCore/SpeechRecognitionRequestInfo.h>
 #include <WebCore/SpeechRecognitionUpdate.h>
@@ -97,6 +98,14 @@ void WebSpeechRecognitionConnection::abort(WebCore::SpeechRecognitionConnectionC
 {
     send(Messages::SpeechRecognitionServer::Abort(clientIdentifier));
 }
+
+#if ENABLE(MEDIA_STREAM)
+void WebSpeechRecognitionConnection::dispatchCaptureSourceCreated(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier, WebCore::RealtimeMediaSource& source)
+{
+    if (RefPtr client = m_clientMap.get(clientIdentifier))
+        client->captureSourceCreated(source);
+}
+#endif
 
 void WebSpeechRecognitionConnection::invalidate(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class RealtimeMediaSource;
 class SpeechRecognitionConnectionClient;
 class SpeechRecognitionUpdate;
 
@@ -53,6 +54,9 @@ public:
     void start(WebCore::SpeechRecognitionConnectionClientIdentifier, const String& lang, bool continuous, bool interimResults, uint64_t maxAlternatives, WebCore::ClientOrigin&&, WebCore::FrameIdentifier) final;
     void stop(WebCore::SpeechRecognitionConnectionClientIdentifier) final;
     void abort(WebCore::SpeechRecognitionConnectionClientIdentifier) final;
+#if ENABLE(MEDIA_STREAM)
+    void dispatchCaptureSourceCreated(WebCore::SpeechRecognitionConnectionClientIdentifier, WebCore::RealtimeMediaSource&) final;
+#endif
 
 private:
     explicit WebSpeechRecognitionConnection(SpeechRecognitionConnectionIdentifier);


### PR DESCRIPTION
#### 2f88bc0b118178fdb588f9143366246f09e21eb8
<pre>
Speech recognition microphone source should make sure to keep its audio session active while capturing
<a href="https://rdar.apple.com/174786023">rdar://174786023</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317741">https://bugs.webkit.org/show_bug.cgi?id=317741</a>

Reviewed by Eric Carlson.

Microphone capture requires the AudioSession unit to stay active.
While for getUserMedia, the WebProcess is ensuring that the AudioSession is active, this is not the case for speech recognition.
This can cause issues in case other WebProcess deactivate the AudioSession.

To prevent this, we make sure that SpeechRecognitionRealtimeMediaSourceManager sources are tied to the MediaSessionManager, by making each source an AudioCaptureSource.
It ensures that the audio session is properly set up whenever capture for speech recgonition starts.
We also make sure to deactivate the AudioSession as needed when capture stops.

We have to fix a race condition in how RemoteAudioSession is returning whether active or not.
When AudioSession is enabled/disabled very quickly, there might be configuration changed messages being received in between.
They might change the active state creating flakiness in tests.

To prevent this, we only set RemoteAudioSession::m_active in tryToSetActiveInternal and no longer synchronize it when configuration changes.
We add a protected setActive in AudioSession, so that RemoteAudioSession can set it back to false when GPU process crashes.
We no longer need AudioSession::isActive to be virtual as a small bonus.

This test can be flaky in case of rerunning it since navigating away stops the recognition right away but was stopping the capture asynchronously in WebProcess
since it needs to go through UIProcess.
We add a way for the source created in the WebProcess to register itself to the SpeechRecognition object.
This allows to synchronously stop capture when the SpeechRecognition gets stopped.

Test: fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition.html

* LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition-expected.txt: Added.
* LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition.html: Added.
* LayoutTests/http/tests/webrtc/audioSessionInFrames.html:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::stopTrack):
(WebCore::MediaStreamTrack::trackMutedChanged):
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(WebCore::SpeechRecognition::stop):
(WebCore::SpeechRecognition::captureSourceCreated):
* Source/WebCore/Modules/speech/SpeechRecognition.h:
* Source/WebCore/Modules/speech/SpeechRecognitionConnection.h:
(WebCore::SpeechRecognitionConnection::dispatchCaptureSourceCreated):
* Source/WebCore/Modules/speech/SpeechRecognitionConnectionClient.h:
(WebCore::SpeechRecognitionConnectionClient::captureSourceCreated):
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::tryToSetActive):
(WebCore::AudioSession::setActive):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::audioCaptureSourceStateChanged):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::configuration):
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::tryToSetActiveInternal):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSource::create):
(WebKit::SpeechRecognitionRemoteRealtimeMediaSource::SpeechRecognitionRemoteRealtimeMediaSource):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSource::clientIdentifier const):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::addSource):
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
(WebKit::SpeechRecognitionServer::handleRequest):
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createRealtimeMediaSourceForSpeechRecognition):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::createSpeechRecognitionServer):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::gpuProcessConnectionDidClose):
(WebKit::RemoteAudioSession::tryToSetActiveInternal):
(WebKit::RemoteAudioSession::configurationChanged):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in:
* Source/WebKit/WebProcess/Media/RemoteMediaSessionManager.cpp:
(WebKit::RemoteMediaSessionManager::RemoteMediaSessionManager):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::createSource):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::start):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::stop):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp:
(WebKit::WebSpeechRecognitionConnection::dispatchCaptureSourceCreated):
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h:

Canonical link: <a href="https://commits.webkit.org/315887@main">https://commits.webkit.org/315887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8fb02d523a27ff7c2f1b7b64b31a44d38c28060

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170390 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128102 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec1036f1-32cf-439f-b2c7-e97529247822) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df154b1c-533b-463e-8ed1-5567d17f8a09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36041 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113359 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2eeba72-c731-4b06-8d40-1ab19d107b38) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28448 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182350 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35139 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141311 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43970 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152763 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141129 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37994 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44659 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109118 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36399 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116541 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43169 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7779 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42575 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42815 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->