### PR TITLE
WebGL: Use default frame buffer properties from WebGLDefaultFramebuffer

### DIFF
--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<WebGLDefaultFramebuffer> WebGLDefaultFramebuffer::create(WebGLRe
 WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& context)
     : m_context(context)
 {
-    auto attributes = context.graphicsContextGL()->contextAttributes();
+    auto& attributes = context.attributes();
     m_hasStencil = attributes.stencil;
     m_hasDepth = attributes.depth;
     if (!attributes.preserveDrawingBuffer) {
@@ -57,11 +57,12 @@ WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& cont
 
 IntSize WebGLDefaultFramebuffer::size() const
 {
-    return m_context->graphicsContextGL()->getInternalFramebufferSize();
+    return m_size;
 }
 
 void WebGLDefaultFramebuffer::reshape(IntSize size)
 {
+    m_size = size;
     protect(m_context->graphicsContextGL())->reshape(size.width(), size.height());
 }
 

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
@@ -54,6 +54,7 @@ private:
 
     WeakRef<WebGLRenderingContextBase> m_context;
 
+    IntSize m_size;
     GCGLbitfield m_unpreservedBuffers { 0 };
     GCGLbitfield m_dirtyBuffers { 0 };
     bool m_hasStencil : 1;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -583,7 +583,7 @@ void WebGLRenderingContextBase::initializeContextState()
         if (m_attributes.depth)
             m_attributes.depth = glAttributes.depth;
         if (m_attributes.stencil)
-            m_attributes.depth = glAttributes.depth;
+            m_attributes.stencil = glAttributes.stencil;
     }
     // WebXR might use multisampling in WebGL2 context. Multisample extensions are also enabled in WebGL 1 case context
     // is antialiased.

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -252,6 +252,7 @@ public:
     WebGLAny getBufferParameter(GCGLenum target, GCGLenum pname);
     WEBCORE_EXPORT std::optional<WebGLContextAttributes> NODELETE getContextAttributes();
     WebGLContextAttributes creationAttributes() const { return m_creationAttributes; }
+    const WebGLContextAttributes& attributes() const { return m_attributes; }
     GCGLenum getError();
     virtual std::optional<WebGLExtensionAny> getExtension(const String& name) = 0;
     virtual WebGLAny getFramebufferAttachmentParameter(GCGLenum target, GCGLenum attachment, GCGLenum pname) = 0;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -132,10 +132,11 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
         auto requestableExtensions = context->requestableExtensions();
         auto [externalImageTarget, externalImageBindingQuery] = context->externalImageTextureBindingPoint();
         RemoteGraphicsContextGLInitializationState initializationState {
+            .attributes = context->contextAttributes(),
             .knownActiveExtensions = knownActiveExtensions.toRaw(),
             .requestableExtensions = requestableExtensions.toRaw(),
             .externalImageTarget = externalImageTarget,
-            .externalImageBindingQuery = externalImageBindingQuery
+            .externalImageBindingQuery = externalImageBindingQuery,
         };
         send(Messages::RemoteGraphicsContextGLProxy::WasCreated(workQueue().wakeUpSemaphore(), m_connection->clientWaitSemaphore(), { initializationState }));
         m_connection->startReceivingMessages(*this, Messages::RemoteGraphicsContextGL::messageReceiverName(), m_identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h
@@ -28,12 +28,14 @@
 #if ENABLE(WEBGL)
 
 #include <WebCore/GCGLExtension.h>
+#include <WebCore/GraphicsContextGLAttributes.h>
 #include <WebCore/GraphicsTypesGL.h>
 #include <wtf/OptionSet.h>
 
 namespace WebKit {
 
 struct RemoteGraphicsContextGLInitializationState {
+    WebCore::GraphicsContextGLAttributes attributes;
     uint64_t knownActiveExtensions { 0 }; // EnumSet<WebCore::GCGLExtension> when EnumSet serialization works.
     uint64_t requestableExtensions { 0 }; // EnumSet<WebCore::GCGLExtension> when EnumSet serialization works.
     GCGLenum externalImageTarget { 0 };

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in
@@ -23,6 +23,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
 struct WebKit::RemoteGraphicsContextGLInitializationState {
+    WebCore::GraphicsContextGLAttributes attributes;
     uint64_t knownActiveExtensions;
     uint64_t requestableExtensions;
     GCGLenum externalImageTarget;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -149,6 +149,7 @@ bool RemoteGraphicsContextGLProxy::enableExtension(GCGLExtension extension)
 
 void RemoteGraphicsContextGLProxy::initialize(const RemoteGraphicsContextGLInitializationState& initializationState)
 {
+    setContextAttributes(initializationState.attributes);
     m_knownActiveExtensions = EnumSet<GCGLExtension>::fromRaw(initializationState.knownActiveExtensions);
     m_requestableExtensions = EnumSet<GCGLExtension>::fromRaw(initializationState.requestableExtensions);
     m_externalImageTarget = initializationState.externalImageTarget;


### PR DESCRIPTION
#### cfd20438976858a9fac390266da08f6b480d60f5
<pre>
WebGL: Use default frame buffer properties from WebGLDefaultFramebuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=317748">https://bugs.webkit.org/show_bug.cgi?id=317748</a>
<a href="https://rdar.apple.com/180505090">rdar://180505090</a>

Reviewed by Dan Glastonbury.

Access context attributes through WebGLDefaultFramebuffer instead
of GraphicsContextGL.

This is work to reduce bugs due to state management in
GraphicsContextGL, preparing to move the context default framebuffer
implementation (MSAA management, etc.) from GraphicsContextGL into the
WebGL layer.

Fixes following theoretical bugs:
 - Theoretically adjusted contextAttributes were not communicated
   back from GPUP.
 - The theoretically adjusted stencil attribute wasn&apos;t adjusted
   in WCP side due to copy-paste error:
   `if (m_attributes.stencil) m_attributes.depth = glAttributes.depth;`

* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp:
(WebCore::WebGLDefaultFramebuffer::WebGLDefaultFramebuffer):
(WebCore::WebGLDefaultFramebuffer::size const):
(WebCore::WebGLDefaultFramebuffer::reshape):
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::attributes const):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::initialize):

Canonical link: <a href="https://commits.webkit.org/315882@main">https://commits.webkit.org/315882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2112c2d42c96460e04418739daf41714e740bb33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179516 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127866 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5664527-e7cd-401f-b1bb-0b1662948027) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132641 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c922cb93-9914-463f-9ab9-ffbc3fda7ae3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113143 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/250e642c-15ae-4bed-8ad8-1286d018cc42) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28212 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182113 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34902 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36944 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141093 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43734 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140918 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37991 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44423 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108794 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36188 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116303 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42933 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7556 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42325 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42579 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42468 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->