### PR TITLE
[iOS] WKWebView should not reserve space for another app's keyboard

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3558,8 +3558,9 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
         return YES;
 #endif
 
-    NSNumber *isLocalKeyboard = [keyboardInfo valueForKey:UIKeyboardIsLocalUserInfoKey];
-    return isLocalKeyboard && !isLocalKeyboard.boolValue;
+    // Ignore keyboards owned by another app (isLocal == NO); reserving space for them
+    // displaces this page's fixed; bottom:0 content even though it is not our keyboard.
+    return NO;
 }
 
 - (void)_keyboardWillChangeFrame:(NSNotification *)notification
@@ -3570,7 +3571,8 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
 
 - (void)_keyboardDidChangeFrame:(NSNotification *)notification
 {
-    [self _keyboardChangedWithInfo:notification.userInfo adjustScrollView:NO];
+    if ([self _shouldUpdateKeyboardWithInfo:notification.userInfo])
+        [self _keyboardChangedWithInfo:notification.userInfo adjustScrollView:NO];
 }
 
 - (void)_keyboardWillShow:(NSNotification *)notification

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
@@ -34,6 +34,7 @@
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestUIDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import "TestInputDelegate.h"
 #import "UIKitSPIForTesting.h"
 #import "Helpers/ios/UserInterfaceSwizzler.h"
 #import "WKBrowserEngineDefinitions.h"
@@ -1444,6 +1445,69 @@ TEST(WKScrollViewTests, FixedClippingViewTracksRubberBandDuringInteractiveObscur
     EXPECT_NEAR(clipBounds.origin.y, -150.0, 1.0);
 
     [webView _endInteractiveObscuredInsetsChange];
+}
+
+static RetainPtr<NSDictionary> keyboardUserInfo(CGRect endFrameInScreen, BOOL isLocal)
+{
+    return @{
+        UIKeyboardFrameBeginUserInfoKey: [NSValue valueWithCGRect:CGRectOffset(endFrameInScreen, 0, CGRectGetHeight(endFrameInScreen))],
+        UIKeyboardFrameEndUserInfoKey: [NSValue valueWithCGRect:endFrameInScreen],
+        UIKeyboardAnimationDurationUserInfoKey: @0.0,
+        UIKeyboardAnimationCurveUserInfoKey: @0,
+        UIKeyboardIsLocalUserInfoKey: @(isLocal),
+    };
+}
+
+// -_keyboardDidChangeFrame: does not go through -_shouldUpdateKeyboardWithInfo:, so post
+// the full show sequence to exercise every path.
+static void postKeyboardShowSequence(NSDictionary *info)
+{
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    [center postNotificationName:UIKeyboardWillShowNotification object:nil userInfo:info];
+    [center postNotificationName:UIKeyboardWillChangeFrameNotification object:nil userInfo:info];
+    [center postNotificationName:UIKeyboardDidChangeFrameNotification object:nil userInfo:info];
+}
+
+static CGRect bottomKeyboardFrame(WKWebView *webView)
+{
+    CGRect screen = webView.window.screen.bounds;
+    return CGRectMake(0, CGRectGetHeight(screen) - 336, CGRectGetWidth(screen), 336);
+}
+
+// A keyboard owned by another app must not make this web view reserve space for it,
+// which would push the page's position:fixed; bottom:0 content up.
+TEST(WKScrollViewTests, ForeignKeyboardDoesNotReserveSpace)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 844)]);
+    [webView addToTestWindow];
+    [webView synchronouslyLoadHTMLString:@"<body></body>"];
+    [webView waitForNextPresentationUpdate];
+
+    postKeyboardShowSequence(keyboardUserInfo(bottomKeyboardFrame(webView.get()), NO).get());
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_TRUE(CGRectIsEmpty([webView _inputViewBoundsInWindow]));
+}
+
+// A keyboard for this web view's own focused element must still reserve space
+// (regression guard against ignoring every keyboard).
+TEST(WKScrollViewTests, LocalKeyboardForFocusedElementReservesSpace)
+{
+    RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 390, 844)]);
+    [webView _setInputDelegate:inputDelegate.get()];
+    [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
+        return _WKFocusStartsInputSessionPolicyAllow;
+    }];
+    [webView addToTestWindow];
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><input>"];
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.querySelector('input').focus()"];
+    [webView waitForNextPresentationUpdate];
+
+    postKeyboardShowSequence(keyboardUserInfo(bottomKeyboardFrame(webView.get()), YES).get());
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FALSE(CGRectIsEmpty([webView _inputViewBoundsInWindow]));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 51e00680b17d2f88fad64b99648114bf34e4d0ae
<pre>
[iOS] WKWebView should not reserve space for another app&apos;s keyboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=317749">https://bugs.webkit.org/show_bug.cgi?id=317749</a>

Reviewed by NOBODY (OOPS!).

When a keyboard appears, WKWebView reserves space equal to the keyboard
height so that position:fixed; bottom:0 content is not obscured. This also
happened for a keyboard owned by another app (UIKeyboardIsLocalUserInfoKey
== NO) — e.g. when switching to an app that already has the keyboard up, or
the adjacent app in Split View. Since our web view is not the first
responder, reserving space for that keyboard needlessly pushes fixed;
bottom:0 content up and shrinks window.visualViewport; on some OS versions
the area is never restored, leaving the content displaced until the web
view is destroyed.

-_shouldUpdateKeyboardWithInfo: already returns YES for the focused-element
and find cases (our own keyboard), but otherwise returned YES specifically
for non-local keyboards. Stop reacting to those. Additionally,
-_keyboardDidChangeFrame: called -_keyboardChangedWithInfo: directly,
bypassing that gate, so the reservation still happened via the
UIKeyboardDidChangeFrameNotification path; route it through the gate too.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _shouldUpdateKeyboardWithInfo:]): Return NO for keyboards that
are not our focused-element/find keyboard, instead of reacting to non-local
keyboards.
(-[WKWebView _keyboardDidChangeFrame:]): Gate on -_shouldUpdateKeyboardWithInfo:
like the other keyboard handlers.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm:
(TestWebKitAPI::ForeignKeyboardDoesNotReserveSpace): Added. Posts the full
non-local keyboard show sequence and verifies no space is reserved.
(TestWebKitAPI::LocalKeyboardForFocusedElementReservesSpace): Added.
Regression guard that a focused web input&apos;s keyboard still reserves space.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cb2d6f1cd0237e2b4a4bbeaed4ac6293266c8cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137100 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96230 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37591 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37365 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34110 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188063 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49647 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146110 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50328 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145945 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40727 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122523 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/116439 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48834 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12344 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->