### PR TITLE
Logging using os_log is incorrect in some cases

### DIFF
--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -71,4 +71,13 @@ const Logger& emptyLogger()
     return emptyLogger->get();
 }
 
+#if USE(OS_LOG)
+void Logger::osLog(WTFLogChannel& channel, const CString& message)
+{
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    SUPPRESS_UNRETAINED_LOCAL os_log(channel.osLogChannel, "%{public}s", message.data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+#endif // USE(OS_LOG)
+
 } // namespace WTF

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -365,6 +365,10 @@ private:
     {
     }
 
+#if USE(OS_LOG)
+    WTF_EXPORT_PRIVATE static void osLog(WTFLogChannel&, const CString& message);
+#endif
+
     template<typename... Argument>
     static inline void log(WTFLogChannel& channel, WTFLogLevel level, const Argument&... arguments)
     {
@@ -373,9 +377,7 @@ private:
 #if RELEASE_LOG_DISABLED
         WTFLog(&channel, "%s", logMessage.utf8().data());
 #elif USE(OS_LOG)
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        SUPPRESS_UNRETAINED_LOCAL os_log(channel.osLogChannel, "%{public}s", logMessage.utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        osLog(channel, logMessage.utf8());
 #elif OS(ANDROID)
         __android_log_print(ANDROID_LOG_VERBOSE, LOG_CHANNEL_WEBKIT_SUBSYSTEM, "[%s] %s", channel.name, logMessage.utf8().data());
 #elif ENABLE(JOURNALD_LOG)
@@ -411,9 +413,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #if RELEASE_LOG_DISABLED
         WTFLogVerbose(file, line, function, &channel, "%s", logMessage.utf8().data());
 #elif USE(OS_LOG)
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        SUPPRESS_UNRETAINED_LOCAL os_log(channel.osLogChannel, "%{public}s", logMessage.utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        osLog(channel, logMessage.utf8());
         UNUSED_PARAM(file);
         UNUSED_PARAM(line);
         UNUSED_PARAM(function);


### PR DESCRIPTION
#### 6521420c005ad3c90e20e164455f01041c83f5fc
<pre>
Logging using os_log is incorrect in some cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=317750">https://bugs.webkit.org/show_bug.cgi?id=317750</a>
<a href="https://rdar.apple.com/180418990">rdar://180418990</a>

Reviewed by Chris Dumez and Jer Noble.

In some cases, an incorrect format string is being used, leading to incorrect logs.

This is caused by calling os_log in inline functions, which can lead to ODR violations. See <a href="https://rdar.apple.com/145164014">rdar://145164014</a>.

This is addressed by moving the use of os_log to the implementation file.

* Source/WTF/wtf/Logger.cpp:
(WTF::Logger::osLog):
* Source/WTF/wtf/Logger.h:
(WTF::Logger::log):
(WTF::Logger::logVerbose):

Canonical link: <a href="https://commits.webkit.org/315840@main">https://commits.webkit.org/315840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/720c33b4db6e5f137fdfd440d9a71944979639d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170198 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44121 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37538 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127910 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a268671f-b9ba-4021-923d-e4072f811e83) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132697 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/513f9e69-a27f-4e39-a239-9e3e34156590) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173157 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113198 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f1101a5-b50a-44e1-af39-f58ff6a15dd5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28256 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1530 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182157 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31453 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34946 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36986 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141136 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43778 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37961 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44467 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29496 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108863 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36228 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116347 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202877 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42977 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7595 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->