### PR TITLE
[LibWebRTC][GCC] Fix build failure after M150 update

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/call/payload_type_picker.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/call/payload_type_picker.cc
@@ -370,7 +370,7 @@ void PayloadTypeRecorder::Rollback() {
 RTCError RtpHeaderExtensionRecorder::AddMapping(RtpHeaderExtensionId id,
                                                 absl::string_view uri,
                                                 bool encrypt) {
-  auto it = uri_to_id_.find(std::pair{uri, encrypt});
+  auto it = uri_to_id_.find(std::pair{std::string(uri), encrypt});
   if (it != uri_to_id_.end()) {
     if (it->second != id) {
       RTC_HISTOGRAM_BOOLEAN(
@@ -393,7 +393,7 @@ RTCError RtpHeaderExtensionRecorder::AddMapping(RtpHeaderExtensionId id,
 RTCErrorOr<RtpHeaderExtensionId> RtpHeaderExtensionRecorder::LookupId(
     absl::string_view uri,
     bool encrypt) const {
-  auto it = uri_to_id_.find(std::pair{uri, encrypt});
+  auto it = uri_to_id_.find(std::pair{std::string(uri), encrypt});
   if (it == uri_to_id_.end()) {
     return RTCError(RTCErrorType::INVALID_PARAMETER,
                     "No ID found for extension");


### PR DESCRIPTION
#### 0f5a12e43c0e1cfef3ce2b240cf971730c8def7a
<pre>
[LibWebRTC][GCC] Fix build failure after M150 update
<a href="https://bugs.webkit.org/show_bug.cgi?id=317751">https://bugs.webkit.org/show_bug.cgi?id=317751</a>

Unreviewed build fix.

Set explicit cast for variable &apos;uri_to_id&apos; from type &apos;absl::string&apos; to
&apos;std::string&apos; since GCC fails to deduce the expected pair type.

* Source/ThirdParty/libwebrtc/Source/webrtc/call/payload_type_picker.cc:

Canonical link: <a href="https://commits.webkit.org/315754@main">https://commits.webkit.org/315754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fe06ae58d7a4c522ad04785fe99426411beba63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132495 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172942 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35586 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/152925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112997 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28041 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181942 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140945 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43561 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140779 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44250 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108588 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25896 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36044 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42761 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42153 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->