### PR TITLE
[TZone] Remove dead hasDisableTZoneEntitlement callback

### DIFF
--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -465,15 +465,6 @@ void Thread::dump(PrintStream& out) const
 ThreadSpecificKey Thread::s_key = InvalidThreadSpecificKey;
 #endif
 
-#if USE(TZONE_MALLOC)
-#if PLATFORM(COCOA)
-static bool hasDisableTZoneEntitlement()
-{
-    return processHasEntitlement("webkit.tzone.disable"_s);
-}
-#endif
-#endif
-
 void initialize()
 {
     static std::once_flag onceKey;
@@ -484,9 +475,6 @@ void initialize()
         setPermissionsOfConfigPage();
         Config::initialize();
 #if USE(TZONE_MALLOC)
-#if PLATFORM(COCOA)
-        bmalloc::api::TZoneHeapManager::setHasDisableTZoneEntitlementCallback(hasDisableTZoneEntitlement);
-#endif
         bmalloc::api::TZoneHeapManager::ensureSingleton(); // Force initialization.
 #endif
         Gigacage::ensureGigacage();

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -46,8 +46,6 @@
 
 namespace bmalloc { namespace api {
 
-static bool (*hasDisableTZoneEntitlement)();
-
 #define BUSE_BUCKETS_FOR_SIZE_CLASSES_FROM_ENVVAR 0
 
 TZoneHeapManager* tzoneHeapManager;
@@ -95,11 +93,6 @@ static TypeNameTemplate typeNameTemplate;
 static void dumpRegisteredTypesAtExit(void)
 {
     TZoneHeapManager::singleton().dumpRegisteredTypes();
-}
-
-void TZoneHeapManager::setHasDisableTZoneEntitlementCallback(bool (*disableTZoneEntitlementCheck)())
-{
-    hasDisableTZoneEntitlement = disableTZoneEntitlementCheck;
 }
 
 TZoneHeapManager::TZoneHeapManager()

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -176,8 +176,6 @@ public:
         return *tzoneHeapManager;
     }
 
-    static void setHasDisableTZoneEntitlementCallback(bool (*hasDisableTZoneEntitlement)());
-
     pas_heap_ref* heapRefForTZoneType(const TZoneSpecification&);
     pas_heap_ref* heapRefForTZoneTypeDifferentSize(size_t requestedSize, const TZoneSpecification&);
 


### PR DESCRIPTION
#### 074869732f70212de49196ecee0fbee34e3807dd
<pre>
[TZone] Remove dead hasDisableTZoneEntitlement callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=317755">https://bugs.webkit.org/show_bug.cgi?id=317755</a>
<a href="https://rdar.apple.com/180447615">rdar://180447615</a>

Reviewed by Yijia Huang.

Remove some dead code for hasDisableTZoneEntitlement checks. The
callback is set but never checked or called.

No new tests, dead code removal.

Canonical link: <a href="https://commits.webkit.org/315761@main">https://commits.webkit.org/315761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbb768a68a594189a300b39c23bc8c56f6e8958c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43910 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37324 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179349 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127700 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d39b1c02-7da8-4e21-b1fa-7c1ba95da20a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132498 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5950821-ec7c-4e23-b4c1-66491387bd6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172947 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35590 "Build is in progress. Recent messages:") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152932 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 4 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113000 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/439d43a2-0afc-4fcb-b155-2e6aff246eb4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28046 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1348 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed JSC tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181947 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31243 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140947 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43566 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140781 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44255 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108599 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25900 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36047 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116020 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202667 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42766 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7412 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54315 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42413 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->