### PR TITLE
[CMake, Cocoa] Fix build under certain configurations

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -263,8 +263,13 @@ NS_HEADER_AUDIT_END(nullability, sendability)
 
 #if HAVE(NSREFRESHCONTROLLER)
 
-#if !defined(__has_include) || !__has_include(<AppKit/NSRefreshControl_Private.h>)
+#if !defined(__has_include) || (!__has_include(<AppKit/NSRefreshControl_Private.h>) && !__has_include(<AppKit/NSRefreshControl.h>))
 @interface NSRefreshControl : NSView
+@end
+#endif
+
+#if !defined(__has_include) || (!__has_include(<AppKit/NSRefreshController_Private.h>) && !__has_include(<AppKit/NSRefreshController.h>))
+@interface NSRefreshController : NSObject
 @end
 #endif
 


### PR DESCRIPTION
#### be421c1f84a6eee5c650befebe2f612240daf7c2
<pre>
[CMake, Cocoa] Fix build under certain configurations
<a href="https://rdar.apple.com/180532500">rdar://180532500</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317759">https://bugs.webkit.org/show_bug.cgi?id=317759</a>

Unreviewed, build fix.

In some configurations, we need to forward declare NSRefreshController where
it is not in the SDK.

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be421c1f84a6eee5c650befebe2f612240daf7c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127749 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a17ddb3-027e-4413-9f93-a5a1a4346836) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132536 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93393 "11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92c75012-d143-448b-9fc2-0f34340bb0a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113038 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9460766b-8cda-4a0a-814d-82707d3a4cd1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34291 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32676 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28095 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181996 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34785 "Found 100 new failures in Modules/speech/SpeechRecognitionResult.cpp, plugins/DOMPluginArray.cpp, accessibility/AccessibilityScrollView.cpp, Modules/webaudio/ChannelMergerNode.cpp, css/StyleSheetContents.cpp, jit/GdbJIT.cpp, dom/TreeScope.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, dom/ImageOverlay.cpp, inspector/ScriptCallStack.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140987 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43615 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140819 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44304 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29355 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108654 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36088 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116186 "Found 109 new failures in css/typedom/transform/CSSTransformValue.cpp, runtime/IndexingType.cpp, css/SelectorFilter.cpp, Modules/webaudio/ChannelMergerNode.cpp, bytecompiler/BytecodeGenerator.cpp, BindGroup.mm, dom/EventPath.cpp, css/SelectorChecker.cpp, platform/audio/AudioBus.cpp, Shared/API/c/WKArray.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42815 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7454 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42350 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->