### PR TITLE
Select a scroll-state query container ahead of scroll state evaluation

### DIFF
--- a/Source/WebCore/css/query/ContainerQuery.h
+++ b/Source/WebCore/css/query/ContainerQuery.h
@@ -58,12 +58,18 @@ OptionSet<Axis> requiredAxesForFeature(const MQ::Feature&);
 // the queried property and, for style ranges, bare <custom-property-name> operands and var() references.
 void collectCustomPropertyNames(const MQ::Feature&, HashSet<AtomString>&);
 
+struct ContainerRequirements {
+    OptionSet<Axis> sizeAxes;
+    bool scrollState { false };
+    bool needsSizeContainer() const { return !sizeAxes.isEmpty(); }
+};
+
 enum class ContainsUnknownFeature : bool { No, Yes };
 
 struct ContainerQuery {
     AtomString name;
     MQ::Condition condition;
-    OptionSet<CQ::Axis> requiredAxes;
+    ContainerRequirements requirements;
     ContainsUnknownFeature containsUnknownFeature;
 };
 

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -547,6 +547,14 @@ const MQ::FeatureSchema* scrollState(const AtomString& name)
     return nullptr;
 }
 
+bool isScrollStateFeature(const MQ::FeatureSchema* schema)
+{
+    return schema == &scrollableFeatureSchema()
+        || schema == &scrolledFeatureSchema()
+        || schema == &stuckFeatureSchema()
+        || schema == &snappedFeatureSchema();
+}
+
 Vector<const MQ::FeatureSchema*> allSchemas()
 {
     return {

--- a/Source/WebCore/css/query/ContainerQueryFeatures.h
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.h
@@ -55,6 +55,8 @@ const MQ::FeatureSchema& style();
 // (scrollable/scrolled/stuck/snapped), or nullptr. Used inside scroll-state().
 const MQ::FeatureSchema* scrollState(const AtomString&);
 
+bool isScrollStateFeature(const MQ::FeatureSchema*);
+
 Vector<const MQ::FeatureSchema*> allSchemas();
 
 } // namespace Features

--- a/Source/WebCore/css/query/ContainerQueryParser.cpp
+++ b/Source/WebCore/css/query/ContainerQueryParser.cpp
@@ -197,16 +197,18 @@ std::optional<ContainerQuery> ContainerQueryParser::consumeContainerQuery(CSSPar
         condition = MQ::Condition { };
     }
 
-    OptionSet<Axis> requiredAxes;
+    ContainerRequirements requirements;
     auto containsUnknownFeature = ContainsUnknownFeature::No;
 
     traverseFeatures(*condition, [&](auto& feature) {
-        requiredAxes.add(requiredAxesForFeature(feature));
+        requirements.sizeAxes.add(requiredAxesForFeature(feature));
+        if (Features::isScrollStateFeature(feature.schema))
+            requirements.scrollState = true;
         if (!feature.schema)
             containsUnknownFeature = ContainsUnknownFeature::Yes;
     });
 
-    return ContainerQuery { name, *condition, requiredAxes, containsUnknownFeature };
+    return ContainerQuery { name, *condition, requirements, containsUnknownFeature };
 }
 
 bool ContainerQueryParser::isValidFunctionId(CSSValueID functionId)

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -63,11 +63,12 @@ bool ContainerQueryEvaluator::evaluate(const CQ::ContainerQuery& containerQuery)
     return evaluateCondition(containerQuery.condition, *context) == MQ::EvaluationResult::True;
 }
 
-static const Style::ComputedStyle* styleForContainer(const Element& container, OptionSet<CQ::Axis> requiredAxes, const ContainerQueryEvaluationState* evaluationState)
+static const Style::ComputedStyle* styleForContainer(const Element& container, CQ::ContainerRequirements requirements, const ContainerQueryEvaluationState* evaluationState)
 {
-    // Any element can be a style container and we haven't necessarily committed the style to render tree yet.
+    // Queries that don't need a size container (style and scroll-state queries) resolve
+    // against the container's style, which may not be committed to the render tree yet.
     // Look it up from the currently computed style update instead.
-    if (requiredAxes.isEmpty() && evaluationState && evaluationState->styleUpdate)
+    if (!requirements.needsSizeContainer() && evaluationState && evaluationState->styleUpdate)
         return evaluationState->styleUpdate->elementStyle(container);
 
     return container.existingComputedStyle();
@@ -86,16 +87,16 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
         return { };
 
     Ref element = m_element;
-    RefPtr container = selectContainer(containerQuery.requiredAxes, containerQuery.name, element.get(), m_selectionMode, m_scopeOrdinal, m_evaluationState);
+    RefPtr container = selectContainer(containerQuery.requirements, containerQuery.name, element.get(), m_selectionMode, m_scopeOrdinal, m_evaluationState);
     if (!container)
         return { };
 
-    CheckedPtr containerStyle = styleForContainer(*container.get(), containerQuery.requiredAxes, m_evaluationState);
+    CheckedPtr containerStyle = styleForContainer(*container.get(), containerQuery.requirements, m_evaluationState);
     if (!containerStyle)
         return { };
 
     RefPtr containerParent = container->parentElementInComposedTree();
-    CheckedPtr containerParentStyle = containerParent ? CheckedPtr { styleForContainer(*containerParent, containerQuery.requiredAxes, m_evaluationState) } : containerStyle;
+    CheckedPtr containerParentStyle = containerParent ? CheckedPtr { styleForContainer(*containerParent, containerQuery.requirements, m_evaluationState) } : containerStyle;
 
     Ref document = element->document();
     CheckedPtr rootStyle = document->documentElement()->renderStyle();
@@ -107,7 +108,7 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
     };
 }
 
-RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requiredAxes, const WTF::String& name, const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, const ContainerQueryEvaluationState* evaluationState)
+RefPtr<const Element> ContainerQueryEvaluator::selectContainer(CQ::ContainerRequirements requirements, const WTF::String& name, const Element& element, SelectionMode selectionMode, ScopeOrdinal scopeOrdinal, const ContainerQueryEvaluationState* evaluationState)
 {
     // "For each element, the query container to be queried is selected from among the element’s
     // ancestor query containers that have a valid container-type for all the container features
@@ -115,9 +116,14 @@ RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axi
     // considered to just those with a matching query container name."
     // https://drafts.csswg.org/css-contain-3/#container-rule
 
-    auto isValidContainerForRequiredAxes = [&](const Style::ContainerType& containerType, const RenderElement* principalBox) {
-        // Any container is valid for style queries.
-        if (requiredAxes.isEmpty())
+    auto isValidContainer = [&](const Style::ContainerType& containerType, const RenderElement* principalBox) {
+        // A scroll-state query requires a scroll-state container.
+        if (requirements.scrollState && !containerType.hasScrollState())
+            return false;
+
+        // No size container required: any container is valid (style query), or the
+        // scroll-state requirement above has already been satisfied.
+        if (!requirements.needsSizeContainer())
             return true;
 
         if (containerType.hasSize())
@@ -126,20 +132,22 @@ RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axi
             // Without a principal box the container matches but the query against it will evaluate to Unknown.
             if (!principalBox)
                 return true;
-            if (requiredAxes.contains(CQ::Axis::Block))
+            if (requirements.sizeAxes.contains(CQ::Axis::Block))
                 return false;
-            return !requiredAxes.contains(principalBox->isHorizontalWritingMode() ? CQ::Axis::Height : CQ::Axis::Width);
+            return !requirements.sizeAxes.contains(principalBox->isHorizontalWritingMode() ? CQ::Axis::Height : CQ::Axis::Width);
         }
-        if (containerType.isNormal())
+        // A normal container, or a scroll-state-only container, provides no size
+        // containment and so is not a valid container for a size query.
+        if (containerType.isNormal() || containerType.hasScrollState())
             return false;
         RELEASE_ASSERT_NOT_REACHED();
     };
 
     auto isContainerForQuery = [&](const Element& candidateElement, const Element* originatingElement = nullptr) {
-        CheckedPtr style = styleForContainer(candidateElement, requiredAxes, evaluationState);
+        CheckedPtr style = styleForContainer(candidateElement, requirements, evaluationState);
         if (!style)
             return false;
-        if (!isValidContainerForRequiredAxes(style->containerType(), candidateElement.renderer()))
+        if (!isValidContainer(style->containerType(), candidateElement.renderer()))
             return false;
         if (name.isEmpty())
             return true;
@@ -188,7 +196,7 @@ RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axi
         return nullptr;
     }
 
-    if (evaluationState && !requiredAxes.isEmpty()) {
+    if (evaluationState && requirements.needsSizeContainer()) {
         for (auto& container : evaluationState->sizeQueryContainers | std::views::reverse) {
             if (isContainerForQuery(container))
                 return container.ptr();

--- a/Source/WebCore/style/ContainerQueryEvaluator.h
+++ b/Source/WebCore/style/ContainerQueryEvaluator.h
@@ -48,7 +48,7 @@ public:
 
     bool evaluate(const CQ::ContainerQuery&) const;
 
-    static RefPtr<const Element> selectContainer(OptionSet<CQ::Axis>, const WTF::String& name, const Element&, SelectionMode = SelectionMode::Element, ScopeOrdinal = ScopeOrdinal::Element, const ContainerQueryEvaluationState* = nullptr);
+    static RefPtr<const Element> selectContainer(CQ::ContainerRequirements, const WTF::String& name, const Element&, SelectionMode = SelectionMode::Element, ScopeOrdinal = ScopeOrdinal::Element, const ContainerQueryEvaluationState* = nullptr);
 
 private:
     std::optional<MQ::FeatureEvaluationContext> featureEvaluationContextForQuery(const CQ::ContainerQuery&) const;

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -276,7 +276,7 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
             : Style::ContainerQueryEvaluator::SelectionMode::PseudoElement;
 
         // "The query container for each axis is the nearest ancestor container that accepts container size queries on that axis."
-        while ((element = Style::ContainerQueryEvaluator::selectContainer(physicalAxis, nullString(), *element, mode))) {
+        while ((element = Style::ContainerQueryEvaluator::selectContainer(CQ::ContainerRequirements { physicalAxis }, nullString(), *element, mode))) {
             auto* containerRenderer = dynamicDowncast<RenderBox>(element->renderer());
             if (containerRenderer && containerRenderer->hasEligibleContainmentForSizeQuery()) {
                 auto widthOrHeight = physicalAxis == CQ::Axis::Width ? containerRenderer->contentBoxWidth() : containerRenderer->contentBoxHeight();


### PR DESCRIPTION
#### 42e9fa251171f9e4f0ec6f3599c63f04972cfd31
<pre>
Select a scroll-state query container ahead of scroll state evaluation
<a href="https://bugs.webkit.org/show_bug.cgi?id=317758">https://bugs.webkit.org/show_bug.cgi?id=317758</a>

Reviewed by Antti Koivisto.

A scroll-state() container query (scrollable/scrolled/stuck/snapped) must select
an ancestor query container whose container-type includes scroll-state, just as
a size query selects a size container. Previously a query only recorded the size
axes it needs, so scroll-state queries recorded nothing and were treated like
style queries, matching any ancestor container.

Introduce CQ::ContainerRequirements, bundling the size axes a query constrains
with whether it needs a scroll-state container, and store it on ContainerQuery.
selectContainer() requires ContainerType::hasScrollState() for scroll-state
queries and keeps the writing-mode-aware size-axis matching for size queries;
style and scroll-state queries (which need no size container) follow the same
ancestor walk and resolve against the container&apos;s pending style.

Feature evaluation remains stubbed; actual scrollable/scrolled/stuck/snapped
evaluation, and tests exercising container selection, are a follow-up.

Spec: <a href="https://drafts.csswg.org/css-conditional-5/#scroll-state-container">https://drafts.csswg.org/css-conditional-5/#scroll-state-container</a>

* Source/WebCore/css/query/ContainerQuery.h:
* Source/WebCore/css/query/ContainerQueryFeatures.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
* Source/WebCore/css/query/ContainerQueryParser.cpp:
* Source/WebCore/style/ContainerQueryEvaluator.h:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:

Canonical link: <a href="https://commits.webkit.org/316961@main">https://commits.webkit.org/316961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb9fd249ce9eed7f08803b38930cf318ad034013

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135257 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115735 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37325 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35694 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31984 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185926 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144157 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47526 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48205 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113535 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26447 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38924 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120089 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46711 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10495 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46114 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->