### PR TITLE
ArrayBuffer-backed I420/I420A/NV12 VideoFrame ignores non-zero visibleRect origin and crops from the coded top-left

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt
@@ -16,6 +16,7 @@ PASS Test codedRect.
 PASS Test empty rect.
 PASS Test left crop.
 PASS Test invalid rect.
-FAIL copyTo from byte data with non-default visibleRect assert_array_equals: Copied frame data incorrect. expected property 0 to be 76 but got 0 (expected array object "76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76" got object "0,0,76,76,0,0,76,76,0,0,76,76,0,0,76,76,0,0,76,76")
+PASS copyTo from byte data with non-default visibleRect
 PASS copyTo from byte data with codedHeight larger than visibleRect height
+PASS copyTo from byte data with non-zero visibleRect x origin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.js
@@ -419,3 +419,55 @@ promise_test(async t => {
 
   assert_array_equals(copied_data, packed_data, `Copied frame data incorrect.`);
 }, 'copyTo from byte data with codedHeight larger than visibleRect height');
+
+promise_test(async t => {
+  // Companion to the codedHeight case: a non-zero visibleRect origin must offset
+  // the source read. Here codedHeight == visibleRect.height so only the
+  // horizontal crop (visibleRect.x / sourceLeftBytes) is exercised. The visible
+  // region must be read starting at x, not from the coded left edge.
+  let init = {
+    format: 'I420',
+    timestamp: 1234,
+    codedWidth: 8,
+    codedHeight: 4,
+    visibleRect: {
+      x: 2,
+      y: 0,
+      width: 4,
+      height: 4,
+    },
+    colorSpace: {
+      primaries: 'smpte170m',
+      transfer: 'smpte170m',
+      matrix: 'smpte170m',
+      fullRange: false,
+    }
+  };
+
+  // Define YUV values for BT.601 red.
+  const redY = 76;
+  const redU = 84;
+  const redV = 255;
+
+  const ySize = init.codedWidth * init.codedHeight;
+  const uvSize = ySize / 4;
+  let data = new Uint8Array(ySize + 2 * uvSize);
+  fillYUV(data, init.codedWidth, init.codedHeight, init.visibleRect, redY, redU,
+          redV);
+
+  let frame = new VideoFrame(data, init);
+  assert_equals(frame.codedWidth, init.visibleRect.width);
+  assert_equals(frame.codedHeight, init.visibleRect.height);
+  assert_equals(frame.visibleRect.width, init.visibleRect.width);
+  assert_equals(frame.visibleRect.height, init.visibleRect.height);
+
+  let options = {rect: frame.visibleRect};
+  let copied_data = new Uint8Array(frame.allocationSize(options));
+  await frame.copyTo(copied_data, options);
+
+  let packed_data = new Uint8Array(frame.allocationSize(options));
+  fillYUV(packed_data, frame.codedWidth, frame.codedHeight, frame.visibleRect,
+          redY, redU, redV);
+
+  assert_array_equals(copied_data, packed_data, `Copied frame data incorrect.`);
+}, 'copyTo from byte data with non-zero visibleRect x origin');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt
@@ -16,6 +16,7 @@ PASS Test codedRect.
 PASS Test empty rect.
 PASS Test left crop.
 PASS Test invalid rect.
-FAIL copyTo from byte data with non-default visibleRect assert_array_equals: Copied frame data incorrect. expected property 0 to be 76 but got 0 (expected array object "76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76,76" got object "0,0,76,76,0,0,76,76,0,0,76,76,0,0,76,76,0,0,76,76")
+PASS copyTo from byte data with non-default visibleRect
 PASS copyTo from byte data with codedHeight larger than visibleRect height
+PASS copyTo from byte data with non-zero visibleRect x origin
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/WebKit/WebKitUtilities.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/webkit_sdk/WebKit/WebKitUtilities.mm
@@ -97,10 +97,18 @@ static bool copyI420BufferToPixelBuffer(CVPixelBufferRef pixelBuffer, const uint
 
     auto* sourceEnd = buffer + length;
     size_t sourceULength, sourceVLength, sourceYLength = 0;
-    if (__builtin_mul_overflow(sourceHeightUV, layout.strideU, &sourceULength)
-        || __builtin_mul_overflow(sourceHeightUV, layout.strideV, &sourceVLength)
-        || __builtin_mul_overflow(sourceHeightY, layout.strideY, &sourceYLength))
+    // libyuv reads the visible row width from each plane and steps by the row stride, so the last
+    // row only needs its visible bytes, not a full trailing stride. Computing the extent from the
+    // full stride would reject a frame cropped from a larger coded size, whose plane offsets carry
+    // the visibleRect origin (a non-zero visibleRect x/y leaves less than one stride after the last
+    // visible row).
+    if (__builtin_mul_overflow(sourceHeightUV ? sourceHeightUV - 1 : 0, layout.strideU, &sourceULength)
+        || __builtin_mul_overflow(sourceHeightUV ? sourceHeightUV - 1 : 0, layout.strideV, &sourceVLength)
+        || __builtin_mul_overflow(sourceHeightY ? sourceHeightY - 1 : 0, layout.strideY, &sourceYLength))
         return false;
+    sourceYLength += sourceHeightY ? sourceWidthY : 0;
+    sourceULength += sourceHeightUV ? sourceWidthUV : 0;
+    sourceVLength += sourceHeightUV ? sourceWidthUV : 0;
 
     RTC_DCHECK(sourceEnd >= sourceY + sourceYLength);
     RTC_DCHECK(sourceEnd >= sourceU + sourceULength);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -293,7 +293,12 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         return parsedRectOrExtension.releaseException();
 
     auto parsedRect = parsedRectOrExtension.releaseReturnValue();
-    auto layoutOrException = computeLayoutAndAllocationSize(defaultRect, init.layout, pixelFormat);
+    // The buffer is laid out for the coded size and visibleRect only crops the output. Compute the
+    // plane layout over the coded extent but anchored at the visible origin, so each plane's
+    // sourceTop/sourceLeftBytes carry the visibleRect crop while sourceHeight, stride and the
+    // allocation size stay coded (matching the coded-size buffer the caller provided).
+    DOMRectInit sourceRect { parsedRect.x, parsedRect.y, static_cast<double>(init.codedWidth), static_cast<double>(init.codedHeight) };
+    auto layoutOrException = computeLayoutAndAllocationSize(sourceRect, init.layout, pixelFormat);
     if (layoutOrException.hasException())
         return layoutOrException.releaseException();
 

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -65,12 +65,16 @@ RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
     return transferSession->createVideoFrame(image.platformImage().get(), { }, image.size());
 }
 
-static std::span<const uint8_t> copyToCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex, std::span<const uint8_t> source, size_t height, uint32_t bytesPerRowSource)
+static std::span<const uint8_t> copyToCVPixelBufferPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex, std::span<const uint8_t> source, size_t height, uint32_t bytesPerRowSource, uint32_t bytesPerRowToCopy)
 {
     auto destination = CVPixelBufferGetSpanOfPlane(pixelBuffer, planeIndex);
     uint32_t bytesPerRowDestination = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
+    // Copy only the visible row bytes, but step the source by its (coded) row stride so a frame
+    // cropped from a larger coded size reads each row from the correct position without running
+    // past the end of the source buffer.
+    auto count = std::min(bytesPerRowToCopy, bytesPerRowDestination);
     for (unsigned i = 0; i < height; ++i) {
-        memcpySpan(destination, source.first(std::min(bytesPerRowSource, bytesPerRowDestination)));
+        memcpySpan(destination, source.first(count));
         skip(source, bytesPerRowSource);
         skip(destination, bytesPerRowDestination);
     }
@@ -124,19 +128,28 @@ RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t 
     if (span.size() < height * planeY.sourceWidthBytes)
         return nullptr;
 
-    auto data = span;
-    data = copyToCVPixelBufferPlane(pixelBuffer.get(), 0, data, height, planeY.sourceWidthBytes);
-    // Source height may be bigger than destination height in case of a cropped frame, skip the cropped lines.
-    if (planeY.sourceHeight > height)
-        data = data.subspan((planeY.sourceHeight - height) * planeY.sourceWidthBytes);
+    // Each plane is laid out for the coded size; read it from its coded base (destinationOffset)
+    // offset by the visibleRect crop origin (sourceTop rows + sourceLeftBytes). Stepping over the
+    // coded plane heights keeps UV aligned when codedHeight exceeds visibleRect.height, and the
+    // crop origin honors a non-zero visibleRect x/y.
+    auto planeOffset = [](const ComputedPlaneLayout& plane) {
+        return plane.destinationOffset + plane.sourceTop * plane.destinationStride + plane.sourceLeftBytes;
+    };
+    auto lastRowExtent = [](size_t rowCount, uint32_t sourceStride, uint32_t bytesToCopy) -> size_t {
+        return rowCount ? (rowCount - 1) * sourceStride + bytesToCopy : 0;
+    };
+
+    copyToCVPixelBufferPlane(pixelBuffer.get(), 0, span.subspan(planeOffset(planeY)), height, planeY.destinationStride, width);
     if (CVPixelBufferGetPlaneCount(pixelBuffer.get()) == 2) {
         const auto heightUV = height / 2;
-        ASSERT(std::to_address(span.end()) >= data.subspan(heightUV * planeUV.sourceWidthBytes).data());
+        const uint32_t widthUV = ((width + 1) / 2) * 2;
+        auto dataUV = span.subspan(planeOffset(planeUV));
+        ASSERT(dataUV.size() >= lastRowExtent(heightUV, planeUV.destinationStride, widthUV));
         if (CVPixelBufferGetWidthOfPlane(pixelBuffer.get(), 1) != (width / 2)
             || CVPixelBufferGetHeightOfPlane(pixelBuffer.get(), 1) != heightUV
-            || (data.subspan(heightUV * planeUV.sourceWidthBytes).data() > std::to_address(span.end())))
+            || dataUV.size() < lastRowExtent(heightUV, planeUV.destinationStride, widthUV))
             return nullptr;
-        copyToCVPixelBufferPlane(pixelBuffer.get(), 1, data, height / 2, planeUV.sourceWidthBytes);
+        copyToCVPixelBufferPlane(pixelBuffer.get(), 1, dataUV, heightUV, planeUV.destinationStride, widthUV);
     }
 
     return VideoFrameCV::create({ }, false, Rotation::None, WTF::move(pixelBuffer), WTF::move(colorSpace));
@@ -199,15 +212,17 @@ RefPtr<VideoFrame> VideoFrame::createBGRA(std::span<const uint8_t> span, size_t 
 RefPtr<VideoFrame> VideoFrame::createI420(std::span<const uint8_t> buffer, size_t width, size_t height, const ComputedPlaneLayout& layoutY, const ComputedPlaneLayout& layoutU, const ComputedPlaneLayout& layoutV, PlatformVideoColorSpace&& colorSpace)
 {
 #if USE(LIBWEBRTC)
-    // Plane offsets must step over the full coded plane heights (layout*.sourceHeight), not the
-    // visible output height, otherwise a frame whose codedHeight exceeds visibleRect.height (e.g.
-    // a 1920x1088 frame cropped to 1920x1080) reads the chroma planes from the wrong offset.
-    size_t offsetLayoutU = layoutY.sourceLeftBytes + layoutY.sourceWidthBytes * layoutY.sourceHeight;
-    size_t offsetLayoutV = offsetLayoutU + layoutU.sourceLeftBytes + layoutU.sourceWidthBytes * layoutU.sourceHeight;
+    // Each plane is laid out for the coded size; read it from its coded base (destinationOffset)
+    // offset by the visibleRect crop origin (sourceTop rows + sourceLeftBytes). Stepping over the
+    // coded plane heights keeps the chroma planes aligned when codedHeight exceeds visibleRect.height,
+    // and the crop origin honors a non-zero visibleRect x/y.
+    auto planeOffset = [](const ComputedPlaneLayout& plane) {
+        return plane.destinationOffset + plane.sourceTop * plane.destinationStride + plane.sourceLeftBytes;
+    };
     webrtc::I420BufferLayout layout {
-        layoutY.sourceLeftBytes, layoutY.sourceWidthBytes,
-        offsetLayoutU, layoutU.sourceWidthBytes,
-        offsetLayoutV, layoutV.sourceWidthBytes
+        planeOffset(layoutY), layoutY.destinationStride,
+        planeOffset(layoutU), layoutU.destinationStride,
+        planeOffset(layoutV), layoutV.destinationStride
     };
     auto pixelBuffer = adoptCF(webrtc::createPixelBufferFromI420Buffer(buffer.data(), buffer.size(), width, height, layout, colorSpace.fullRange.value_or(false)));
 
@@ -230,16 +245,17 @@ RefPtr<VideoFrame> VideoFrame::createI420(std::span<const uint8_t> buffer, size_
 RefPtr<VideoFrame> VideoFrame::createI420A(std::span<const uint8_t> buffer, size_t width, size_t height, const ComputedPlaneLayout& layoutY, const ComputedPlaneLayout& layoutU, const ComputedPlaneLayout& layoutV, const ComputedPlaneLayout& layoutA, PlatformVideoColorSpace&& colorSpace)
 {
 #if USE(LIBWEBRTC)
-    size_t offsetLayoutU = layoutY.sourceLeftBytes + layoutY.sourceWidthBytes * layoutY.sourceHeight;
-    size_t offsetLayoutV = offsetLayoutU + layoutU.sourceLeftBytes + layoutU.sourceWidthBytes * layoutU.sourceHeight;
-    size_t offsetLayoutA = offsetLayoutV + layoutV.sourceLeftBytes + layoutV.sourceWidthBytes * layoutV.sourceHeight;
+    // See createI420: read each plane from its coded base offset by the visibleRect crop origin.
+    auto planeOffset = [](const ComputedPlaneLayout& plane) {
+        return plane.destinationOffset + plane.sourceTop * plane.destinationStride + plane.sourceLeftBytes;
+    };
     webrtc::I420ABufferLayout layout {
         {
-            layoutY.sourceLeftBytes, layoutY.sourceWidthBytes,
-            offsetLayoutU, layoutU.sourceWidthBytes,
-            offsetLayoutV, layoutV.sourceWidthBytes
+            planeOffset(layoutY), layoutY.destinationStride,
+            planeOffset(layoutU), layoutU.destinationStride,
+            planeOffset(layoutV), layoutV.destinationStride
         },
-        offsetLayoutA, layoutA.sourceWidthBytes
+        planeOffset(layoutA), layoutA.destinationStride
     };
     auto pixelBuffer = adoptCF(webrtc::createPixelBufferFromI420ABuffer(buffer.data(), buffer.size(), width, height, layout));
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -221,21 +221,31 @@ RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
     return VideoFrameGStreamer::create(WTF::move(sample), { { width, height }, WTF::move(info) });
 }
 
-static void copyToGstBufferPlane(std::span<uint8_t> destination, const GstVideoInfo& info, size_t planeIndex, std::span<const uint8_t> source, size_t height, uint32_t bytesPerRowSource)
+static void copyToGstBufferPlane(std::span<uint8_t> destination, const GstVideoInfo& info, size_t planeIndex, std::span<const uint8_t> source, size_t rowCount, uint32_t bytesPerRowSource, uint32_t bytesPerRowToCopy)
 {
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN; // GLib port
     auto destinationOffset = GST_VIDEO_INFO_PLANE_OFFSET(&info, planeIndex);
     uint32_t bytesPerRowDestination = GST_VIDEO_INFO_PLANE_STRIDE(&info, planeIndex);
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END; // GLib port
     gsize sourceOffset = 0;
-    auto count = std::min(bytesPerRowSource, bytesPerRowDestination);
-    for (size_t i = 0; i < height; ++i) {
+    // Copy only the visible row bytes, but step the source by its (coded) row stride so a frame
+    // cropped from a larger coded size reads each row from the correct position without running
+    // past the end of the source buffer.
+    auto count = std::min(bytesPerRowToCopy, bytesPerRowDestination);
+    for (size_t i = 0; i < rowCount; ++i) {
         auto sourceSpan = source.subspan(sourceOffset, count);
         auto destinationSpan = destination.subspan(destinationOffset, count);
         memcpySpan(destinationSpan, sourceSpan);
         sourceOffset += bytesPerRowSource;
         destinationOffset += bytesPerRowDestination;
     }
+}
+
+// Each plane is laid out for the coded size; its source base is the coded plane offset
+// (destinationOffset) shifted by the visibleRect crop origin (sourceTop rows + sourceLeftBytes).
+static inline size_t planeSourceOffset(const ComputedPlaneLayout& plane)
+{
+    return plane.destinationOffset + plane.sourceTop * plane.destinationStride + plane.sourceLeftBytes;
 }
 
 RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t width, size_t height, const ComputedPlaneLayout& planeY, const ComputedPlaneLayout& planeUV, PlatformVideoColorSpace&& colorSpace)
@@ -251,8 +261,8 @@ RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t 
     {
         GstMappedBuffer mappedBuffer(buffer, GST_MAP_WRITE);
         auto destinationSpan = mappedBuffer.mutableSpan<uint8_t>();
-        copyToGstBufferPlane(destinationSpan, info, 0, span, height, planeY.sourceWidthBytes);
-        copyToGstBufferPlane(destinationSpan, info, 1, span.subspan(planeUV.destinationOffset), height / 2, planeUV.sourceWidthBytes);
+        copyToGstBufferPlane(destinationSpan, info, 0, span.subspan(planeSourceOffset(planeY)), height, planeY.destinationStride, width);
+        copyToGstBufferPlane(destinationSpan, info, 1, span.subspan(planeSourceOffset(planeUV)), height / 2, planeUV.destinationStride, ((width + 1) / 2) * 2);
     }
     gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_NV12, width, height);
 
@@ -302,12 +312,12 @@ RefPtr<VideoFrame> VideoFrame::createI420(std::span<const uint8_t> span, size_t 
         GstMappedBuffer mappedBuffer(buffer, GST_MAP_WRITE);
         auto destinationSpan = mappedBuffer.mutableSpan<uint8_t>();
         auto stride = ((height + 1) / 2);
-        // The source planes are laid out for the coded size; use each plane's coded offset (as the
-        // NV12 path does) rather than deriving it from the visible height, otherwise a frame whose
-        // codedHeight exceeds visibleRect.height reads the chroma planes from the wrong offset.
-        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_Y, span, height, planeY.sourceWidthBytes);
-        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_U, span.subspan(planeU.destinationOffset), stride, planeU.sourceWidthBytes);
-        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_V, span.subspan(planeV.destinationOffset), stride, planeV.sourceWidthBytes);
+        auto widthUV = (width + 1) / 2;
+        // Read each plane from its coded base offset by the visibleRect crop origin (see
+        // planeSourceOffset), keeping the chroma planes aligned for cropped frames.
+        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_Y, span.subspan(planeSourceOffset(planeY)), height, planeY.destinationStride, width);
+        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_U, span.subspan(planeSourceOffset(planeU)), stride, planeU.destinationStride, widthUV);
+        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_V, span.subspan(planeSourceOffset(planeV)), stride, planeV.destinationStride, widthUV);
     }
     gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_I420, width, height);
 
@@ -328,11 +338,12 @@ RefPtr<VideoFrame> VideoFrame::createI420A(std::span<const uint8_t> span, size_t
         GstMappedBuffer mappedBuffer(buffer, GST_MAP_WRITE);
         auto destinationSpan = mappedBuffer.mutableSpan<uint8_t>();
         auto stride = ((height + 1) / 2);
-        // Use each plane's coded offset rather than deriving it from the visible height (see createI420).
-        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_Y, span, height, planeY.sourceWidthBytes);
-        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_U, span.subspan(planeU.destinationOffset), stride, planeU.sourceWidthBytes);
-        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_V, span.subspan(planeV.destinationOffset), stride, planeV.sourceWidthBytes);
-        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_A, span.subspan(planeA.destinationOffset), height, planeA.sourceWidthBytes);
+        auto widthUV = (width + 1) / 2;
+        // Read each plane from its coded base offset by the visibleRect crop origin (see createI420).
+        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_Y, span.subspan(planeSourceOffset(planeY)), height, planeY.destinationStride, width);
+        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_U, span.subspan(planeSourceOffset(planeU)), stride, planeU.destinationStride, widthUV);
+        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_V, span.subspan(planeSourceOffset(planeV)), stride, planeV.destinationStride, widthUV);
+        copyToGstBufferPlane(destinationSpan, info, GST_VIDEO_COMP_A, span.subspan(planeSourceOffset(planeA)), height, planeA.destinationStride, width);
     }
     gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_A420, width, height);
 


### PR DESCRIPTION
#### e8acfc9b6ee52aaf61371da2681f255be9876ae0
<pre>
ArrayBuffer-backed I420/I420A/NV12 VideoFrame ignores non-zero visibleRect origin and crops from the coded top-left
<a href="https://bugs.webkit.org/show_bug.cgi?id=317761">https://bugs.webkit.org/show_bug.cgi?id=317761</a>
<a href="https://rdar.apple.com/180533361">rdar://180533361</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium, and is a
follow-up to 317524 (codedHeight &gt; visibleRect.height chroma offset).

A buffer-backed VideoFrame is laid out for its coded size, and visibleRect only
crops the output. WebCodecsVideoFrame::create computed the plane layout from the
coded rect anchored at (0, 0), so each ComputedPlaneLayout&apos;s sourceTop /
sourceLeftBytes were always zero and the crop origin (parsedRect.x / parsedRect.y)
never reached the platform copy. The platform create functions then read the
visible region starting at the coded top-left, so a frame with a non-zero
visibleRect.x or .y (e.g. coded 8x4 shown as the 4x4 region at x=2) was cropped
from the wrong position.

Compute the layout over the coded extent but anchored at the visible origin, so
each plane carries the crop in sourceTop / sourceLeftBytes while sourceHeight,
stride and the allocation size stay coded (the codedHeight case is unchanged at
x=y=0). Read each plane from its coded base (destinationOffset) offset by the crop
origin (sourceTop * destinationStride + sourceLeftBytes) in createI420 /
createI420A / createNV12 on both the Cocoa (libwebrtc) and GStreamer paths,
replacing the per-plane offset arithmetic that conflated the previous plane&apos;s
sourceLeftBytes into the next plane&apos;s base and ignored sourceTop. This also uses
the destination stride / offset, correctly handling user-supplied padded layouts.

The per-row copy in the GStreamer and Cocoa NV12 helpers must copy only the
visible row width while stepping the source by its coded row stride; otherwise a
left-cropped frame (sourceLeftBytes &gt; 0) reads a full coded-stride row from the
crop offset and runs past the end of the source buffer. Pass the visible
bytes-to-copy separately from the source stride, and base the Cocoa NV12 bounds
check on the actual read extent. For the same reason, relax the source-length
check in the libwebrtc I420-&gt;NV12 helper to the actual read extent
((height - 1) * stride + visible row bytes), since libyuv reads only the visible
width per row; the full-stride check rejected a frame cropped from a larger coded
size.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::createNV12):
(WebCore::VideoFrame::createI420):
(WebCore::VideoFrame::createI420A):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::planeSourceOffset):
(WebCore::VideoFrame::createNV12):
(WebCore::VideoFrame::createI420):
(WebCore::VideoFrame::createI420A):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8acfc9b6ee52aaf61371da2681f255be9876ae0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127799 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93fe2545-880e-46fe-892f-243421458064) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132576 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93420 "12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f6b0fb8-3052-492c-852e-07f183453df3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153009 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113078 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16268454-4c06-48f5-a0f1-649061905917) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34351 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32716 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28145 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182046 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31342 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34835 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 28351 issues; Running display-safer-cpp-results") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36930 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141027 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43666 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152479 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140855 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44355 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108706 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36124 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116236 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42866 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7653 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42258 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42512 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->