### PR TITLE
[GLib][Site Isolation] Internals::resetToConsistentState corrupts memory with unchecked static_cast to MediaSessionManagerGLib in site-isolation tests

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5574,9 +5574,6 @@ webkit.org/b/316712 fast/forms/validation-message-clone.html [ Failure ]
 webkit.org/b/292843 fast/dom/Window/open-window-min-size.html [ Failure ]
 
 webkit.org/b/316718 imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses-multiple-sessions.https.html [ Pass Failure ]
-webkit.org/b/316719 fast/images/alt-text-with-right-to-left-inline-direction-reordering.html [ Pass Crash ]
-webkit.org/b/316719 fast/html/HTMLCollection-set-property.html [ Pass Crash ]
-webkit.org/b/316719 fast/inline/001.html [ Pass Crash ]
 
 webkit.org/b/316573 fast/parser/empty-text-resource.html [ Pass Timeout ]
 webkit.org/b/316575 [ x86_64 ] http/tests/IndexedDB/collect-IDB-objects.https.html [ Pass Crash ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1316,16 +1316,6 @@ webkit.org/b/316584 [ arm64 ] imported/w3c/web-platform-tests/wasm/core/simd/sim
 webkit.org/b/316585 [ arm64 ] fullscreen/full-screen-disables-viewport-clipping.html [ Pass ImageOnlyFailure ]
 webkit.org/b/316586 [ arm64 ] http/tests/cache/cache-control-immutable-http.html [ Pass Crash ]
 
-# Flaky refCount teardown crash (FontCascade::~FontCascade), much more frequent on arm64.
-webkit.org/b/316719 [ arm64 ] fast/inspector-support/cssURLQuotes.html [ Pass Crash ]
-webkit.org/b/316719 [ arm64 ] fast/layers/accumulated-offset-overflow-Render-geometry-map.html [ Pass Crash ]
-webkit.org/b/316719 [ arm64 ] fast/inline-block/001.html [ Pass Crash ]
-webkit.org/b/316719 [ arm64 ] fast/js-promise/js-promise-from-detached-iframe.html [ Pass Crash ]
-webkit.org/b/316719 [ arm64 ] fast/innerHTML/001.html [ Pass Crash ]
-webkit.org/b/316719 [ arm64 ] fast/invalid/001.html [ Pass Crash ]
-webkit.org/b/316719 [ arm64 ] fast/layout/bounding-client-rect-no-layer-updates.html [ Pass Crash ]
-webkit.org/b/316719 [ arm64 ] fast/images/png-suite/test.html [ Pass Crash ]
-
 webkit.org/b/315758 imported/w3c/web-platform-tests/webrtc/simulcast/vp8.https.html [ Crash Pass ]
 webkit.org/b/315758 imported/w3c/web-platform-tests/webrtc/simulcast/av1.https.html [ Crash Pass ]
 

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -133,6 +133,11 @@ void MediaSessionManagerInterface::resetRestrictions()
     m_restrictions[indexFromMediaType(PlatformMediaSession::MediaType::DOMMediaSession)] = MediaSessionRestriction::NoRestrictions;
 }
 
+bool MediaSessionManagerInterface::isMediaSessionManagerGLib() const
+{
+    return false;
+}
+
 bool MediaSessionManagerInterface::has(PlatformMediaSession::MediaType type) const
 {
     return anyOfSessions([type] (auto& session) {

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -156,6 +156,8 @@ public:
     virtual void scheduleSessionStatusUpdate() { }
     virtual void resetSessionState() { };
 
+    virtual bool isMediaSessionManagerGLib() const;
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
 #endif

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -24,6 +24,7 @@
 #include "NowPlayingManager.h"
 #include "PlatformMediaSessionManager.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/TypeCasts.h>
 #include <wtf/glib/GRefPtr.h>
 
 namespace WebCore {
@@ -62,6 +63,8 @@ public:
 
     void setDBusNotificationsEnabled(bool dbusNotificationsEnabled) { m_dbusNotificationsEnabled = dbusNotificationsEnabled; }
     bool areDBusNotificationsEnabled() const { return m_dbusNotificationsEnabled; }
+
+    bool isMediaSessionManagerGLib() const final { return true; }
 
 protected:
     MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&&, PageIdentifier);
@@ -116,5 +119,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::MediaSessionManagerGLib)
+static bool isType(const WebCore::MediaSessionManagerInterface& manager) { return manager.isMediaSessionManagerGLib(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // USE(GLIB) && ENABLE(MEDIA_SESSION)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -757,8 +757,8 @@ void Internals::resetToConsistentState(Page& page)
 #endif
 
 #if ENABLE(MEDIA_SESSION) && USE(GLIB)
-    MediaSessionManagerGLib* glibSessionManager = static_cast<MediaSessionManagerGLib*>(sessionManager.get());
-    glibSessionManager->setDBusNotificationsEnabled(false);
+    if (auto* glibSessionManager = dynamicDowncast<MediaSessionManagerGLib>(sessionManager.get()))
+        glibSessionManager->setDBusNotificationsEnabled(false);
 #endif
 
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### ea237a349ded2681fcb6ced807a8fc484f71a876
<pre>
[GLib][Site Isolation] Internals::resetToConsistentState corrupts memory with unchecked static_cast to MediaSessionManagerGLib in site-isolation tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=316719">https://bugs.webkit.org/show_bug.cgi?id=316719</a>

Reviewed by Nikolas Zimmermann.

Since 314640@main, WebPage installs a RemoteMediaSessionManager for
tests with SiteIsolationEnabled. As Internals::resetToConsistentState
unconditionally static_casts the manager to MediaSessionManagerGLib and
calls setters on it, it writes out of bounds on the actual underlying
object.

For example, this was leading to corruption of adjacent objects, like
the refcount of FontCascade-related classes or the vtable of objects
used by FrameLoader::stopAllLoaders.

This commit guards the MediaSessionManagerGLib with a dynamicDowncast,
so only objects of the proper type are written to, mirroring the pattern
already used in other classes in this file.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::isMediaSessionManagerGLib const):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
(isType):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):

Canonical link: <a href="https://commits.webkit.org/315794@main">https://commits.webkit.org/315794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94ad85dcdee811de32f963023a4e87dd60de89d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43933 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37437 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132515 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172967 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113017 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32656 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28066 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181967 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140969 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43633 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152489 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140796 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37925 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44322 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108620 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36101 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116168 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42833 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7499 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42225 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->