### PR TITLE
`git-webkit pr` may leak username/password as plain text in stdout if certain Bugzilla requests time out

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -23,7 +23,9 @@
 import argparse
 import logging
 import os
+import re
 import sys
+import traceback
 
 from .blame import Blame
 from .branch import Branch
@@ -183,14 +185,22 @@ def main(
         parser.print_help()
         return -1
 
+    # Bugzilla's REST API embeds credentials as plain-text query parameters (login= and
+    # password=), which means they can appear in exception tracebacks when requests fail.
+    # Scrub them here at the top level so they're never printed to the terminal.
+    # This can be removed once Bugzilla auth no longer uses credentials in URLs.
     with Terminal.disable_keyboard_interrupt_stacktracktrace():
-        return parsed.main(
-            args=parsed,
-            repository=repository,
-            identifier_template=identifier_template,
-            subversion=subversion,
-            additional_setup=additional_setup,
-            hooks=hooks,
-            canonical_svn=canonical_svn,
-            fallback_path=fallback_path,
-        )
+        try:
+            return parsed.main(
+                args=parsed,
+                repository=repository,
+                identifier_template=identifier_template,
+                subversion=subversion,
+                additional_setup=additional_setup,
+                hooks=hooks,
+                canonical_svn=canonical_svn,
+                fallback_path=fallback_path,
+            )
+        except Exception:
+            sys.stderr.write(re.sub(r'(login|password)=[^&]+', r'\1=<REDACTED>', traceback.format_exc()))
+            return -1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -2357,6 +2357,21 @@ No pre-PR checks to run""")
             ],
         )
 
+    def test_redacts_credentials_in_traceback(self):
+        with OutputCapture(level=logging.INFO) as captured, \
+             mocks.local.Git(self.path), \
+             patch('webkitbugspy.Tracker._trackers', []), \
+             patch('webkitscmpy.program.pull_request.PullRequest.main', side_effect=Exception(
+                 "url: /rest/bug/1?login=myuser&password=mysecret"
+             )):
+            self.assertEqual(-1, program.main(
+                args=('pull-request',),
+                path=self.path,
+            ))
+        self.assertIn('login=<REDACTED>', captured.stderr.getvalue())
+        self.assertIn('password=<REDACTED>', captured.stderr.getvalue())
+        self.assertNotIn('myuser', captured.stderr.getvalue())
+        self.assertNotIn('mysecret', captured.stderr.getvalue())
 
 class TestNetworkPullRequestGitHub(unittest.TestCase):
     remote = 'https://github.example.com/WebKit/WebKit'


### PR DESCRIPTION
#### 3dd07fee85869b16f635ec53e3ff6f23d88e5941
<pre>
`git-webkit pr` may leak username/password as plain text in stdout if certain Bugzilla requests time out
<a href="https://rdar.apple.com/180346543">rdar://180346543</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317765">https://bugs.webkit.org/show_bug.cgi?id=317765</a>

Reviewed by Sam Sneddon and Elliott Williams.

Fixed by wrapping the top-level `parsed.main()` call in a try/except that
catches all unhandled exceptions, scrubs `login=` and `password=` query
parameters from the full traceback string via regex, and prints the
sanitized traceback to `stderr`.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
Wrap `parsed.main()` in a try/except, redacting credentials from the
traceback before printing to stderr.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestDoPullRequest.test_redacts_credentials_in_traceback): Added.

Canonical link: <a href="https://commits.webkit.org/315864@main">https://commits.webkit.org/315864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e02a232b2851dd9e165354a9c2e11e14b0951660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132728 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173202 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113229 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169564 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28301 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182202 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141168 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/169643 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43823 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140992 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44512 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29525 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108923 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36263 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43022 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7625 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->