### PR TITLE
CRASH in TrackBuffer::removeCodedFrames(...)

### DIFF
--- a/LayoutTests/media/media-source/media-source-remove-divisible-sample-overlap-expected.txt
+++ b/LayoutTests/media/media-source/media-source-remove-divisible-sample-overlap-expected.txt
@@ -1,0 +1,13 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer('audio/mp4; codecs="mp4a.40.2"'))
+RUN(sourceBuffer.appendBuffer(MP4.concat(seg1Init, seg1Media)))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(seg2Media))
+EVENT(updateend)
+RUN(sourceBuffer.remove(4200/44100, 4500/44100))
+EVENT(updateend)
+PASS: remove() returned without crashing
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-remove-divisible-sample-overlap.html
+++ b/LayoutTests/media/media-source/media-source-remove-divisible-sample-overlap.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SourceBuffer.remove() with divisible AAC sample overlapped by a smaller sample</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    let source;
+    let sourceBuffer;
+    let seg1Init;
+    let seg1Media;
+    let seg2Media;
+
+    async function runTest() {
+        findMediaElement();
+        if (!MediaSource.isTypeSupported(MP4.AUDIO_TYPE)) {
+            failTest(`${MP4.AUDIO_TYPE} not supported`);
+            return;
+        }
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run(`sourceBuffer = source.addSourceBuffer('${MP4.AUDIO_TYPE}')`);
+
+        const TIMESCALE = 44100;
+        const FRAME = 1024;
+
+        seg1Init = MP4.initSegment({
+            timescale: TIMESCALE,
+            tracks: [{ id: 1, type: 'audio', timescale: TIMESCALE }],
+        });
+        seg1Media = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'audio', baseDecodeTime: 0,
+                samples: Array.from({length: 32}, () => ({
+                    duration: FRAME, compositionTimeOffset: 0, isSync: true,
+                })),
+            }],
+        });
+        seg2Media = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{ id: 1, type: 'audio', baseDecodeTime: 4600,
+                samples: [{ duration: FRAME, compositionTimeOffset: 0, isSync: true }],
+            }],
+        });
+
+        run('sourceBuffer.appendBuffer(MP4.concat(seg1Init, seg1Media))');
+        await waitFor(sourceBuffer, 'updateend');
+        run('sourceBuffer.appendBuffer(seg2Media)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.remove(4200/44100, 4500/44100)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        consoleWrite('PASS: remove() returned without crashing');
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -481,8 +481,9 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
     return Ref { a.second }->decodeTime() < Ref { b.second }->decodeTime();
 };
 
-int64_t TrackBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime)
+int64_t TrackBuffer::removeCodedFrames(const MediaTime& startIn, const MediaTime& end, const MediaTime& currentTime)
 {
+    MediaTime start = startIn;
     ASSERT(start.isValid());
     ASSERT(end.isValid());
     // 3.5.9 Coded Frame Removal Algorithm
@@ -503,12 +504,21 @@ int64_t TrackBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& 
     // first sample to erase — find it by its actual PTS (which may differ slightly from `start`
     // due to timescale rounding, in either direction). Otherwise the original sample (with PTS <
     // start) must be retained per spec; use findSampleStartingOnOrAfter to skip it.
-    auto splitAtStart = tryDivideSampleAtTime(start, ApplyDivide::Yes);
-    tryDivideSampleAtTime(end, ApplyDivide::Yes);
+    auto splitAtStart = tryDivideSampleAtTime(start, ApplyDivide::No);
+    if (splitAtStart.afterSplitPresentationTime.isValid()) {
+        // NOTE: When the sample at `start` is divisible, `tryDivideSampleAtTime()` snaps the
+        // split point UP to the next sub-sample boundary at or after `start`. That boundary
+        // can land beyond `end` when the requested removal range is shorter than one sub-sample
+        // (e.g. shorter than one AAC frame inside a bundled CMSampleBuffer). If another sample
+        // happens to sit at PTS in [end, afterSplitPresentationTime), the lower_bound calls
+        // below would invert iterator order and walk std::minmax_element off the end of the map.
+        if (splitAtStart.afterSplitPresentationTime >= end)
+            return 0;
+    }
 
-    auto removePresentationStart = splitAtStart.afterSplitPresentationTime.isValid()
-        ? m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(splitAtStart.afterSplitPresentationTime)
-        : m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(start);
+    splitAtStart = tryDivideSampleAtTime(start, ApplyDivide::Yes);
+    tryDivideSampleAtTime(end, ApplyDivide::Yes);
+    auto removePresentationStart = m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(start);
     auto removePresentationEnd = m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(end);
     if (removePresentationStart == m_samples.presentationOrder().end() || removePresentationStart == removePresentationEnd)
         return framesSizeBefore - samples().sizeInBytes(); // This could be negative if new frames were created above.
@@ -546,19 +556,25 @@ int64_t TrackBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& 
     return framesSizeBefore - samples().sizeInBytes();
 }
 
-int64_t TrackBuffer::codedFramesIntervalSize(const MediaTime& start, const MediaTime& end)
+int64_t TrackBuffer::codedFramesIntervalSize(const MediaTime& startIn, const MediaTime& end)
 {
-    ASSERT(start.isValid());
+    ASSERT(startIn.isValid());
     ASSERT(end.isValid());
+
+    MediaTime start = startIn;
 
     // Mirror removeCodedFrames' iterator selection. Compute split sizes without mutating the
     // sample map (ApplyDivide::No).
     auto splitAtStart = tryDivideSampleAtTime(start, ApplyDivide::No);
-    auto splitAtEnd = tryDivideSampleAtTime(end, ApplyDivide::No);
+    if (splitAtStart.afterSplitPresentationTime.isValid()) {
+        start = splitAtStart.afterSplitPresentationTime;
+        // See removeCodedFrames() for why this guard is required.
+        if (start >= end)
+            return 0;
+    }
 
-    auto removePresentationStart = splitAtStart.afterSplitPresentationTime.isValid()
-        ? m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(splitAtStart.afterSplitPresentationTime)
-        : m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(start);
+    auto splitAtEnd = tryDivideSampleAtTime(end, ApplyDivide::No);
+    auto removePresentationStart = m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(start);
     auto removePresentationEnd = m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(end);
     if (removePresentationStart == m_samples.presentationOrder().end() || removePresentationStart == removePresentationEnd)
         return 0;


### PR DESCRIPTION
#### b5b4ce70e1fb3cc097222cd3a13bd9cabe2b9756
<pre>
CRASH in TrackBuffer::removeCodedFrames(...)
<a href="https://rdar.apple.com/180378045">rdar://180378045</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317770">https://bugs.webkit.org/show_bug.cgi?id=317770</a>

Reviewed by Jean-Yves Avenard.

When splitting a sample during a remove() operation, it&apos;s possible to have the start time for the removal range
to advance such that it becomes &gt;= the end time, which causes subsequent range iterations to walk off the end of
the SampleMap and hit a null dereference when incrementing the end() iterator. Protect against this by adding an
additional order validation step before iterating over the discovered range. Because this same pattern exists in
TrackBuffer::codedFramesIntervalSize(...) as well, perform the same validation there.

Test: media/media-source/media-source-remove-divisible-sample-overlap.html

* LayoutTests/media/media-source/media-source-remove-divisible-sample-overlap-expected.txt: Added.
* LayoutTests/media/media-source/media-source-remove-divisible-sample-overlap.html: Added.
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::removeCodedFrames):
(WebCore::TrackBuffer::codedFramesIntervalSize):

Canonical link: <a href="https://commits.webkit.org/315869@main">https://commits.webkit.org/315869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c5eb7b07f3e6a58bc902185fd7924c7e1cb5fe7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127980 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7cb9409-64b1-4bb4-ac2f-900ef84c60f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132747 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f910c245-9a39-4e96-8ef4-adee78ef44e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113248 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de5b918a-cdf9-4bd7-a4b9-31afdf8db154) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28326 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182227 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141196 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141019 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37979 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44537 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29560 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108953 "Hash 2c5eb7b0 for PR 67793 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36285 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116419 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43047 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7661 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42453 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42693 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42582 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->