### PR TITLE
Only expose evaluateScript in non-normal worlds

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -109,6 +109,7 @@ public:
 
     Type type() const { return m_type; }
     bool isNormal() const { return m_type == Type::Normal; }
+    bool isNonNormal() const { return m_type != Type::Normal; }
     bool isUser() const { return m_type == Type::User; }
 
     const String& name() const LIFETIME_BOUND { return m_name; }

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -32,7 +32,7 @@
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace? messageHandlers;
     readonly attribute WebKitBufferNamespace buffers;
-    [CallWith=CurrentGlobalObject] any evaluateScript(DOMString source, optional USVString? url = null);
+    [EnabledForWorld=isNonNormal, CallWith=CurrentGlobalObject] any evaluateScript(DOMString source, optional USVString? url = null);
     [EnabledForGlobalObject=allowsJSHandleCreation] WebKitJSHandle createJSHandle(object object);
     [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init = {});
 };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WKContentWorld.h>
 #import <WebKit/WKContentWorldConfiguration.h>
 #import <WebKit/WKContentWorldPrivate.h>
+#import <WebKit/WKJSScriptingBuffer.h>
 #import <WebKit/WKJSSerializedNode.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKScriptMessage.h>
@@ -2053,4 +2054,38 @@ TEST(WKUserContentController, MessageHandlerReplyWithSerializedNode)
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
+}
+
+TEST(WKUserContentController, MessageHandlerInjectsWebKitNamespace)
+{
+    RetainPtr handler = adoptNS([ScriptMessageHandler new]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<body>test</body>"];
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"!!window.webkit.messageHandlers.testHandler"] boolValue]);
+
+    // The other WebKitNamespace attributes shouldn't be accessible.
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.evaluateScript"] boolValue]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle"] boolValue]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.serializeNode"] boolValue]);
+}
+
+TEST(WKUserContentController, JSBufferInjectsWebKitNamespace)
+{
+    RetainPtr buffer = adoptNS([[WKJSScriptingBuffer alloc] initWithData:[NSData dataWithBytes:"abc" length:3]]);
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [[configuration userContentController] addBuffer:buffer.get() name:@"testBuffer" contentWorld:WKContentWorld.pageWorld];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<body>test</body>"];
+
+    EXPECT_WK_STREQ([webView objectByEvaluatingJavaScript:@"window.webkit.buffers.testBuffer.asLatin1String()"], "abc");
+
+    // The other WebKitNamespace attributes shouldn't be accessible.
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.evaluateScript"] boolValue]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle"] boolValue]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"window.webkit.serializeNode"] boolValue]);
 }


### PR DESCRIPTION
#### 869eb5505b526c284d74ba427c400061315fb2c2
<pre>
Only expose evaluateScript in non-normal worlds
<a href="https://bugs.webkit.org/show_bug.cgi?id=317774">https://bugs.webkit.org/show_bug.cgi?id=317774</a>
<a href="https://rdar.apple.com/180545219">rdar://180545219</a>

Reviewed by Per Arne Vollan.

`window.webkit.evaluateScript` is exposed to the normal world if the user registers a message
handler or WKJSBuffer in the normal world. This isn&apos;t intended; regular webpages can just call
`eval` instead. `evaluateScript` just gives the ability to customize the source URL of the script
for Web Inspector, which isn&apos;t something intended to be exposed to regular webpages.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm

* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::isNonNormal const):
* Source/WebCore/page/WebKitNamespace.idl:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm:
(TEST(WKUserContentController, MessageHandlerInjectsWebKitNamespace)):
(TEST(WKUserContentController, JSBufferInjectsWebKitNamespace)):

Canonical link: <a href="https://commits.webkit.org/315837@main">https://commits.webkit.org/315837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6697f290a7a1baf69931ea849c15e850a944958a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127762 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a001989-9844-41ff-9812-3b111aaa7ae0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132546 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93400 "1 flakes 12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7455947-f642-4d41-9151-e7097b575fcb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113048 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/062dad44-505d-412c-b33b-0673c1fca963) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32687 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28108 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182009 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140999 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43628 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37960 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44317 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29364 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108667 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36095 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116199 "Found 120 new failures in Modules/speech/SpeechRecognitionResult.cpp, css/typedom/transform/CSSTransformValue.cpp, css/SelectorFilter.cpp, rendering/NinePieceImagePainter.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm, dom/ImageOverlay.cpp, dfg/DFGLoopUnrollingPhase.cpp, Modules/webauthn/apdu/ApduCommand.cpp, platform/audio/AudioBus.cpp, NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42828 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7463 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42220 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42475 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42363 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->