### PR TITLE
REGRESSION(315159@main): loadFileURL:allowingReadAccessToURL: fails to load file:// URLs when NetworkProcess sandbox blocks the read

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -37,6 +37,8 @@ using namespace WebCore;
 void NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary()
 {
     if (request.url().protocolIsFile()) {
+        if (resourceSandboxExtension)
+            return;
         String path = request.url().fileSystemPath();
 #if HAVE(AUDIT_TOKEN)
         if (auto networkProcessAuditToken = WebProcess::singleton().ensureNetworkProcessConnection().networkProcessAuditToken()) {

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -60,6 +60,9 @@ struct LoadParameters {
 
     WebCore::ResourceRequest request;
     SandboxExtension::Handle sandboxExtensionHandle;
+#if HAVE(AUDIT_TOKEN)
+    std::optional<SandboxExtension::Handle> networkProcessSandboxExtensionHandle;
+#endif
 
     RefPtr<WebCore::SharedBuffer> data;
     String MIMEType;

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -29,6 +29,9 @@ enum class WebCore::LockBackForwardList : bool;
     std::optional<WebCore::FrameIdentifier> frameIdentifier;
     [EncodeRequestBody] WebCore::ResourceRequest request;
     WebKit::SandboxExtensionHandle sandboxExtensionHandle;
+#if HAVE(AUDIT_TOKEN)
+    std::optional<WebKit::SandboxExtensionHandle> networkProcessSandboxExtensionHandle;
+#endif
     RefPtr<WebCore::SharedBuffer> data;
 
     String MIMEType;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2157,6 +2157,19 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
     completionHandler(std::nullopt);
 }
 
+#if HAVE(AUDIT_TOKEN)
+std::optional<SandboxExtensionHandle> WebPageProxy::createNetworkProcessSandboxExtensionForFileURL(const URL& url)
+{
+    auto& networkProcess = websiteDataStore().networkProcess();
+    if (!networkProcess.hasConnection())
+        return std::nullopt;
+    auto networkToken = protect(networkProcess.connection())->getAuditToken();
+    if (!networkToken)
+        return std::nullopt;
+    return SandboxExtension::createHandleForReadByAuditToken(url.fileSystemPath(), *networkToken);
+}
+#endif
+
 void WebPageProxy::prepareToLoadWebPage(WebProcessProxy& process, LoadParameters& parameters)
 {
     addPlatformLoadParameters(process, parameters);
@@ -2390,7 +2403,7 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     loadParameters.publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(loadParameters.request.url());
     loadParameters.isRequestFromClientOrUserInput = isAppInitiated;
     Ref process = m_legacyMainFrameProcess;
-    maybeInitializeSandboxExtensionHandle(process, fileURL, resourceDirectoryURL, true, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, loadParameters = WTF::move(loadParameters), resourceDirectoryURL] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
+    maybeInitializeSandboxExtensionHandle(process, fileURL, resourceDirectoryURL, true, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, loadParameters = WTF::move(loadParameters), resourceDirectoryURL, fileURL] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
         const bool checkAssumedReadAccessToResourceURL = false;
         RefPtr protectedProcess = weakProcess.get();
         RefPtr protectedThis = weakThis.get();
@@ -2399,7 +2412,10 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
         if (sandboxExtension)
             loadParameters.sandboxExtensionHandle = WTF::move(*sandboxExtension);
 
-        protectedThis->prepareToLoadWebPage(*protectedProcess, loadParameters);
+#if HAVE(AUDIT_TOKEN)
+        if (auto handle = protectedThis->createNetworkProcessSandboxExtensionForFileURL(fileURL))
+            loadParameters.networkProcessSandboxExtensionHandle = WTF::move(*handle);
+#endif
 
         protectedProcess->markProcessAsRecentlyUsed();
         if (protectedProcess->isLaunching())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2383,6 +2383,9 @@ public:
 #endif
 
     void maybeInitializeSandboxExtensionHandle(WebProcessProxy&, const URL&, const URL& resourceDirectoryURL, bool checkAssumedReadAccessToResourceURL, CompletionHandler<void(std::optional<SandboxExtensionHandle>&&)>&&);
+#if HAVE(AUDIT_TOKEN)
+    std::optional<SandboxExtensionHandle> createNetworkProcessSandboxExtensionForFileURL(const URL&);
+#endif
 
 #if ENABLE(WEB_AUTHN)
     // Web Authentication API

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -644,11 +644,17 @@ bool WebProcessProxy::shouldSendPendingMessage(const IPC::Encoder& encoder)
         if (loadParameters && resourceDirectoryURL && pageID && checkAssumedReadAccessToResourceURL) {
             if (RefPtr page = WebProcessProxy::webPage(*pageID)) {
                 auto url = loadParameters->request.url();
-                page->maybeInitializeSandboxExtensionHandle(static_cast<WebProcessProxy&>(*this), url, *resourceDirectoryURL,  *checkAssumedReadAccessToResourceURL, [weakThis = WeakPtr { *this }, destinationID, loadParameters = WTF::move(loadParameters)] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
+                page->maybeInitializeSandboxExtensionHandle(static_cast<WebProcessProxy&>(*this), url, *resourceDirectoryURL, *checkAssumedReadAccessToResourceURL, [weakThis = WeakPtr { *this }, destinationID, loadParameters = WTF::move(loadParameters), page] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
                     if (!weakThis)
                         return;
                     if (sandboxExtension)
                         loadParameters->sandboxExtensionHandle = WTF::move(*sandboxExtension);
+#if HAVE(AUDIT_TOKEN)
+                    if (loadParameters->request.url().protocolIsFile()) {
+                        if (auto handle = page->createNetworkProcessSandboxExtensionForFileURL(loadParameters->request.url()))
+                            loadParameters->networkProcessSandboxExtensionHandle = WTF::move(*handle);
+                    }
+#endif
                     weakThis->send(Messages::WebPage::LoadRequest(WTF::move(*loadParameters)), destinationID);
                 });
             }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -470,6 +470,15 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         trackingParameters.frameID,
         request
     };
+#if HAVE(AUDIT_TOKEN)
+    if (request.url().protocolIsFile()) {
+        RefPtr frame = resourceLoader.frame();
+        RefPtr page = frame ? frame->page() : nullptr;
+        RefPtr webPage = page ? WebPage::fromCorePage(*page) : nullptr;
+        if (auto pendingExtension = webPage ? webPage->takePendingNetworkProcessSandboxExtension() : std::nullopt)
+            loadParameters.resourceSandboxExtension = WTF::move(*pendingExtension);
+    }
+#endif
     loadParameters.createSandboxExtensionHandlesIfNecessary();
 
     loadParameters.identifier = identifier;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2436,6 +2436,11 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
     m_pendingNavigationID = loadParameters.navigationID;
     m_internals->pendingWebsitePolicies = WTF::move(loadParameters.websitePolicies);
 
+#if HAVE(AUDIT_TOKEN)
+    if (loadParameters.request.url().protocolIsFile() && loadParameters.networkProcessSandboxExtensionHandle)
+        m_pendingNetworkProcessSandboxExtension = WTF::move(loadParameters.networkProcessSandboxExtensionHandle);
+#endif
+
     m_sandboxExtensionTracker.beginLoad(WTF::move(loadParameters.sandboxExtensionHandle));
 
     // Let the InjectedBundle know we are about to start the load, passing the user data from the UIProcess
@@ -6740,7 +6745,8 @@ void WebPage::SandboxExtensionTracker::willPerformLoadDragDestinationAction(RefP
 
 void WebPage::SandboxExtensionTracker::beginLoad(SandboxExtension::Handle&& handle)
 {
-    setPendingProvisionalSandboxExtension(SandboxExtension::create(WTF::move(handle)));
+    auto extension = SandboxExtension::create(WTF::move(handle));
+    setPendingProvisionalSandboxExtension(WTF::move(extension));
 }
 
 void WebPage::SandboxExtensionTracker::beginReload(WebFrame* frame, SandboxExtension::Handle&& handle)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1432,6 +1432,10 @@ public:
     void performDragOperation(std::optional<WebCore::FrameIdentifier>, WebCore::DragData&&, SandboxExtension::Handle&&, Vector<SandboxExtension::Handle>&&,  CompletionHandler<void(DragOperationResult dragOperationResult)>&&);
 #endif
 
+#if HAVE(AUDIT_TOKEN)
+    std::optional<SandboxExtension::Handle> takePendingNetworkProcessSandboxExtension() { return std::exchange(m_pendingNetworkProcessSandboxExtension, std::nullopt); }
+#endif
+
 #if ENABLE(DRAG_SUPPORT)
     void dragEnded(std::optional<WebCore::FrameIdentifier>, WebCore::IntPoint clientPosition, WebCore::IntPoint globalPosition, OptionSet<WebCore::DragOperation>, CompletionHandler<void(std::optional<WebCore::RemoteUserInputEventData>)>&&);
 
@@ -3029,6 +3033,9 @@ private:
 
     std::optional<SandboxExtension::Handle> m_pendingDropSandboxExtensionHandle;
     std::optional<Vector<SandboxExtension::Handle>> m_pendingDropExtensionHandlesForFileUpload;
+#if HAVE(AUDIT_TOKEN)
+    std::optional<SandboxExtension::Handle> m_pendingNetworkProcessSandboxExtension;
+#endif
 
     PAL::HysteresisActivity m_pageScrolledHysteresis;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileURL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileURL.mm
@@ -46,6 +46,18 @@ TEST(WKWebView, LoadFileWithLoadRequest)
     [delegate waitForDidFinishNavigation];
 }
 
+TEST(WKWebView, LoadFileWithFileURL)
+{
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+
+    RetainPtr delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    NSURL *file = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadFileURL:file allowingReadAccessToURL:file.URLByDeletingLastPathComponent];
+    [delegate waitForDidFinishNavigation];
+}
+
 TEST(WKWebView, LoadTwoFiles)
 {
     RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);


### PR DESCRIPTION
#### e925f54a3d94dc6fa5ff156df16ea97c925384b7
<pre>
REGRESSION(<a href="https://commits.webkit.org/315159@main">315159@main</a>): loadFileURL:allowingReadAccessToURL: fails to load file:// URLs when NetworkProcess sandbox blocks the read
<a href="https://bugs.webkit.org/show_bug.cgi?id=317777">https://bugs.webkit.org/show_bug.cgi?id=317777</a>
<a href="https://rdar.apple.com/180546444">rdar://180546444</a>

Reviewed by NOBODY (OOPS!).

When loadFileURL:allowingReadAccessToURL: is called, the UI process grants the WebContent process a
sandbox extension scoped to the provided read-access directory (e.g. the resource bundle). When the
WebContent process subsequently schedules the file:// resource load through the Network process via
createSandboxExtensionHandlesIfNecessary, it calls sandbox_extension_issue_file_to_process to grant
the Network process read access to the specific file. This call fails because a WebContent process
with only a directory-scoped sandbox extension does not have the privilege to re-issue extensions to
other processes for paths within that directory.

This regressed in <a href="https://commits.webkit.org/315159@main">315159@main</a>, which deleted networkProcessHasAccessViaSandboxExtension. That
function previously allowed the Network process to proceed with file loads when it had already been
granted access via AllowFileAccessFromWebProcess, providing a fallback path that tolerated the
WebContent process failing to issue a file-specific extension. Once that fallback was removed and
the blocking check moved to the Network process, loadFileURL:allowingReadAccessToURL: had no working
path to give the Network process file access.

The fix is to have the UI process — which has full sandbox extension issuing rights — create the
Network process sandbox extension directly using the Network process&apos;s audit token, and pass it
through LoadParameters to the WebContent process. The WebContent process stores it temporarily in
WebPage, and WebLoaderStrategy forwards it to the Network process via NetworkResourceLoadParameters
when scheduling the resource load. createSandboxExtensionHandlesIfNecessary returns early if the
extension was already provided, so the WebContent process no longer needs to issue its own.

The extension is created in two places to cover both launch paths: in the loadFile callback for the
case where the WebContent process is already running, and in the shouldSendPendingMessage callback
for the case where the WebContent process was still launching. Both sites guard against the Network
process connection not yet being established.

Additionally, networkProcessSandboxExtensionHandle in LoadParameters is now std::optional to ensure
that WebPage::loadRequest only stores a pending extension when one was actually created by the UI
process. Previously, the non-optional Handle was unconditionally stored as a truthy optional even
when empty (e.g. for loads via loadURL where no extension was created), causing
createSandboxExtensionHandlesIfNecessary to incorrectly skip the fallback extension creation path
and leaving the Network process without any sandbox access to the file.

API test: WKWebView.LoadFileWithFileURL

* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::createSandboxExtensionHandlesIfNecessary):
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createNetworkProcessSandboxExtensionForFileURL):
(WebKit::WebPageProxy::loadFile):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldSendPendingMessage):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::SandboxExtensionTracker::beginLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadFileURL.mm:
(TEST(WKWebView, LoadFileWithFileURL)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e925f54a3d94dc6fa5ff156df16ea97c925384b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170228 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127940 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c13f4715-ee67-448e-a2c0-dba1fd4f9770) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172094 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Running bindings-tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132719 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4234850-ed18-4dec-8f0a-bf3b4a7d1bf3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113220 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b209848-a9a3-4ef7-8705-78e589709bfc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28286 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182187 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34976 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37012 "Found 1 new test failure: http/tests/site-isolation/https-load.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141159 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43808 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140983 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44497 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108906 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36251 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116378 "Found 3 new failures in UIProcess/WebPageProxy.cpp") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43007 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7622 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42399 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42653 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42542 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->