### PR TITLE
[Site Isolation] Preserve Private Click Measurement across cross-process top-frame navigations

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -217,7 +217,6 @@ http/tests/paymentrequest/page-cache-created-payment-request.https.html [ Failur
 http/tests/paymentrequest/page-cache-created-payment-response.https.html [ Failure ]
 http/tests/paymentrequest/page-cache-interactive-payment-request.https.html [ Failure ]
 http/tests/paymentrequest/page-cache-retried-payment-response.https.html [ Failure ]
-http/tests/privateClickMeasurement/store-private-click-measurement-nested.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
 http/tests/security/allow-top-level-navigations-by-third-party-iframes-with-previous-user-activation.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -51,7 +51,6 @@ http/tests/media/media-stream/speech-recognition-iframe-allow-attribute.html [ F
 http/tests/misc/will-send-request-returns-null-on-redirect.html [ Failure ]
 http/tests/navigation/cross-origin-navigation-fires-onload.html [ Failure ]
 http/tests/navigation/page-cache-xhr-in-loading-iframe.html [ Failure ]
-http/tests/privateClickMeasurement/store-private-click-measurement-nested.html [ Failure ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Pass ]

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1639,9 +1639,13 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
 
     // The search for a target frame is done earlier in the case of form submission.
     RefPtr effectiveTargetFrame = findFrameForNavigation(effectiveFrameName);
-    if (is<RemoteFrame>(effectiveTargetFrame)) {
-        updateRequestAndAddExtraFields(*effectiveTargetFrame, frameLoadRequest.resourceRequest(), IsMainResource::Yes, newLoadType, ShouldUpdateAppInitiatedValue::Yes, FrameLoader::IsServiceWorkerNavigationLoad::No, WillOpenInNewWindow::No, protect(frameLoadRequest.requester()).ptr());
-        effectiveTargetFrame->changeLocation(WTF::move(frameLoadRequest));
+    if (RefPtr remoteEffectiveTargetFrame = dynamicDowncast<RemoteFrame>(effectiveTargetFrame)) {
+        updateRequestAndAddExtraFields(*remoteEffectiveTargetFrame, frameLoadRequest.resourceRequest(), IsMainResource::Yes, newLoadType, ShouldUpdateAppInitiatedValue::Yes, FrameLoader::IsServiceWorkerNavigationLoad::No, WillOpenInNewWindow::No, protect(frameLoadRequest.requester()).ptr());
+        // The local-frame path below attaches Private Click Measurement to the NavigationAction once the load
+        // reaches the main frame (see the frame->isMainFrame() check below). When the main frame is remote (site
+        // isolation) that path is never reached, so hand the data to the RemoteFrameClient directly to be
+        // re-attached to the cross-process NavigationAction.
+        remoteEffectiveTargetFrame->client().changeLocation(WTF::move(frameLoadRequest), remoteEffectiveTargetFrame->isMainFrame() ? WTF::move(privateClickMeasurement) : std::nullopt);
         return;
     }
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -33,6 +33,7 @@
 #include "HTMLFrameOwnerElement.h"
 #include "FrameInlines.h"
 #include "NodeDocument.h"
+#include "PrivateClickMeasurement.h"
 #include "RemoteDOMWindow.h"
 #include "RemoteFrameClient.h"
 #include "RemoteFrameView.h"
@@ -106,12 +107,12 @@ bool RemoteFrame::preventsParentFromBeingComplete() const
 
 void RemoteFrame::changeLocation(FrameLoadRequest&& request)
 {
-    m_client->changeLocation(WTF::move(request));
+    m_client->changeLocation(WTF::move(request), std::nullopt);
 }
 
 void RemoteFrame::loadFrameRequest(FrameLoadRequest&& request, Event*)
 {
-    m_client->changeLocation(WTF::move(request));
+    m_client->changeLocation(WTF::move(request), std::nullopt);
 }
 
 void RemoteFrame::updateRemoteFrameAccessibilityOffset(IntPoint offset)

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -37,6 +37,7 @@ class DataSegment;
 class FrameLoadRequest;
 class GraphicsContext;
 class IntSize;
+class PrivateClickMeasurement;
 class ResourceTiming;
 class SecurityOriginData;
 
@@ -57,7 +58,7 @@ public:
     virtual void frameRectDidChange(IntRect) = 0;
     virtual void paintContents(GraphicsContext&, const IntRect&) = 0;
     virtual void postMessageToRemote(FrameIdentifier source, const SecurityOriginData& sourceOrigin, FrameIdentifier target, std::optional<SecurityOriginData> targetOrigin, const MessageWithMessagePorts&, const std::optional<UserGestureTokenData>&) = 0;
-    virtual void changeLocation(FrameLoadRequest&&) = 0;
+    virtual void changeLocation(FrameLoadRequest&&, std::optional<PrivateClickMeasurement>&&) = 0;
     virtual String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>) = 0;
     virtual String layerTreeAsText(size_t baseIndent, OptionSet<LayerTreeAsTextOptions>) = 0;
     virtual void closePage() = 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -43,6 +43,7 @@
 #include <WebCore/HitTestResult.h>
 #include <WebCore/NodeDocument.h>
 #include <WebCore/PolicyChecker.h>
+#include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/RemoteFrame.h>
 #include <WebCore/UserGestureIndicator.h>
 
@@ -98,9 +99,14 @@ void WebRemoteFrameClient::postMessageToRemote(FrameIdentifier source, const Sec
         page->send(Messages::WebPageProxy::PostMessageToRemote(source, sourceOrigin, target, targetOrigin, message, userGestureToken));
 }
 
-void WebRemoteFrameClient::changeLocation(FrameLoadRequest&& request)
+void WebRemoteFrameClient::changeLocation(FrameLoadRequest&& request, std::optional<PrivateClickMeasurement>&& privateClickMeasurement)
 {
     NavigationAction action(request);
+    // Private Click Measurement parsed in this process for a cross-process main-frame navigation
+    // (e.g. <a target="_top"> in a cross-origin iframe) is passed in explicitly; attach it to the
+    // NavigationAction so it is sent to the UI process in the NavigationActionData.
+    if (privateClickMeasurement)
+        action.setPrivateClickMeasurement(WTF::move(*privateClickMeasurement));
     // FIXME: action.request and request are probably duplicate information. <rdar://116203126>
     // FIXME: Get more parameters correct and add tests for each one. <rdar://116203354>
     dispatchDecidePolicyForNavigationAction(action, action.originalRequest(), ResourceResponse(), nullptr, { }, { }, { }, { }, NavigationUpgradeToHTTPSBehavior::BasedOnPolicy, { }, PolicyDecisionMode::Asynchronous, [protectedFrame = Ref { m_frame }, request = WTF::move(request)] (PolicyAction policyAction) mutable {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -46,7 +46,7 @@ private:
     void frameRectDidChange(WebCore::IntRect) final;
     void paintContents(WebCore::GraphicsContext&, const WebCore::IntRect&) final;
     void postMessageToRemote(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&, const std::optional<WebCore::UserGestureTokenData>&) final;
-    void changeLocation(WebCore::FrameLoadRequest&&) final;
+    void changeLocation(WebCore::FrameLoadRequest&&, std::optional<WebCore::PrivateClickMeasurement>&&) final;
     String renderTreeAsText(size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>) final;
     String layerTreeAsText(size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>) final;
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, WebCore::AccessibilityRemoteToken, CompletionHandler<void(WebCore::AccessibilityRemoteToken, int)>&&) final;


### PR DESCRIPTION
#### 221e657b4111aac908f10f176e4889f3766724a2
<pre>
[Site Isolation] Preserve Private Click Measurement across cross-process top-frame navigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=317781">https://bugs.webkit.org/show_bug.cgi?id=317781</a>
<a href="https://rdar.apple.com/180548257">rdar://180548257</a>

Reviewed by Alex Christensen.

When an &lt;a target=&quot;_top&quot;&gt; link with attribution attributes is clicked
inside a cross-origin iframe, the main frame lives in another process
and is a RemoteFrame. FrameLoader::loadURL parsed the Private Click
Measurement correctly but then handed the load to the RemoteFrameClient,
which never received the data: WebRemoteFrameClient::changeLocation built
a NavigationAction without it and nothing was stored. The local-frame
path attaches the data at the main frame (FrameLoader::loadURL&apos;s
frame-&gt;isMainFrame() check), but that path is never reached when the
target frame is remote.

Add an explicit Private Click Measurement parameter to
RemoteFrameClient::changeLocation and pass it from loadURL&apos;s RemoteFrame
branch (gated on isMainFrame() to match the local path) so
WebRemoteFrameClient::changeLocation can re-attach it to the
NavigationAction sent to the UI process. The UI-process storage path was
already measurement-aware, so no changes were needed there.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::changeLocation):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::changeLocation):
(WebCore::RemoteFrame::loadFrameRequest):
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:

Canonical link: <a href="https://commits.webkit.org/317409@main">https://commits.webkit.org/317409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed751939fa2936e1ac50836f976c10c1eb7f278e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/133049 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0081bd56-63ef-4dc7-b414-a31df6474b1a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136323 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/48ba5737-cd40-44bb-b158-461a1a5c052e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116802 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/256f8d65-a639-4b8f-9b4d-f19f1a97ee7c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36783 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33200 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187147 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145266 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48741 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39117 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49421 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115256 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39979 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/121594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47927 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11575 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47330 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->