### PR TITLE
[GTK][WPE] Reland Swift toolchain support for Yocto cross-builds, with a fix to link with lld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,29 @@ if (SWIFT_REQUIRED)
         endif ()
     endif ()
 
+    # Derive the Swift triple from the C compiler's target when cross-compiling
+    # (Yocto bakes --target=<sys> into CC, not CMAKE_C_COMPILER_TARGET).
+    if ((PORT STREQUAL "WPE" OR PORT STREQUAL "GTK") AND CMAKE_CROSSCOMPILING AND NOT CMAKE_Swift_COMPILER_TARGET)
+        set(_swift_target "")
+        if (CMAKE_C_COMPILER_TARGET)
+            set(_swift_target "${CMAKE_C_COMPILER_TARGET}")
+        elseif (CMAKE_C_COMPILER_ARG1 MATCHES "--target=([^ \t]+)")
+            set(_swift_target "${CMAKE_MATCH_1}")
+        endif ()
+        if (_swift_target)
+            set(CMAKE_Swift_COMPILER_TARGET "${_swift_target}" CACHE STRING "Swift target triple" FORCE)
+        elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+            set(CMAKE_Swift_COMPILER_TARGET "aarch64-unknown-linux-gnu" CACHE STRING "Swift target triple" FORCE)
+        elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv7" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
+            set(CMAKE_Swift_COMPILER_TARGET "armv7-unknown-linux-gnueabihf" CACHE STRING "Swift target triple" FORCE)
+        else ()
+            message(FATAL_ERROR
+                "Cannot derive a Swift target triple for "
+                "CMAKE_SYSTEM_PROCESSOR='${CMAKE_SYSTEM_PROCESSOR}'. "
+                "Pass -DCMAKE_Swift_COMPILER_TARGET=<triple> explicitly.")
+        endif ()
+    endif ()
+
     enable_language(Swift)
 
     # -F causes Swift to find C++23 framework headers in implicit module builds.
@@ -55,11 +78,24 @@ if (SWIFT_REQUIRED)
     set(CMAKE_Swift_COMPILER "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc-wrapper.sh")
     add_compile_options($<$<COMPILE_LANGUAGE:Swift>:--original-swift-compiler=${ORIGINAL_Swift_COMPILER}>)
     add_link_options($<$<LINK_LANGUAGE:Swift>:--original-swift-compiler=${ORIGINAL_Swift_COMPILER}>)
+    # CMake drops the bare -fuse-ld driver flag when forwarding USE_LD_LLD's
+    # CMAKE_*_LINKER_FLAGS to swiftc (only -Wl,/LINKER: items survive), so Swift
+    # links fall back to the default ld and miss lld's tighter layout
+    # (webkit.org/b/317573). Re-add it. The swiftc-wrapper maps -fuse-ld=* through,
+    # and lld is target-agnostic, so this works for cross-builds too.
+    if (USE_LD_LLD)
+        add_link_options($<$<LINK_LANGUAGE:Swift>:-fuse-ld=lld>)
+    endif ()
     # The static archive rule (<CMAKE_Swift_CREATE_STATIC_LIBRARY>) uses neither
     # <FLAGS> nor link options, so inject the flag directly into the template.
     string(REPLACE "<CMAKE_Swift_COMPILER>"
         "<CMAKE_Swift_COMPILER> --original-swift-compiler=${ORIGINAL_Swift_COMPILER}"
         CMAKE_Swift_CREATE_STATIC_LIBRARY "${CMAKE_Swift_CREATE_STATIC_LIBRARY}")
+else ()
+    # The Yocto cross-toolchain env injects -DCMAKE_Swift_FLAGS_INIT whenever the
+    # SDK ships swiftc, but only enable_language(Swift) above consumes it. Without
+    # Swift, touch it here so CMake doesn't warn that it went unused.
+    set(_unused_swift_flags_init "${CMAKE_Swift_FLAGS_INIT}")
 endif ()
 
 # -----------------------------------------------------------------------------

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -1425,6 +1425,12 @@ endif ()
 
 list(APPEND WebKit_SOURCES ${WebKit_DERIVED_SOURCES})
 
+if (SWIFT_REQUIRED)
+    # WebKit_SwiftCxxHeader is created by a DEFER CALL, so defer wiring its dep too.
+    add_custom_target(WebKit_DerivedHeadersForSwift DEPENDS ${WebKit_HEADERS} ${WebKit_DERIVED_SOURCES})
+    cmake_language(DEFER CALL add_dependencies WebKit_SwiftCxxHeader WebKit_DerivedHeadersForSwift)
+endif ()
+
 WEBKIT_COMPUTE_SOURCES(WebKit)
 if (DEFINED WebKit_SWIFT_INTEROP_SOURCES)
     list(REMOVE_ITEM WebKit_SOURCES ${WebKit_SWIFT_INTEROP_SOURCES})
@@ -1462,6 +1468,9 @@ if (DEFINED WebKit_SWIFT_INTEROP_SOURCES)
     WEBKIT_DEFINE_SUBTARGET(WebKit_SwiftInterop WebKit ${WebKit_SWIFT_INTEROP_SOURCES})
     WEBKIT_REUSE_PREFIX_HEADER(WebKit_SwiftInterop WebKit WebKitPrefix.h PREFIX_LANGUAGES CXX OBJCXX)
     target_compile_definitions(WebKit_SwiftInterop PRIVATE WK_COMPILING_SWIFT_INTEROP_SUBTARGET)
+    # Kept out of cmake_object_order_depends_target_WebKit (see below), so depend
+    # on the derived headers explicitly to avoid racing *Messages.h generation.
+    add_dependencies(WebKit_SwiftInterop WebKit_DerivedHeadersForSwift)
     # Feed objects into the WebKit link via a response file + LINK_DEPENDS so
     # cmake_object_order_depends_target_WebKit doesn't pick up this sub-target
     # (and through it, WebKit_SwiftCxxHeader).

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -883,7 +883,15 @@ function(_webkit_generate_platform_swift_args _target _resp_path _ordering_dep)
     if (CMAKE_OSX_SYSROOT)
         list(APPEND _clang_cmd "-isysroot" "${CMAKE_OSX_SYSROOT}")
     endif ()
-    if (CMAKE_Swift_COMPILER_TARGET)
+    # CMAKE_CXX_COMPILER_ARG1 holds the bundle clang's triple, --sysroot,
+    # --gcc-install-dir and libstdc++ dirs. Mirror them so this hand-built
+    # preprocess doesn't leak host glibc into wtf/Platform.h. Supplies --target
+    # too, so the block below is just a fallback when ARG1 is empty.
+    if (CMAKE_CXX_COMPILER_ARG1)
+        separate_arguments(_cxx_compiler_arg1 NATIVE_COMMAND "${CMAKE_CXX_COMPILER_ARG1}")
+        list(APPEND _clang_cmd ${_cxx_compiler_arg1})
+    endif ()
+    if (CMAKE_Swift_COMPILER_TARGET AND NOT CMAKE_CXX_COMPILER_ARG1)
         list(APPEND _clang_cmd "-target" "${CMAKE_Swift_COMPILER_TARGET}")
     endif ()
     if (WEBKIT_ADDITIONS_INCLUDE_PATH)
@@ -1106,6 +1114,12 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
                 if (_dir MATCHES "/clang/[0-9]+/include(/|$)")
                     continue ()
                 endif ()
+                # In cross-builds, forwarding host implicit C include dirs as
+                # explicit -I breaks the libstdc++ `std` module. The sysroot
+                # already covers the target.
+                if (CMAKE_CROSSCOMPILING)
+                    continue ()
+                endif ()
                 list(APPEND _swift_options "-Xcc" "-I${_dir}")
             endforeach ()
         endif ()
@@ -1157,7 +1171,11 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         endif ()
         list(APPEND _swift_options "-module-cache-path" "${CMAKE_BINARY_DIR}/SwiftModuleCache")
         set_property(DIRECTORY "${CMAKE_BINARY_DIR}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/SwiftModuleCache")
-        list(APPEND _swift_options "-track-system-dependencies")
+        # -track-system-dependencies resolves libstdc++'s modulemap via a
+        # /lib->/usr/lib path Yocto doesn't expose, breaking the cross build.
+        if (NOT CMAKE_CROSSCOMPILING)
+            list(APPEND _swift_options "-track-system-dependencies")
+        endif ()
         # We'll use these options both for mainstream cmake invocations of swiftc (here)
         # and for our own invocation to output an interoperability .h file (later).
         # target_compile_options deduplicates repeated tokens, so collapse each

--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -546,52 +546,91 @@ class YoctoCrossBuilder():
             original_setup_env_path = self._get_cross_toolchain_env_path(check_toolchain_built=False)
             _log.info('Patching toolchain environment-setup file to remove optimizations by default: {original_setup_env_path}'.format(original_setup_env_path=original_setup_env_path))
             # This does the following:
-            # 1. Remove any line that exports CFLAGS/CXXFLAGS/LDFLAGS/CPPFLAGS
-            # 2. On the line that exports the compiler variables (export CC, export CXX and export CPP)
-            #    remove any compiler flag that is not machine related (-m*) or is '-E' (for cpp) or is for the sysroot/target.
-            # 3. Do not override CC/CXX with the cross-compiled GCC compiler if the user wants to use Clang, instead
-            #    set CC/CXX pointing to the cross-compiled Clang (assuming the support was built in the toolchain).
+            # 1. Drop the CFLAGS/CXXFLAGS/LDFLAGS/CPPFLAGS exports.
+            # 2. On the CC/CXX/CPP exports, keep only machine flags (-m*), '-E', and
+            #    the sysroot.
+            # 3. If the SDK ships clang (swift.org bundle), also emit a Clang form
+            #    swapping `<sys>-gcc/g++/cpp` for `clang/clang++/clang-cpp --target=<sys>`
+            #    (Swift/C++ interop is Clang-only), selected by the user via CC/CXX.
             patched_setup_env_path = original_setup_env_path + "-no-opt-flags"
+            # Anchor on the trailing '=' so we don't also strip unrelated exports
+            # like CPPFLAGS_FOR_BUILD. No whitespace before '=' since shell variable
+            # assignments don't allow it.
             flags_regex = re.compile(r'export\s+(C|CXX|LD|CPP)FLAGS=')
-            gcc_compiler_regex = re.compile(r'export\s+C(C|XX|PP)=')
-            clang_compiler_regex = re.compile(r'export\s+CLANGC(C|XX|PP)=')
+            compiler_regex = re.compile(r'export\s+C(C|XX|PP)=')
+            toolchain_binary_regex = re.compile(r'([\w-]+-)(gcc|g\+\+|cpp)$')
+            clang_for = {'gcc': 'clang', 'g++': 'clang++', 'cpp': 'clang-cpp'}
+            # Detect whether any SDK host sysroot has clang / swiftc binaries.
+            sysroots_dir = os.path.join(os.path.dirname(original_setup_env_path), 'sysroots')
+            sdk_has_clang = False
+            sdk_has_swiftc = False
+            if os.path.isdir(sysroots_dir):
+                for entry in os.listdir(sysroots_dir):
+                    host_bin = os.path.join(sysroots_dir, entry, 'usr', 'bin')
+                    if os.path.isfile(os.path.join(host_bin, 'clang')):
+                        sdk_has_clang = True
+                    if os.path.isfile(os.path.join(host_bin, 'swiftc')):
+                        sdk_has_swiftc = True
             gcc_lines = []
             clang_lines = []
             with open(original_setup_env_path, 'r') as fr:
                 with open(patched_setup_env_path, 'w') as fw:
                     for line in fr.readlines():
                         if not flags_regex.match(line):
-                            if gcc_compiler_regex.match(line) or clang_compiler_regex.match(line):
-                                newline = ""
+                            if compiler_regex.match(line):
+                                # GCC form always. Clang form too when the SDK ships clang.
+                                gcc_line = ""
+                                clang_line = ""
                                 for word in line.strip().split():
                                     if word.startswith('-'):
-                                        if word == '-E' or any(word.startswith(p) for p in ['-m', '--sysroot=', '--target=']):
-                                            newline += " " + word
+                                        if word.startswith('-m') or word == '-E' or word.startswith('--sysroot'):
+                                            gcc_line += " " + word
+                                            clang_line += " " + word
                                     else:
-                                        newline += " " + word
-                                if '="' in newline and not newline.endswith('"'):
-                                    newline += '"'
-                                newline = newline.strip() + '\n'
-                                (clang_lines if clang_compiler_regex.match(line) else gcc_lines).append(newline)
+                                        gcc_line += " " + word
+                                        m = toolchain_binary_regex.search(word)
+                                        if m and sdk_has_clang:
+                                            target = m.group(1).rstrip('-')
+                                            # --gcc-install-dir/-isystem point at the
+                                            # sysroot so crt*.o/libgcc.a and the c++
+                                            # headers resolve. Globs expand at source time.
+                                            gcc_dir = ('$(ls -d "$SDKTARGETSYSROOT/usr/lib/gcc/' + target
+                                                       + '"/* 2>/dev/null | head -1)')
+                                            cxx_inc = ('$(ls -d "$SDKTARGETSYSROOT/usr/include/c++"'
+                                                       '/* 2>/dev/null | head -1)')
+                                            clang_line += " " + word.replace(m.group(0),
+                                                clang_for[m.group(2)] + " --target=" + target
+                                                + " --gcc-install-dir=" + gcc_dir
+                                                + " -isystem " + cxx_inc
+                                                + " -isystem " + cxx_inc + "/" + target)
+                                        else:
+                                            clang_line += " " + word
+                                if '="' in gcc_line and not gcc_line.endswith('"'):
+                                    gcc_line += '"'
+                                if '="' in clang_line and not clang_line.endswith('"'):
+                                    clang_line += '"'
+                                gcc_lines.append(gcc_line.strip() + '\n')
+                                clang_lines.append(clang_line.strip() + '\n')
                             else:
                                 fw.write(line)
-                    # The script should check the CC/CXX env var from the user, if is set to clang then export
-                    # the CLANGCC and CLANGCXX as CC/CXX, otherwise keep the default (GCC)
+                    # Be strict: the setup-environment script is expected to export
+                    # exactly CC/CXX/CPP. If the count ever differs from 3 the file
+                    # changed shape and this has to be inspected to see what is going on.
                     if len(gcc_lines) != 3:
                         raise RuntimeError('Unexpected CC/CXX/CPP parameters in setup-environment script')
-                    if clang_lines:
+                    # Emit the compiler exports: Clang form when the SDK ships clang
+                    # and the user asked for it via CC/CXX, otherwise GCC.
+                    if sdk_has_clang and clang_lines:
                         fw.write('\nif echo "${CC} ${CXX}" | grep -qi clang; then\n')
-                        for line in clang_lines:
-                            # Remove the CLANG prefix, so for example CLANGCXX becomes CXX
-                            line = re.sub(r'(export\s+)CLANG(CC|CXX|CPP)(=)', r'\1\2\3', line)
-                            fw.write(f'    {line}')
+                        for _cl in clang_lines:
+                            fw.write('    ' + _cl)
                         fw.write('else\n')
-                        for line in gcc_lines:
-                            fw.write(f'    {line}')
+                        for _gl in gcc_lines:
+                            fw.write('    ' + _gl)
                         fw.write('fi\n')
                     else:
-                        for line in gcc_lines:
-                            fw.write(line)
+                        for _gl in gcc_lines:
+                            fw.write(_gl)
                     # When building cog, meson tries to load the wpe headers that are on the repo from the sysroot path.
                     # That is not really a bug on meson as system libraries should be loaded from the sysroot when cross-building.
                     # Workaround the issue by creating a symlink that also resolves this WebKit repository path inside the sysroot.
@@ -599,6 +638,50 @@ class YoctoCrossBuilder():
                              '    mkdir -p "${{OECORE_TARGET_SYSROOT}}/{webkit_dir_up}"\n'
                              '    ln -s "{webkit_dir}" "${{OECORE_TARGET_SYSROOT}}/{webkit_dir_up}"\n'
                              'fi\n'.format(webkit_dir=self._webkit_dir, webkit_dir_up=os.path.dirname(self._webkit_dir)))
+                    # When the SDK ships swiftc, splice -DCMAKE_Swift_FLAGS_INIT into
+                    # BUILD_WEBKIT_ARGS to wire swiftc to the Yocto sysroot:
+                    #   -sdk / -I        target headers and Swift modules.
+                    #   -Xcc ...         swiftc's compile step spawns clang -cc1, which
+                    #                    -sdk doesn't reach, so pass it the sysroot and
+                    #                    gcc-install-dir.
+                    #   -Xclang-linker   swiftc's link step spawns a separate clang that
+                    #                    doesn't inherit -Xcc, so repeat the sysroot and
+                    #                    gcc-install-dir for it.
+                    # The linker flavor (lld) is not set here. WebKit's CMake adds
+                    # -fuse-ld=lld for Swift-linked targets under USE_LD_LLD
+                    # (webkit.org/b/317573), so this splice only wires the sysroot and
+                    # gcc-install-dir. Paths resolve at env-setup source time via shell.
+                    if sdk_has_swiftc:
+                        # Yocto splits gcc-install across usr/lib/<sys> and
+                        # usr/lib/gcc/<sys>. Swift's libstdc++ probe needs crtbegin.o
+                        # in the gcc/ tree, so copy what's missing (symlinks aren't
+                        # followed by the clang driver). Idempotent.
+                        fw.write(
+                            '\nif [ -n "${OECORE_TARGET_SYSROOT:-}" ] && [ -d "${OECORE_TARGET_SYSROOT}/usr/lib/swift" ]; then\n'
+                            '    _target_prefix="${TARGET_PREFIX%-}"\n'
+                            '    _gcc_src=$(ls -d "${OECORE_TARGET_SYSROOT}/usr/lib/${_target_prefix}"/* 2>/dev/null | head -1)\n'
+                            '    if [ -n "${_gcc_src}" ]; then\n'
+                            '        _gcc_ver=$(basename "${_gcc_src}")\n'
+                            '        _gcc_dst="${OECORE_TARGET_SYSROOT}/usr/lib/gcc/${_target_prefix}/${_gcc_ver}"\n'
+                            '        if [ -d "${_gcc_dst}" ] && [ ! -e "${_gcc_dst}/crtbegin.o" ]; then\n'
+                            '            for _f in "${_gcc_src}"/*; do\n'
+                            '                _bn=$(basename "${_f}")\n'
+                            '                [ -e "${_gcc_dst}/${_bn}" ] || cp -rp "${_f}" "${_gcc_dst}/${_bn}"\n'
+                            '            done\n'
+                            '            unset _f _bn\n'
+                            '        fi\n'
+                            '        unset _gcc_ver _gcc_dst\n'
+                            '    fi\n'
+                            '    unset _target_prefix _gcc_src\n'
+                            'fi\n'
+                            '\nif [ -n "${BUILD_WEBKIT_ARGS:-}" ] && [ -d "${OECORE_TARGET_SYSROOT}/usr/lib/swift" ]; then\n'
+                            '    _target_prefix="${TARGET_PREFIX%-}"\n'
+                            '    _gcc_install_dir=$(ls -d "${OECORE_TARGET_SYSROOT}/usr/lib/gcc/${_target_prefix}"/* 2>/dev/null | head -1)\n'
+                            '    _swift_flags="-sdk ${OECORE_TARGET_SYSROOT} -I ${OECORE_TARGET_SYSROOT}/usr/lib/swift/linux -I ${OECORE_TARGET_SYSROOT}/usr/lib/swift -Xcc --sysroot=${OECORE_TARGET_SYSROOT} -Xcc --gcc-install-dir=${_gcc_install_dir} -Xclang-linker --sysroot=${OECORE_TARGET_SYSROOT} -Xclang-linker --gcc-install-dir=${_gcc_install_dir}"\n'
+                            '    BUILD_WEBKIT_ARGS="${BUILD_WEBKIT_ARGS} --cmakeargs=\\"-DCMAKE_Swift_FLAGS_INIT=\'${_swift_flags}\'\\""\n'
+                            '    export BUILD_WEBKIT_ARGS\n'
+                            '    unset _swift_flags _target_prefix _gcc_install_dir\n'
+                            'fi\n')
 
             # Put the patched setup-environ file in place of the other
             # and save a copy of the original just for debugging purposes

--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -51,8 +51,23 @@ for arg in "$@"; do
         pass_next_verbatim=
         continue
     fi
+    # Drop bare host `-I /usr/include` (or /usr/local/include): in a cross-build
+    # they leak host glibc into the clang importer and break the libstdc++ `std`
+    # module. Safe everywhere (clang searches /usr/include by default).
+    if [[ -n "$pending_dash_I" ]]; then
+        pending_dash_I=
+        case "$arg" in
+            "/usr/include"|"/usr/local/include") ;;
+            *) args+=("-I" "$arg") ;;
+        esac
+        continue
+    fi
     case "$arg" in
-        "-Xcc"|"-Xlinker"|"-Xfrontend")
+        "-I")
+            pending_dash_I=1
+            ;;
+        "-I/usr/include"|"-I/usr/local/include") ;;
+        "-Xcc"|"-Xlinker"|"-Xfrontend"|"-Xclang-linker")
             args+=("$arg")
             pass_next_verbatim=1
             ;;
@@ -70,7 +85,10 @@ for arg in "$@"; do
             ;;
         "-include") skip_next=1 ;;
         "-fuse-ld="*)
-            args+=("-Xcc" "$arg")
+            # Link-only flag leaked into CFLAGS. -Xclang-linker hands it to the
+            # clang swiftc spawns when linking, so it's ignored at compile time
+            # instead of being rejected.
+            args+=("-Xclang-linker" "$arg")
             ;;
         # swiftc does not understand clang-specific include flags like
         # -isystem / -iquote / -idirafter; wrap them (and their following

--- a/Tools/yocto/README.md
+++ b/Tools/yocto/README.md
@@ -30,6 +30,33 @@ The script ```cross-toolchain-helper``` will parse this file and it will do the 
 
 For more info see the file ```${WebKitDirectory}/Tools/yocto/targets.conf```
 
+### Swift toolchain
+
+Swift support for WPE WebKit aarch64 and armv7 builds is provided by
+[jeremy-prater/meta-swift](https://github.com/jeremy-prater/meta-swift)
+(branch ```scarthgap```), pinned in
+```rpi/manifest.xml```. This fork carries the WPE-specific meta-swift bits (the
+Yocto-aligned Swift module triple, the additive ```do_fix_gcc_install_dir```
+copy, and the ```nativesdk-swift``` host-toolchain recipe), which are being
+upstreamed to [jeremy-prater/meta-swift](https://github.com/jeremy-prater/meta-swift).
+Once merged, the pin can move back. The swift.org prebuilt bundle (wrapped by the
+meta-swift ```nativesdk-swift``` recipe) provides both swiftc and the clang/LLVM
+toolchain used to cross-build the GLib ports, so the whole toolchain is a single,
+consistent clang. WPE-specific glue lives as bbappends inside
+```meta-openembedded_and_meta-webkit.patch```.
+
+| Target                    | Swift | Toolchain | Notes |
+| ------------------------- | ----- | --------- | ----- |
+| rpi3/4/5 64-bit (mesa)    | yes   | clang     | aarch64 |
+| rpi3/4 32-bit (mesa)      | yes   | clang     | armv7 |
+| rpi3-32bits-userland      | no    | gcc       | wpebackend-rdk + constrained build; Swift opted out in its local.conf |
+| qemu-riscv64              | no    | gcc       | upstream Swift has no riscv64 target |
+
+meta-swift builds ```swift-stdlib```, ```swift-foundation``` and
+```libdispatch``` **from source** for each target architecture. Its
+```SWIFT_VERSION``` must match the swift.org bundle pinned by
+```nativesdk-swift```; bump them in lockstep.
+
 
 ### Integration with WebKit tooling script
 

--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -714,7 +714,7 @@ diff --git a/sources/meta-webkit/conf/distro/webkitdevci.conf b/sources/meta-web
 index 1f952c2..d299d1f 100644
 --- a/sources/meta-webkit/conf/distro/webkitdevci.conf
 +++ b/sources/meta-webkit/conf/distro/webkitdevci.conf
-@@ -47,6 +47,17 @@ PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
+@@ -47,6 +47,18 @@ PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
  PACKAGECONFIG:append:pn-php = " apache2"
  # Disable mysql support as we don't need to build mysql/mariadb
  PACKAGECONFIG:remove:pn-php = "mysql"
@@ -730,8 +730,9 @@ index 1f952c2..d299d1f 100644
  # Whitelist license from some deps.
  LICENSE_FLAGS_ACCEPTED:append = " commercial synaptics-killswitch"
 +
-+# Optional support for clang if meta-clang is enabled
-+CLANGSDK ?= "1"
++# The SDK host clang comes from the swift.org bundle (nativesdk-swift), so keep
++# meta-clang's nativesdk-clang out of the SDK host to avoid a conflict.
++CLANGSDK = "0"
 diff --git a/sources/meta-webkit/conf/layer.conf b/sources/meta-webkit/conf/layer.conf
 index 124c13d..1a38638 100644
 --- a/sources/meta-webkit/conf/layer.conf
@@ -745,14 +746,6 @@ index 124c13d..1a38638 100644
      "
  
  BBFILE_COLLECTIONS += "webkit"
-diff --git a/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend b/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend
-new file mode 100644
-index 0000000..b1950a5
---- /dev/null
-+++ b/sources/meta-webkit/dynamic-layers/clang-layer/recipes-core/images/webkit-dev-ci-tools.bbappend
-@@ -0,0 +1,2 @@
-+TOOLCHAIN_HOST_TASK:append = " nativesdk-clang nativesdk-compiler-rt nativesdk-compiler-rt-sanitizers"
-+IMAGE_INSTALL:append = " clang compiler-rt compiler-rt-sanitizers libcxx"
 diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
 index 205c058..9cf85c8 100644
 --- a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -835,3 +828,31 @@ index 2355936..0820dd9 100644
          if ${@bb.utils.contains('PACKAGECONFIG', 'dhcp-ethernet', 'true', 'false', d)}; then
                 install -D -m0644 ${WORKDIR}/wired.network ${D}${systemd_unitdir}/network/80-wired.network
          fi
+diff --git a/sources/meta-webkit/recipes-browser/wpewebkit/wpewebkit_%.bbappend b/sources/meta-webkit/recipes-browser/wpewebkit/wpewebkit_%.bbappend
+new file mode 100644
+index 0000000..1a2b3c4
+--- /dev/null
++++ b/sources/meta-webkit/recipes-browser/wpewebkit/wpewebkit_%.bbappend
+@@ -0,0 +1,12 @@
++# Optional Swift/C++ interop support for WPE WebKit (contributed upstream to
++# meta-webkit). Off by default. Enable per distro/image on a Swift-capable arch
++# (aarch64 or armv7, riscv64 has no upstream Swift target) with:
++#     PACKAGECONFIG:append:pn-wpewebkit = " swift"
++# CMAKE_Swift_COMPILER is the in-tree wrapper that ships in release tarballs.
++# The Swift target triple is derived from CMAKE_SYSTEM_PROCESSOR in CMakeLists.txt.
++PACKAGECONFIG[swift] = " \
++    -DENABLE_SWIFT_DEMO_URI_SCHEME=ON -DENABLE_BACK_FORWARD_LIST_SWIFT=ON \
++    -DCMAKE_Swift_COMPILER=${S}/Tools/Scripts/swift/swiftc-wrapper.sh \
++    -DCMAKE_Swift_FLAGS_INIT='-sdk ${STAGING_DIR_TARGET} -resource-dir ${STAGING_DIR_TARGET}${libdir}/swift' \
++    ,-DENABLE_SWIFT_DEMO_URI_SCHEME=OFF -DENABLE_BACK_FORWARD_LIST_SWIFT=OFF \
++    ,swift-native swift-stdlib swift-foundation libdispatch"
+diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend
+new file mode 100644
+index 0000000..2b3c4d5
+--- /dev/null
++++ b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend
+@@ -0,0 +1,4 @@
++# Pull the Swift runtime from meta-swift into the WPE WebKit packagegroup.
++# Built for aarch64 and armv7. riscv64 has no upstream Swift target yet.
++RDEPENDS:packagegroup-wpewebkit-depends-core:append:aarch64 = " swift-stdlib swift-foundation libdispatch"
++RDEPENDS:packagegroup-wpewebkit-depends-core:append:arm = " swift-stdlib swift-foundation libdispatch"

--- a/Tools/yocto/rpi/bblayers.conf
+++ b/Tools/yocto/rpi/bblayers.conf
@@ -21,4 +21,5 @@ BBLAYERS ?= " \
   %(BSPDIR)s/sources/meta-browser/meta-chromium \
   %(BSPDIR)s/sources/meta-lts-mixins \
   %(BSPDIR)s/sources/meta-raspberrypi \
+  %(BSPDIR)s/sources/meta-swift \
   "

--- a/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-mesa.conf
@@ -46,3 +46,6 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
+# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
+TOOLCHAIN:pn-wpewebkit = "clang"

--- a/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
+++ b/Tools/yocto/rpi/local-rpi3-32bits-userland.conf
@@ -49,3 +49,8 @@ IMAGE_INSTALL:append = " gstreamer1.0-omx"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
 
+
+# This constrained armv7 target stays on GCC, so opt out of the Swift-gated
+# WebKit features that the meta-swift integration enables by default for :arm.
+DEPENDS:pn-wpewebkit:remove = "swift-native swift-stdlib swift-foundation libdispatch"
+EXTRA_OECMAKE:pn-wpewebkit:append = " -DENABLE_SWIFT_DEMO_URI_SCHEME=OFF -DENABLE_BACK_FORWARD_LIST_SWIFT=OFF"

--- a/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi3-64bits-mesa.conf
@@ -46,3 +46,6 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
+# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
+TOOLCHAIN:pn-wpewebkit = "clang"

--- a/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-32bits-mesa.conf
@@ -46,3 +46,6 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
+# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
+TOOLCHAIN:pn-wpewebkit = "clang"

--- a/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi4-64bits-mesa.conf
@@ -46,3 +46,6 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
+# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
+TOOLCHAIN:pn-wpewebkit = "clang"

--- a/Tools/yocto/rpi/local-rpi5-64bits-mesa.conf
+++ b/Tools/yocto/rpi/local-rpi5-64bits-mesa.conf
@@ -46,3 +46,6 @@ PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " v4l2codecs"
 # Enable opus codec support in GStreamer
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-base = " opus"
 PACKAGECONFIG:append:pn-gstreamer1.0-plugins-bad = " opusparse"
+
+# Build wpewebkit with clang (meta-swift): Swift/C++ interop is Clang-only.
+TOOLCHAIN:pn-wpewebkit = "clang"

--- a/Tools/yocto/rpi/manifest.xml
+++ b/Tools/yocto/rpi/manifest.xml
@@ -15,5 +15,6 @@
   <project remote="github" revision="f26bab34e6c208149fe1ad04521864b663489f4d" name="kraj/meta-clang.git" path="sources/meta-clang"/>
   <project remote="github" revision="85eeb6b50883d22c977396f5e8fe211a7961cf2e" name="OSSystems/meta-browser.git" path="sources/meta-browser"/>
   <project remote="yocto" revision="c19b6da5a3afd3c892b3b1b44983e993ac6d5308" name="meta-lts-mixins" path="sources/meta-lts-mixins"/>
+  <project remote="github" revision="395888676eaa9174705b00b8d504ac58109b860b" name="jeremy-prater/meta-swift.git" path="sources/meta-swift"/>
 
 </manifest>


### PR DESCRIPTION
#### 435b7de227bd6722fb317be7e09b3d2daa91a9b1
<pre>
[GTK][WPE] Reland Swift toolchain support for Yocto cross-builds, with a fix to link with lld
<a href="https://bugs.webkit.org/show_bug.cgi?id=317649">https://bugs.webkit.org/show_bug.cgi?id=317649</a>

Reviewed by NOBODY (OOPS!).

Relands <a href="https://commits.webkit.org/315523@main">315523@main</a>, reverted in <a href="https://commits.webkit.org/317573@main">317573@main</a> because the Swift-enabled
rpi4-64bits-mesa build regressed: libWPEWebKit grew ~40 MiB and benchmarks
slowed ~10%. This reland also re-enables Swift on armv7 (32-bit), reverting
<a href="https://commits.webkit.org/315550@main">315550@main</a> which had dropped the Swift runtime injection, so Swift now
builds for both aarch64 and armv7. Upstream fixes landed in meta-swift
reducing the need for any local patches to that repo.

The regression was in the linker, not the Swift code. USE_LD_LLD appends
-fuse-ld=lld to CMAKE_*_LINKER_FLAGS, but for a Swift link CMake forwards
only the -Wl,/LINKER: items to swiftc and drops the bare -fuse-ld driver
flag. The original patch worked around the resulting &quot;default ld&quot; fallback
by hardcoding the GNU bfd cross-ld, which seems to dead-strips less, bloating
the library and slowing everything linked into it.

Fix it where the linker is chosen: under USE_LD_LLD, add -fuse-ld=lld for
Swift-linked targets via add_link_options($&lt;$&lt;LINK_LANGUAGE:Swift&gt;:...&gt;).
The swiftc-wrapper maps -fuse-ld=* to -Xclang-linker, and lld is
target-agnostic, so this works for the cross-build too. The
cross-toolchain-helper splice no longer hardcodes -fuse-ld and only wires
the target sysroot and gcc-install-dir.

* CMakeLists.txt:
* Source/WebKit/CMakeLists.txt:
* Source/cmake/WebKitMacros.cmake:
* Tools/Scripts/cross-toolchain-helper:
(YoctoCrossBuilder.build_toolchain):
* Tools/Scripts/swift/swiftc-wrapper.sh:
* Tools/yocto/README.md:
* Tools/yocto/meta-openembedded_and_meta-webkit.patch:
* Tools/yocto/rpi/bblayers.conf:
* Tools/yocto/rpi/local-rpi3-32bits-mesa.conf:
* Tools/yocto/rpi/local-rpi3-32bits-userland.conf:
* Tools/yocto/rpi/local-rpi3-64bits-mesa.conf:
* Tools/yocto/rpi/local-rpi4-32bits-mesa.conf:
* Tools/yocto/rpi/local-rpi4-64bits-mesa.conf:
* Tools/yocto/rpi/local-rpi5-64bits-mesa.conf:
* Tools/yocto/rpi/manifest.xml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/435b7de227bd6722fb317be7e09b3d2daa91a9b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43979 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37394 "Hash 435b7de2 for PR 67804 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132550 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93404 "1 flakes 12 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35723 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/37394 "Hash 435b7de2 for PR 67804 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34303 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32691 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28114 "Built successfully") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/37394 "Hash 435b7de2 for PR 67804 does not build (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144797 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/37394 "Hash 435b7de2 for PR 67804 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182015 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31311 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34804 "Found 125 new failures in Modules/speech/SpeechRecognitionResult.cpp, css/typedom/transform/CSSTransformValue.cpp, dfg/DFGBasicBlock.cpp, rendering/RenderFlexibleBox.h, Modules/webaudio/ChannelMergerNode.cpp, jit/GdbJIT.cpp, Modules/webauthn/fido/U2fResponseConverter.cpp, inspector/ScriptCallStack.cpp, editing/cocoa/WebContentReaderCocoa.mm, rendering/cocoa/RenderThemeCocoa.mm ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141003 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43635 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/37394 "Hash 435b7de2 for PR 67804 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140833 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44324 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/37394 "Hash 435b7de2 for PR 67804 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108673 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36100 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116205 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202735 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42835 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/37394 "Hash 435b7de2 for PR 67804 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54328 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42227 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->