### PR TITLE
JSON::Value::dump corrupts large string values via PrintStream truncation

### DIFF
--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -621,7 +621,14 @@ void Value::dump(PrintStream& out) const
     }, [&](const String& string) {
         StringBuilder builder;
         builder.appendQuotedJSONString(string);
-        out.print(builder.toString());
+        // PrintStream truncates >5 MB CStrings for log readability, which would corrupt JSON. Bypass via const char*.
+        // FIXME: needs a systematic fix in PrintStream — log-output truncation
+        // should not apply to file persistence. Every site that prints large
+        // Strings to disk (this JSON dumper, SamplingProfiler reports, future
+        // text dumps, ...) is silently exposed to the same corruption; this
+        // patch only covers the JSON path.
+        auto utf8 = builder.toString().utf8();
+        out.print(utf8.data());
     }, [&](ObjectTypeTag) {
         // Safety: This lambda runs synchronously so it is safe to capture `this` without refing.
         SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE auto& object = *static_cast<const ObjectBase*>(this);


### PR DESCRIPTION
#### cd07e3f6c0c048727d29f1c470315bcbf81cad36
<pre>
JSON::Value::dump corrupts large string values via PrintStream truncation
<a href="https://bugs.webkit.org/show_bug.cgi?id=317785">https://bugs.webkit.org/show_bug.cgi?id=317785</a>
<a href="https://rdar.apple.com/180554350">rdar://180554350</a>

Reviewed by Yusuke Suzuki.

JSON::Value::dump prints String values via out.print(builder.toString()),
which dispatches through PrintStream&apos;s printInternal(const CString&amp;)
overload. That overload truncates large CStrings, replacing the tail
with &quot;...[N characters not shown]&quot; — a sane policy for terminal log
output, but it silently corrupts the JSON we just escaped: the closing
&apos;&quot;&apos; of the string literal gets eaten, and the next &quot;key&quot;: appears as if
inside the string, leaving an unparseable file.

Reachable in practice via the JSC bytecode profiler (jsc -p file.json):
JS source code in the &quot;source&quot; field of each Bytecodes record routinely
crosses the truncation threshold on JetStream3 subtests like
babylonjs-startup-es5 (30+ truncations in one profile, breaking
downstream parsers).

Bypass by routing through PrintStream&apos;s const char* overload, which is a
plain printf(&quot;%s&quot;, ...) with no length cap. CString from String::utf8()
is null-terminated, so this is safe.

A FIXME notes that PrintStream&apos;s truncation policy should not apply to
file persistence at all — a systematic fix in PrintStream would also
cover SamplingProfiler text dumps and any future site that prints large
Strings to disk. This patch only covers the JSON path, which is the
only one currently observed to break structured output.

Canonical link: <a href="https://commits.webkit.org/315824@main">https://commits.webkit.org/315824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb8c199359891e84b6e970ebc4202922dfcc5ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170061 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43984 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127773 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6963fd0f-ef82-4d5c-81c5-9d8eecd11fa2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2aac87d3-194f-4aed-bddd-2badf1439155) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113055 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1df3061d-b29e-4e56-89e3-05096aabfab0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32694 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28119 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1411 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182020 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31316 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled JSC (warnings); Passed JSC tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34809 "Found 125 new failures in platform/graphics/IntRect.cpp, css/typedom/transform/CSSTransformValue.cpp, css/SelectorFilter.cpp, layout/formattingContexts/inline/InlineFormattingContext.cpp, rendering/svg/RenderSVGText.cpp, bytecompiler/BytecodeGenerator.cpp, dom/EventPath.cpp, Modules/speech/SpeechRecognitionResultList.cpp, dfg/DFGFixupPhase.cpp, css/SelectorChecker.cpp ...") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36861 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141007 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43640 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140836 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44329 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29376 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108678 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25947 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36103 "Passed tests") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202740 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42840 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7475 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54330 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42232 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->