### PR TITLE
[iOS] MediaSelectionOption in MediaDeviceRoute shadows an existing struct

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -81,19 +81,8 @@ struct MediaPlaybackSourceError {
     const String localizedDescription;
 };
 
-struct MediaSelectionOption {
-    enum class Type : uint8_t {
-        Audio,
-        Legible,
-    };
-
-    const String displayName;
-    const String identifier;
-    const Type type;
-    const String extendedLanguageTag;
-};
-
 class MediaDeviceRoute;
+struct MediaSelectionOption;
 
 class MediaDeviceRouteClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaDeviceRouteClient> {
 public:

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
+#import "MediaSelectionOption.h"
 #import <AVKit/AVKit.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <wtf/darwin/DispatchExtras.h>
@@ -282,9 +283,9 @@ static Vector<MediaSelectionOption> convert(NSArray * _Nullable options)
     return Vector<MediaSelectionOption>(options.count, [&](size_t i) {
         id option = options[i];
         return MediaSelectionOption {
+            MediaSelectionOption::MediaType::Audio,
             [option displayName],
-            [option identifier],
-            MediaSelectionOption::Type::Audio,
+            MediaSelectionOption::LegibleType::Regular,
             [option extendedLanguageTag],
         };
     });

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -31,6 +31,7 @@
 #include "Logging.h"
 #include "MediaDeviceRoute.h"
 #include "MediaPlaybackTargetWirelessPlayback.h"
+#include "MediaSelectionOption.h"
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/TZoneMallocInlines.h>


### PR DESCRIPTION
#### 67e969df0ff86c5148fe3570ed17f8023c4ebf37
<pre>
[iOS] MediaSelectionOption in MediaDeviceRoute shadows an existing struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=317793">https://bugs.webkit.org/show_bug.cgi?id=317793</a>
<a href="https://rdar.apple.com/180562637">rdar://180562637</a>

Reviewed by Eric Carlson.

MediaDeviceRoute.h defined a struct MediaSelectionOption, whose name shadows a different struct
defined in MediaSelectionOption.h. Instead of defining a new struct, we can just use the struct
from MediaSelectionOption.h in MediaDeviceRoute.

No new tests. Covered by existing tests.

* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(WebCore::convert):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:

Canonical link: <a href="https://commits.webkit.org/315802@main">https://commits.webkit.org/315802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc2fe745e6852732a6f369166ecea2fc00b4a41c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127836 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93667c29-1462-491f-91d0-10f8692fb2a7) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171990 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Passed bindings tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45290 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit (warnings)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43679 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132610 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81ec2a8d-30a8-4707-9d89-8f196e4dcd64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173083 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113112 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/460a14a5-2010-42d6-a472-6f94299d0a47) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28182 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32442 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182083 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Running compile-webkit") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31379 "Build is in progress. Recent messages:") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34872 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 28351 issues; Found 151 new failures in Modules/speech/SpeechRecognitionResult.cpp, wasm/WasmIPIntGenerator.cpp, dfg/DFGBasicBlock.cpp, accessibility/AccessibilityScrollView.cpp, loader/TextResourceDecoder.cpp, bytecompiler/BytecodeGenerator.cpp, BindGroup.mm, WGSL/UniformityAnalysis.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, editing/cocoa/WebContentReaderCocoa.mm ...") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141063 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43703 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37939 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44392 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108753 "Build is being retried. Recent messages:") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36159 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116273 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202803 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42903 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7525 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/202803 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42295 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->