### PR TITLE
[JSC][Temporal] Polish Duration converters, accessors, and arithmetic

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -138,7 +138,6 @@ runtime/ScriptExecutable.h
 runtime/Structure.cpp
 runtime/StructureInlines.h
 runtime/SymbolTable.cpp
-runtime/TemporalDuration.cpp
 runtime/TemporalObject.cpp
 runtime/TypeProfiler.cpp
 runtime/TypeProfilerLog.cpp

--- a/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
@@ -90,7 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormat, (JSGlobalObject*
     if (!argument.isObject() && !argument.isString()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.format argument needs to be an object or a string"_s);
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, argument);
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, argument);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(durationFormat->format(globalObject, WTF::move(duration))));
@@ -110,7 +110,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormatToParts, (JSGlobal
     if (!argument.isObject() && !argument.isString()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.formatToParts argument needs to be an object or a string"_s);
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, argument);
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, argument);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(durationFormat->formatToParts(globalObject, WTF::move(duration))));

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -84,134 +84,120 @@ TemporalDuration* TemporalDuration::tryCreateIfValid(JSGlobalObject* globalObjec
     return TemporalDuration::create(vm, structure ? structure : globalObject->durationStructure(), WTF::move(duration));
 }
 
-// ToTemporalDurationRecord ( temporalDurationLike )
-// https://tc39.es/proposal-temporal/#sec-temporal-totemporaldurationrecord
-ISO8601::Duration TemporalDuration::fromDurationLike(JSGlobalObject* globalObject, JSObject* durationLike)
+// ToTemporalPartialDurationRecord ( temporalDurationLike )
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporalpartialdurationrecord
+static std::optional<std::array<std::optional<double>, numberOfTemporalUnits>>
+toTemporalPartialDurationRecord(JSGlobalObject* globalObject, JSObject* durationLike)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (durationLike->inherits<TemporalDuration>())
-        return uncheckedDowncast<TemporalDuration>(durationLike)->m_duration;
+    // Step 2: Let result be a new partial Duration Record with each field set to undefined.
+    //   We model "undefined" with std::optional default-init (nullopt).
+    std::array<std::optional<double>, numberOfTemporalUnits> result;
 
-    ISO8601::Duration result;
-    auto hasRelevantProperty = false;
+    // Step 3 NOTE: properties read in alphabetical order (days, hours, microseconds, ...).
+    //   `temporalUnitsInTableOrder` is, despite its name, the spec's alphabetical order.
+    // Steps 4-22 (per unit): Get(durationLike, "<unit>"); if !undefined, ? ToIntegerIfIntegral.
+    bool any = false;
     for (TemporalUnit unit : temporalUnitsInTableOrder) {
         JSValue value = durationLike->get(globalObject, temporalUnitPluralPropertyName(vm, unit));
-        RETURN_IF_EXCEPTION(scope, { });
-
+        RETURN_IF_EXCEPTION(scope, std::nullopt);
         if (value.isUndefined())
             continue;
 
-        hasRelevantProperty = true;
+        any = true;
+        // ToIntegerIfIntegral: `+ 0.0` does step 4 (-0 → +0); !isInteger covers steps 2-3
+        // (NaN/±∞ are non-finite, isInteger returns false).
         double v = value.toNumber(globalObject) + 0.0;
-        RETURN_IF_EXCEPTION(scope, { });
-
-        if (!isInteger(v) || !std::isfinite(v)) [[unlikely]] {
+        RETURN_IF_EXCEPTION(scope, std::nullopt);
+        if (!isInteger(v)) [[unlikely]] {
             throwRangeError(globalObject, scope, "Temporal.Duration properties must be integers"_s);
-            return { };
+            return std::nullopt;
         }
-        result.setField(unit, v);
+        result[static_cast<size_t>(unit)] = v;
     }
 
-    if (!hasRelevantProperty) [[unlikely]] {
+    // Step 23: If all properties were undefined, throw TypeError.
+    if (!any) [[unlikely]] {
         throwTypeError(globalObject, scope, "Object must contain at least one Temporal.Duration property"_s);
-        return { };
+        return std::nullopt;
     }
 
+    // Step 24: Return result.
     return result;
 }
 
-// ToLimitedTemporalDuration ( temporalDurationLike, disallowedFields )
-// https://tc39.es/proposal-temporal/#sec-temporal-tolimitedtemporalduration
-ISO8601::Duration TemporalDuration::toISO8601Duration(JSGlobalObject* globalObject, JSValue itemValue)
+// ToTemporalDuration ( item ) — returns the raw Duration Record (skips JSCell wrap).
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporalduration
+ISO8601::Duration TemporalDuration::toTemporalDurationRecord(JSGlobalObject* globalObject, JSValue itemValue)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ISO8601::Duration duration;
+    // Step 1: If item is Object and item has [[InitializedTemporalDuration]] internal slot,
+    //   return ! CreateTemporalDuration(item.[[Years]], ..., item.[[Nanoseconds]]).
     if (itemValue.isObject()) {
-        duration = fromDurationLike(globalObject, asObject(itemValue));
+        if (auto* duration = dynamicDowncast<TemporalDuration>(asObject(itemValue)))
+            return duration->m_duration;
+
+        // Steps 3-15 (Object branch): partial record extraction with default-0.
+        // Step 4: ? ToTemporalPartialDurationRecord(item).
+        auto partial = toTemporalPartialDurationRecord(globalObject, asObject(itemValue));
         RETURN_IF_EXCEPTION(scope, { });
-    } else {
-        if (!itemValue.isString()) [[unlikely]] {
-            throwTypeError(globalObject, scope, "can only convert to Duration from object or string values"_s);
-            return { };
+        ASSERT(partial);
+
+        // Step 3: result = new Partial Duration Record with each field set to 0.
+        // Steps 5-14 (per unit): if partial.X is not undefined, result.X = partial.X.
+        ISO8601::Duration result;
+        for (size_t i = 0; i < numberOfTemporalUnits; ++i) {
+            if ((*partial)[i].has_value())
+                result.setField(i, *(*partial)[i]);
         }
 
-        String string = itemValue.toWTFString(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-
-        auto parsedDuration = ISO8601::parseDuration(string);
-        if (!parsedDuration) {
-            // 3090: 308 digits * 10 fields + 10 designators
-            throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(3090, string), "' is not a valid Duration string"_s));
+        // Step 15: Return ! CreateTemporalDuration(...). IsValidDuration check below.
+        if (!ISO8601::isValidDuration(result)) [[unlikely]] {
+            throwRangeError(globalObject, scope, "Temporal.Duration properties must be finite and of consistent sign"_s);
             return { };
         }
-
-        duration = parsedDuration.value();
+        return result;
     }
 
-    if (!ISO8601::isValidDuration(duration)) [[unlikely]] {
-        throwRangeError(globalObject, scope, "Temporal.Duration properties must be finite and of consistent sign"_s);
+    // Step 2.a: If item is not Object and not String, throw TypeError.
+    if (!itemValue.isString()) [[unlikely]] {
+        throwTypeError(globalObject, scope, "can only convert to Duration from object or string values"_s);
         return { };
     }
 
-    return duration;
-}
-
-// ToTemporalDuration ( item )
-// https://tc39.es/proposal-temporal/#sec-temporal-totemporalduration
-TemporalDuration* TemporalDuration::toTemporalDuration(JSGlobalObject* globalObject, JSValue itemValue)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (itemValue.inherits<TemporalDuration>())
-        return uncheckedDowncast<TemporalDuration>(itemValue);
-
-    auto result = toISO8601Duration(globalObject, itemValue);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-
-    return TemporalDuration::create(vm, globalObject->durationStructure(), WTF::move(result));
-}
-
-// ToLimitedTemporalDuration ( temporalDurationLike, disallowedFields )
-// https://tc39.es/proposal-temporal/#sec-temporal-tolimitedtemporalduration
-ISO8601::Duration TemporalDuration::toLimitedDuration(JSGlobalObject* globalObject, JSValue itemValue, std::initializer_list<TemporalUnit> disallowedUnits)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    ISO8601::Duration duration = toISO8601Duration(globalObject, itemValue);
+    // Step 2.b: Return ? ParseTemporalDurationString(item).
+    String string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (!isValidDuration(duration)) [[unlikely]] {
-        throwRangeError(globalObject, scope, "Temporal.Duration properties must be finite and of consistent sign"_s);
+    auto parsed = ISO8601::parseDuration(string);
+    if (!parsed) [[unlikely]] {
+        // 3090: 308 digits * 10 fields + 10 designators
+        throwRangeError(globalObject, scope, makeString("'"_s, ellipsizeAt(3090, string), "' is not a valid Duration string"_s));
         return { };
     }
 
-    for (TemporalUnit unit : disallowedUnits) {
-        if (duration[unit]) [[unlikely]] {
-            throwRangeError(globalObject, scope, makeString("Adding "_s, temporalUnitPluralPropertyName(vm, unit).publicName(), " not supported by Temporal.Instant. Try Temporal.ZonedDateTime instead"_s));
-            return { };
-        }
+    if (!ISO8601::isValidDuration(*parsed)) [[unlikely]] {
+        throwRangeError(globalObject, scope, "Temporal.Duration properties must be finite and of consistent sign"_s);
+        return { };
     }
-
-    return duration;
+    return *parsed;
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.from
 TemporalDuration* TemporalDuration::from(JSGlobalObject* globalObject, JSValue itemValue)
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (itemValue.inherits<TemporalDuration>()) {
-        ISO8601::Duration cloned = uncheckedDowncast<TemporalDuration>(itemValue)->m_duration;
-        return TemporalDuration::create(vm, globalObject->durationStructure(), WTF::move(cloned));
-    }
-
-    return toTemporalDuration(globalObject, itemValue);
+    // Step 1: Return ? ToTemporalDuration(item). Always returns a fresh cell — spec's
+    //   CreateTemporalDuration constructs a new instance even when item already is one.
+    auto record = toTemporalDurationRecord(globalObject, itemValue);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    return TemporalDuration::create(vm, globalObject->durationStructure(), WTF::move(record));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-add24hourdaystonormalizedtimeduration
@@ -602,10 +588,11 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* one = toTemporalDuration(globalObject, valueOne);
+    // Steps 1-2: one = ? ToTemporalDuration(one); two = ? ToTemporalDuration(two).
+    //   We use the raw record form — compare only reads fields, no JSCell needed.
+    auto one = toTemporalDurationRecord(globalObject, valueOne);
     RETURN_IF_EXCEPTION(scope, { });
-
-    auto* two = toTemporalDuration(globalObject, valueTwo);
+    auto two = toTemporalDurationRecord(globalObject, valueTwo);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Always validate options type (even if we don't need relativeTo).
@@ -620,28 +607,28 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
     }
 
     // After parsing relativeTo, identical durations always compare equal.
-    if (one->years() == two->years()
-        && one->months() == two->months()
-        && one->weeks() == two->weeks() && one->days() == two->days()
-        && one->hours() == two->hours() && one->minutes() == two->minutes()
-        && one->seconds() == two->seconds() && one->milliseconds() == two->milliseconds()
-        && one->microseconds() == two->microseconds() && one->nanoseconds() == two->nanoseconds()) {
+    if (one.years() == two.years()
+        && one.months() == two.months()
+        && one.weeks() == two.weeks() && one.days() == two.days()
+        && one.hours() == two.hours() && one.minutes() == two.minutes()
+        && one.seconds() == two.seconds() && one.milliseconds() == two.milliseconds()
+        && one.microseconds() == two.microseconds() && one.nanoseconds() == two.nanoseconds()) {
         return jsNumber(0);
     }
 
     // ZDT path: use addZonedDateTime when either duration has a non-zero date-category unit
     // (years, months, weeks, or days). Pure time durations don't need TZ-aware comparison.
-    bool hasDateUnit1 = one->years() || one->months() || one->weeks() || one->days();
-    bool hasDateUnit2 = two->years() || two->months() || two->weeks() || two->days();
+    bool hasDateUnit1 = one.years() || one.months() || one.weeks() || one.days();
+    bool hasDateUnit2 = two.years() || two.months() || two.weeks() || two.days();
     if (relativeTo.zonedRelativeTo && (hasDateUnit1 || hasDateUnit2)) {
         auto* zdt = relativeTo.zonedRelativeTo;
         auto startExact = zdt->exactTime();
-        auto endTime1 = TemporalCore::addZonedDateTime(startExact, zdt->timeZone(), one->m_duration, TemporalOverflow::Constrain, zdt->calendarID());
+        auto endTime1 = TemporalCore::addZonedDateTime(startExact, zdt->timeZone(), one, TemporalOverflow::Constrain, zdt->calendarID());
         if (!endTime1) [[unlikely]] {
             throwRangeError(globalObject, scope, endTime1.error().message);
             return { };
         }
-        auto endTime2 = TemporalCore::addZonedDateTime(startExact, zdt->timeZone(), two->m_duration, TemporalOverflow::Constrain, zdt->calendarID());
+        auto endTime2 = TemporalCore::addZonedDateTime(startExact, zdt->timeZone(), two, TemporalOverflow::Constrain, zdt->calendarID());
         if (!endTime2) [[unlikely]] {
             throwRangeError(globalObject, scope, endTime2.error().message);
             return { };
@@ -652,11 +639,11 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
     }
 
     // Fast path: no ZDT addZonedDateTime needed — pure 24h-day time comparison.
-    bool hasCalendarUnits = one->years() || two->years() || one->months() || two->months() || one->weeks() || two->weeks();
+    bool hasCalendarUnits = one.years() || two.years() || one.months() || two.months() || one.weeks() || two.weeks();
     if (!hasCalendarUnits) {
-        auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(one->m_duration).time(), one->days());
+        auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(one).time(), one.days());
         RETURN_IF_EXCEPTION(scope, { });
-        auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(two->m_duration).time(), two->days());
+        auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(two).time(), two.days());
         RETURN_IF_EXCEPTION(scope, { });
         return jsNumber(timeDuration1 > timeDuration2 ? 1 : timeDuration1 < timeDuration2 ? -1 : 0);
     }
@@ -669,18 +656,18 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
     // PlainDate relativeTo: DateDurationDays(dateDuration, plainDate).
     auto& plainDate = relativeTo.plainDate;
 
-    ISO8601::Duration dateDuration1(one->years(), one->months(), one->weeks(), one->days(), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
+    ISO8601::Duration dateDuration1(one.years(), one.months(), one.weeks(), one.days(), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
     auto endDate1 = calendarAwareDateAdd(globalObject, relativeTo.calendarId, plainDate, dateDuration1, TemporalOverflow::Constrain);
     RETURN_IF_EXCEPTION(scope, { });
     auto daysDiff1 = TemporalCore::diffISODate(plainDate, endDate1, TemporalUnit::Day);
-    auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(one->m_duration).time(), daysDiff1.days());
+    auto timeDuration1 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(one).time(), daysDiff1.days());
     RETURN_IF_EXCEPTION(scope, { });
 
-    ISO8601::Duration dateDuration2(two->years(), two->months(), two->weeks(), two->days(), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
+    ISO8601::Duration dateDuration2(two.years(), two.months(), two.weeks(), two.days(), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
     auto endDate2 = calendarAwareDateAdd(globalObject, relativeTo.calendarId, plainDate, dateDuration2, TemporalOverflow::Constrain);
     RETURN_IF_EXCEPTION(scope, { });
     auto daysDiff2 = TemporalCore::diffISODate(plainDate, endDate2, TemporalUnit::Day);
-    auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(two->m_duration).time(), daysDiff2.days());
+    auto timeDuration2 = add24HourDaysToTimeDuration(globalObject, TemporalCore::toInternalDuration(two).time(), daysDiff2.days());
     RETURN_IF_EXCEPTION(scope, { });
 
     return jsNumber(timeDuration1 > timeDuration2 ? 1 : timeDuration1 < timeDuration2 ? -1 : 0);
@@ -689,36 +676,19 @@ JSValue TemporalDuration::compare(JSGlobalObject* globalObject, JSValue valueOne
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.with
 ISO8601::Duration TemporalDuration::with(JSGlobalObject* globalObject, JSObject* durationLike) const
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
+    // Step 3: Let temporalDurationLike be ? ToTemporalPartialDurationRecord(temporalDurationLike).
+    auto partial = toTemporalPartialDurationRecord(globalObject, durationLike);
+    RETURN_IF_EXCEPTION(scope, { });
+    ASSERT(partial);
+
+    // Steps 4-23 (per unit): if partial.X is not undefined, x = partial.X; else x = duration.X.
     ISO8601::Duration result;
-    auto hasRelevantProperty = false;
-    for (TemporalUnit unit : temporalUnitsInTableOrder) {
-        JSValue value = durationLike->get(globalObject, temporalUnitPluralPropertyName(vm, unit));
-        RETURN_IF_EXCEPTION(scope, { });
+    for (size_t i = 0; i < numberOfTemporalUnits; ++i)
+        result.setField(i, (*partial)[i].value_or(m_duration[i]));
 
-        if (value.isUndefined()) {
-            result.setField(unit, m_duration[unit]);
-            continue;
-        }
-
-        hasRelevantProperty = true;
-        double v = value.toNumber(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-
-        if (!isInteger(v) || !std::isfinite(v)) [[unlikely]] {
-            throwRangeError(globalObject, scope, "Temporal.Duration properties must be integers"_s);
-            return { };
-        }
-        result.setField(unit, v);
-    }
-
-    if (!hasRelevantProperty) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Object must contain at least one Temporal.Duration property"_s);
-        return { };
-    }
-
+    // Step 24: Return ! CreateTemporalDuration(...). (Caller wraps in tryCreateIfValid.)
     return result;
 }
 
@@ -756,47 +726,53 @@ ISO8601::Duration TemporalDuration::toDateDurationRecordWithoutTime(JSGlobalObje
     return *result;
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.add
-// Spec: Duration.prototype.add(other) — no relativeTo; throws RangeError if calendar units present.
-ISO8601::Duration TemporalDuration::add(JSGlobalObject* globalObject, JSValue otherValue) const
+// AddDurations ( operation, duration, other )
+// https://tc39.es/proposal-temporal/#sec-temporal-adddurations
+template<AddOrSubtract op>
+ISO8601::Duration TemporalDuration::addDurations(JSGlobalObject* globalObject, JSValue otherValue) const
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto other = toISO8601Duration(globalObject, otherValue);
+    // Step 1: Set other to ? ToTemporalDuration(other).
+    auto other = toTemporalDurationRecord(globalObject, otherValue);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto largestUnit = std::min(TemporalCore::largestSubduration(m_duration), TemporalCore::largestSubduration(other));
-    RELEASE_AND_RETURN(scope, addDurations(globalObject, AddOrSubtract::Add, other, largestUnit));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal-adddurations
-/* static */ ISO8601::Duration TemporalDuration::addDurations(JSGlobalObject* globalObject,
-    AddOrSubtract op, ISO8601::Duration other, TemporalUnit largestUnit) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (op == AddOrSubtract::Subtract)
+    // Step 2: If operation is subtract, set other to CreateNegatedTemporalDuration(other).
+    if constexpr (op == AddOrSubtract::Subtract)
         other = -other;
 
-    // Spec step 6: if either duration has calendar units, throw RangeError.
+    // Steps 3-5: largestUnit = LargerOfTwoTemporalUnits(
+    //   DefaultTemporalLargestUnit(duration), DefaultTemporalLargestUnit(other)).
+    //   In our enum, smaller index = larger unit (Year=0..Nanosecond=9), so std::min.
+    auto largestUnit = std::min(TemporalCore::largestSubduration(m_duration),
+        TemporalCore::largestSubduration(other));
+
+    // Step 6: If IsCalendarUnit(largestUnit) is true, throw a RangeError exception.
     if (isCalendarUnit(largestUnit)) [[unlikely]] {
         throwRangeError(globalObject, scope, "Cannot add or subtract durations with calendar units (years, months, or weeks)"_s);
         return { };
     }
 
+    // Step 7: Let d1 be ToInternalDurationRecordWith24HourDays(duration).
     auto d1 = toInternalDurationRecordWith24HourDays(globalObject, m_duration);
     RETURN_IF_EXCEPTION(scope, { });
+    // Step 8: Let d2 be ToInternalDurationRecordWith24HourDays(other).
     auto d2 = toInternalDurationRecordWith24HourDays(globalObject, other);
     RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 9: Let timeResult be ? AddTimeDuration(d1.[[Time]], d2.[[Time]]).
+    //   AddTimeDuration is `a + b` followed by an overflow check against maxTimeDuration.
     auto timeResult = d1.time() + d2.time();
     if (absInt128(timeResult) > ISO8601::InternalDuration::maxTimeDuration) [[unlikely]] {
         throwRangeError(globalObject, scope, "Sum of durations exceeds maximum time duration"_s);
         return { };
     }
 
+    // Step 10: Let result be CombineDateAndTimeDuration(ZeroDateDuration(), timeResult).
     auto result = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), timeResult);
+
+    // Step 11: Return ? TemporalDurationFromInternal(result, largestUnit).
     auto durResult = TemporalCore::temporalDurationFromInternal(result, largestUnit);
     if (!durResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult.error());
@@ -805,19 +781,8 @@ ISO8601::Duration TemporalDuration::add(JSGlobalObject* globalObject, JSValue ot
     return *durResult;
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract
-// Spec: Duration.prototype.subtract(other) — no relativeTo; throws RangeError if calendar units present.
-ISO8601::Duration TemporalDuration::subtract(JSGlobalObject* globalObject, JSValue otherValue) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto other = toISO8601Duration(globalObject, otherValue);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    auto largestUnit = std::min(TemporalCore::largestSubduration(m_duration), TemporalCore::largestSubduration(other));
-    RELEASE_AND_RETURN(scope, addDurations(globalObject, AddOrSubtract::Subtract, other, largestUnit));
-}
+template ISO8601::Duration TemporalDuration::addDurations<AddOrSubtract::Add>(JSGlobalObject*, JSValue) const;
+template ISO8601::Duration TemporalDuration::addDurations<AddOrSubtract::Subtract>(JSGlobalObject*, JSValue) const;
 
 // RoundDuration ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, increment, unit, roundingMode [ , relativeTo ] )
 // https://tc39.es/proposal-temporal/#sec-temporal-roundduration
@@ -1276,29 +1241,6 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, JSValue optionsV
     RELEASE_AND_RETURN(scope, toString(globalObject, roundedDuration, data.precision));
 }
 
-static TemporalUnit NODELETE defaultTemporalLargestUnit(const ISO8601::Duration& duration)
-{
-    if (duration.years())
-        return TemporalUnit::Year;
-    if (duration.months())
-        return TemporalUnit::Month;
-    if (duration.weeks())
-        return TemporalUnit::Week;
-    if (duration.days())
-        return TemporalUnit::Day;
-    if (duration.hours())
-        return TemporalUnit::Hour;
-    if (duration.minutes())
-        return TemporalUnit::Minute;
-    if (duration.seconds())
-        return TemporalUnit::Second;
-    if (duration.milliseconds())
-        return TemporalUnit::Millisecond;
-    if (duration.microseconds())
-        return TemporalUnit::Microsecond;
-    return TemporalUnit::Nanosecond;
-}
-
 static void appendInteger(JSGlobalObject* globalObject, StringBuilder& builder, double value)
 {
     ASSERT(std::isfinite(value));
@@ -1374,7 +1316,7 @@ String TemporalDuration::toString(JSGlobalObject* globalObject, const ISO8601::D
         builder.append('M');
     }
 
-    bool zeroMinutesAndHigher = defaultTemporalLargestUnit(duration) >= TemporalUnit::Second;
+    bool zeroMinutesAndHigher = TemporalCore::largestSubduration(duration) >= TemporalUnit::Second;
 
     if (secondsDuration || (zeroMinutesAndHigher || std::get<0>(precision) != Precision::Auto)) {
         double secondsPart = std::abs(static_cast<double>(static_cast<int64_t>(secondsDuration / 1000000000)));

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -50,8 +50,7 @@ public:
 
     DECLARE_INFO;
 
-    static TemporalDuration* toTemporalDuration(JSGlobalObject*, JSValue);
-    static ISO8601::Duration toLimitedDuration(JSGlobalObject*, JSValue, std::initializer_list<TemporalUnit> disallowedUnits);
+    static ISO8601::Duration toTemporalDurationRecord(JSGlobalObject*, JSValue);
     static TemporalDuration* from(JSGlobalObject*, JSValue);
     static JSValue compare(JSGlobalObject*, JSValue, JSValue, JSValue options);
 
@@ -65,18 +64,14 @@ public:
     const ISO8601::Duration& duration() const { return m_duration; }
 
     ISO8601::Duration with(JSGlobalObject*, JSObject* durationLike) const;
-    ISO8601::Duration add(JSGlobalObject*, JSValue other) const;
-    ISO8601::Duration subtract(JSGlobalObject*, JSValue other) const;
+    template<AddOrSubtract op>
+    ISO8601::Duration addDurations(JSGlobalObject*, JSValue other) const;
     ISO8601::Duration round(JSGlobalObject*, JSValue options) const;
     double total(JSGlobalObject*, JSValue options) const;
     String toString(JSGlobalObject*, JSValue options) const;
     String toString(JSGlobalObject* globalObject, std::tuple<Precision, unsigned> precision = { Precision::Auto, 0 }) const { return toString(globalObject, m_duration, precision); }
 
     static ISO8601::InternalDuration toInternalDurationRecordWith24HourDays(JSGlobalObject*, ISO8601::Duration);
-    ISO8601::Duration addDurations(JSGlobalObject*, AddOrSubtract, ISO8601::Duration, TemporalUnit) const;
-
-    static ISO8601::Duration fromDurationLike(JSGlobalObject*, JSObject*);
-    static ISO8601::Duration toISO8601Duration(JSGlobalObject*, JSValue);
 
     static ISO8601::InternalDuration round(JSGlobalObject*, ISO8601::InternalDuration, double increment, TemporalUnit, RoundingMode);
     static std::optional<ISO8601::PlainDate> regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow);

--- a/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationConstructor.cpp
@@ -86,12 +86,13 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalDuration, (JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: NewTarget check done by JSC engine.
+    // Step 1: NewTarget undefined check — handled by JSC's call/construct split (see callTemporalDuration).
     JSObject* newTarget = asObject(callFrame->newTarget());
     Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, durationStructure, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Steps 2-10: If arg is undefined use 0; else ToIntegerIfIntegral(arg).
+    // Steps 2-11: For each unit X (years..nanoseconds), if X is undefined let it be 0;
+    //   else ? ToIntegerIfIntegral(X). `+ 0.0` normalizes -0 → +0 (ToIntegerIfIntegral step 4).
     ISO8601::Duration result;
     auto count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalUnits);
     for (size_t i = 0; i < count; i++) {
@@ -107,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalDuration, (JSGlobalObject* globalObjec
         result.setField(i, v);
     }
 
-    // Steps 11-12: IsValidDuration + CreateTemporalDuration.
+    // Step 12: Return ? CreateTemporalDuration(...). tryCreateIfValid runs IsValidDuration.
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), structure)));
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDurationPrototype.cpp
@@ -124,20 +124,21 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncWith, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: branding check via dynamicDowncast.
     auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.with called on value that's not a Duration"_s);
 
-    // Step 2: If temporalDurationLike is not an Object, throw TypeError.
+    // Step 3.a: ToTemporalPartialDurationRecord step 1 throws TypeError for non-Object input.
     JSValue durationLike = callFrame->argument(0);
     if (!durationLike.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "First argument to Temporal.Duration.prototype.with must be an object"_s);
 
-    // Steps 3-4: ToTemporalPartialDurationRecord + CreateTemporalDuration.
+    // Steps 3-23: with() merges partial into existing fields.
     auto result = duration->with(globalObject, asObject(durationLike));
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 24: Return ! CreateTemporalDuration(...). tryCreateIfValid runs IsValidDuration.
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result))));
 }
 
@@ -147,12 +148,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncNegated, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: branding check.
     auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.negated called on value that's not a Duration"_s);
 
-    // Step 2: Return CreateNegatedTemporalDuration(duration).
+    // Step 3: Return CreateNegatedTemporalDuration(duration).
+    //   Negation preserves IsValidDuration → skip tryCreateIfValid.
     return JSValue::encode(TemporalDuration::create(vm, globalObject->durationStructure(), TemporalCore::negateDuration(duration->duration())));
 }
 
@@ -162,12 +164,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncAbs, (JSGlobalObject* glob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: branding check.
     auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.abs called on value that's not a Duration"_s);
 
-    // Step 2: Return CreateAbsTemporalDuration(duration).
+    // Step 3: Return ! CreateTemporalDuration(abs(years), ..., abs(nanoseconds)).
+    //   Per-field non-negative is stricter than IsValidDuration → skip tryCreateIfValid.
     return JSValue::encode(TemporalDuration::create(vm, globalObject->durationStructure(), TemporalCore::absDuration(duration->duration())));
 }
 
@@ -177,13 +180,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncAdd, (JSGlobalObject* glob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: branding check via dynamicDowncast.
     auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.add called on value that's not a Duration"_s);
 
-    // Steps 2-3: AddDurations(add, duration, other) → CreateTemporalDuration.
-    auto result = duration->add(globalObject, callFrame->argument(0));
+    // Step 3: Return ? AddDurations(add, duration, other).
+    auto result = duration->addDurations<AddOrSubtract::Add>(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result))));
@@ -195,13 +198,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncSubtract, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: branding check via dynamicDowncast.
     auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.subtract called on value that's not a Duration"_s);
 
-    // Steps 2-3: AddDurations(subtract, duration, other) → CreateTemporalDuration.
-    auto result = duration->subtract(globalObject, callFrame->argument(0));
+    // Step 3: Return ? AddDurations(subtract, duration, other).
+    auto result = duration->addDurations<AddOrSubtract::Subtract>(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result))));
@@ -256,12 +259,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncToString, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: branding check via dynamicDowncast.
     auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.toString called on value that's not a Duration"_s);
 
-    // Steps 2-5: GetOptionsObject + precision settings + TemporalDurationToString.
+    // Steps 3-18: option parsing + RoundTimeDuration + TemporalDurationToString.
+    //   Line-by-line spec mapping is in TemporalDuration::toString below.
     RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, duration->toString(globalObject, callFrame->argument(0)))));
 }
 
@@ -271,34 +275,33 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncToJSON, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: branding check via dynamicDowncast.
     auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.toJSON called on value that's not a Duration"_s);
 
-    // Step 2: Return TemporalDurationToString(duration, "auto").
+    // Step 3: Return TemporalDurationToString(duration, "auto"). No option parsing.
     RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, duration->toString(globalObject))));
 }
 
 // https://tc39.es/proposal-temporal/#sup-temporal.duration.prototype.tolocalestring
+//   ECMA-402 override: when Intl is present, this delegates to IntlDurationFormat.
 JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncToLocaleString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: RequireInternalSlot — branding check.
+    // Steps 1-2: branding check via dynamicDowncast.
     auto* duration = dynamicDowncast<TemporalDuration>(callFrame->thisValue());
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.toLocaleString called on value that's not a Duration"_s);
 
+    // Step 3 (ECMA-402): one-shot DurationFormat with locales/options + format.
     auto* formatter = IntlDurationFormat::create(vm, globalObject->durationFormatStructure());
     formatter->initializeDurationFormat(globalObject, callFrame->argument(0), callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
-    ISO8601::Duration dur(duration->years(), duration->months(), duration->weeks(), duration->days(),
-        duration->hours(), duration->minutes(), duration->seconds(),
-        duration->milliseconds(), Int128(duration->microseconds()), Int128(duration->nanoseconds()));
-    RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, dur)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, duration->duration())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof
@@ -307,163 +310,54 @@ JSC_DEFINE_HOST_FUNCTION(temporalDurationPrototypeFuncValueOf, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: Throw TypeError — Duration has no primitive value.
+    // Step 1: Throw TypeError. Duration has no primitive value — use Temporal.Duration.compare.
     return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.valueOf must not be called. To compare Duration values, use Temporal.Duration.compare"_s);
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.years
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterYears, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
+// https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.<unit>
+//   Step 1: Let duration be the this value.
+//   Step 2: Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
+//   Step 3: Return 𝔽(duration.[[<Unit>]]).
+#define JSC_DEFINE_TEMPORAL_DURATION_UNIT_GETTER(name, capitalizedName) \
+    JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetter##capitalizedName##s, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName)) \
+    { \
+        VM& vm = globalObject->vm(); \
+        auto scope = DECLARE_THROW_SCOPE(vm); \
+        auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue)); \
+        if (!duration) [[unlikely]] \
+            return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype." #name "s called on value that's not a Duration"_s); \
+        return JSValue::encode(jsNumber(duration->name##s())); \
+    }
+JSC_TEMPORAL_UNITS(JSC_DEFINE_TEMPORAL_DURATION_UNIT_GETTER)
+#undef JSC_DEFINE_TEMPORAL_DURATION_UNIT_GETTER
 
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.years called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->years()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.months
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterMonths, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.months called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->months()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.weeks
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterWeeks, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.weeks called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->weeks()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.days
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterDays, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.days called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->days()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.hours
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterHours, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.hours called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->hours()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.minutes
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterMinutes, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.minutes called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->minutes()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.seconds
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterSeconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.seconds called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->seconds()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.milliseconds
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterMilliseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.milliseconds called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->milliseconds()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.microseconds
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterMicroseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.microseconds called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->microseconds()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.nanoseconds
-JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterNanoseconds, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
-    if (!duration) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.nanoseconds called on value that's not a Duration"_s);
-
-    return JSValue::encode(jsNumber(duration->nanoseconds()));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.sign
+// https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.sign
 JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterSign, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: Branding check via dynamicDowncast.
     auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.sign called on value that's not a Duration"_s);
 
+    // Step 3: Return 𝔽(! DurationSign(duration.[[Years]], ..., duration.[[Nanoseconds]])).
     return JSValue::encode(jsNumber(duration->sign()));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.blank
+// https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.blank
 JSC_DEFINE_CUSTOM_GETTER(temporalDurationPrototypeGetterBlank, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: Branding check via dynamicDowncast.
     auto* duration = dynamicDowncast<TemporalDuration>(JSValue::decode(thisValue));
     if (!duration) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.Duration.prototype.blank called on value that's not a Duration"_s);
 
+    // Steps 3-5: Return DurationSign == 0 ? true : false.
     return JSValue::encode(jsBoolean(!duration->sign()));
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstantPrototype.cpp
@@ -121,13 +121,23 @@ static TemporalInstant* addDurationToInstant(JSGlobalObject* globalObject, Tempo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Steps 1, 3-4: ToTemporalDuration + reject date-category units (fused into toLimitedDuration).
-    ISO8601::Duration duration = TemporalDuration::toLimitedDuration(globalObject, durationLike, disallowedAdditionUnits);
+    // Step 1: duration = ? ToTemporalDuration(temporalDurationLike).
+    ISO8601::Duration duration = TemporalDuration::toTemporalDurationRecord(globalObject, durationLike);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    // Step 2: If operation is SUBTRACT, set duration to CreateNegatedTemporalDuration(duration).
+    // Step 2: If operation is subtract, set duration to CreateNegatedTemporalDuration(duration).
     if constexpr (operation == AddInstantOperation::Subtract)
         duration = -duration;
+
+    // Steps 3-4: reject when DefaultTemporalLargestUnit(duration) is in the date category
+    //   (Y/Mo/W/D). ZonedDateTime handles those calendrical units.
+    for (TemporalUnit unit : disallowedAdditionUnits) {
+        if (duration[unit]) [[unlikely]] {
+            StringView unitName { temporalUnitPluralPropertyName(vm, unit).publicName() };
+            throwRangeError(globalObject, scope, makeString("Adding "_s, unitName, " not supported by Temporal.Instant. Try Temporal.ZonedDateTime instead"_s));
+            return nullptr;
+        }
+    }
 
     // Steps 5-6: ToInternalDurationRecordWith24HourDays + AddInstant (both done by ExactTime::add).
     std::optional<ISO8601::ExactTime> newExactTime = instant->exactTime().add(duration);

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -270,7 +270,8 @@ Variant<TemporalAuto, std::optional<TemporalUnit>> temporalUnitValued(JSGlobalOb
     // Step 4: If value is undefined:
     if (!unit) {
         if (defaultValue == TemporalUnitDefault::Required) [[unlikely]] {
-            throwRangeError(globalObject, scope, makeString('\'', key.publicName(), "' option is required"_s));
+            StringView keyName { key.publicName() };
+            throwRangeError(globalObject, scope, makeString('\'', keyName, "' option is required"_s));
             return std::nullopt;
         }
         return std::nullopt;
@@ -552,7 +553,8 @@ static double doubleNumberOption(JSGlobalObject* globalObject, JSObject* options
     RETURN_IF_EXCEPTION(scope, 0);
 
     if (std::isnan(doubleValue)) [[unlikely]] {
-        throwRangeError(globalObject, scope, makeString(property.publicName(), " is NaN"_s));
+        StringView propertyName { property.publicName() };
+        throwRangeError(globalObject, scope, makeString(propertyName, " is NaN"_s));
         return 0;
     }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -233,7 +233,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncAdd, (JSGlobalObject* glo
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.add called on value that's not a PlainDate"_s);
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     return addDurationToPlainDate(globalObject, scope, plainDate, duration, callFrame->argument(1));
 }
@@ -248,7 +248,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSubtract, (JSGlobalObject
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.subtract called on value that's not a PlainDate"_s);
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     return addDurationToPlainDate(globalObject, scope, plainDate, -duration, callFrame->argument(1));
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -203,7 +203,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncAdd, (JSGlobalObject*
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.add called on value that's not a PlainDateTime"_s);
 
     // Step 1: Return ? AddDurationToDateTime(add, plainDateTime, duration, options).
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     return addDurationToPlainDateTime(globalObject, scope, plainDateTime, WTF::move(duration), callFrame->argument(1));
 }
@@ -219,7 +219,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncSubtract, (JSGlobalOb
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.subtract called on value that's not a PlainDateTime"_s);
 
     // Step 1: Return ? AddDurationToDateTime(subtract, ...) — step 2 negates duration.
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     return addDurationToPlainDateTime(globalObject, scope, plainDateTime, -WTF::move(duration), callFrame->argument(1));
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
@@ -118,7 +118,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncAdd, (JSGlobalObject* glo
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.add called on value that's not a PlainTime"_s);
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
     auto result = TemporalPlainTime::toPlainTime(globalObject, TemporalPlainTime::addTime(plainTime->plainTime(), duration));
@@ -137,7 +137,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncSubtract, (JSGlobalObject
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.subtract called on value that's not a PlainTime"_s);
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
     auto result = TemporalPlainTime::toPlainTime(globalObject, TemporalPlainTime::addTime(plainTime->plainTime(), -duration));

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -133,7 +133,7 @@ static JSC::EncodedJSValue temporalPlainYearMonthPrototypeAddOrSubtract(JSGlobal
             return throwVMTypeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.subtract called on value that's not a PlainYearMonth"_s);
     }
 
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
     TemporalOverflow overflow = toTemporalOverflow(globalObject, callFrame->argument(1));

--- a/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalZonedDateTimePrototype.cpp
@@ -301,7 +301,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncAdd, (JSGlobalObject*
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.add called on value that's not a ZonedDateTime"_s);
 
     // Step 3: Return ? AddDurationToZonedDateTime(~add~, zonedDateTime, temporalDurationLike, options).
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     RELEASE_AND_RETURN(scope, addDurationToZonedDateTime(globalObject, scope, zdt, WTF::move(duration), callFrame->argument(1)));
 }
@@ -320,7 +320,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalZonedDateTimePrototypeFuncSubtract, (JSGlobalOb
         return throwVMTypeError(globalObject, scope, "Temporal.ZonedDateTime.prototype.subtract called on value that's not a ZonedDateTime"_s);
 
     // Step 3: Return ? AddDurationToZonedDateTime(~subtract~, ...). Step 2 of that AO negates.
-    auto duration = TemporalDuration::toISO8601Duration(globalObject, callFrame->argument(0));
+    auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     RELEASE_AND_RETURN(scope, addDurationToZonedDateTime(globalObject, scope, zdt, -WTF::move(duration), callFrame->argument(1)));
 }


### PR DESCRIPTION
#### e9a2811a8b97dad042b40fa6cf1f897f50a85f6c
<pre>
[JSC][Temporal] Polish Duration converters, accessors, and arithmetic
<a href="https://bugs.webkit.org/show_bug.cgi?id=317792">https://bugs.webkit.org/show_bug.cgi?id=317792</a>
<a href="https://rdar.apple.com/180562156">rdar://180562156</a>

Reviewed by Sosuke Suzuki.

Pre-existing entry points had naming inconsistencies and dead spec links:
fromDurationLike (no spec name), toISO8601Duration / toLimitedDuration
(linked to sec-temporal-tolimitedtemporalduration, an abstract op removed
from the current spec). Per-unit getters duplicated boilerplate;
addDurations took a runtime AddOrSubtract tag where every callsite passes
a constant.

This patch consolidates to two entry points: ToTemporalDuration (raw
record) and ToTemporalPartialDurationRecord (shared by the object branch
and Duration.prototype.with). AddDurations becomes a template member
function with `if constexpr` operation tag, DCEing the unused branch.
The per-unit getters collapse into one macro applied via
JSC_TEMPORAL_UNITS.

Canonical link: <a href="https://commits.webkit.org/315844@main">https://commits.webkit.org/315844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b237a339f0a0b7e80ab36aeffb98eb324d965aac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127956 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9503e48d-b255-4049-a3ad-731d5cf6b72f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132729 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3ab4185-cd81-46b9-bfba-11208b088fdc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173203 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113230 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c89064a-2486-401c-9941-eabe817a0396) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28302 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1565 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182203 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31499 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34993 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141172 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43824 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140996 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44513 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108924 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36264 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116395 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202923 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43023 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7631 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54380 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42415 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42558 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->